### PR TITLE
KIND-agnostic BLAS interface

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -18,4 +18,4 @@ source-form = "free"
 source-dir="src"
 [preprocess]
 [preprocess.cpp]
-
+macros = ["STDLIB_EXTERNAL_BLAS"]

--- a/scripts/modularize_blas.py
+++ b/scripts/modularize_blas.py
@@ -214,7 +214,35 @@ def write_interface_module(INDENT,out_folder,module_name,used_modules,fortran_fu
     # Add quad-precision modules
     initials = ['aux','s','d','q','c','z','w']
 
-    interfaces = ['gemv']
+#     public :: stdlib_drot
+#     public :: stdlib_drotg
+#     public :: stdlib_drotm
+#     public :: stdlib_drotmg
+#     public :: stdlib_dsbmv
+#     public :: stdlib_dscal
+#     public :: stdlib_dsdot
+#     public :: stdlib_dspmv
+#     public :: stdlib_dspr
+#     public :: stdlib_dspr2
+#     public :: stdlib_dswap
+#     public :: stdlib_dsymm
+#     public :: stdlib_dsymv
+#     public :: stdlib_dsyr
+#     public :: stdlib_dsyr2
+#     public :: stdlib_dsyr2k
+#     public :: stdlib_dsyrk
+#     public :: stdlib_dtbmv
+#     public :: stdlib_dtbsv
+#     public :: stdlib_dtpmv
+#     public :: stdlib_dtpsv
+#     public :: stdlib_dtrmm
+#     public :: stdlib_dtrmv
+#     public :: stdlib_dtrsm
+#     public :: stdlib_dtrsv
+#     public :: stdlib_dzasum
+#     public :: stdlib_dznrm2
+
+    interfaces = ['axpy','copy','gbmv','gemm','gemv','ger']
 
     module_file = module_name + ".f90"
     module_path = os.path.join(out_folder,module_file)
@@ -232,14 +260,14 @@ def write_interface_module(INDENT,out_folder,module_name,used_modules,fortran_fu
     fid.write(INDENT + "public\n")
 
     # Type-agnostic procedure interfaces
-    interf_functions = []
-    for f in fortran_functions:
-        for j in range(len(interfaces)):
+    for j in range(len(interfaces)):
+        interf_functions = []
+        for f in fortran_functions:
             if interfaces[j] == f.old_name[1:]:
                 interf_functions.append(f)
 
-    # Write interface
-    if len(interf_functions)>0: write_interface(fid,interfaces[0],interf_functions,INDENT,prefix)
+        # Write interface
+        if len(interf_functions)>0: write_interface(fid,interfaces[j],interf_functions,INDENT,prefix)
 
 
     # Close module
@@ -284,7 +312,7 @@ def write_interface(fid,name,functions,INDENT,prefix):
         fid.write("#endif\n".format(name))
 
     # Close interface
-    fid.write(INDENT*2+"end interface {}\n".format(name))
+    fid.write(INDENT*2+"end interface {}\n\n\n".format(name))
 
 # Identify quad-precision functions
 def patch_blas_aux(fid,fortran_functions,prefix,INDENT,blas):

--- a/scripts/modularize_blas.py
+++ b/scripts/modularize_blas.py
@@ -1019,7 +1019,14 @@ class Fortran_Source:
                     if name in args:
                         var_names.append(v[k])
                         var_types.append(datatype)
-                        var_decl.append(datatype+" :: "+v[k])
+
+                        # Declarations are combined by datatype
+                        exists = False
+                        for d in range(len(var_decl)):
+                            if var_decl[d].startswith(datatype):
+                                exists = True
+                                var_decl[d] = var_decl[d] + "," + v[k]
+                        if not exists: var_decl.append(datatype+" :: "+v[k])
                     else:
                         print("variable <"+v[k]+"> not in args")
 

--- a/scripts/modularize_blas.py
+++ b/scripts/modularize_blas.py
@@ -214,9 +214,13 @@ def write_interface_module(INDENT,out_folder,module_name,used_modules,fortran_fu
     # Add quad-precision modules
     initials = ['aux','s','d','q','c','z','w']
 
-    interfaces = ['asu,','axpy','copy','dot','gbmv','demm','demv','ger','nrm2','rot','rotg','rotm','rotmg', \
+    interfaces = ['asu','axpy','copy','dot','gbmv','gemm','gemv','ger','nrm2','rot','rotg','rotm','rotmg', \
                   'sbmv','scal','sdot','spmv','spr','spr2','swap','symm','symv','syr','syr2','syr2k','syrk', \
-                  'tbmv','tbsv','tpmv','tpsv','trmm','trmv','trsm','trsv','zasum','znrm2']
+                  'tbmv','tbsv','tpmv','tpsv','trmm','trmv','trsm','trsv', \
+                  'dotc','dotu','gerc','geru','hbmv','hemm','hemv','her','her2','her2k','herk','hpmv', \
+                  'hpr','hpr2','srot','sscal']
+    interfaces.sort()
+
 
     module_file = module_name + ".f90"
     module_path = os.path.join(out_folder,module_file)

--- a/scripts/modularize_blas.py
+++ b/scripts/modularize_blas.py
@@ -249,10 +249,18 @@ def write_interface_module(INDENT,out_folder,module_name,used_modules,fortran_fu
 # write interface
 def write_interface(fid,name,functions,INDENT,prefix):
 
+    MAX_LINE_LENGTH = 150 # No line limits for the comments
+
     # Ensure all functions are sorted
     functions.sort(key=lambda x: x.old_name, reverse=False)
 
-    fid.write(INDENT+INDENT+"interface {}\n".format(name))
+    # Write comment header
+    for h in range(len(functions[0].header)):
+       functions[0].header[h] = re.sub(functions[0].old_name.upper(),name.upper(),functions[0].header[h])
+
+    write_function_body(fid,functions[0].header,INDENT*2,MAX_LINE_LENGTH,False)
+
+    fid.write(INDENT*2+"interface {}\n".format(name))
 
     # The external blas interface is fine-grained to each function, because external
     # implementations may not offer the double precision or quad precision implementation

--- a/src/stdlib_linalg_blas.f90
+++ b/src/stdlib_linalg_blas.f90
@@ -129,6 +129,60 @@ module stdlib_linalg_blas
 
 
 
+          ! DOTC forms the dot product of two complex vectors
+          ! DOTC = X^H * Y
+          interface dotc
+#ifdef STDLIB_EXTERNAL_BLAS
+               complex(sp) function cdotc(n,cx,incx,cy,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,incy,n 
+                    complex(sp) :: cx(*),cy(*) 
+               end function cdotc
+#else
+               module procedure stdlib_cdotc
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               complex(dp) function zdotc(n,zx,incx,zy,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,incy,n 
+                    complex(dp) :: zx(*),zy(*) 
+               end function zdotc
+#else
+               module procedure stdlib_zdotc
+#endif
+          end interface dotc
+
+
+
+          ! DOTU forms the dot product of two complex vectors
+          ! DOTU = X^T * Y
+          interface dotu
+#ifdef STDLIB_EXTERNAL_BLAS
+               complex(sp) function cdotu(n,cx,incx,cy,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,incy,n 
+                    complex(sp) :: cx(*),cy(*) 
+               end function cdotu
+#else
+               module procedure stdlib_cdotu
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               complex(dp) function zdotu(n,zx,incx,zy,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,incy,n 
+                    complex(dp) :: zx(*),zy(*) 
+               end function zdotu
+#else
+               module procedure stdlib_zdotu
+#endif
+          end interface dotu
+
+
+
           ! GBMV  performs one of the matrix-vector operations
           ! y := alpha*A*x + beta*y,   or   y := alpha*A**T*x + beta*y,   or
           ! y := alpha*A**H*x + beta*y,
@@ -183,6 +237,115 @@ module stdlib_linalg_blas
 
 
 
+          ! GEMM  performs one of the matrix-matrix operations
+          ! C := alpha*op( A )*op( B ) + beta*C,
+          ! where  op( X ) is one of
+          ! op( X ) = X   or   op( X ) = X**T   or   op( X ) = X**H,
+          ! alpha and beta are scalars, and A, B and C are matrices, with op( A )
+          ! an m by k matrix,  op( B )  a  k by n matrix and  C an m by n matrix.
+          interface gemm
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine cgemm(transa,transb,m,n,k,alpha,a,lda,b,ldb,beta,c,ldc)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(sp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
+                    integer(ilp) :: k,lda,ldb,ldc,m,n 
+                    character :: transa,transb 
+               end subroutine cgemm
+#else
+               module procedure stdlib_cgemm
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine dgemm(transa,transb,m,n,k,alpha,a,lda,b,ldb,beta,c,ldc)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(dp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
+                    integer(ilp) :: k,lda,ldb,ldc,m,n 
+                    character :: transa,transb 
+               end subroutine dgemm
+#else
+               module procedure stdlib_dgemm
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine sgemm(transa,transb,m,n,k,alpha,a,lda,b,ldb,beta,c,ldc)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(sp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
+                    integer(ilp) :: k,lda,ldb,ldc,m,n 
+                    character :: transa,transb 
+               end subroutine sgemm
+#else
+               module procedure stdlib_sgemm
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine zgemm(transa,transb,m,n,k,alpha,a,lda,b,ldb,beta,c,ldc)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(dp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
+                    integer(ilp) :: k,lda,ldb,ldc,m,n 
+                    character :: transa,transb 
+               end subroutine zgemm
+#else
+               module procedure stdlib_zgemm
+#endif
+          end interface gemm
+
+
+
+          ! GEMV performs one of the matrix-vector operations
+          ! y := alpha*A*x + beta*y,   or   y := alpha*A**T*x + beta*y,   or
+          ! y := alpha*A**H*x + beta*y,
+          ! where alpha and beta are scalars, x and y are vectors and A is an
+          ! m by n matrix.
+          interface gemv
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine cgemv(trans,m,n,alpha,a,lda,x,incx,beta,y,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(sp) :: alpha,beta,a(lda,*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,lda,m,n 
+                    character :: trans 
+               end subroutine cgemv
+#else
+               module procedure stdlib_cgemv
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine dgemv(trans,m,n,alpha,a,lda,x,incx,beta,y,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(dp) :: alpha,beta,a(lda,*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,lda,m,n 
+                    character :: trans 
+               end subroutine dgemv
+#else
+               module procedure stdlib_dgemv
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine sgemv(trans,m,n,alpha,a,lda,x,incx,beta,y,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(sp) :: alpha,beta,a(lda,*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,lda,m,n 
+                    character :: trans 
+               end subroutine sgemv
+#else
+               module procedure stdlib_sgemv
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine zgemv(trans,m,n,alpha,a,lda,x,incx,beta,y,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(dp) :: alpha,beta,a(lda,*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,lda,m,n 
+                    character :: trans 
+               end subroutine zgemv
+#else
+               module procedure stdlib_zgemv
+#endif
+          end interface gemv
+
+
+
           ! GER   performs the rank 1 operation
           ! A := alpha*x*y**T + A,
           ! where alpha is a scalar, x is an m element vector, y is an n element
@@ -209,6 +372,390 @@ module stdlib_linalg_blas
                module procedure stdlib_sger
 #endif
           end interface ger
+
+
+
+          ! GERC  performs the rank 1 operation
+          ! A := alpha*x*y**H + A,
+          ! where alpha is a scalar, x is an m element vector, y is an n element
+          ! vector and A is an m by n matrix.
+          interface gerc
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine cgerc(m,n,alpha,x,incx,y,incy,a,lda)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(sp) :: alpha,a(lda,*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,lda,m,n 
+               end subroutine cgerc
+#else
+               module procedure stdlib_cgerc
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine zgerc(m,n,alpha,x,incx,y,incy,a,lda)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(dp) :: alpha,a(lda,*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,lda,m,n 
+               end subroutine zgerc
+#else
+               module procedure stdlib_zgerc
+#endif
+          end interface gerc
+
+
+
+          ! GERU  performs the rank 1 operation
+          ! A := alpha*x*y**T + A,
+          ! where alpha is a scalar, x is an m element vector, y is an n element
+          ! vector and A is an m by n matrix.
+          interface geru
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine cgeru(m,n,alpha,x,incx,y,incy,a,lda)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(sp) :: alpha,a(lda,*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,lda,m,n 
+               end subroutine cgeru
+#else
+               module procedure stdlib_cgeru
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine zgeru(m,n,alpha,x,incx,y,incy,a,lda)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(dp) :: alpha,a(lda,*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,lda,m,n 
+               end subroutine zgeru
+#else
+               module procedure stdlib_zgeru
+#endif
+          end interface geru
+
+
+
+          ! HBMV  performs the matrix-vector  operation
+          ! y := alpha*A*x + beta*y,
+          ! where alpha and beta are scalars, x and y are n element vectors and
+          ! A is an n by n hermitian band matrix, with k super-diagonals.
+          interface hbmv
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine chbmv(uplo,n,k,alpha,a,lda,x,incx,beta,y,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(sp) :: alpha,beta,a(lda,*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,k,lda,n 
+                    character :: uplo 
+               end subroutine chbmv
+#else
+               module procedure stdlib_chbmv
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine zhbmv(uplo,n,k,alpha,a,lda,x,incx,beta,y,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(dp) :: alpha,beta,a(lda,*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,k,lda,n 
+                    character :: uplo 
+               end subroutine zhbmv
+#else
+               module procedure stdlib_zhbmv
+#endif
+          end interface hbmv
+
+
+
+          ! HEMM  performs one of the matrix-matrix operations
+          ! C := alpha*A*B + beta*C,
+          ! or
+          ! C := alpha*B*A + beta*C,
+          ! where alpha and beta are scalars, A is an hermitian matrix and  B and
+          ! C are m by n matrices.
+          interface hemm
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine chemm(side,uplo,m,n,alpha,a,lda,b,ldb,beta,c,ldc)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(sp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
+                    integer(ilp) :: lda,ldb,ldc,m,n 
+                    character :: side,uplo 
+               end subroutine chemm
+#else
+               module procedure stdlib_chemm
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine zhemm(side,uplo,m,n,alpha,a,lda,b,ldb,beta,c,ldc)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(dp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
+                    integer(ilp) :: lda,ldb,ldc,m,n 
+                    character :: side,uplo 
+               end subroutine zhemm
+#else
+               module procedure stdlib_zhemm
+#endif
+          end interface hemm
+
+
+
+          ! HEMV  performs the matrix-vector  operation
+          ! y := alpha*A*x + beta*y,
+          ! where alpha and beta are scalars, x and y are n element vectors and
+          ! A is an n by n hermitian matrix.
+          interface hemv
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine chemv(uplo,n,alpha,a,lda,x,incx,beta,y,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(sp) :: alpha,beta,a(lda,*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,lda,n 
+                    character :: uplo 
+               end subroutine chemv
+#else
+               module procedure stdlib_chemv
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine zhemv(uplo,n,alpha,a,lda,x,incx,beta,y,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(dp) :: alpha,beta,a(lda,*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,lda,n 
+                    character :: uplo 
+               end subroutine zhemv
+#else
+               module procedure stdlib_zhemv
+#endif
+          end interface hemv
+
+
+
+          ! HER   performs the hermitian rank 1 operation
+          ! A := alpha*x*x**H + A,
+          ! where alpha is a real scalar, x is an n element vector and A is an
+          ! n by n hermitian matrix.
+          interface her
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine cher(uplo,n,alpha,x,incx,a,lda)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(sp) :: alpha 
+                    integer(ilp) :: incx,lda,n 
+                    character :: uplo 
+                    complex(sp) :: a(lda,*),x(*) 
+               end subroutine cher
+#else
+               module procedure stdlib_cher
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine zher(uplo,n,alpha,x,incx,a,lda)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(dp) :: alpha 
+                    integer(ilp) :: incx,lda,n 
+                    character :: uplo 
+                    complex(dp) :: a(lda,*),x(*) 
+               end subroutine zher
+#else
+               module procedure stdlib_zher
+#endif
+          end interface her
+
+
+
+          ! HER2  performs the hermitian rank 2 operation
+          ! A := alpha*x*y**H + conjg( alpha )*y*x**H + A,
+          ! where alpha is a scalar, x and y are n element vectors and A is an n
+          ! by n hermitian matrix.
+          interface her2
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine cher2(uplo,n,alpha,x,incx,y,incy,a,lda)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(sp) :: alpha,a(lda,*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,lda,n 
+                    character :: uplo 
+               end subroutine cher2
+#else
+               module procedure stdlib_cher2
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine zher2(uplo,n,alpha,x,incx,y,incy,a,lda)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(dp) :: alpha,a(lda,*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,lda,n 
+                    character :: uplo 
+               end subroutine zher2
+#else
+               module procedure stdlib_zher2
+#endif
+          end interface her2
+
+
+
+          ! HER2K  performs one of the hermitian rank 2k operations
+          ! C := alpha*A*B**H + conjg( alpha )*B*A**H + beta*C,
+          ! or
+          ! C := alpha*A**H*B + conjg( alpha )*B**H*A + beta*C,
+          ! where  alpha and beta  are scalars with  beta  real,  C is an  n by n
+          ! hermitian matrix and  A and B  are  n by k matrices in the first case
+          ! and  k by n  matrices in the second case.
+          interface her2k
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine cher2k(uplo,trans,n,k,alpha,a,lda,b,ldb,beta,c,ldc)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(sp) :: alpha,a(lda,*),b(ldb,*),c(ldc,*) 
+                    real(sp) :: beta 
+                    integer(ilp) :: k,lda,ldb,ldc,n 
+                    character :: trans,uplo 
+               end subroutine cher2k
+#else
+               module procedure stdlib_cher2k
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine zher2k(uplo,trans,n,k,alpha,a,lda,b,ldb,beta,c,ldc)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(dp) :: alpha,a(lda,*),b(ldb,*),c(ldc,*) 
+                    real(dp) :: beta 
+                    integer(ilp) :: k,lda,ldb,ldc,n 
+                    character :: trans,uplo 
+               end subroutine zher2k
+#else
+               module procedure stdlib_zher2k
+#endif
+          end interface her2k
+
+
+
+          ! HERK  performs one of the hermitian rank k operations
+          ! C := alpha*A*A**H + beta*C,
+          ! or
+          ! C := alpha*A**H*A + beta*C,
+          ! where  alpha and beta  are  real scalars,  C is an  n by n  hermitian
+          ! matrix and  A  is an  n by k  matrix in the  first case and a  k by n
+          ! matrix in the second case.
+          interface herk
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine cherk(uplo,trans,n,k,alpha,a,lda,beta,c,ldc)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(sp) :: alpha,beta 
+                    integer(ilp) :: k,lda,ldc,n 
+                    character :: trans,uplo 
+                    complex(sp) :: a(lda,*),c(ldc,*) 
+               end subroutine cherk
+#else
+               module procedure stdlib_cherk
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine zherk(uplo,trans,n,k,alpha,a,lda,beta,c,ldc)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(dp) :: alpha,beta 
+                    integer(ilp) :: k,lda,ldc,n 
+                    character :: trans,uplo 
+                    complex(dp) :: a(lda,*),c(ldc,*) 
+               end subroutine zherk
+#else
+               module procedure stdlib_zherk
+#endif
+          end interface herk
+
+
+
+          ! HPMV  performs the matrix-vector operation
+          ! y := alpha*A*x + beta*y,
+          ! where alpha and beta are scalars, x and y are n element vectors and
+          ! A is an n by n hermitian matrix, supplied in packed form.
+          interface hpmv
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine chpmv(uplo,n,alpha,ap,x,incx,beta,y,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(sp) :: alpha,beta,ap(*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,n 
+                    character :: uplo 
+               end subroutine chpmv
+#else
+               module procedure stdlib_chpmv
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine zhpmv(uplo,n,alpha,ap,x,incx,beta,y,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(dp) :: alpha,beta,ap(*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,n 
+                    character :: uplo 
+               end subroutine zhpmv
+#else
+               module procedure stdlib_zhpmv
+#endif
+          end interface hpmv
+
+
+
+          ! HPR    performs the hermitian rank 1 operation
+          ! A := alpha*x*x**H + A,
+          ! where alpha is a real scalar, x is an n element vector and A is an
+          ! n by n hermitian matrix, supplied in packed form.
+          interface hpr
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine chpr(uplo,n,alpha,x,incx,ap)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(sp) :: alpha 
+                    integer(ilp) :: incx,n 
+                    character :: uplo 
+                    complex(sp) :: ap(*),x(*) 
+               end subroutine chpr
+#else
+               module procedure stdlib_chpr
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine zhpr(uplo,n,alpha,x,incx,ap)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(dp) :: alpha 
+                    integer(ilp) :: incx,n 
+                    character :: uplo 
+                    complex(dp) :: ap(*),x(*) 
+               end subroutine zhpr
+#else
+               module procedure stdlib_zhpr
+#endif
+          end interface hpr
+
+
+
+          ! HPR2  performs the hermitian rank 2 operation
+          ! A := alpha*x*y**H + conjg( alpha )*y*x**H + A,
+          ! where alpha is a scalar, x and y are n element vectors and A is an
+          ! n by n hermitian matrix, supplied in packed form.
+          interface hpr2
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine chpr2(uplo,n,alpha,x,incx,y,incy,ap)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(sp) :: alpha,ap(*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,n 
+                    character :: uplo 
+               end subroutine chpr2
+#else
+               module procedure stdlib_chpr2
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine zhpr2(uplo,n,alpha,x,incx,y,incy,ap)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(dp) :: alpha,ap(*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,n 
+                    character :: uplo 
+               end subroutine zhpr2
+#else
+               module procedure stdlib_zhpr2
+#endif
+          end interface hpr2
 
 
 
@@ -584,6 +1131,42 @@ module stdlib_linalg_blas
                module procedure stdlib_sspr2
 #endif
           end interface spr2
+
+
+
+          ! SROT applies a plane rotation, where the cos and sin (c and s) are real
+          ! and the vectors cx and cy are complex.
+          ! jack dongarra, linpack, 3/11/78.
+          interface srot
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine csrot( n, cx, incx, cy, incy, c, s )
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,incy,n 
+                    real(sp) :: c,s 
+                    complex(sp) :: cx,cy 
+               end subroutine csrot
+#else
+               module procedure stdlib_csrot
+#endif
+          end interface srot
+
+
+
+          ! SSCAL scales a complex vector by a real constant.
+          interface sscal
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine csscal(n,sa,cx,incx)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(sp) :: sa 
+                    integer(ilp) :: incx,n 
+                    complex(sp) :: cx(*) 
+               end subroutine csscal
+#else
+               module procedure stdlib_csscal
+#endif
+          end interface sscal
 
 
 
@@ -1324,43 +1907,6 @@ module stdlib_linalg_blas
                module procedure stdlib_ztrsv
 #endif
           end interface trsv
-
-
-
-          ! ZASUM takes the sum of the (|Re(.)| + |Im(.)|)'s of a complex vector and
-          ! returns a double precision result.
-          interface zasum
-#ifdef STDLIB_EXTERNAL_BLAS
-               real(dp) function dzasum(n,zx,incx)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,n 
-                    complex(dp) :: zx(*) 
-               end function dzasum
-#else
-               module procedure stdlib_dzasum
-#endif
-          end interface zasum
-
-
-
-          ! !
-          ! ZNRM2 returns the euclidean norm of a vector via the function
-          ! name, so that
-          ! ZNRM2 := sqrt( x**H*x )
-          interface znrm2
-#ifdef STDLIB_EXTERNAL_BLAS
-               function dznrm2( n, x, incx )
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(dp) :: dznrm2 
-                    integer(ilp) :: incx,n 
-                    complex(dp) :: x(*) 
-               end function dznrm2
-#else
-               module procedure stdlib_dznrm2
-#endif
-          end interface znrm2
 
 
 

--- a/src/stdlib_linalg_blas.f90
+++ b/src/stdlib_linalg_blas.f90
@@ -56,6 +56,33 @@ module stdlib_linalg_blas
 
 
 
+          ! DOT forms the dot product of two vectors.
+          ! uses unrolled loops for increments equal to one.
+          interface dot
+#ifdef STDLIB_EXTERNAL_BLAS
+               real(dp) function ddot(n,dx,incx,dy,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,incy,n,i 
+                    real(dp) :: dx(*),dy(*) 
+               end function ddot
+#else
+               module procedure stdlib_ddot
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               real(sp) function sdot(n,sx,incx,sy,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,incy,n,i 
+                    real(sp) :: sx(*),sy(*) 
+               end function sdot
+#else
+               module procedure stdlib_sdot
+#endif
+          end interface dot
+
+
+
           ! COPY copies a vector x to a vector y.
           interface copy
 #ifdef STDLIB_EXTERNAL_BLAS

--- a/src/stdlib_linalg_blas.f90
+++ b/src/stdlib_linalg_blas.f90
@@ -10,6 +10,315 @@ module stdlib_linalg_blas
      implicit none(type,external)
      public
 
+          ! AXPY constant times a vector plus a vector.
+          interface axpy
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine caxpy(n,ca,cx,incx,cy,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(sp) :: ca 
+                    integer(ilp) :: incx 
+                    integer(ilp) :: incy 
+                    integer(ilp) :: n 
+                    complex(sp) :: cx(*) 
+                    complex(sp) :: cy(*) 
+               end subroutine caxpy
+#else
+               module procedure stdlib_caxpy
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine daxpy(n,da,dx,incx,dy,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(dp) :: da 
+                    integer(ilp) :: incx 
+                    integer(ilp) :: incy 
+                    integer(ilp) :: n 
+                    real(dp) :: dx(*) 
+                    real(dp) :: dy(*) 
+               end subroutine daxpy
+#else
+               module procedure stdlib_daxpy
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine saxpy(n,sa,sx,incx,sy,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(sp) :: sa 
+                    integer(ilp) :: incx 
+                    integer(ilp) :: incy 
+                    integer(ilp) :: n 
+                    real(sp) :: sx(*) 
+                    real(sp) :: sy(*) 
+               end subroutine saxpy
+#else
+               module procedure stdlib_saxpy
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine zaxpy(n,za,zx,incx,zy,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(dp) :: za 
+                    integer(ilp) :: incx 
+                    integer(ilp) :: incy 
+                    integer(ilp) :: n 
+                    complex(dp) :: zx(*) 
+                    complex(dp) :: zy(*) 
+               end subroutine zaxpy
+#else
+               module procedure stdlib_zaxpy
+#endif
+          end interface axpy
+
+
+
+          ! COPY copies a vector x to a vector y.
+          interface copy
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine ccopy(n,cx,incx,cy,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx 
+                    integer(ilp) :: incy 
+                    integer(ilp) :: n 
+                    complex(sp) :: cx(*) 
+                    complex(sp) :: cy(*) 
+               end subroutine ccopy
+#else
+               module procedure stdlib_ccopy
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine dcopy(n,dx,incx,dy,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx 
+                    integer(ilp) :: incy 
+                    integer(ilp) :: n 
+                    real(dp) :: dx(*) 
+                    real(dp) :: dy(*) 
+               end subroutine dcopy
+#else
+               module procedure stdlib_dcopy
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine scopy(n,sx,incx,sy,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx 
+                    integer(ilp) :: incy 
+                    integer(ilp) :: n 
+                    real(sp) :: sx(*) 
+                    real(sp) :: sy(*) 
+               end subroutine scopy
+#else
+               module procedure stdlib_scopy
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine zcopy(n,zx,incx,zy,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx 
+                    integer(ilp) :: incy 
+                    integer(ilp) :: n 
+                    complex(dp) :: zx(*) 
+                    complex(dp) :: zy(*) 
+               end subroutine zcopy
+#else
+               module procedure stdlib_zcopy
+#endif
+          end interface copy
+
+
+
+          ! GBMV  performs one of the matrix-vector operations
+          ! y := alpha*A*x + beta*y,   or   y := alpha*A**T*x + beta*y,   or
+          ! y := alpha*A**H*x + beta*y,
+          ! where alpha and beta are scalars, x and y are vectors and A is an
+          ! m by n band matrix, with kl sub-diagonals and ku super-diagonals.
+          interface gbmv
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine cgbmv(trans,m,n,kl,ku,alpha,a,lda,x,incx,beta,y,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(sp) :: alpha 
+                    complex(sp) :: beta 
+                    integer(ilp) :: incx 
+                    integer(ilp) :: incy 
+                    integer(ilp) :: kl 
+                    integer(ilp) :: ku 
+                    integer(ilp) :: lda 
+                    integer(ilp) :: m 
+                    integer(ilp) :: n 
+                    character :: trans 
+                    complex(sp) :: a(lda,*) 
+                    complex(sp) :: x(*) 
+                    complex(sp) :: y(*) 
+               end subroutine cgbmv
+#else
+               module procedure stdlib_cgbmv
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine dgbmv(trans,m,n,kl,ku,alpha,a,lda,x,incx,beta,y,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(dp) :: alpha 
+                    real(dp) :: beta 
+                    integer(ilp) :: incx 
+                    integer(ilp) :: incy 
+                    integer(ilp) :: kl 
+                    integer(ilp) :: ku 
+                    integer(ilp) :: lda 
+                    integer(ilp) :: m 
+                    integer(ilp) :: n 
+                    character :: trans 
+                    real(dp) :: a(lda,*) 
+                    real(dp) :: x(*) 
+                    real(dp) :: y(*) 
+               end subroutine dgbmv
+#else
+               module procedure stdlib_dgbmv
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine sgbmv(trans,m,n,kl,ku,alpha,a,lda,x,incx,beta,y,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(sp) :: alpha 
+                    real(sp) :: beta 
+                    integer(ilp) :: incx 
+                    integer(ilp) :: incy 
+                    integer(ilp) :: kl 
+                    integer(ilp) :: ku 
+                    integer(ilp) :: lda 
+                    integer(ilp) :: m 
+                    integer(ilp) :: n 
+                    character :: trans 
+                    real(sp) :: a(lda,*) 
+                    real(sp) :: x(*) 
+                    real(sp) :: y(*) 
+               end subroutine sgbmv
+#else
+               module procedure stdlib_sgbmv
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine zgbmv(trans,m,n,kl,ku,alpha,a,lda,x,incx,beta,y,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(dp) :: alpha 
+                    complex(dp) :: beta 
+                    integer(ilp) :: incx 
+                    integer(ilp) :: incy 
+                    integer(ilp) :: kl 
+                    integer(ilp) :: ku 
+                    integer(ilp) :: lda 
+                    integer(ilp) :: m 
+                    integer(ilp) :: n 
+                    character :: trans 
+                    complex(dp) :: a(lda,*) 
+                    complex(dp) :: x(*) 
+                    complex(dp) :: y(*) 
+               end subroutine zgbmv
+#else
+               module procedure stdlib_zgbmv
+#endif
+          end interface gbmv
+
+
+
+          ! GEMM  performs one of the matrix-matrix operations
+          ! C := alpha*op( A )*op( B ) + beta*C,
+          ! where  op( X ) is one of
+          ! op( X ) = X   or   op( X ) = X**T   or   op( X ) = X**H,
+          ! alpha and beta are scalars, and A, B and C are matrices, with op( A )
+          ! an m by k matrix,  op( B )  a  k by n matrix and  C an m by n matrix.
+          interface gemm
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine cgemm(transa,transb,m,n,k,alpha,a,lda,b,ldb,beta,c,ldc)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(sp) :: alpha 
+                    complex(sp) :: beta 
+                    integer(ilp) :: k 
+                    integer(ilp) :: lda 
+                    integer(ilp) :: ldb 
+                    integer(ilp) :: ldc 
+                    integer(ilp) :: m 
+                    integer(ilp) :: n 
+                    character :: transa 
+                    character :: transb 
+                    complex(sp) :: a(lda,*) 
+                    complex(sp) :: b(ldb,*) 
+                    complex(sp) :: c(ldc,*) 
+               end subroutine cgemm
+#else
+               module procedure stdlib_cgemm
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine dgemm(transa,transb,m,n,k,alpha,a,lda,b,ldb,beta,c,ldc)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(dp) :: alpha 
+                    real(dp) :: beta 
+                    integer(ilp) :: k 
+                    integer(ilp) :: lda 
+                    integer(ilp) :: ldb 
+                    integer(ilp) :: ldc 
+                    integer(ilp) :: m 
+                    integer(ilp) :: n 
+                    character :: transa 
+                    character :: transb 
+                    real(dp) :: a(lda,*) 
+                    real(dp) :: b(ldb,*) 
+                    real(dp) :: c(ldc,*) 
+               end subroutine dgemm
+#else
+               module procedure stdlib_dgemm
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine sgemm(transa,transb,m,n,k,alpha,a,lda,b,ldb,beta,c,ldc)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(sp) :: alpha 
+                    real(sp) :: beta 
+                    integer(ilp) :: k 
+                    integer(ilp) :: lda 
+                    integer(ilp) :: ldb 
+                    integer(ilp) :: ldc 
+                    integer(ilp) :: m 
+                    integer(ilp) :: n 
+                    character :: transa 
+                    character :: transb 
+                    real(sp) :: a(lda,*) 
+                    real(sp) :: b(ldb,*) 
+                    real(sp) :: c(ldc,*) 
+               end subroutine sgemm
+#else
+               module procedure stdlib_sgemm
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine zgemm(transa,transb,m,n,k,alpha,a,lda,b,ldb,beta,c,ldc)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(dp) :: alpha 
+                    complex(dp) :: beta 
+                    integer(ilp) :: k 
+                    integer(ilp) :: lda 
+                    integer(ilp) :: ldb 
+                    integer(ilp) :: ldc 
+                    integer(ilp) :: m 
+                    integer(ilp) :: n 
+                    character :: transa 
+                    character :: transb 
+                    complex(dp) :: a(lda,*) 
+                    complex(dp) :: b(ldb,*) 
+                    complex(dp) :: c(ldc,*) 
+               end subroutine zgemm
+#else
+               module procedure stdlib_zgemm
+#endif
+          end interface gemm
+
+
+
           ! GEMV performs one of the matrix-vector operations
           ! y := alpha*A*x + beta*y,   or   y := alpha*A**T*x + beta*y,   or
           ! y := alpha*A**H*x + beta*y,
@@ -93,6 +402,51 @@ module stdlib_linalg_blas
                module procedure stdlib_zgemv
 #endif
           end interface gemv
+
+
+
+          ! GER   performs the rank 1 operation
+          ! A := alpha*x*y**T + A,
+          ! where alpha is a scalar, x is an m element vector, y is an n element
+          ! vector and A is an m by n matrix.
+          interface ger
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine dger(m,n,alpha,x,incx,y,incy,a,lda)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(dp) :: alpha 
+                    integer(ilp) :: incx 
+                    integer(ilp) :: incy 
+                    integer(ilp) :: lda 
+                    integer(ilp) :: m 
+                    integer(ilp) :: n 
+                    real(dp) :: a(lda,*) 
+                    real(dp) :: x(*) 
+                    real(dp) :: y(*) 
+               end subroutine dger
+#else
+               module procedure stdlib_dger
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine sger(m,n,alpha,x,incx,y,incy,a,lda)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(sp) :: alpha 
+                    integer(ilp) :: incx 
+                    integer(ilp) :: incy 
+                    integer(ilp) :: lda 
+                    integer(ilp) :: m 
+                    integer(ilp) :: n 
+                    real(sp) :: a(lda,*) 
+                    real(sp) :: x(*) 
+                    real(sp) :: y(*) 
+               end subroutine sger
+#else
+               module procedure stdlib_sger
+#endif
+          end interface ger
+
+
 
 
 

--- a/src/stdlib_linalg_blas.f90
+++ b/src/stdlib_linalg_blas.f90
@@ -56,33 +56,6 @@ module stdlib_linalg_blas
 
 
 
-          ! DOT forms the dot product of two vectors.
-          ! uses unrolled loops for increments equal to one.
-          interface dot
-#ifdef STDLIB_EXTERNAL_BLAS
-               real(dp) function ddot(n,dx,incx,dy,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,incy,n,i 
-                    real(dp) :: dx(*),dy(*) 
-               end function ddot
-#else
-               module procedure stdlib_ddot
-#endif
-#ifdef STDLIB_EXTERNAL_BLAS
-               real(sp) function sdot(n,sx,incx,sy,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,incy,n,i 
-                    real(sp) :: sx(*),sy(*) 
-               end function sdot
-#else
-               module procedure stdlib_sdot
-#endif
-          end interface dot
-
-
-
           ! COPY copies a vector x to a vector y.
           interface copy
 #ifdef STDLIB_EXTERNAL_BLAS
@@ -126,6 +99,33 @@ module stdlib_linalg_blas
                module procedure stdlib_zcopy
 #endif
           end interface copy
+
+
+
+          ! DOT forms the dot product of two vectors.
+          ! uses unrolled loops for increments equal to one.
+          interface dot
+#ifdef STDLIB_EXTERNAL_BLAS
+               real(dp) function ddot(n,dx,incx,dy,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,incy,n 
+                    real(dp) :: dx(*),dy(*) 
+               end function ddot
+#else
+               module procedure stdlib_ddot
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               real(sp) function sdot(n,sx,incx,sy,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,incy,n 
+                    real(sp) :: sx(*),sy(*) 
+               end function sdot
+#else
+               module procedure stdlib_sdot
+#endif
+          end interface dot
 
 
 
@@ -183,115 +183,6 @@ module stdlib_linalg_blas
 
 
 
-          ! GEMM  performs one of the matrix-matrix operations
-          ! C := alpha*op( A )*op( B ) + beta*C,
-          ! where  op( X ) is one of
-          ! op( X ) = X   or   op( X ) = X**T   or   op( X ) = X**H,
-          ! alpha and beta are scalars, and A, B and C are matrices, with op( A )
-          ! an m by k matrix,  op( B )  a  k by n matrix and  C an m by n matrix.
-          interface gemm
-#ifdef STDLIB_EXTERNAL_BLAS
-               subroutine cgemm(transa,transb,m,n,k,alpha,a,lda,b,ldb,beta,c,ldc)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(sp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
-                    integer(ilp) :: k,lda,ldb,ldc,m,n 
-                    character :: transa,transb 
-               end subroutine cgemm
-#else
-               module procedure stdlib_cgemm
-#endif
-#ifdef STDLIB_EXTERNAL_BLAS
-               subroutine dgemm(transa,transb,m,n,k,alpha,a,lda,b,ldb,beta,c,ldc)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(dp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
-                    integer(ilp) :: k,lda,ldb,ldc,m,n 
-                    character :: transa,transb 
-               end subroutine dgemm
-#else
-               module procedure stdlib_dgemm
-#endif
-#ifdef STDLIB_EXTERNAL_BLAS
-               subroutine sgemm(transa,transb,m,n,k,alpha,a,lda,b,ldb,beta,c,ldc)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(sp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
-                    integer(ilp) :: k,lda,ldb,ldc,m,n 
-                    character :: transa,transb 
-               end subroutine sgemm
-#else
-               module procedure stdlib_sgemm
-#endif
-#ifdef STDLIB_EXTERNAL_BLAS
-               subroutine zgemm(transa,transb,m,n,k,alpha,a,lda,b,ldb,beta,c,ldc)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(dp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
-                    integer(ilp) :: k,lda,ldb,ldc,m,n 
-                    character :: transa,transb 
-               end subroutine zgemm
-#else
-               module procedure stdlib_zgemm
-#endif
-          end interface gemm
-
-
-
-          ! GEMV performs one of the matrix-vector operations
-          ! y := alpha*A*x + beta*y,   or   y := alpha*A**T*x + beta*y,   or
-          ! y := alpha*A**H*x + beta*y,
-          ! where alpha and beta are scalars, x and y are vectors and A is an
-          ! m by n matrix.
-          interface gemv
-#ifdef STDLIB_EXTERNAL_BLAS
-               subroutine cgemv(trans,m,n,alpha,a,lda,x,incx,beta,y,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(sp) :: alpha,beta,a(lda,*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,lda,m,n 
-                    character :: trans 
-               end subroutine cgemv
-#else
-               module procedure stdlib_cgemv
-#endif
-#ifdef STDLIB_EXTERNAL_BLAS
-               subroutine dgemv(trans,m,n,alpha,a,lda,x,incx,beta,y,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(dp) :: alpha,beta,a(lda,*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,lda,m,n 
-                    character :: trans 
-               end subroutine dgemv
-#else
-               module procedure stdlib_dgemv
-#endif
-#ifdef STDLIB_EXTERNAL_BLAS
-               subroutine sgemv(trans,m,n,alpha,a,lda,x,incx,beta,y,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(sp) :: alpha,beta,a(lda,*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,lda,m,n 
-                    character :: trans 
-               end subroutine sgemv
-#else
-               module procedure stdlib_sgemv
-#endif
-#ifdef STDLIB_EXTERNAL_BLAS
-               subroutine zgemv(trans,m,n,alpha,a,lda,x,incx,beta,y,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(dp) :: alpha,beta,a(lda,*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,lda,m,n 
-                    character :: trans 
-               end subroutine zgemv
-#else
-               module procedure stdlib_zgemv
-#endif
-          end interface gemv
-
-
-
           ! GER   performs the rank 1 operation
           ! A := alpha*x*y**T + A,
           ! where alpha is a scalar, x is an m element vector, y is an n element
@@ -318,6 +209,1158 @@ module stdlib_linalg_blas
                module procedure stdlib_sger
 #endif
           end interface ger
+
+
+
+          ! !
+          ! NRM2 returns the euclidean norm of a vector via the function
+          ! name, so that
+          ! NRM2 := sqrt( x'*x )
+          interface nrm2
+#ifdef STDLIB_EXTERNAL_BLAS
+               function dnrm2( n, x, incx )
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(dp) :: dnrm2,x(*) 
+                    integer(ilp) :: incx,n 
+               end function dnrm2
+#else
+               module procedure stdlib_dnrm2
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               function snrm2( n, x, incx )
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(sp) :: snrm2,x(*) 
+                    integer(ilp) :: incx,n 
+               end function snrm2
+#else
+               module procedure stdlib_snrm2
+#endif
+          end interface nrm2
+
+
+
+          ! ROT applies a plane rotation.
+          interface rot
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine drot(n,dx,incx,dy,incy,c,s)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(dp) :: c,s,dx(*),dy(*) 
+                    integer(ilp) :: incx,incy,n 
+               end subroutine drot
+#else
+               module procedure stdlib_drot
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine srot(n,sx,incx,sy,incy,c,s)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(sp) :: c,s,sx(*),sy(*) 
+                    integer(ilp) :: incx,incy,n 
+               end subroutine srot
+#else
+               module procedure stdlib_srot
+#endif
+          end interface rot
+
+
+
+          ! !
+          ! The computation uses the formulas
+          ! |x| = sqrt( Re(x)**2 + Im(x)**2 )
+          ! sgn(x) = x / |x|  if x /= 0
+          ! = 1        if x  = 0
+          ! c = |a| / sqrt(|a|**2 + |b|**2)
+          ! s = sgn(a) * conjg(b) / sqrt(|a|**2 + |b|**2)
+          ! When a and b are real and r /= 0, the formulas simplify to
+          ! r = sgn(a)*sqrt(|a|**2 + |b|**2)
+          ! c = a / r
+          ! s = b / r
+          ! the same as in SROTG when |a| > |b|.  When |b| >= |a|, the
+          ! sign of c and s will be different from those computed by SROTG
+          ! if the signs of a and b are not the same.
+          interface rotg
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine crotg( a, b, c, s )
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(sp) :: c 
+                    complex(sp) :: a,b,s 
+               end subroutine crotg
+#else
+               module procedure stdlib_crotg
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine drotg( a, b, c, s )
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(dp) :: a,b,c,s 
+               end subroutine drotg
+#else
+               module procedure stdlib_drotg
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine srotg( a, b, c, s )
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(sp) :: a,b,c,s 
+               end subroutine srotg
+#else
+               module procedure stdlib_srotg
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine zrotg( a, b, c, s )
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(dp) :: c 
+                    complex(dp) :: a,b,s 
+               end subroutine zrotg
+#else
+               module procedure stdlib_zrotg
+#endif
+          end interface rotg
+
+
+
+          ! APPLY THE MODIFIED GIVENS TRANSFORMATION, H, TO THE 2 BY N MATRIX
+          ! (DX**T) , WHERE **T INDICATES TRANSPOSE. THE ELEMENTS OF DX ARE IN
+          ! (DY**T)
+          ! DX(LX+I*INCX), I = 0 TO N-1, WHERE LX = 1 IF INCX >= 0, ELSE
+          ! LX = (-INCX)*N, AND SIMILARLY FOR SY USING LY AND INCY.
+          ! WITH DPARAM(1)=DFLAG, H HAS ONE OF THE FOLLOWING FORMS..
+          ! DFLAG=-1._dp     DFLAG=0._dp        DFLAG=1._dp     DFLAG=-2.D0
+          ! (DH11  DH12)    (1._dp  DH12)    (DH11  1._dp)    (1._dp  0._dp)
+          ! H=(          )    (          )    (          )    (          )
+          ! (DH21  DH22),   (DH21  1._dp),   (-1._dp DH22),   (0._dp  1._dp).
+          ! SEE ROTMG FOR A DESCRIPTION OF DATA STORAGE IN DPARAM.
+          interface rotm
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine drotm(n,dx,incx,dy,incy,dparam)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,incy,n 
+                    real(dp) :: dparam(5),dx(*),dy(*) 
+               end subroutine drotm
+#else
+               module procedure stdlib_drotm
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine srotm(n,sx,incx,sy,incy,sparam)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,incy,n 
+                    real(sp) :: sparam(5),sx(*),sy(*) 
+               end subroutine srotm
+#else
+               module procedure stdlib_srotm
+#endif
+          end interface rotm
+
+
+
+          ! CONSTRUCT THE MODIFIED GIVENS TRANSFORMATION MATRIX H WHICH ZEROS
+          ! THE SECOND COMPONENT OF THE 2-VECTOR  (SQRT(DD1)*DX1,SQRT(DD2)    DY2)**T.
+          ! WITH DPARAM(1)=DFLAG, H HAS ONE OF THE FOLLOWING FORMS..
+          ! DFLAG=-1._dp     DFLAG=0._dp        DFLAG=1._dp     DFLAG=-2.D0
+          ! (DH11  DH12)    (1._dp  DH12)    (DH11  1._dp)    (1._dp  0._dp)
+          ! H=(          )    (          )    (          )    (          )
+          ! (DH21  DH22),   (DH21  1._dp),   (-1._dp DH22),   (0._dp  1._dp).
+          ! LOCATIONS 2-4 OF DPARAM CONTAIN DH11, DH21, DH12, AND DH22
+          ! RESPECTIVELY. (VALUES OF 1._dp, -1._dp, OR 0._dp IMPLIED BY THE
+          ! VALUE OF DPARAM(1) ARE NOT STORED IN DPARAM.)
+          ! THE VALUES OF GAMSQ AND RGAMSQ SET IN THE DATA STATEMENT MAY BE
+          ! INEXACT.  THIS IS OK AS THEY ARE ONLY USED FOR TESTING THE SIZE
+          ! OF DD1 AND DD2.  ALL ACTUAL SCALING OF DATA IS DONE USING GAM.
+          interface rotmg
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine drotmg(dd1,dd2,dx1,dy1,dparam)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(dp) :: dd1,dd2,dx1,dy1,dparam(5) 
+               end subroutine drotmg
+#else
+               module procedure stdlib_drotmg
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine srotmg(sd1,sd2,sx1,sy1,sparam)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(sp) :: sd1,sd2,sx1,sy1,sparam(5) 
+               end subroutine srotmg
+#else
+               module procedure stdlib_srotmg
+#endif
+          end interface rotmg
+
+
+
+          ! SBMV  performs the matrix-vector  operation
+          ! y := alpha*A*x + beta*y,
+          ! where alpha and beta are scalars, x and y are n element vectors and
+          ! A is an n by n symmetric band matrix, with k super-diagonals.
+          interface sbmv
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine dsbmv(uplo,n,k,alpha,a,lda,x,incx,beta,y,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(dp) :: alpha,beta,a(lda,*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,k,lda,n 
+                    character :: uplo 
+               end subroutine dsbmv
+#else
+               module procedure stdlib_dsbmv
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine ssbmv(uplo,n,k,alpha,a,lda,x,incx,beta,y,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(sp) :: alpha,beta,a(lda,*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,k,lda,n 
+                    character :: uplo 
+               end subroutine ssbmv
+#else
+               module procedure stdlib_ssbmv
+#endif
+          end interface sbmv
+
+
+
+          ! SCAL scales a vector by a constant.
+          interface scal
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine cscal(n,ca,cx,incx)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(sp) :: ca,cx(*) 
+                    integer(ilp) :: incx,n 
+               end subroutine cscal
+#else
+               module procedure stdlib_cscal
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine dscal(n,da,dx,incx)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(dp) :: da,dx(*) 
+                    integer(ilp) :: incx,n 
+               end subroutine dscal
+#else
+               module procedure stdlib_dscal
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine sscal(n,sa,sx,incx)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(sp) :: sa,sx(*) 
+                    integer(ilp) :: incx,n 
+               end subroutine sscal
+#else
+               module procedure stdlib_sscal
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine zscal(n,za,zx,incx)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(dp) :: za,zx(*) 
+                    integer(ilp) :: incx,n 
+               end subroutine zscal
+#else
+               module procedure stdlib_zscal
+#endif
+          end interface scal
+
+
+
+          ! Compute the inner product of two vectors with extended
+          ! precision accumulation and result.
+          ! Returns D.P. dot product accumulated in D.P., for S.P. SX and SY
+          ! SDOT = sum for I = 0 to N-1 of  SX(LX+I*INCX) * SY(LY+I*INCY),
+          ! where LX = 1 if INCX >= 0, else LX = 1+(1-N)*INCX, and LY is
+          ! defined in a similar way using INCY.
+          interface sdot
+#ifdef STDLIB_EXTERNAL_BLAS
+               real(dp) function dsdot(n,sx,incx,sy,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,incy,n 
+                    real(sp) :: sx(*),sy(*) 
+               end function dsdot
+#else
+               module procedure stdlib_dsdot
+#endif
+          end interface sdot
+
+
+
+          ! SPMV  performs the matrix-vector operation
+          ! y := alpha*A*x + beta*y,
+          ! where alpha and beta are scalars, x and y are n element vectors and
+          ! A is an n by n symmetric matrix, supplied in packed form.
+          interface spmv
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine dspmv(uplo,n,alpha,ap,x,incx,beta,y,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(dp) :: alpha,beta,ap(*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,n 
+                    character :: uplo 
+               end subroutine dspmv
+#else
+               module procedure stdlib_dspmv
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine sspmv(uplo,n,alpha,ap,x,incx,beta,y,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(sp) :: alpha,beta,ap(*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,n 
+                    character :: uplo 
+               end subroutine sspmv
+#else
+               module procedure stdlib_sspmv
+#endif
+          end interface spmv
+
+
+
+          ! SPR    performs the symmetric rank 1 operation
+          ! A := alpha*x*x**T + A,
+          ! where alpha is a real scalar, x is an n element vector and A is an
+          ! n by n symmetric matrix, supplied in packed form.
+          interface spr
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine dspr(uplo,n,alpha,x,incx,ap)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(dp) :: alpha,ap(*),x(*) 
+                    integer(ilp) :: incx,n 
+                    character :: uplo 
+               end subroutine dspr
+#else
+               module procedure stdlib_dspr
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine sspr(uplo,n,alpha,x,incx,ap)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(sp) :: alpha,ap(*),x(*) 
+                    integer(ilp) :: incx,n 
+                    character :: uplo 
+               end subroutine sspr
+#else
+               module procedure stdlib_sspr
+#endif
+          end interface spr
+
+
+
+          ! SPR2  performs the symmetric rank 2 operation
+          ! A := alpha*x*y**T + alpha*y*x**T + A,
+          ! where alpha is a scalar, x and y are n element vectors and A is an
+          ! n by n symmetric matrix, supplied in packed form.
+          interface spr2
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine dspr2(uplo,n,alpha,x,incx,y,incy,ap)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(dp) :: alpha,ap(*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,n 
+                    character :: uplo 
+               end subroutine dspr2
+#else
+               module procedure stdlib_dspr2
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine sspr2(uplo,n,alpha,x,incx,y,incy,ap)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(sp) :: alpha,ap(*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,n 
+                    character :: uplo 
+               end subroutine sspr2
+#else
+               module procedure stdlib_sspr2
+#endif
+          end interface spr2
+
+
+
+          ! SWAP interchanges two vectors.
+          interface swap
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine cswap(n,cx,incx,cy,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,incy,n 
+                    complex(sp) :: cx(*),cy(*) 
+               end subroutine cswap
+#else
+               module procedure stdlib_cswap
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine dswap(n,dx,incx,dy,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,incy,n 
+                    real(dp) :: dx(*),dy(*) 
+               end subroutine dswap
+#else
+               module procedure stdlib_dswap
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine sswap(n,sx,incx,sy,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,incy,n 
+                    real(sp) :: sx(*),sy(*) 
+               end subroutine sswap
+#else
+               module procedure stdlib_sswap
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine zswap(n,zx,incx,zy,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,incy,n 
+                    complex(dp) :: zx(*),zy(*) 
+               end subroutine zswap
+#else
+               module procedure stdlib_zswap
+#endif
+          end interface swap
+
+
+
+          ! SYMM  performs one of the matrix-matrix operations
+          ! C := alpha*A*B + beta*C,
+          ! or
+          ! C := alpha*B*A + beta*C,
+          ! where  alpha and beta are scalars, A is a symmetric matrix and  B and
+          ! C are m by n matrices.
+          interface symm
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine csymm(side,uplo,m,n,alpha,a,lda,b,ldb,beta,c,ldc)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(sp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
+                    integer(ilp) :: lda,ldb,ldc,m,n 
+                    character :: side,uplo 
+               end subroutine csymm
+#else
+               module procedure stdlib_csymm
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine dsymm(side,uplo,m,n,alpha,a,lda,b,ldb,beta,c,ldc)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(dp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
+                    integer(ilp) :: lda,ldb,ldc,m,n 
+                    character :: side,uplo 
+               end subroutine dsymm
+#else
+               module procedure stdlib_dsymm
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine ssymm(side,uplo,m,n,alpha,a,lda,b,ldb,beta,c,ldc)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(sp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
+                    integer(ilp) :: lda,ldb,ldc,m,n 
+                    character :: side,uplo 
+               end subroutine ssymm
+#else
+               module procedure stdlib_ssymm
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine zsymm(side,uplo,m,n,alpha,a,lda,b,ldb,beta,c,ldc)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(dp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
+                    integer(ilp) :: lda,ldb,ldc,m,n 
+                    character :: side,uplo 
+               end subroutine zsymm
+#else
+               module procedure stdlib_zsymm
+#endif
+          end interface symm
+
+
+
+          ! SYMV  performs the matrix-vector  operation
+          ! y := alpha*A*x + beta*y,
+          ! where alpha and beta are scalars, x and y are n element vectors and
+          ! A is an n by n symmetric matrix.
+          interface symv
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine dsymv(uplo,n,alpha,a,lda,x,incx,beta,y,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(dp) :: alpha,beta,a(lda,*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,lda,n 
+                    character :: uplo 
+               end subroutine dsymv
+#else
+               module procedure stdlib_dsymv
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine ssymv(uplo,n,alpha,a,lda,x,incx,beta,y,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(sp) :: alpha,beta,a(lda,*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,lda,n 
+                    character :: uplo 
+               end subroutine ssymv
+#else
+               module procedure stdlib_ssymv
+#endif
+          end interface symv
+
+
+
+          ! SYR   performs the symmetric rank 1 operation
+          ! A := alpha*x*x**T + A,
+          ! where alpha is a real scalar, x is an n element vector and A is an
+          ! n by n symmetric matrix.
+          interface syr
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine dsyr(uplo,n,alpha,x,incx,a,lda)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(dp) :: alpha,a(lda,*),x(*) 
+                    integer(ilp) :: incx,lda,n 
+                    character :: uplo 
+               end subroutine dsyr
+#else
+               module procedure stdlib_dsyr
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine ssyr(uplo,n,alpha,x,incx,a,lda)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(sp) :: alpha,a(lda,*),x(*) 
+                    integer(ilp) :: incx,lda,n 
+                    character :: uplo 
+               end subroutine ssyr
+#else
+               module procedure stdlib_ssyr
+#endif
+          end interface syr
+
+
+
+          ! SYR2  performs the symmetric rank 2 operation
+          ! A := alpha*x*y**T + alpha*y*x**T + A,
+          ! where alpha is a scalar, x and y are n element vectors and A is an n
+          ! by n symmetric matrix.
+          interface syr2
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine dsyr2(uplo,n,alpha,x,incx,y,incy,a,lda)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(dp) :: alpha,a(lda,*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,lda,n 
+                    character :: uplo 
+               end subroutine dsyr2
+#else
+               module procedure stdlib_dsyr2
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine ssyr2(uplo,n,alpha,x,incx,y,incy,a,lda)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(sp) :: alpha,a(lda,*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,lda,n 
+                    character :: uplo 
+               end subroutine ssyr2
+#else
+               module procedure stdlib_ssyr2
+#endif
+          end interface syr2
+
+
+
+          ! SYR2K  performs one of the symmetric rank 2k operations
+          ! C := alpha*A*B**T + alpha*B*A**T + beta*C,
+          ! or
+          ! C := alpha*A**T*B + alpha*B**T*A + beta*C,
+          ! where  alpha and beta  are scalars,  C is an  n by n symmetric matrix
+          ! and  A and B  are  n by k  matrices  in the  first  case  and  k by n
+          ! matrices in the second case.
+          interface syr2k
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine csyr2k(uplo,trans,n,k,alpha,a,lda,b,ldb,beta,c,ldc)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(sp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
+                    integer(ilp) :: k,lda,ldb,ldc,n 
+                    character :: trans,uplo 
+               end subroutine csyr2k
+#else
+               module procedure stdlib_csyr2k
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine dsyr2k(uplo,trans,n,k,alpha,a,lda,b,ldb,beta,c,ldc)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(dp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
+                    integer(ilp) :: k,lda,ldb,ldc,n 
+                    character :: trans,uplo 
+               end subroutine dsyr2k
+#else
+               module procedure stdlib_dsyr2k
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine ssyr2k(uplo,trans,n,k,alpha,a,lda,b,ldb,beta,c,ldc)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(sp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
+                    integer(ilp) :: k,lda,ldb,ldc,n 
+                    character :: trans,uplo 
+               end subroutine ssyr2k
+#else
+               module procedure stdlib_ssyr2k
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine zsyr2k(uplo,trans,n,k,alpha,a,lda,b,ldb,beta,c,ldc)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(dp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
+                    integer(ilp) :: k,lda,ldb,ldc,n 
+                    character :: trans,uplo 
+               end subroutine zsyr2k
+#else
+               module procedure stdlib_zsyr2k
+#endif
+          end interface syr2k
+
+
+
+          ! SYRK  performs one of the symmetric rank k operations
+          ! C := alpha*A*A**T + beta*C,
+          ! or
+          ! C := alpha*A**T*A + beta*C,
+          ! where  alpha and beta  are scalars,  C is an  n by n symmetric matrix
+          ! and  A  is an  n by k  matrix in the first case and a  k by n  matrix
+          ! in the second case.
+          interface syrk
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine csyrk(uplo,trans,n,k,alpha,a,lda,beta,c,ldc)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(sp) :: alpha,beta,a(lda,*),c(ldc,*) 
+                    integer(ilp) :: k,lda,ldc,n 
+                    character :: trans,uplo 
+               end subroutine csyrk
+#else
+               module procedure stdlib_csyrk
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine dsyrk(uplo,trans,n,k,alpha,a,lda,beta,c,ldc)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(dp) :: alpha,beta,a(lda,*),c(ldc,*) 
+                    integer(ilp) :: k,lda,ldc,n 
+                    character :: trans,uplo 
+               end subroutine dsyrk
+#else
+               module procedure stdlib_dsyrk
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine ssyrk(uplo,trans,n,k,alpha,a,lda,beta,c,ldc)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(sp) :: alpha,beta,a(lda,*),c(ldc,*) 
+                    integer(ilp) :: k,lda,ldc,n 
+                    character :: trans,uplo 
+               end subroutine ssyrk
+#else
+               module procedure stdlib_ssyrk
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine zsyrk(uplo,trans,n,k,alpha,a,lda,beta,c,ldc)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(dp) :: alpha,beta,a(lda,*),c(ldc,*) 
+                    integer(ilp) :: k,lda,ldc,n 
+                    character :: trans,uplo 
+               end subroutine zsyrk
+#else
+               module procedure stdlib_zsyrk
+#endif
+          end interface syrk
+
+
+
+          ! TBMV  performs one of the matrix-vector operations
+          ! x := A*x,   or   x := A**T*x,   or   x := A**H*x,
+          ! where x is an n element vector and  A is an n by n unit, or non-unit,
+          ! upper or lower triangular band matrix, with ( k + 1 ) diagonals.
+          interface tbmv
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine ctbmv(uplo,trans,diag,n,k,a,lda,x,incx)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,k,lda,n 
+                    character :: diag,trans,uplo 
+                    complex(sp) :: a(lda,*),x(*) 
+               end subroutine ctbmv
+#else
+               module procedure stdlib_ctbmv
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine dtbmv(uplo,trans,diag,n,k,a,lda,x,incx)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,k,lda,n 
+                    character :: diag,trans,uplo 
+                    real(dp) :: a(lda,*),x(*) 
+               end subroutine dtbmv
+#else
+               module procedure stdlib_dtbmv
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine stbmv(uplo,trans,diag,n,k,a,lda,x,incx)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,k,lda,n 
+                    character :: diag,trans,uplo 
+                    real(sp) :: a(lda,*),x(*) 
+               end subroutine stbmv
+#else
+               module procedure stdlib_stbmv
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine ztbmv(uplo,trans,diag,n,k,a,lda,x,incx)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,k,lda,n 
+                    character :: diag,trans,uplo 
+                    complex(dp) :: a(lda,*),x(*) 
+               end subroutine ztbmv
+#else
+               module procedure stdlib_ztbmv
+#endif
+          end interface tbmv
+
+
+
+          ! TBSV  solves one of the systems of equations
+          ! A*x = b,   or   A**T*x = b,   or   A**H*x = b,
+          ! where b and x are n element vectors and A is an n by n unit, or
+          ! non-unit, upper or lower triangular band matrix, with ( k + 1 )
+          ! diagonals.
+          ! No test for singularity or near-singularity is included in this
+          ! routine. Such tests must be performed before calling this routine.
+          interface tbsv
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine ctbsv(uplo,trans,diag,n,k,a,lda,x,incx)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,k,lda,n 
+                    character :: diag,trans,uplo 
+                    complex(sp) :: a(lda,*),x(*) 
+               end subroutine ctbsv
+#else
+               module procedure stdlib_ctbsv
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine dtbsv(uplo,trans,diag,n,k,a,lda,x,incx)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,k,lda,n 
+                    character :: diag,trans,uplo 
+                    real(dp) :: a(lda,*),x(*) 
+               end subroutine dtbsv
+#else
+               module procedure stdlib_dtbsv
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine stbsv(uplo,trans,diag,n,k,a,lda,x,incx)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,k,lda,n 
+                    character :: diag,trans,uplo 
+                    real(sp) :: a(lda,*),x(*) 
+               end subroutine stbsv
+#else
+               module procedure stdlib_stbsv
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine ztbsv(uplo,trans,diag,n,k,a,lda,x,incx)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,k,lda,n 
+                    character :: diag,trans,uplo 
+                    complex(dp) :: a(lda,*),x(*) 
+               end subroutine ztbsv
+#else
+               module procedure stdlib_ztbsv
+#endif
+          end interface tbsv
+
+
+
+          ! TPMV  performs one of the matrix-vector operations
+          ! x := A*x,   or   x := A**T*x,   or   x := A**H*x,
+          ! where x is an n element vector and  A is an n by n unit, or non-unit,
+          ! upper or lower triangular matrix, supplied in packed form.
+          interface tpmv
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine ctpmv(uplo,trans,diag,n,ap,x,incx)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,n 
+                    character :: diag,trans,uplo 
+                    complex(sp) :: ap(*),x(*) 
+               end subroutine ctpmv
+#else
+               module procedure stdlib_ctpmv
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine dtpmv(uplo,trans,diag,n,ap,x,incx)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,n 
+                    character :: diag,trans,uplo 
+                    real(dp) :: ap(*),x(*) 
+               end subroutine dtpmv
+#else
+               module procedure stdlib_dtpmv
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine stpmv(uplo,trans,diag,n,ap,x,incx)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,n 
+                    character :: diag,trans,uplo 
+                    real(sp) :: ap(*),x(*) 
+               end subroutine stpmv
+#else
+               module procedure stdlib_stpmv
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine ztpmv(uplo,trans,diag,n,ap,x,incx)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,n 
+                    character :: diag,trans,uplo 
+                    complex(dp) :: ap(*),x(*) 
+               end subroutine ztpmv
+#else
+               module procedure stdlib_ztpmv
+#endif
+          end interface tpmv
+
+
+
+          ! TPSV  solves one of the systems of equations
+          ! A*x = b,   or   A**T*x = b,   or   A**H*x = b,
+          ! where b and x are n element vectors and A is an n by n unit, or
+          ! non-unit, upper or lower triangular matrix, supplied in packed form.
+          ! No test for singularity or near-singularity is included in this
+          ! routine. Such tests must be performed before calling this routine.
+          interface tpsv
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine ctpsv(uplo,trans,diag,n,ap,x,incx)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,n 
+                    character :: diag,trans,uplo 
+                    complex(sp) :: ap(*),x(*) 
+               end subroutine ctpsv
+#else
+               module procedure stdlib_ctpsv
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine dtpsv(uplo,trans,diag,n,ap,x,incx)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,n 
+                    character :: diag,trans,uplo 
+                    real(dp) :: ap(*),x(*) 
+               end subroutine dtpsv
+#else
+               module procedure stdlib_dtpsv
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine stpsv(uplo,trans,diag,n,ap,x,incx)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,n 
+                    character :: diag,trans,uplo 
+                    real(sp) :: ap(*),x(*) 
+               end subroutine stpsv
+#else
+               module procedure stdlib_stpsv
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine ztpsv(uplo,trans,diag,n,ap,x,incx)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,n 
+                    character :: diag,trans,uplo 
+                    complex(dp) :: ap(*),x(*) 
+               end subroutine ztpsv
+#else
+               module procedure stdlib_ztpsv
+#endif
+          end interface tpsv
+
+
+
+          ! TRMM  performs one of the matrix-matrix operations
+          ! B := alpha*op( A )*B,   or   B := alpha*B*op( A )
+          ! where  alpha  is a scalar,  B  is an m by n matrix,  A  is a unit, or
+          ! non-unit,  upper or lower triangular matrix  and  op( A )  is one  of
+          ! op( A ) = A   or   op( A ) = A**T   or   op( A ) = A**H.
+          interface trmm
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine ctrmm(side,uplo,transa,diag,m,n,alpha,a,lda,b,ldb)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(sp) :: alpha,a(lda,*),b(ldb,*) 
+                    integer(ilp) :: lda,ldb,m,n 
+                    character :: diag,side,transa,uplo 
+               end subroutine ctrmm
+#else
+               module procedure stdlib_ctrmm
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine dtrmm(side,uplo,transa,diag,m,n,alpha,a,lda,b,ldb)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(dp) :: alpha,a(lda,*),b(ldb,*) 
+                    integer(ilp) :: lda,ldb,m,n 
+                    character :: diag,side,transa,uplo 
+               end subroutine dtrmm
+#else
+               module procedure stdlib_dtrmm
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine strmm(side,uplo,transa,diag,m,n,alpha,a,lda,b,ldb)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(sp) :: alpha,a(lda,*),b(ldb,*) 
+                    integer(ilp) :: lda,ldb,m,n 
+                    character :: diag,side,transa,uplo 
+               end subroutine strmm
+#else
+               module procedure stdlib_strmm
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine ztrmm(side,uplo,transa,diag,m,n,alpha,a,lda,b,ldb)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(dp) :: alpha,a(lda,*),b(ldb,*) 
+                    integer(ilp) :: lda,ldb,m,n 
+                    character :: diag,side,transa,uplo 
+               end subroutine ztrmm
+#else
+               module procedure stdlib_ztrmm
+#endif
+          end interface trmm
+
+
+
+          ! TRMV  performs one of the matrix-vector operations
+          ! x := A*x,   or   x := A**T*x,   or   x := A**H*x,
+          ! where x is an n element vector and  A is an n by n unit, or non-unit,
+          ! upper or lower triangular matrix.
+          interface trmv
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine ctrmv(uplo,trans,diag,n,a,lda,x,incx)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,lda,n 
+                    character :: diag,trans,uplo 
+                    complex(sp) :: a(lda,*),x(*) 
+               end subroutine ctrmv
+#else
+               module procedure stdlib_ctrmv
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine dtrmv(uplo,trans,diag,n,a,lda,x,incx)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,lda,n 
+                    character :: diag,trans,uplo 
+                    real(dp) :: a(lda,*),x(*) 
+               end subroutine dtrmv
+#else
+               module procedure stdlib_dtrmv
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine strmv(uplo,trans,diag,n,a,lda,x,incx)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,lda,n 
+                    character :: diag,trans,uplo 
+                    real(sp) :: a(lda,*),x(*) 
+               end subroutine strmv
+#else
+               module procedure stdlib_strmv
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine ztrmv(uplo,trans,diag,n,a,lda,x,incx)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,lda,n 
+                    character :: diag,trans,uplo 
+                    complex(dp) :: a(lda,*),x(*) 
+               end subroutine ztrmv
+#else
+               module procedure stdlib_ztrmv
+#endif
+          end interface trmv
+
+
+
+          ! TRSM  solves one of the matrix equations
+          ! op( A )*X = alpha*B,   or   X*op( A ) = alpha*B,
+          ! where alpha is a scalar, X and B are m by n matrices, A is a unit, or
+          ! non-unit,  upper or lower triangular matrix  and  op( A )  is one  of
+          ! op( A ) = A   or   op( A ) = A**T   or   op( A ) = A**H.
+          ! The matrix X is overwritten on B.
+          interface trsm
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine ctrsm(side,uplo,transa,diag,m,n,alpha,a,lda,b,ldb)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(sp) :: alpha,a(lda,*),b(ldb,*) 
+                    integer(ilp) :: lda,ldb,m,n 
+                    character :: diag,side,transa,uplo 
+               end subroutine ctrsm
+#else
+               module procedure stdlib_ctrsm
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine dtrsm(side,uplo,transa,diag,m,n,alpha,a,lda,b,ldb)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(dp) :: alpha,a(lda,*),b(ldb,*) 
+                    integer(ilp) :: lda,ldb,m,n 
+                    character :: diag,side,transa,uplo 
+               end subroutine dtrsm
+#else
+               module procedure stdlib_dtrsm
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine strsm(side,uplo,transa,diag,m,n,alpha,a,lda,b,ldb)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(sp) :: alpha,a(lda,*),b(ldb,*) 
+                    integer(ilp) :: lda,ldb,m,n 
+                    character :: diag,side,transa,uplo 
+               end subroutine strsm
+#else
+               module procedure stdlib_strsm
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine ztrsm(side,uplo,transa,diag,m,n,alpha,a,lda,b,ldb)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(dp) :: alpha,a(lda,*),b(ldb,*) 
+                    integer(ilp) :: lda,ldb,m,n 
+                    character :: diag,side,transa,uplo 
+               end subroutine ztrsm
+#else
+               module procedure stdlib_ztrsm
+#endif
+          end interface trsm
+
+
+
+          ! TRSV  solves one of the systems of equations
+          ! A*x = b,   or   A**T*x = b,   or   A**H*x = b,
+          ! where b and x are n element vectors and A is an n by n unit, or
+          ! non-unit, upper or lower triangular matrix.
+          ! No test for singularity or near-singularity is included in this
+          ! routine. Such tests must be performed before calling this routine.
+          interface trsv
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine ctrsv(uplo,trans,diag,n,a,lda,x,incx)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,lda,n 
+                    character :: diag,trans,uplo 
+                    complex(sp) :: a(lda,*),x(*) 
+               end subroutine ctrsv
+#else
+               module procedure stdlib_ctrsv
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine dtrsv(uplo,trans,diag,n,a,lda,x,incx)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,lda,n 
+                    character :: diag,trans,uplo 
+                    real(dp) :: a(lda,*),x(*) 
+               end subroutine dtrsv
+#else
+               module procedure stdlib_dtrsv
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine strsv(uplo,trans,diag,n,a,lda,x,incx)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,lda,n 
+                    character :: diag,trans,uplo 
+                    real(sp) :: a(lda,*),x(*) 
+               end subroutine strsv
+#else
+               module procedure stdlib_strsv
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine ztrsv(uplo,trans,diag,n,a,lda,x,incx)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,lda,n 
+                    character :: diag,trans,uplo 
+                    complex(dp) :: a(lda,*),x(*) 
+               end subroutine ztrsv
+#else
+               module procedure stdlib_ztrsv
+#endif
+          end interface trsv
+
+
+
+          ! ZASUM takes the sum of the (|Re(.)| + |Im(.)|)'s of a complex vector and
+          ! returns a double precision result.
+          interface zasum
+#ifdef STDLIB_EXTERNAL_BLAS
+               real(dp) function dzasum(n,zx,incx)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    integer(ilp) :: incx,n 
+                    complex(dp) :: zx(*) 
+               end function dzasum
+#else
+               module procedure stdlib_dzasum
+#endif
+          end interface zasum
+
+
+
+          ! !
+          ! ZNRM2 returns the euclidean norm of a vector via the function
+          ! name, so that
+          ! ZNRM2 := sqrt( x**H*x )
+          interface znrm2
+#ifdef STDLIB_EXTERNAL_BLAS
+               function dznrm2( n, x, incx )
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(dp) :: dznrm2 
+                    integer(ilp) :: incx,n 
+                    complex(dp) :: x(*) 
+               end function dznrm2
+#else
+               module procedure stdlib_dznrm2
+#endif
+          end interface znrm2
 
 
 

--- a/src/stdlib_linalg_blas.f90
+++ b/src/stdlib_linalg_blas.f90
@@ -7,7 +7,87 @@ module stdlib_linalg_blas
      use stdlib_linalg_blas_c
      use stdlib_linalg_blas_z
      use stdlib_linalg_blas_w
-     implicit none(type, external)
+     implicit none(type,external)
      public
+          interface gemv
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine cgemv(trans,m,n,alpha,a,lda,x,incx,beta,y,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(sp) :: alpha 
+                    complex(sp) :: beta 
+                    integer(ilp) :: incx 
+                    integer(ilp) :: incy 
+                    integer(ilp) :: lda 
+                    integer(ilp) :: m 
+                    integer(ilp) :: n 
+                    character :: trans 
+                    complex(sp) :: a(lda,*) 
+                    complex(sp) :: x(*) 
+                    complex(sp) :: y(*) 
+               end subroutine cgemv
+#else
+               module procedure stdlib_cgemv
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine dgemv(trans,m,n,alpha,a,lda,x,incx,beta,y,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(dp) :: alpha 
+                    real(dp) :: beta 
+                    integer(ilp) :: incx 
+                    integer(ilp) :: incy 
+                    integer(ilp) :: lda 
+                    integer(ilp) :: m 
+                    integer(ilp) :: n 
+                    character :: trans 
+                    real(dp) :: a(lda,*) 
+                    real(dp) :: x(*) 
+                    real(dp) :: y(*) 
+               end subroutine dgemv
+#else
+               module procedure stdlib_dgemv
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine sgemv(trans,m,n,alpha,a,lda,x,incx,beta,y,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    real(sp) :: alpha 
+                    real(sp) :: beta 
+                    integer(ilp) :: incx 
+                    integer(ilp) :: incy 
+                    integer(ilp) :: lda 
+                    integer(ilp) :: m 
+                    integer(ilp) :: n 
+                    character :: trans 
+                    real(sp) :: a(lda,*) 
+                    real(sp) :: x(*) 
+                    real(sp) :: y(*) 
+               end subroutine sgemv
+#else
+               module procedure stdlib_sgemv
+#endif
+#ifdef STDLIB_EXTERNAL_BLAS
+               subroutine zgemv(trans,m,n,alpha,a,lda,x,incx,beta,y,incy)
+                    import sp,dp,qp,ilp,lk 
+                    implicit none(type,external) 
+                    complex(dp) :: alpha 
+                    complex(dp) :: beta 
+                    integer(ilp) :: incx 
+                    integer(ilp) :: incy 
+                    integer(ilp) :: lda 
+                    integer(ilp) :: m 
+                    integer(ilp) :: n 
+                    character :: trans 
+                    complex(dp) :: a(lda,*) 
+                    complex(dp) :: x(*) 
+                    complex(dp) :: y(*) 
+               end subroutine zgemv
+#else
+               module procedure stdlib_zgemv
+#endif
+          end interface gemv
+
+
 
 end module stdlib_linalg_blas

--- a/src/stdlib_linalg_blas.f90
+++ b/src/stdlib_linalg_blas.f90
@@ -9,6 +9,12 @@ module stdlib_linalg_blas
      use stdlib_linalg_blas_w
      implicit none(type,external)
      public
+
+          ! GEMV performs one of the matrix-vector operations
+          ! y := alpha*A*x + beta*y,   or   y := alpha*A**T*x + beta*y,   or
+          ! y := alpha*A**H*x + beta*y,
+          ! where alpha and beta are scalars, x and y are vectors and A is an
+          ! m by n matrix.
           interface gemv
 #ifdef STDLIB_EXTERNAL_BLAS
                subroutine cgemv(trans,m,n,alpha,a,lda,x,incx,beta,y,incy)

--- a/src/stdlib_linalg_blas.f90
+++ b/src/stdlib_linalg_blas.f90
@@ -7,181 +7,178 @@ module stdlib_linalg_blas
      use stdlib_linalg_blas_c
      use stdlib_linalg_blas_z
      use stdlib_linalg_blas_w
-     implicit none(type,external)
+     implicit none(type, external)
      public
 
           ! AXPY constant times a vector plus a vector.
           interface axpy
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine caxpy(n,ca,cx,incx,cy,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(sp) :: ca,cx(*),cy(*) 
-                    integer(ilp) :: incx,incy,n 
+               subroutine caxpy(n, ca, cx, incx, cy, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(sp) :: ca, cx(*), cy(*)
+                    integer(ilp) :: incx, incy, n
                end subroutine caxpy
 #else
                module procedure stdlib_caxpy
 #endif
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine daxpy(n,da,dx,incx,dy,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(dp) :: da,dx(*),dy(*) 
-                    integer(ilp) :: incx,incy,n 
+               subroutine daxpy(n, da, dx, incx, dy, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(dp) :: da, dx(*), dy(*)
+                    integer(ilp) :: incx, incy, n
                end subroutine daxpy
 #else
                module procedure stdlib_daxpy
 #endif
+               module procedure stdlib_qaxpy
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine saxpy(n,sa,sx,incx,sy,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(sp) :: sa,sx(*),sy(*) 
-                    integer(ilp) :: incx,incy,n 
+               subroutine saxpy(n, sa, sx, incx, sy, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(sp) :: sa, sx(*), sy(*)
+                    integer(ilp) :: incx, incy, n
                end subroutine saxpy
 #else
                module procedure stdlib_saxpy
 #endif
+               module procedure stdlib_waxpy
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine zaxpy(n,za,zx,incx,zy,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(dp) :: za,zx(*),zy(*) 
-                    integer(ilp) :: incx,incy,n 
+               subroutine zaxpy(n, za, zx, incx, zy, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(dp) :: za, zx(*), zy(*)
+                    integer(ilp) :: incx, incy, n
                end subroutine zaxpy
 #else
                module procedure stdlib_zaxpy
 #endif
           end interface axpy
 
-
-
           ! COPY copies a vector x to a vector y.
           interface copy
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine ccopy(n,cx,incx,cy,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,incy,n 
-                    complex(sp) :: cx(*),cy(*) 
+               subroutine ccopy(n, cx, incx, cy, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, incy, n
+                    complex(sp) :: cx(*), cy(*)
                end subroutine ccopy
 #else
                module procedure stdlib_ccopy
 #endif
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine dcopy(n,dx,incx,dy,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,incy,n 
-                    real(dp) :: dx(*),dy(*) 
+               subroutine dcopy(n, dx, incx, dy, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, incy, n
+                    real(dp) :: dx(*), dy(*)
                end subroutine dcopy
 #else
                module procedure stdlib_dcopy
 #endif
+               module procedure stdlib_qcopy
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine scopy(n,sx,incx,sy,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,incy,n 
-                    real(sp) :: sx(*),sy(*) 
+               subroutine scopy(n, sx, incx, sy, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, incy, n
+                    real(sp) :: sx(*), sy(*)
                end subroutine scopy
 #else
                module procedure stdlib_scopy
 #endif
+               module procedure stdlib_wcopy
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine zcopy(n,zx,incx,zy,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,incy,n 
-                    complex(dp) :: zx(*),zy(*) 
+               subroutine zcopy(n, zx, incx, zy, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, incy, n
+                    complex(dp) :: zx(*), zy(*)
                end subroutine zcopy
 #else
                module procedure stdlib_zcopy
 #endif
           end interface copy
 
-
-
           ! DOT forms the dot product of two vectors.
           ! uses unrolled loops for increments equal to one.
           interface dot
 #ifdef STDLIB_EXTERNAL_BLAS
-               real(dp) function ddot(n,dx,incx,dy,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,incy,n 
-                    real(dp) :: dx(*),dy(*) 
+               real(dp) function ddot(n, dx, incx, dy, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, incy, n
+                    real(dp) :: dx(*), dy(*)
                end function ddot
 #else
                module procedure stdlib_ddot
 #endif
+               module procedure stdlib_qdot
 #ifdef STDLIB_EXTERNAL_BLAS
-               real(sp) function sdot(n,sx,incx,sy,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,incy,n 
-                    real(sp) :: sx(*),sy(*) 
+               real(sp) function sdot(n, sx, incx, sy, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, incy, n
+                    real(sp) :: sx(*), sy(*)
                end function sdot
 #else
                module procedure stdlib_sdot
 #endif
           end interface dot
 
-
-
           ! DOTC forms the dot product of two complex vectors
           ! DOTC = X^H * Y
           interface dotc
 #ifdef STDLIB_EXTERNAL_BLAS
-               complex(sp) function cdotc(n,cx,incx,cy,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,incy,n 
-                    complex(sp) :: cx(*),cy(*) 
+               complex(sp) function cdotc(n, cx, incx, cy, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, incy, n
+                    complex(sp) :: cx(*), cy(*)
                end function cdotc
 #else
                module procedure stdlib_cdotc
 #endif
+               module procedure stdlib_wdotc
 #ifdef STDLIB_EXTERNAL_BLAS
-               complex(dp) function zdotc(n,zx,incx,zy,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,incy,n 
-                    complex(dp) :: zx(*),zy(*) 
+               complex(dp) function zdotc(n, zx, incx, zy, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, incy, n
+                    complex(dp) :: zx(*), zy(*)
                end function zdotc
 #else
                module procedure stdlib_zdotc
 #endif
           end interface dotc
 
-
-
           ! DOTU forms the dot product of two complex vectors
           ! DOTU = X^T * Y
           interface dotu
 #ifdef STDLIB_EXTERNAL_BLAS
-               complex(sp) function cdotu(n,cx,incx,cy,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,incy,n 
-                    complex(sp) :: cx(*),cy(*) 
+               complex(sp) function cdotu(n, cx, incx, cy, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, incy, n
+                    complex(sp) :: cx(*), cy(*)
                end function cdotu
 #else
                module procedure stdlib_cdotu
 #endif
+               module procedure stdlib_wdotu
 #ifdef STDLIB_EXTERNAL_BLAS
-               complex(dp) function zdotu(n,zx,incx,zy,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,incy,n 
-                    complex(dp) :: zx(*),zy(*) 
+               complex(dp) function zdotu(n, zx, incx, zy, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, incy, n
+                    complex(dp) :: zx(*), zy(*)
                end function zdotu
 #else
                module procedure stdlib_zdotu
 #endif
           end interface dotu
-
-
 
           ! GBMV  performs one of the matrix-vector operations
           ! y := alpha*A*x + beta*y,   or   y := alpha*A**T*x + beta*y,   or
@@ -190,52 +187,52 @@ module stdlib_linalg_blas
           ! m by n band matrix, with kl sub-diagonals and ku super-diagonals.
           interface gbmv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine cgbmv(trans,m,n,kl,ku,alpha,a,lda,x,incx,beta,y,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(sp) :: alpha,beta,a(lda,*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,kl,ku,lda,m,n 
-                    character :: trans 
+               subroutine cgbmv(trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(sp) :: alpha, beta, a(lda, *), x(*), y(*)
+                    integer(ilp) :: incx, incy, kl, ku, lda, m, n
+                    character :: trans
                end subroutine cgbmv
 #else
                module procedure stdlib_cgbmv
 #endif
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine dgbmv(trans,m,n,kl,ku,alpha,a,lda,x,incx,beta,y,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(dp) :: alpha,beta,a(lda,*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,kl,ku,lda,m,n 
-                    character :: trans 
+               subroutine dgbmv(trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(dp) :: alpha, beta, a(lda, *), x(*), y(*)
+                    integer(ilp) :: incx, incy, kl, ku, lda, m, n
+                    character :: trans
                end subroutine dgbmv
 #else
                module procedure stdlib_dgbmv
 #endif
+               module procedure stdlib_qgbmv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine sgbmv(trans,m,n,kl,ku,alpha,a,lda,x,incx,beta,y,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(sp) :: alpha,beta,a(lda,*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,kl,ku,lda,m,n 
-                    character :: trans 
+               subroutine sgbmv(trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(sp) :: alpha, beta, a(lda, *), x(*), y(*)
+                    integer(ilp) :: incx, incy, kl, ku, lda, m, n
+                    character :: trans
                end subroutine sgbmv
 #else
                module procedure stdlib_sgbmv
 #endif
+               module procedure stdlib_wgbmv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine zgbmv(trans,m,n,kl,ku,alpha,a,lda,x,incx,beta,y,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(dp) :: alpha,beta,a(lda,*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,kl,ku,lda,m,n 
-                    character :: trans 
+               subroutine zgbmv(trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(dp) :: alpha, beta, a(lda, *), x(*), y(*)
+                    integer(ilp) :: incx, incy, kl, ku, lda, m, n
+                    character :: trans
                end subroutine zgbmv
 #else
                module procedure stdlib_zgbmv
 #endif
           end interface gbmv
-
-
 
           ! GEMM  performs one of the matrix-matrix operations
           ! C := alpha*op( A )*op( B ) + beta*C,
@@ -245,52 +242,52 @@ module stdlib_linalg_blas
           ! an m by k matrix,  op( B )  a  k by n matrix and  C an m by n matrix.
           interface gemm
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine cgemm(transa,transb,m,n,k,alpha,a,lda,b,ldb,beta,c,ldc)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(sp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
-                    integer(ilp) :: k,lda,ldb,ldc,m,n 
-                    character :: transa,transb 
+               subroutine cgemm(transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(sp) :: alpha, beta, a(lda, *), b(ldb, *), c(ldc, *)
+                    integer(ilp) :: k, lda, ldb, ldc, m, n
+                    character :: transa, transb
                end subroutine cgemm
 #else
                module procedure stdlib_cgemm
 #endif
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine dgemm(transa,transb,m,n,k,alpha,a,lda,b,ldb,beta,c,ldc)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(dp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
-                    integer(ilp) :: k,lda,ldb,ldc,m,n 
-                    character :: transa,transb 
+               subroutine dgemm(transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(dp) :: alpha, beta, a(lda, *), b(ldb, *), c(ldc, *)
+                    integer(ilp) :: k, lda, ldb, ldc, m, n
+                    character :: transa, transb
                end subroutine dgemm
 #else
                module procedure stdlib_dgemm
 #endif
+               module procedure stdlib_qgemm
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine sgemm(transa,transb,m,n,k,alpha,a,lda,b,ldb,beta,c,ldc)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(sp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
-                    integer(ilp) :: k,lda,ldb,ldc,m,n 
-                    character :: transa,transb 
+               subroutine sgemm(transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(sp) :: alpha, beta, a(lda, *), b(ldb, *), c(ldc, *)
+                    integer(ilp) :: k, lda, ldb, ldc, m, n
+                    character :: transa, transb
                end subroutine sgemm
 #else
                module procedure stdlib_sgemm
 #endif
+               module procedure stdlib_wgemm
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine zgemm(transa,transb,m,n,k,alpha,a,lda,b,ldb,beta,c,ldc)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(dp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
-                    integer(ilp) :: k,lda,ldb,ldc,m,n 
-                    character :: transa,transb 
+               subroutine zgemm(transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(dp) :: alpha, beta, a(lda, *), b(ldb, *), c(ldc, *)
+                    integer(ilp) :: k, lda, ldb, ldc, m, n
+                    character :: transa, transb
                end subroutine zgemm
 #else
                module procedure stdlib_zgemm
 #endif
           end interface gemm
-
-
 
           ! GEMV performs one of the matrix-vector operations
           ! y := alpha*A*x + beta*y,   or   y := alpha*A**T*x + beta*y,   or
@@ -299,52 +296,52 @@ module stdlib_linalg_blas
           ! m by n matrix.
           interface gemv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine cgemv(trans,m,n,alpha,a,lda,x,incx,beta,y,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(sp) :: alpha,beta,a(lda,*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,lda,m,n 
-                    character :: trans 
+               subroutine cgemv(trans, m, n, alpha, a, lda, x, incx, beta, y, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(sp) :: alpha, beta, a(lda, *), x(*), y(*)
+                    integer(ilp) :: incx, incy, lda, m, n
+                    character :: trans
                end subroutine cgemv
 #else
                module procedure stdlib_cgemv
 #endif
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine dgemv(trans,m,n,alpha,a,lda,x,incx,beta,y,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(dp) :: alpha,beta,a(lda,*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,lda,m,n 
-                    character :: trans 
+               subroutine dgemv(trans, m, n, alpha, a, lda, x, incx, beta, y, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(dp) :: alpha, beta, a(lda, *), x(*), y(*)
+                    integer(ilp) :: incx, incy, lda, m, n
+                    character :: trans
                end subroutine dgemv
 #else
                module procedure stdlib_dgemv
 #endif
+               module procedure stdlib_qgemv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine sgemv(trans,m,n,alpha,a,lda,x,incx,beta,y,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(sp) :: alpha,beta,a(lda,*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,lda,m,n 
-                    character :: trans 
+               subroutine sgemv(trans, m, n, alpha, a, lda, x, incx, beta, y, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(sp) :: alpha, beta, a(lda, *), x(*), y(*)
+                    integer(ilp) :: incx, incy, lda, m, n
+                    character :: trans
                end subroutine sgemv
 #else
                module procedure stdlib_sgemv
 #endif
+               module procedure stdlib_wgemv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine zgemv(trans,m,n,alpha,a,lda,x,incx,beta,y,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(dp) :: alpha,beta,a(lda,*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,lda,m,n 
-                    character :: trans 
+               subroutine zgemv(trans, m, n, alpha, a, lda, x, incx, beta, y, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(dp) :: alpha, beta, a(lda, *), x(*), y(*)
+                    integer(ilp) :: incx, incy, lda, m, n
+                    character :: trans
                end subroutine zgemv
 #else
                module procedure stdlib_zgemv
 #endif
           end interface gemv
-
-
 
           ! GER   performs the rank 1 operation
           ! A := alpha*x*y**T + A,
@@ -352,28 +349,27 @@ module stdlib_linalg_blas
           ! vector and A is an m by n matrix.
           interface ger
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine dger(m,n,alpha,x,incx,y,incy,a,lda)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(dp) :: alpha,a(lda,*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,lda,m,n 
+               subroutine dger(m, n, alpha, x, incx, y, incy, a, lda)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(dp) :: alpha, a(lda, *), x(*), y(*)
+                    integer(ilp) :: incx, incy, lda, m, n
                end subroutine dger
 #else
                module procedure stdlib_dger
 #endif
+               module procedure stdlib_qger
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine sger(m,n,alpha,x,incx,y,incy,a,lda)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(sp) :: alpha,a(lda,*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,lda,m,n 
+               subroutine sger(m, n, alpha, x, incx, y, incy, a, lda)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(sp) :: alpha, a(lda, *), x(*), y(*)
+                    integer(ilp) :: incx, incy, lda, m, n
                end subroutine sger
 #else
                module procedure stdlib_sger
 #endif
           end interface ger
-
-
 
           ! GERC  performs the rank 1 operation
           ! A := alpha*x*y**H + A,
@@ -381,28 +377,27 @@ module stdlib_linalg_blas
           ! vector and A is an m by n matrix.
           interface gerc
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine cgerc(m,n,alpha,x,incx,y,incy,a,lda)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(sp) :: alpha,a(lda,*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,lda,m,n 
+               subroutine cgerc(m, n, alpha, x, incx, y, incy, a, lda)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(sp) :: alpha, a(lda, *), x(*), y(*)
+                    integer(ilp) :: incx, incy, lda, m, n
                end subroutine cgerc
 #else
                module procedure stdlib_cgerc
 #endif
+               module procedure stdlib_wgerc
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine zgerc(m,n,alpha,x,incx,y,incy,a,lda)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(dp) :: alpha,a(lda,*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,lda,m,n 
+               subroutine zgerc(m, n, alpha, x, incx, y, incy, a, lda)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(dp) :: alpha, a(lda, *), x(*), y(*)
+                    integer(ilp) :: incx, incy, lda, m, n
                end subroutine zgerc
 #else
                module procedure stdlib_zgerc
 #endif
           end interface gerc
-
-
 
           ! GERU  performs the rank 1 operation
           ! A := alpha*x*y**T + A,
@@ -410,28 +405,27 @@ module stdlib_linalg_blas
           ! vector and A is an m by n matrix.
           interface geru
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine cgeru(m,n,alpha,x,incx,y,incy,a,lda)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(sp) :: alpha,a(lda,*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,lda,m,n 
+               subroutine cgeru(m, n, alpha, x, incx, y, incy, a, lda)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(sp) :: alpha, a(lda, *), x(*), y(*)
+                    integer(ilp) :: incx, incy, lda, m, n
                end subroutine cgeru
 #else
                module procedure stdlib_cgeru
 #endif
+               module procedure stdlib_wgeru
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine zgeru(m,n,alpha,x,incx,y,incy,a,lda)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(dp) :: alpha,a(lda,*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,lda,m,n 
+               subroutine zgeru(m, n, alpha, x, incx, y, incy, a, lda)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(dp) :: alpha, a(lda, *), x(*), y(*)
+                    integer(ilp) :: incx, incy, lda, m, n
                end subroutine zgeru
 #else
                module procedure stdlib_zgeru
 #endif
           end interface geru
-
-
 
           ! HBMV  performs the matrix-vector  operation
           ! y := alpha*A*x + beta*y,
@@ -439,30 +433,29 @@ module stdlib_linalg_blas
           ! A is an n by n hermitian band matrix, with k super-diagonals.
           interface hbmv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine chbmv(uplo,n,k,alpha,a,lda,x,incx,beta,y,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(sp) :: alpha,beta,a(lda,*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,k,lda,n 
-                    character :: uplo 
+               subroutine chbmv(uplo, n, k, alpha, a, lda, x, incx, beta, y, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(sp) :: alpha, beta, a(lda, *), x(*), y(*)
+                    integer(ilp) :: incx, incy, k, lda, n
+                    character :: uplo
                end subroutine chbmv
 #else
                module procedure stdlib_chbmv
 #endif
+               module procedure stdlib_whbmv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine zhbmv(uplo,n,k,alpha,a,lda,x,incx,beta,y,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(dp) :: alpha,beta,a(lda,*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,k,lda,n 
-                    character :: uplo 
+               subroutine zhbmv(uplo, n, k, alpha, a, lda, x, incx, beta, y, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(dp) :: alpha, beta, a(lda, *), x(*), y(*)
+                    integer(ilp) :: incx, incy, k, lda, n
+                    character :: uplo
                end subroutine zhbmv
 #else
                module procedure stdlib_zhbmv
 #endif
           end interface hbmv
-
-
 
           ! HEMM  performs one of the matrix-matrix operations
           ! C := alpha*A*B + beta*C,
@@ -472,30 +465,29 @@ module stdlib_linalg_blas
           ! C are m by n matrices.
           interface hemm
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine chemm(side,uplo,m,n,alpha,a,lda,b,ldb,beta,c,ldc)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(sp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
-                    integer(ilp) :: lda,ldb,ldc,m,n 
-                    character :: side,uplo 
+               subroutine chemm(side, uplo, m, n, alpha, a, lda, b, ldb, beta, c, ldc)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(sp) :: alpha, beta, a(lda, *), b(ldb, *), c(ldc, *)
+                    integer(ilp) :: lda, ldb, ldc, m, n
+                    character :: side, uplo
                end subroutine chemm
 #else
                module procedure stdlib_chemm
 #endif
+               module procedure stdlib_whemm
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine zhemm(side,uplo,m,n,alpha,a,lda,b,ldb,beta,c,ldc)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(dp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
-                    integer(ilp) :: lda,ldb,ldc,m,n 
-                    character :: side,uplo 
+               subroutine zhemm(side, uplo, m, n, alpha, a, lda, b, ldb, beta, c, ldc)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(dp) :: alpha, beta, a(lda, *), b(ldb, *), c(ldc, *)
+                    integer(ilp) :: lda, ldb, ldc, m, n
+                    character :: side, uplo
                end subroutine zhemm
 #else
                module procedure stdlib_zhemm
 #endif
           end interface hemm
-
-
 
           ! HEMV  performs the matrix-vector  operation
           ! y := alpha*A*x + beta*y,
@@ -503,30 +495,29 @@ module stdlib_linalg_blas
           ! A is an n by n hermitian matrix.
           interface hemv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine chemv(uplo,n,alpha,a,lda,x,incx,beta,y,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(sp) :: alpha,beta,a(lda,*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,lda,n 
-                    character :: uplo 
+               subroutine chemv(uplo, n, alpha, a, lda, x, incx, beta, y, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(sp) :: alpha, beta, a(lda, *), x(*), y(*)
+                    integer(ilp) :: incx, incy, lda, n
+                    character :: uplo
                end subroutine chemv
 #else
                module procedure stdlib_chemv
 #endif
+               module procedure stdlib_whemv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine zhemv(uplo,n,alpha,a,lda,x,incx,beta,y,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(dp) :: alpha,beta,a(lda,*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,lda,n 
-                    character :: uplo 
+               subroutine zhemv(uplo, n, alpha, a, lda, x, incx, beta, y, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(dp) :: alpha, beta, a(lda, *), x(*), y(*)
+                    integer(ilp) :: incx, incy, lda, n
+                    character :: uplo
                end subroutine zhemv
 #else
                module procedure stdlib_zhemv
 #endif
           end interface hemv
-
-
 
           ! HER   performs the hermitian rank 1 operation
           ! A := alpha*x*x**H + A,
@@ -534,32 +525,31 @@ module stdlib_linalg_blas
           ! n by n hermitian matrix.
           interface her
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine cher(uplo,n,alpha,x,incx,a,lda)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(sp) :: alpha 
-                    integer(ilp) :: incx,lda,n 
-                    character :: uplo 
-                    complex(sp) :: a(lda,*),x(*) 
+               subroutine cher(uplo, n, alpha, x, incx, a, lda)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(sp) :: alpha
+                    integer(ilp) :: incx, lda, n
+                    character :: uplo
+                    complex(sp) :: a(lda, *), x(*)
                end subroutine cher
 #else
                module procedure stdlib_cher
 #endif
+               module procedure stdlib_wher
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine zher(uplo,n,alpha,x,incx,a,lda)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(dp) :: alpha 
-                    integer(ilp) :: incx,lda,n 
-                    character :: uplo 
-                    complex(dp) :: a(lda,*),x(*) 
+               subroutine zher(uplo, n, alpha, x, incx, a, lda)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(dp) :: alpha
+                    integer(ilp) :: incx, lda, n
+                    character :: uplo
+                    complex(dp) :: a(lda, *), x(*)
                end subroutine zher
 #else
                module procedure stdlib_zher
 #endif
           end interface her
-
-
 
           ! HER2  performs the hermitian rank 2 operation
           ! A := alpha*x*y**H + conjg( alpha )*y*x**H + A,
@@ -567,30 +557,29 @@ module stdlib_linalg_blas
           ! by n hermitian matrix.
           interface her2
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine cher2(uplo,n,alpha,x,incx,y,incy,a,lda)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(sp) :: alpha,a(lda,*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,lda,n 
-                    character :: uplo 
+               subroutine cher2(uplo, n, alpha, x, incx, y, incy, a, lda)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(sp) :: alpha, a(lda, *), x(*), y(*)
+                    integer(ilp) :: incx, incy, lda, n
+                    character :: uplo
                end subroutine cher2
 #else
                module procedure stdlib_cher2
 #endif
+               module procedure stdlib_wher2
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine zher2(uplo,n,alpha,x,incx,y,incy,a,lda)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(dp) :: alpha,a(lda,*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,lda,n 
-                    character :: uplo 
+               subroutine zher2(uplo, n, alpha, x, incx, y, incy, a, lda)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(dp) :: alpha, a(lda, *), x(*), y(*)
+                    integer(ilp) :: incx, incy, lda, n
+                    character :: uplo
                end subroutine zher2
 #else
                module procedure stdlib_zher2
 #endif
           end interface her2
-
-
 
           ! HER2K  performs one of the hermitian rank 2k operations
           ! C := alpha*A*B**H + conjg( alpha )*B*A**H + beta*C,
@@ -601,32 +590,31 @@ module stdlib_linalg_blas
           ! and  k by n  matrices in the second case.
           interface her2k
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine cher2k(uplo,trans,n,k,alpha,a,lda,b,ldb,beta,c,ldc)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(sp) :: alpha,a(lda,*),b(ldb,*),c(ldc,*) 
-                    real(sp) :: beta 
-                    integer(ilp) :: k,lda,ldb,ldc,n 
-                    character :: trans,uplo 
+               subroutine cher2k(uplo, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(sp) :: alpha, a(lda, *), b(ldb, *), c(ldc, *)
+                    real(sp) :: beta
+                    integer(ilp) :: k, lda, ldb, ldc, n
+                    character :: trans, uplo
                end subroutine cher2k
 #else
                module procedure stdlib_cher2k
 #endif
+               module procedure stdlib_wher2k
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine zher2k(uplo,trans,n,k,alpha,a,lda,b,ldb,beta,c,ldc)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(dp) :: alpha,a(lda,*),b(ldb,*),c(ldc,*) 
-                    real(dp) :: beta 
-                    integer(ilp) :: k,lda,ldb,ldc,n 
-                    character :: trans,uplo 
+               subroutine zher2k(uplo, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(dp) :: alpha, a(lda, *), b(ldb, *), c(ldc, *)
+                    real(dp) :: beta
+                    integer(ilp) :: k, lda, ldb, ldc, n
+                    character :: trans, uplo
                end subroutine zher2k
 #else
                module procedure stdlib_zher2k
 #endif
           end interface her2k
-
-
 
           ! HERK  performs one of the hermitian rank k operations
           ! C := alpha*A*A**H + beta*C,
@@ -637,32 +625,31 @@ module stdlib_linalg_blas
           ! matrix in the second case.
           interface herk
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine cherk(uplo,trans,n,k,alpha,a,lda,beta,c,ldc)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(sp) :: alpha,beta 
-                    integer(ilp) :: k,lda,ldc,n 
-                    character :: trans,uplo 
-                    complex(sp) :: a(lda,*),c(ldc,*) 
+               subroutine cherk(uplo, trans, n, k, alpha, a, lda, beta, c, ldc)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(sp) :: alpha, beta
+                    integer(ilp) :: k, lda, ldc, n
+                    character :: trans, uplo
+                    complex(sp) :: a(lda, *), c(ldc, *)
                end subroutine cherk
 #else
                module procedure stdlib_cherk
 #endif
+               module procedure stdlib_wherk
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine zherk(uplo,trans,n,k,alpha,a,lda,beta,c,ldc)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(dp) :: alpha,beta 
-                    integer(ilp) :: k,lda,ldc,n 
-                    character :: trans,uplo 
-                    complex(dp) :: a(lda,*),c(ldc,*) 
+               subroutine zherk(uplo, trans, n, k, alpha, a, lda, beta, c, ldc)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(dp) :: alpha, beta
+                    integer(ilp) :: k, lda, ldc, n
+                    character :: trans, uplo
+                    complex(dp) :: a(lda, *), c(ldc, *)
                end subroutine zherk
 #else
                module procedure stdlib_zherk
 #endif
           end interface herk
-
-
 
           ! HPMV  performs the matrix-vector operation
           ! y := alpha*A*x + beta*y,
@@ -670,30 +657,29 @@ module stdlib_linalg_blas
           ! A is an n by n hermitian matrix, supplied in packed form.
           interface hpmv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine chpmv(uplo,n,alpha,ap,x,incx,beta,y,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(sp) :: alpha,beta,ap(*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,n 
-                    character :: uplo 
+               subroutine chpmv(uplo, n, alpha, ap, x, incx, beta, y, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(sp) :: alpha, beta, ap(*), x(*), y(*)
+                    integer(ilp) :: incx, incy, n
+                    character :: uplo
                end subroutine chpmv
 #else
                module procedure stdlib_chpmv
 #endif
+               module procedure stdlib_whpmv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine zhpmv(uplo,n,alpha,ap,x,incx,beta,y,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(dp) :: alpha,beta,ap(*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,n 
-                    character :: uplo 
+               subroutine zhpmv(uplo, n, alpha, ap, x, incx, beta, y, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(dp) :: alpha, beta, ap(*), x(*), y(*)
+                    integer(ilp) :: incx, incy, n
+                    character :: uplo
                end subroutine zhpmv
 #else
                module procedure stdlib_zhpmv
 #endif
           end interface hpmv
-
-
 
           ! HPR    performs the hermitian rank 1 operation
           ! A := alpha*x*x**H + A,
@@ -701,32 +687,31 @@ module stdlib_linalg_blas
           ! n by n hermitian matrix, supplied in packed form.
           interface hpr
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine chpr(uplo,n,alpha,x,incx,ap)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(sp) :: alpha 
-                    integer(ilp) :: incx,n 
-                    character :: uplo 
-                    complex(sp) :: ap(*),x(*) 
+               subroutine chpr(uplo, n, alpha, x, incx, ap)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(sp) :: alpha
+                    integer(ilp) :: incx, n
+                    character :: uplo
+                    complex(sp) :: ap(*), x(*)
                end subroutine chpr
 #else
                module procedure stdlib_chpr
 #endif
+               module procedure stdlib_whpr
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine zhpr(uplo,n,alpha,x,incx,ap)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(dp) :: alpha 
-                    integer(ilp) :: incx,n 
-                    character :: uplo 
-                    complex(dp) :: ap(*),x(*) 
+               subroutine zhpr(uplo, n, alpha, x, incx, ap)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(dp) :: alpha
+                    integer(ilp) :: incx, n
+                    character :: uplo
+                    complex(dp) :: ap(*), x(*)
                end subroutine zhpr
 #else
                module procedure stdlib_zhpr
 #endif
           end interface hpr
-
-
 
           ! HPR2  performs the hermitian rank 2 operation
           ! A := alpha*x*y**H + conjg( alpha )*y*x**H + A,
@@ -734,30 +719,29 @@ module stdlib_linalg_blas
           ! n by n hermitian matrix, supplied in packed form.
           interface hpr2
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine chpr2(uplo,n,alpha,x,incx,y,incy,ap)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(sp) :: alpha,ap(*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,n 
-                    character :: uplo 
+               subroutine chpr2(uplo, n, alpha, x, incx, y, incy, ap)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(sp) :: alpha, ap(*), x(*), y(*)
+                    integer(ilp) :: incx, incy, n
+                    character :: uplo
                end subroutine chpr2
 #else
                module procedure stdlib_chpr2
 #endif
+               module procedure stdlib_whpr2
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine zhpr2(uplo,n,alpha,x,incx,y,incy,ap)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(dp) :: alpha,ap(*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,n 
-                    character :: uplo 
+               subroutine zhpr2(uplo, n, alpha, x, incx, y, incy, ap)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(dp) :: alpha, ap(*), x(*), y(*)
+                    integer(ilp) :: incx, incy, n
+                    character :: uplo
                end subroutine zhpr2
 #else
                module procedure stdlib_zhpr2
 #endif
           end interface hpr2
-
-
 
           ! !
           ! NRM2 returns the euclidean norm of a vector via the function
@@ -765,54 +749,52 @@ module stdlib_linalg_blas
           ! NRM2 := sqrt( x'*x )
           interface nrm2
 #ifdef STDLIB_EXTERNAL_BLAS
-               function dnrm2( n, x, incx )
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(dp) :: dnrm2,x(*) 
-                    integer(ilp) :: incx,n 
+               function dnrm2(n, x, incx)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(dp) :: dnrm2, x(*)
+                    integer(ilp) :: incx, n
                end function dnrm2
 #else
                module procedure stdlib_dnrm2
 #endif
+               module procedure stdlib_qnrm2
 #ifdef STDLIB_EXTERNAL_BLAS
-               function snrm2( n, x, incx )
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(sp) :: snrm2,x(*) 
-                    integer(ilp) :: incx,n 
+               function snrm2(n, x, incx)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(sp) :: snrm2, x(*)
+                    integer(ilp) :: incx, n
                end function snrm2
 #else
                module procedure stdlib_snrm2
 #endif
           end interface nrm2
 
-
-
           ! ROT applies a plane rotation.
           interface rot
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine drot(n,dx,incx,dy,incy,c,s)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(dp) :: c,s,dx(*),dy(*) 
-                    integer(ilp) :: incx,incy,n 
+               subroutine drot(n, dx, incx, dy, incy, c, s)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(dp) :: c, s, dx(*), dy(*)
+                    integer(ilp) :: incx, incy, n
                end subroutine drot
 #else
                module procedure stdlib_drot
 #endif
+               module procedure stdlib_qrot
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine srot(n,sx,incx,sy,incy,c,s)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(sp) :: c,s,sx(*),sy(*) 
-                    integer(ilp) :: incx,incy,n 
+               subroutine srot(n, sx, incx, sy, incy, c, s)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(sp) :: c, s, sx(*), sy(*)
+                    integer(ilp) :: incx, incy, n
                end subroutine srot
 #else
                module procedure stdlib_srot
 #endif
           end interface rot
-
-
 
           ! !
           ! The computation uses the formulas
@@ -830,46 +812,46 @@ module stdlib_linalg_blas
           ! if the signs of a and b are not the same.
           interface rotg
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine crotg( a, b, c, s )
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(sp) :: c 
-                    complex(sp) :: a,b,s 
+               subroutine crotg(a, b, c, s)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(sp) :: c
+                    complex(sp) :: a, b, s
                end subroutine crotg
 #else
                module procedure stdlib_crotg
 #endif
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine drotg( a, b, c, s )
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(dp) :: a,b,c,s 
+               subroutine drotg(a, b, c, s)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(dp) :: a, b, c, s
                end subroutine drotg
 #else
                module procedure stdlib_drotg
 #endif
+               module procedure stdlib_qrotg
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine srotg( a, b, c, s )
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(sp) :: a,b,c,s 
+               subroutine srotg(a, b, c, s)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(sp) :: a, b, c, s
                end subroutine srotg
 #else
                module procedure stdlib_srotg
 #endif
+               module procedure stdlib_wrotg
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine zrotg( a, b, c, s )
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(dp) :: c 
-                    complex(dp) :: a,b,s 
+               subroutine zrotg(a, b, c, s)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(dp) :: c
+                    complex(dp) :: a, b, s
                end subroutine zrotg
 #else
                module procedure stdlib_zrotg
 #endif
           end interface rotg
-
-
 
           ! APPLY THE MODIFIED GIVENS TRANSFORMATION, H, TO THE 2 BY N MATRIX
           ! (DX**T) , WHERE **T INDICATES TRANSPOSE. THE ELEMENTS OF DX ARE IN
@@ -884,28 +866,27 @@ module stdlib_linalg_blas
           ! SEE ROTMG FOR A DESCRIPTION OF DATA STORAGE IN DPARAM.
           interface rotm
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine drotm(n,dx,incx,dy,incy,dparam)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,incy,n 
-                    real(dp) :: dparam(5),dx(*),dy(*) 
+               subroutine drotm(n, dx, incx, dy, incy, dparam)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, incy, n
+                    real(dp) :: dparam(5), dx(*), dy(*)
                end subroutine drotm
 #else
                module procedure stdlib_drotm
 #endif
+               module procedure stdlib_qrotm
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine srotm(n,sx,incx,sy,incy,sparam)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,incy,n 
-                    real(sp) :: sparam(5),sx(*),sy(*) 
+               subroutine srotm(n, sx, incx, sy, incy, sparam)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, incy, n
+                    real(sp) :: sparam(5), sx(*), sy(*)
                end subroutine srotm
 #else
                module procedure stdlib_srotm
 #endif
           end interface rotm
-
-
 
           ! CONSTRUCT THE MODIFIED GIVENS TRANSFORMATION MATRIX H WHICH ZEROS
           ! THE SECOND COMPONENT OF THE 2-VECTOR  (SQRT(DD1)*DX1,SQRT(DD2)    DY2)**T.
@@ -922,26 +903,25 @@ module stdlib_linalg_blas
           ! OF DD1 AND DD2.  ALL ACTUAL SCALING OF DATA IS DONE USING GAM.
           interface rotmg
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine drotmg(dd1,dd2,dx1,dy1,dparam)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(dp) :: dd1,dd2,dx1,dy1,dparam(5) 
+               subroutine drotmg(dd1, dd2, dx1, dy1, dparam)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(dp) :: dd1, dd2, dx1, dy1, dparam(5)
                end subroutine drotmg
 #else
                module procedure stdlib_drotmg
 #endif
+               module procedure stdlib_qrotmg
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine srotmg(sd1,sd2,sx1,sy1,sparam)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(sp) :: sd1,sd2,sx1,sy1,sparam(5) 
+               subroutine srotmg(sd1, sd2, sx1, sy1, sparam)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(sp) :: sd1, sd2, sx1, sy1, sparam(5)
                end subroutine srotmg
 #else
                module procedure stdlib_srotmg
 #endif
           end interface rotmg
-
-
 
           ! SBMV  performs the matrix-vector  operation
           ! y := alpha*A*x + beta*y,
@@ -949,76 +929,75 @@ module stdlib_linalg_blas
           ! A is an n by n symmetric band matrix, with k super-diagonals.
           interface sbmv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine dsbmv(uplo,n,k,alpha,a,lda,x,incx,beta,y,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(dp) :: alpha,beta,a(lda,*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,k,lda,n 
-                    character :: uplo 
+               subroutine dsbmv(uplo, n, k, alpha, a, lda, x, incx, beta, y, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(dp) :: alpha, beta, a(lda, *), x(*), y(*)
+                    integer(ilp) :: incx, incy, k, lda, n
+                    character :: uplo
                end subroutine dsbmv
 #else
                module procedure stdlib_dsbmv
 #endif
+               module procedure stdlib_qsbmv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine ssbmv(uplo,n,k,alpha,a,lda,x,incx,beta,y,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(sp) :: alpha,beta,a(lda,*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,k,lda,n 
-                    character :: uplo 
+               subroutine ssbmv(uplo, n, k, alpha, a, lda, x, incx, beta, y, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(sp) :: alpha, beta, a(lda, *), x(*), y(*)
+                    integer(ilp) :: incx, incy, k, lda, n
+                    character :: uplo
                end subroutine ssbmv
 #else
                module procedure stdlib_ssbmv
 #endif
           end interface sbmv
 
-
-
           ! SCAL scales a vector by a constant.
           interface scal
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine cscal(n,ca,cx,incx)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(sp) :: ca,cx(*) 
-                    integer(ilp) :: incx,n 
+               subroutine cscal(n, ca, cx, incx)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(sp) :: ca, cx(*)
+                    integer(ilp) :: incx, n
                end subroutine cscal
 #else
                module procedure stdlib_cscal
 #endif
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine dscal(n,da,dx,incx)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(dp) :: da,dx(*) 
-                    integer(ilp) :: incx,n 
+               subroutine dscal(n, da, dx, incx)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(dp) :: da, dx(*)
+                    integer(ilp) :: incx, n
                end subroutine dscal
 #else
                module procedure stdlib_dscal
 #endif
+               module procedure stdlib_qscal
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine sscal(n,sa,sx,incx)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(sp) :: sa,sx(*) 
-                    integer(ilp) :: incx,n 
+               subroutine sscal(n, sa, sx, incx)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(sp) :: sa, sx(*)
+                    integer(ilp) :: incx, n
                end subroutine sscal
 #else
                module procedure stdlib_sscal
 #endif
+               module procedure stdlib_wscal
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine zscal(n,za,zx,incx)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(dp) :: za,zx(*) 
-                    integer(ilp) :: incx,n 
+               subroutine zscal(n, za, zx, incx)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(dp) :: za, zx(*)
+                    integer(ilp) :: incx, n
                end subroutine zscal
 #else
                module procedure stdlib_zscal
 #endif
           end interface scal
-
-
 
           ! Compute the inner product of two vectors with extended
           ! precision accumulation and result.
@@ -1028,18 +1007,17 @@ module stdlib_linalg_blas
           ! defined in a similar way using INCY.
           interface sdot
 #ifdef STDLIB_EXTERNAL_BLAS
-               real(dp) function dsdot(n,sx,incx,sy,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,incy,n 
-                    real(sp) :: sx(*),sy(*) 
+               real(dp) function dsdot(n, sx, incx, sy, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, incy, n
+                    real(sp) :: sx(*), sy(*)
                end function dsdot
 #else
                module procedure stdlib_dsdot
 #endif
+               module procedure stdlib_qsdot
           end interface sdot
-
-
 
           ! SPMV  performs the matrix-vector operation
           ! y := alpha*A*x + beta*y,
@@ -1047,30 +1025,29 @@ module stdlib_linalg_blas
           ! A is an n by n symmetric matrix, supplied in packed form.
           interface spmv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine dspmv(uplo,n,alpha,ap,x,incx,beta,y,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(dp) :: alpha,beta,ap(*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,n 
-                    character :: uplo 
+               subroutine dspmv(uplo, n, alpha, ap, x, incx, beta, y, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(dp) :: alpha, beta, ap(*), x(*), y(*)
+                    integer(ilp) :: incx, incy, n
+                    character :: uplo
                end subroutine dspmv
 #else
                module procedure stdlib_dspmv
 #endif
+               module procedure stdlib_qspmv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine sspmv(uplo,n,alpha,ap,x,incx,beta,y,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(sp) :: alpha,beta,ap(*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,n 
-                    character :: uplo 
+               subroutine sspmv(uplo, n, alpha, ap, x, incx, beta, y, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(sp) :: alpha, beta, ap(*), x(*), y(*)
+                    integer(ilp) :: incx, incy, n
+                    character :: uplo
                end subroutine sspmv
 #else
                module procedure stdlib_sspmv
 #endif
           end interface spmv
-
-
 
           ! SPR    performs the symmetric rank 1 operation
           ! A := alpha*x*x**T + A,
@@ -1078,30 +1055,29 @@ module stdlib_linalg_blas
           ! n by n symmetric matrix, supplied in packed form.
           interface spr
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine dspr(uplo,n,alpha,x,incx,ap)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(dp) :: alpha,ap(*),x(*) 
-                    integer(ilp) :: incx,n 
-                    character :: uplo 
+               subroutine dspr(uplo, n, alpha, x, incx, ap)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(dp) :: alpha, ap(*), x(*)
+                    integer(ilp) :: incx, n
+                    character :: uplo
                end subroutine dspr
 #else
                module procedure stdlib_dspr
 #endif
+               module procedure stdlib_qspr
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine sspr(uplo,n,alpha,x,incx,ap)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(sp) :: alpha,ap(*),x(*) 
-                    integer(ilp) :: incx,n 
-                    character :: uplo 
+               subroutine sspr(uplo, n, alpha, x, incx, ap)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(sp) :: alpha, ap(*), x(*)
+                    integer(ilp) :: incx, n
+                    character :: uplo
                end subroutine sspr
 #else
                module procedure stdlib_sspr
 #endif
           end interface spr
-
-
 
           ! SPR2  performs the symmetric rank 2 operation
           ! A := alpha*x*y**T + alpha*y*x**T + A,
@@ -1109,112 +1085,107 @@ module stdlib_linalg_blas
           ! n by n symmetric matrix, supplied in packed form.
           interface spr2
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine dspr2(uplo,n,alpha,x,incx,y,incy,ap)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(dp) :: alpha,ap(*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,n 
-                    character :: uplo 
+               subroutine dspr2(uplo, n, alpha, x, incx, y, incy, ap)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(dp) :: alpha, ap(*), x(*), y(*)
+                    integer(ilp) :: incx, incy, n
+                    character :: uplo
                end subroutine dspr2
 #else
                module procedure stdlib_dspr2
 #endif
+               module procedure stdlib_qspr2
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine sspr2(uplo,n,alpha,x,incx,y,incy,ap)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(sp) :: alpha,ap(*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,n 
-                    character :: uplo 
+               subroutine sspr2(uplo, n, alpha, x, incx, y, incy, ap)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(sp) :: alpha, ap(*), x(*), y(*)
+                    integer(ilp) :: incx, incy, n
+                    character :: uplo
                end subroutine sspr2
 #else
                module procedure stdlib_sspr2
 #endif
           end interface spr2
 
-
-
           ! SROT applies a plane rotation, where the cos and sin (c and s) are real
           ! and the vectors cx and cy are complex.
           ! jack dongarra, linpack, 3/11/78.
           interface srot
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine csrot( n, cx, incx, cy, incy, c, s )
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,incy,n 
-                    real(sp) :: c,s 
-                    complex(sp) :: cx,cy 
+               subroutine csrot(n, cx, incx, cy, incy, c, s)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, incy, n
+                    real(sp) :: c, s
+                    complex(sp) :: cx, cy
                end subroutine csrot
 #else
                module procedure stdlib_csrot
 #endif
           end interface srot
 
-
-
           ! SSCAL scales a complex vector by a real constant.
           interface sscal
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine csscal(n,sa,cx,incx)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(sp) :: sa 
-                    integer(ilp) :: incx,n 
-                    complex(sp) :: cx(*) 
+               subroutine csscal(n, sa, cx, incx)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(sp) :: sa
+                    integer(ilp) :: incx, n
+                    complex(sp) :: cx(*)
                end subroutine csscal
 #else
                module procedure stdlib_csscal
 #endif
           end interface sscal
 
-
-
           ! SWAP interchanges two vectors.
           interface swap
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine cswap(n,cx,incx,cy,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,incy,n 
-                    complex(sp) :: cx(*),cy(*) 
+               subroutine cswap(n, cx, incx, cy, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, incy, n
+                    complex(sp) :: cx(*), cy(*)
                end subroutine cswap
 #else
                module procedure stdlib_cswap
 #endif
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine dswap(n,dx,incx,dy,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,incy,n 
-                    real(dp) :: dx(*),dy(*) 
+               subroutine dswap(n, dx, incx, dy, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, incy, n
+                    real(dp) :: dx(*), dy(*)
                end subroutine dswap
 #else
                module procedure stdlib_dswap
 #endif
+               module procedure stdlib_qswap
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine sswap(n,sx,incx,sy,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,incy,n 
-                    real(sp) :: sx(*),sy(*) 
+               subroutine sswap(n, sx, incx, sy, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, incy, n
+                    real(sp) :: sx(*), sy(*)
                end subroutine sswap
 #else
                module procedure stdlib_sswap
 #endif
+               module procedure stdlib_wswap
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine zswap(n,zx,incx,zy,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,incy,n 
-                    complex(dp) :: zx(*),zy(*) 
+               subroutine zswap(n, zx, incx, zy, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, incy, n
+                    complex(dp) :: zx(*), zy(*)
                end subroutine zswap
 #else
                module procedure stdlib_zswap
 #endif
           end interface swap
-
-
 
           ! SYMM  performs one of the matrix-matrix operations
           ! C := alpha*A*B + beta*C,
@@ -1224,52 +1195,52 @@ module stdlib_linalg_blas
           ! C are m by n matrices.
           interface symm
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine csymm(side,uplo,m,n,alpha,a,lda,b,ldb,beta,c,ldc)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(sp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
-                    integer(ilp) :: lda,ldb,ldc,m,n 
-                    character :: side,uplo 
+               subroutine csymm(side, uplo, m, n, alpha, a, lda, b, ldb, beta, c, ldc)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(sp) :: alpha, beta, a(lda, *), b(ldb, *), c(ldc, *)
+                    integer(ilp) :: lda, ldb, ldc, m, n
+                    character :: side, uplo
                end subroutine csymm
 #else
                module procedure stdlib_csymm
 #endif
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine dsymm(side,uplo,m,n,alpha,a,lda,b,ldb,beta,c,ldc)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(dp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
-                    integer(ilp) :: lda,ldb,ldc,m,n 
-                    character :: side,uplo 
+               subroutine dsymm(side, uplo, m, n, alpha, a, lda, b, ldb, beta, c, ldc)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(dp) :: alpha, beta, a(lda, *), b(ldb, *), c(ldc, *)
+                    integer(ilp) :: lda, ldb, ldc, m, n
+                    character :: side, uplo
                end subroutine dsymm
 #else
                module procedure stdlib_dsymm
 #endif
+               module procedure stdlib_qsymm
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine ssymm(side,uplo,m,n,alpha,a,lda,b,ldb,beta,c,ldc)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(sp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
-                    integer(ilp) :: lda,ldb,ldc,m,n 
-                    character :: side,uplo 
+               subroutine ssymm(side, uplo, m, n, alpha, a, lda, b, ldb, beta, c, ldc)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(sp) :: alpha, beta, a(lda, *), b(ldb, *), c(ldc, *)
+                    integer(ilp) :: lda, ldb, ldc, m, n
+                    character :: side, uplo
                end subroutine ssymm
 #else
                module procedure stdlib_ssymm
 #endif
+               module procedure stdlib_wsymm
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine zsymm(side,uplo,m,n,alpha,a,lda,b,ldb,beta,c,ldc)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(dp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
-                    integer(ilp) :: lda,ldb,ldc,m,n 
-                    character :: side,uplo 
+               subroutine zsymm(side, uplo, m, n, alpha, a, lda, b, ldb, beta, c, ldc)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(dp) :: alpha, beta, a(lda, *), b(ldb, *), c(ldc, *)
+                    integer(ilp) :: lda, ldb, ldc, m, n
+                    character :: side, uplo
                end subroutine zsymm
 #else
                module procedure stdlib_zsymm
 #endif
           end interface symm
-
-
 
           ! SYMV  performs the matrix-vector  operation
           ! y := alpha*A*x + beta*y,
@@ -1277,30 +1248,29 @@ module stdlib_linalg_blas
           ! A is an n by n symmetric matrix.
           interface symv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine dsymv(uplo,n,alpha,a,lda,x,incx,beta,y,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(dp) :: alpha,beta,a(lda,*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,lda,n 
-                    character :: uplo 
+               subroutine dsymv(uplo, n, alpha, a, lda, x, incx, beta, y, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(dp) :: alpha, beta, a(lda, *), x(*), y(*)
+                    integer(ilp) :: incx, incy, lda, n
+                    character :: uplo
                end subroutine dsymv
 #else
                module procedure stdlib_dsymv
 #endif
+               module procedure stdlib_qsymv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine ssymv(uplo,n,alpha,a,lda,x,incx,beta,y,incy)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(sp) :: alpha,beta,a(lda,*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,lda,n 
-                    character :: uplo 
+               subroutine ssymv(uplo, n, alpha, a, lda, x, incx, beta, y, incy)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(sp) :: alpha, beta, a(lda, *), x(*), y(*)
+                    integer(ilp) :: incx, incy, lda, n
+                    character :: uplo
                end subroutine ssymv
 #else
                module procedure stdlib_ssymv
 #endif
           end interface symv
-
-
 
           ! SYR   performs the symmetric rank 1 operation
           ! A := alpha*x*x**T + A,
@@ -1308,30 +1278,29 @@ module stdlib_linalg_blas
           ! n by n symmetric matrix.
           interface syr
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine dsyr(uplo,n,alpha,x,incx,a,lda)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(dp) :: alpha,a(lda,*),x(*) 
-                    integer(ilp) :: incx,lda,n 
-                    character :: uplo 
+               subroutine dsyr(uplo, n, alpha, x, incx, a, lda)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(dp) :: alpha, a(lda, *), x(*)
+                    integer(ilp) :: incx, lda, n
+                    character :: uplo
                end subroutine dsyr
 #else
                module procedure stdlib_dsyr
 #endif
+               module procedure stdlib_qsyr
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine ssyr(uplo,n,alpha,x,incx,a,lda)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(sp) :: alpha,a(lda,*),x(*) 
-                    integer(ilp) :: incx,lda,n 
-                    character :: uplo 
+               subroutine ssyr(uplo, n, alpha, x, incx, a, lda)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(sp) :: alpha, a(lda, *), x(*)
+                    integer(ilp) :: incx, lda, n
+                    character :: uplo
                end subroutine ssyr
 #else
                module procedure stdlib_ssyr
 #endif
           end interface syr
-
-
 
           ! SYR2  performs the symmetric rank 2 operation
           ! A := alpha*x*y**T + alpha*y*x**T + A,
@@ -1339,30 +1308,29 @@ module stdlib_linalg_blas
           ! by n symmetric matrix.
           interface syr2
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine dsyr2(uplo,n,alpha,x,incx,y,incy,a,lda)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(dp) :: alpha,a(lda,*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,lda,n 
-                    character :: uplo 
+               subroutine dsyr2(uplo, n, alpha, x, incx, y, incy, a, lda)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(dp) :: alpha, a(lda, *), x(*), y(*)
+                    integer(ilp) :: incx, incy, lda, n
+                    character :: uplo
                end subroutine dsyr2
 #else
                module procedure stdlib_dsyr2
 #endif
+               module procedure stdlib_qsyr2
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine ssyr2(uplo,n,alpha,x,incx,y,incy,a,lda)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(sp) :: alpha,a(lda,*),x(*),y(*) 
-                    integer(ilp) :: incx,incy,lda,n 
-                    character :: uplo 
+               subroutine ssyr2(uplo, n, alpha, x, incx, y, incy, a, lda)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(sp) :: alpha, a(lda, *), x(*), y(*)
+                    integer(ilp) :: incx, incy, lda, n
+                    character :: uplo
                end subroutine ssyr2
 #else
                module procedure stdlib_ssyr2
 #endif
           end interface syr2
-
-
 
           ! SYR2K  performs one of the symmetric rank 2k operations
           ! C := alpha*A*B**T + alpha*B*A**T + beta*C,
@@ -1373,52 +1341,52 @@ module stdlib_linalg_blas
           ! matrices in the second case.
           interface syr2k
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine csyr2k(uplo,trans,n,k,alpha,a,lda,b,ldb,beta,c,ldc)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(sp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
-                    integer(ilp) :: k,lda,ldb,ldc,n 
-                    character :: trans,uplo 
+               subroutine csyr2k(uplo, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(sp) :: alpha, beta, a(lda, *), b(ldb, *), c(ldc, *)
+                    integer(ilp) :: k, lda, ldb, ldc, n
+                    character :: trans, uplo
                end subroutine csyr2k
 #else
                module procedure stdlib_csyr2k
 #endif
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine dsyr2k(uplo,trans,n,k,alpha,a,lda,b,ldb,beta,c,ldc)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(dp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
-                    integer(ilp) :: k,lda,ldb,ldc,n 
-                    character :: trans,uplo 
+               subroutine dsyr2k(uplo, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(dp) :: alpha, beta, a(lda, *), b(ldb, *), c(ldc, *)
+                    integer(ilp) :: k, lda, ldb, ldc, n
+                    character :: trans, uplo
                end subroutine dsyr2k
 #else
                module procedure stdlib_dsyr2k
 #endif
+               module procedure stdlib_qsyr2k
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine ssyr2k(uplo,trans,n,k,alpha,a,lda,b,ldb,beta,c,ldc)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(sp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
-                    integer(ilp) :: k,lda,ldb,ldc,n 
-                    character :: trans,uplo 
+               subroutine ssyr2k(uplo, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(sp) :: alpha, beta, a(lda, *), b(ldb, *), c(ldc, *)
+                    integer(ilp) :: k, lda, ldb, ldc, n
+                    character :: trans, uplo
                end subroutine ssyr2k
 #else
                module procedure stdlib_ssyr2k
 #endif
+               module procedure stdlib_wsyr2k
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine zsyr2k(uplo,trans,n,k,alpha,a,lda,b,ldb,beta,c,ldc)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(dp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
-                    integer(ilp) :: k,lda,ldb,ldc,n 
-                    character :: trans,uplo 
+               subroutine zsyr2k(uplo, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(dp) :: alpha, beta, a(lda, *), b(ldb, *), c(ldc, *)
+                    integer(ilp) :: k, lda, ldb, ldc, n
+                    character :: trans, uplo
                end subroutine zsyr2k
 #else
                module procedure stdlib_zsyr2k
 #endif
           end interface syr2k
-
-
 
           ! SYRK  performs one of the symmetric rank k operations
           ! C := alpha*A*A**T + beta*C,
@@ -1429,52 +1397,52 @@ module stdlib_linalg_blas
           ! in the second case.
           interface syrk
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine csyrk(uplo,trans,n,k,alpha,a,lda,beta,c,ldc)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(sp) :: alpha,beta,a(lda,*),c(ldc,*) 
-                    integer(ilp) :: k,lda,ldc,n 
-                    character :: trans,uplo 
+               subroutine csyrk(uplo, trans, n, k, alpha, a, lda, beta, c, ldc)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(sp) :: alpha, beta, a(lda, *), c(ldc, *)
+                    integer(ilp) :: k, lda, ldc, n
+                    character :: trans, uplo
                end subroutine csyrk
 #else
                module procedure stdlib_csyrk
 #endif
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine dsyrk(uplo,trans,n,k,alpha,a,lda,beta,c,ldc)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(dp) :: alpha,beta,a(lda,*),c(ldc,*) 
-                    integer(ilp) :: k,lda,ldc,n 
-                    character :: trans,uplo 
+               subroutine dsyrk(uplo, trans, n, k, alpha, a, lda, beta, c, ldc)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(dp) :: alpha, beta, a(lda, *), c(ldc, *)
+                    integer(ilp) :: k, lda, ldc, n
+                    character :: trans, uplo
                end subroutine dsyrk
 #else
                module procedure stdlib_dsyrk
 #endif
+               module procedure stdlib_qsyrk
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine ssyrk(uplo,trans,n,k,alpha,a,lda,beta,c,ldc)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(sp) :: alpha,beta,a(lda,*),c(ldc,*) 
-                    integer(ilp) :: k,lda,ldc,n 
-                    character :: trans,uplo 
+               subroutine ssyrk(uplo, trans, n, k, alpha, a, lda, beta, c, ldc)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(sp) :: alpha, beta, a(lda, *), c(ldc, *)
+                    integer(ilp) :: k, lda, ldc, n
+                    character :: trans, uplo
                end subroutine ssyrk
 #else
                module procedure stdlib_ssyrk
 #endif
+               module procedure stdlib_wsyrk
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine zsyrk(uplo,trans,n,k,alpha,a,lda,beta,c,ldc)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(dp) :: alpha,beta,a(lda,*),c(ldc,*) 
-                    integer(ilp) :: k,lda,ldc,n 
-                    character :: trans,uplo 
+               subroutine zsyrk(uplo, trans, n, k, alpha, a, lda, beta, c, ldc)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(dp) :: alpha, beta, a(lda, *), c(ldc, *)
+                    integer(ilp) :: k, lda, ldc, n
+                    character :: trans, uplo
                end subroutine zsyrk
 #else
                module procedure stdlib_zsyrk
 #endif
           end interface syrk
-
-
 
           ! TBMV  performs one of the matrix-vector operations
           ! x := A*x,   or   x := A**T*x,   or   x := A**H*x,
@@ -1482,52 +1450,52 @@ module stdlib_linalg_blas
           ! upper or lower triangular band matrix, with ( k + 1 ) diagonals.
           interface tbmv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine ctbmv(uplo,trans,diag,n,k,a,lda,x,incx)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,k,lda,n 
-                    character :: diag,trans,uplo 
-                    complex(sp) :: a(lda,*),x(*) 
+               subroutine ctbmv(uplo, trans, diag, n, k, a, lda, x, incx)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, k, lda, n
+                    character :: diag, trans, uplo
+                    complex(sp) :: a(lda, *), x(*)
                end subroutine ctbmv
 #else
                module procedure stdlib_ctbmv
 #endif
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine dtbmv(uplo,trans,diag,n,k,a,lda,x,incx)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,k,lda,n 
-                    character :: diag,trans,uplo 
-                    real(dp) :: a(lda,*),x(*) 
+               subroutine dtbmv(uplo, trans, diag, n, k, a, lda, x, incx)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, k, lda, n
+                    character :: diag, trans, uplo
+                    real(dp) :: a(lda, *), x(*)
                end subroutine dtbmv
 #else
                module procedure stdlib_dtbmv
 #endif
+               module procedure stdlib_qtbmv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine stbmv(uplo,trans,diag,n,k,a,lda,x,incx)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,k,lda,n 
-                    character :: diag,trans,uplo 
-                    real(sp) :: a(lda,*),x(*) 
+               subroutine stbmv(uplo, trans, diag, n, k, a, lda, x, incx)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, k, lda, n
+                    character :: diag, trans, uplo
+                    real(sp) :: a(lda, *), x(*)
                end subroutine stbmv
 #else
                module procedure stdlib_stbmv
 #endif
+               module procedure stdlib_wtbmv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine ztbmv(uplo,trans,diag,n,k,a,lda,x,incx)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,k,lda,n 
-                    character :: diag,trans,uplo 
-                    complex(dp) :: a(lda,*),x(*) 
+               subroutine ztbmv(uplo, trans, diag, n, k, a, lda, x, incx)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, k, lda, n
+                    character :: diag, trans, uplo
+                    complex(dp) :: a(lda, *), x(*)
                end subroutine ztbmv
 #else
                module procedure stdlib_ztbmv
 #endif
           end interface tbmv
-
-
 
           ! TBSV  solves one of the systems of equations
           ! A*x = b,   or   A**T*x = b,   or   A**H*x = b,
@@ -1538,52 +1506,52 @@ module stdlib_linalg_blas
           ! routine. Such tests must be performed before calling this routine.
           interface tbsv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine ctbsv(uplo,trans,diag,n,k,a,lda,x,incx)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,k,lda,n 
-                    character :: diag,trans,uplo 
-                    complex(sp) :: a(lda,*),x(*) 
+               subroutine ctbsv(uplo, trans, diag, n, k, a, lda, x, incx)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, k, lda, n
+                    character :: diag, trans, uplo
+                    complex(sp) :: a(lda, *), x(*)
                end subroutine ctbsv
 #else
                module procedure stdlib_ctbsv
 #endif
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine dtbsv(uplo,trans,diag,n,k,a,lda,x,incx)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,k,lda,n 
-                    character :: diag,trans,uplo 
-                    real(dp) :: a(lda,*),x(*) 
+               subroutine dtbsv(uplo, trans, diag, n, k, a, lda, x, incx)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, k, lda, n
+                    character :: diag, trans, uplo
+                    real(dp) :: a(lda, *), x(*)
                end subroutine dtbsv
 #else
                module procedure stdlib_dtbsv
 #endif
+               module procedure stdlib_qtbsv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine stbsv(uplo,trans,diag,n,k,a,lda,x,incx)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,k,lda,n 
-                    character :: diag,trans,uplo 
-                    real(sp) :: a(lda,*),x(*) 
+               subroutine stbsv(uplo, trans, diag, n, k, a, lda, x, incx)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, k, lda, n
+                    character :: diag, trans, uplo
+                    real(sp) :: a(lda, *), x(*)
                end subroutine stbsv
 #else
                module procedure stdlib_stbsv
 #endif
+               module procedure stdlib_wtbsv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine ztbsv(uplo,trans,diag,n,k,a,lda,x,incx)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,k,lda,n 
-                    character :: diag,trans,uplo 
-                    complex(dp) :: a(lda,*),x(*) 
+               subroutine ztbsv(uplo, trans, diag, n, k, a, lda, x, incx)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, k, lda, n
+                    character :: diag, trans, uplo
+                    complex(dp) :: a(lda, *), x(*)
                end subroutine ztbsv
 #else
                module procedure stdlib_ztbsv
 #endif
           end interface tbsv
-
-
 
           ! TPMV  performs one of the matrix-vector operations
           ! x := A*x,   or   x := A**T*x,   or   x := A**H*x,
@@ -1591,52 +1559,52 @@ module stdlib_linalg_blas
           ! upper or lower triangular matrix, supplied in packed form.
           interface tpmv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine ctpmv(uplo,trans,diag,n,ap,x,incx)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,n 
-                    character :: diag,trans,uplo 
-                    complex(sp) :: ap(*),x(*) 
+               subroutine ctpmv(uplo, trans, diag, n, ap, x, incx)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, n
+                    character :: diag, trans, uplo
+                    complex(sp) :: ap(*), x(*)
                end subroutine ctpmv
 #else
                module procedure stdlib_ctpmv
 #endif
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine dtpmv(uplo,trans,diag,n,ap,x,incx)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,n 
-                    character :: diag,trans,uplo 
-                    real(dp) :: ap(*),x(*) 
+               subroutine dtpmv(uplo, trans, diag, n, ap, x, incx)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, n
+                    character :: diag, trans, uplo
+                    real(dp) :: ap(*), x(*)
                end subroutine dtpmv
 #else
                module procedure stdlib_dtpmv
 #endif
+               module procedure stdlib_qtpmv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine stpmv(uplo,trans,diag,n,ap,x,incx)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,n 
-                    character :: diag,trans,uplo 
-                    real(sp) :: ap(*),x(*) 
+               subroutine stpmv(uplo, trans, diag, n, ap, x, incx)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, n
+                    character :: diag, trans, uplo
+                    real(sp) :: ap(*), x(*)
                end subroutine stpmv
 #else
                module procedure stdlib_stpmv
 #endif
+               module procedure stdlib_wtpmv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine ztpmv(uplo,trans,diag,n,ap,x,incx)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,n 
-                    character :: diag,trans,uplo 
-                    complex(dp) :: ap(*),x(*) 
+               subroutine ztpmv(uplo, trans, diag, n, ap, x, incx)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, n
+                    character :: diag, trans, uplo
+                    complex(dp) :: ap(*), x(*)
                end subroutine ztpmv
 #else
                module procedure stdlib_ztpmv
 #endif
           end interface tpmv
-
-
 
           ! TPSV  solves one of the systems of equations
           ! A*x = b,   or   A**T*x = b,   or   A**H*x = b,
@@ -1646,52 +1614,52 @@ module stdlib_linalg_blas
           ! routine. Such tests must be performed before calling this routine.
           interface tpsv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine ctpsv(uplo,trans,diag,n,ap,x,incx)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,n 
-                    character :: diag,trans,uplo 
-                    complex(sp) :: ap(*),x(*) 
+               subroutine ctpsv(uplo, trans, diag, n, ap, x, incx)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, n
+                    character :: diag, trans, uplo
+                    complex(sp) :: ap(*), x(*)
                end subroutine ctpsv
 #else
                module procedure stdlib_ctpsv
 #endif
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine dtpsv(uplo,trans,diag,n,ap,x,incx)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,n 
-                    character :: diag,trans,uplo 
-                    real(dp) :: ap(*),x(*) 
+               subroutine dtpsv(uplo, trans, diag, n, ap, x, incx)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, n
+                    character :: diag, trans, uplo
+                    real(dp) :: ap(*), x(*)
                end subroutine dtpsv
 #else
                module procedure stdlib_dtpsv
 #endif
+               module procedure stdlib_qtpsv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine stpsv(uplo,trans,diag,n,ap,x,incx)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,n 
-                    character :: diag,trans,uplo 
-                    real(sp) :: ap(*),x(*) 
+               subroutine stpsv(uplo, trans, diag, n, ap, x, incx)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, n
+                    character :: diag, trans, uplo
+                    real(sp) :: ap(*), x(*)
                end subroutine stpsv
 #else
                module procedure stdlib_stpsv
 #endif
+               module procedure stdlib_wtpsv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine ztpsv(uplo,trans,diag,n,ap,x,incx)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,n 
-                    character :: diag,trans,uplo 
-                    complex(dp) :: ap(*),x(*) 
+               subroutine ztpsv(uplo, trans, diag, n, ap, x, incx)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, n
+                    character :: diag, trans, uplo
+                    complex(dp) :: ap(*), x(*)
                end subroutine ztpsv
 #else
                module procedure stdlib_ztpsv
 #endif
           end interface tpsv
-
-
 
           ! TRMM  performs one of the matrix-matrix operations
           ! B := alpha*op( A )*B,   or   B := alpha*B*op( A )
@@ -1700,52 +1668,52 @@ module stdlib_linalg_blas
           ! op( A ) = A   or   op( A ) = A**T   or   op( A ) = A**H.
           interface trmm
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine ctrmm(side,uplo,transa,diag,m,n,alpha,a,lda,b,ldb)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(sp) :: alpha,a(lda,*),b(ldb,*) 
-                    integer(ilp) :: lda,ldb,m,n 
-                    character :: diag,side,transa,uplo 
+               subroutine ctrmm(side, uplo, transa, diag, m, n, alpha, a, lda, b, ldb)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(sp) :: alpha, a(lda, *), b(ldb, *)
+                    integer(ilp) :: lda, ldb, m, n
+                    character :: diag, side, transa, uplo
                end subroutine ctrmm
 #else
                module procedure stdlib_ctrmm
 #endif
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine dtrmm(side,uplo,transa,diag,m,n,alpha,a,lda,b,ldb)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(dp) :: alpha,a(lda,*),b(ldb,*) 
-                    integer(ilp) :: lda,ldb,m,n 
-                    character :: diag,side,transa,uplo 
+               subroutine dtrmm(side, uplo, transa, diag, m, n, alpha, a, lda, b, ldb)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(dp) :: alpha, a(lda, *), b(ldb, *)
+                    integer(ilp) :: lda, ldb, m, n
+                    character :: diag, side, transa, uplo
                end subroutine dtrmm
 #else
                module procedure stdlib_dtrmm
 #endif
+               module procedure stdlib_qtrmm
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine strmm(side,uplo,transa,diag,m,n,alpha,a,lda,b,ldb)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(sp) :: alpha,a(lda,*),b(ldb,*) 
-                    integer(ilp) :: lda,ldb,m,n 
-                    character :: diag,side,transa,uplo 
+               subroutine strmm(side, uplo, transa, diag, m, n, alpha, a, lda, b, ldb)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(sp) :: alpha, a(lda, *), b(ldb, *)
+                    integer(ilp) :: lda, ldb, m, n
+                    character :: diag, side, transa, uplo
                end subroutine strmm
 #else
                module procedure stdlib_strmm
 #endif
+               module procedure stdlib_wtrmm
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine ztrmm(side,uplo,transa,diag,m,n,alpha,a,lda,b,ldb)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(dp) :: alpha,a(lda,*),b(ldb,*) 
-                    integer(ilp) :: lda,ldb,m,n 
-                    character :: diag,side,transa,uplo 
+               subroutine ztrmm(side, uplo, transa, diag, m, n, alpha, a, lda, b, ldb)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(dp) :: alpha, a(lda, *), b(ldb, *)
+                    integer(ilp) :: lda, ldb, m, n
+                    character :: diag, side, transa, uplo
                end subroutine ztrmm
 #else
                module procedure stdlib_ztrmm
 #endif
           end interface trmm
-
-
 
           ! TRMV  performs one of the matrix-vector operations
           ! x := A*x,   or   x := A**T*x,   or   x := A**H*x,
@@ -1753,52 +1721,52 @@ module stdlib_linalg_blas
           ! upper or lower triangular matrix.
           interface trmv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine ctrmv(uplo,trans,diag,n,a,lda,x,incx)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,lda,n 
-                    character :: diag,trans,uplo 
-                    complex(sp) :: a(lda,*),x(*) 
+               subroutine ctrmv(uplo, trans, diag, n, a, lda, x, incx)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, lda, n
+                    character :: diag, trans, uplo
+                    complex(sp) :: a(lda, *), x(*)
                end subroutine ctrmv
 #else
                module procedure stdlib_ctrmv
 #endif
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine dtrmv(uplo,trans,diag,n,a,lda,x,incx)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,lda,n 
-                    character :: diag,trans,uplo 
-                    real(dp) :: a(lda,*),x(*) 
+               subroutine dtrmv(uplo, trans, diag, n, a, lda, x, incx)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, lda, n
+                    character :: diag, trans, uplo
+                    real(dp) :: a(lda, *), x(*)
                end subroutine dtrmv
 #else
                module procedure stdlib_dtrmv
 #endif
+               module procedure stdlib_qtrmv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine strmv(uplo,trans,diag,n,a,lda,x,incx)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,lda,n 
-                    character :: diag,trans,uplo 
-                    real(sp) :: a(lda,*),x(*) 
+               subroutine strmv(uplo, trans, diag, n, a, lda, x, incx)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, lda, n
+                    character :: diag, trans, uplo
+                    real(sp) :: a(lda, *), x(*)
                end subroutine strmv
 #else
                module procedure stdlib_strmv
 #endif
+               module procedure stdlib_wtrmv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine ztrmv(uplo,trans,diag,n,a,lda,x,incx)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,lda,n 
-                    character :: diag,trans,uplo 
-                    complex(dp) :: a(lda,*),x(*) 
+               subroutine ztrmv(uplo, trans, diag, n, a, lda, x, incx)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, lda, n
+                    character :: diag, trans, uplo
+                    complex(dp) :: a(lda, *), x(*)
                end subroutine ztrmv
 #else
                module procedure stdlib_ztrmv
 #endif
           end interface trmv
-
-
 
           ! TRSM  solves one of the matrix equations
           ! op( A )*X = alpha*B,   or   X*op( A ) = alpha*B,
@@ -1808,52 +1776,52 @@ module stdlib_linalg_blas
           ! The matrix X is overwritten on B.
           interface trsm
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine ctrsm(side,uplo,transa,diag,m,n,alpha,a,lda,b,ldb)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(sp) :: alpha,a(lda,*),b(ldb,*) 
-                    integer(ilp) :: lda,ldb,m,n 
-                    character :: diag,side,transa,uplo 
+               subroutine ctrsm(side, uplo, transa, diag, m, n, alpha, a, lda, b, ldb)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(sp) :: alpha, a(lda, *), b(ldb, *)
+                    integer(ilp) :: lda, ldb, m, n
+                    character :: diag, side, transa, uplo
                end subroutine ctrsm
 #else
                module procedure stdlib_ctrsm
 #endif
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine dtrsm(side,uplo,transa,diag,m,n,alpha,a,lda,b,ldb)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(dp) :: alpha,a(lda,*),b(ldb,*) 
-                    integer(ilp) :: lda,ldb,m,n 
-                    character :: diag,side,transa,uplo 
+               subroutine dtrsm(side, uplo, transa, diag, m, n, alpha, a, lda, b, ldb)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(dp) :: alpha, a(lda, *), b(ldb, *)
+                    integer(ilp) :: lda, ldb, m, n
+                    character :: diag, side, transa, uplo
                end subroutine dtrsm
 #else
                module procedure stdlib_dtrsm
 #endif
+               module procedure stdlib_qtrsm
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine strsm(side,uplo,transa,diag,m,n,alpha,a,lda,b,ldb)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    real(sp) :: alpha,a(lda,*),b(ldb,*) 
-                    integer(ilp) :: lda,ldb,m,n 
-                    character :: diag,side,transa,uplo 
+               subroutine strsm(side, uplo, transa, diag, m, n, alpha, a, lda, b, ldb)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    real(sp) :: alpha, a(lda, *), b(ldb, *)
+                    integer(ilp) :: lda, ldb, m, n
+                    character :: diag, side, transa, uplo
                end subroutine strsm
 #else
                module procedure stdlib_strsm
 #endif
+               module procedure stdlib_wtrsm
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine ztrsm(side,uplo,transa,diag,m,n,alpha,a,lda,b,ldb)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    complex(dp) :: alpha,a(lda,*),b(ldb,*) 
-                    integer(ilp) :: lda,ldb,m,n 
-                    character :: diag,side,transa,uplo 
+               subroutine ztrsm(side, uplo, transa, diag, m, n, alpha, a, lda, b, ldb)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    complex(dp) :: alpha, a(lda, *), b(ldb, *)
+                    integer(ilp) :: lda, ldb, m, n
+                    character :: diag, side, transa, uplo
                end subroutine ztrsm
 #else
                module procedure stdlib_ztrsm
 #endif
           end interface trsm
-
-
 
           ! TRSV  solves one of the systems of equations
           ! A*x = b,   or   A**T*x = b,   or   A**H*x = b,
@@ -1863,53 +1831,51 @@ module stdlib_linalg_blas
           ! routine. Such tests must be performed before calling this routine.
           interface trsv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine ctrsv(uplo,trans,diag,n,a,lda,x,incx)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,lda,n 
-                    character :: diag,trans,uplo 
-                    complex(sp) :: a(lda,*),x(*) 
+               subroutine ctrsv(uplo, trans, diag, n, a, lda, x, incx)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, lda, n
+                    character :: diag, trans, uplo
+                    complex(sp) :: a(lda, *), x(*)
                end subroutine ctrsv
 #else
                module procedure stdlib_ctrsv
 #endif
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine dtrsv(uplo,trans,diag,n,a,lda,x,incx)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,lda,n 
-                    character :: diag,trans,uplo 
-                    real(dp) :: a(lda,*),x(*) 
+               subroutine dtrsv(uplo, trans, diag, n, a, lda, x, incx)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, lda, n
+                    character :: diag, trans, uplo
+                    real(dp) :: a(lda, *), x(*)
                end subroutine dtrsv
 #else
                module procedure stdlib_dtrsv
 #endif
+               module procedure stdlib_qtrsv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine strsv(uplo,trans,diag,n,a,lda,x,incx)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,lda,n 
-                    character :: diag,trans,uplo 
-                    real(sp) :: a(lda,*),x(*) 
+               subroutine strsv(uplo, trans, diag, n, a, lda, x, incx)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, lda, n
+                    character :: diag, trans, uplo
+                    real(sp) :: a(lda, *), x(*)
                end subroutine strsv
 #else
                module procedure stdlib_strsv
 #endif
+               module procedure stdlib_wtrsv
 #ifdef STDLIB_EXTERNAL_BLAS
-               subroutine ztrsv(uplo,trans,diag,n,a,lda,x,incx)
-                    import sp,dp,qp,ilp,lk 
-                    implicit none(type,external) 
-                    integer(ilp) :: incx,lda,n 
-                    character :: diag,trans,uplo 
-                    complex(dp) :: a(lda,*),x(*) 
+               subroutine ztrsv(uplo, trans, diag, n, a, lda, x, incx)
+                    import sp, dp, qp, ilp, lk
+                    implicit none(type, external)
+                    integer(ilp) :: incx, lda, n
+                    character :: diag, trans, uplo
+                    complex(dp) :: a(lda, *), x(*)
                end subroutine ztrsv
 #else
                module procedure stdlib_ztrsv
 #endif
           end interface trsv
-
-
-
-
 
 end module stdlib_linalg_blas

--- a/src/stdlib_linalg_blas.f90
+++ b/src/stdlib_linalg_blas.f90
@@ -16,12 +16,8 @@ module stdlib_linalg_blas
                subroutine caxpy(n,ca,cx,incx,cy,incy)
                     import sp,dp,qp,ilp,lk 
                     implicit none(type,external) 
-                    complex(sp) :: ca 
-                    integer(ilp) :: incx 
-                    integer(ilp) :: incy 
-                    integer(ilp) :: n 
-                    complex(sp) :: cx(*) 
-                    complex(sp) :: cy(*) 
+                    complex(sp) :: ca,cx(*),cy(*) 
+                    integer(ilp) :: incx,incy,n 
                end subroutine caxpy
 #else
                module procedure stdlib_caxpy
@@ -30,12 +26,8 @@ module stdlib_linalg_blas
                subroutine daxpy(n,da,dx,incx,dy,incy)
                     import sp,dp,qp,ilp,lk 
                     implicit none(type,external) 
-                    real(dp) :: da 
-                    integer(ilp) :: incx 
-                    integer(ilp) :: incy 
-                    integer(ilp) :: n 
-                    real(dp) :: dx(*) 
-                    real(dp) :: dy(*) 
+                    real(dp) :: da,dx(*),dy(*) 
+                    integer(ilp) :: incx,incy,n 
                end subroutine daxpy
 #else
                module procedure stdlib_daxpy
@@ -44,12 +36,8 @@ module stdlib_linalg_blas
                subroutine saxpy(n,sa,sx,incx,sy,incy)
                     import sp,dp,qp,ilp,lk 
                     implicit none(type,external) 
-                    real(sp) :: sa 
-                    integer(ilp) :: incx 
-                    integer(ilp) :: incy 
-                    integer(ilp) :: n 
-                    real(sp) :: sx(*) 
-                    real(sp) :: sy(*) 
+                    real(sp) :: sa,sx(*),sy(*) 
+                    integer(ilp) :: incx,incy,n 
                end subroutine saxpy
 #else
                module procedure stdlib_saxpy
@@ -58,12 +46,8 @@ module stdlib_linalg_blas
                subroutine zaxpy(n,za,zx,incx,zy,incy)
                     import sp,dp,qp,ilp,lk 
                     implicit none(type,external) 
-                    complex(dp) :: za 
-                    integer(ilp) :: incx 
-                    integer(ilp) :: incy 
-                    integer(ilp) :: n 
-                    complex(dp) :: zx(*) 
-                    complex(dp) :: zy(*) 
+                    complex(dp) :: za,zx(*),zy(*) 
+                    integer(ilp) :: incx,incy,n 
                end subroutine zaxpy
 #else
                module procedure stdlib_zaxpy
@@ -78,11 +62,8 @@ module stdlib_linalg_blas
                subroutine ccopy(n,cx,incx,cy,incy)
                     import sp,dp,qp,ilp,lk 
                     implicit none(type,external) 
-                    integer(ilp) :: incx 
-                    integer(ilp) :: incy 
-                    integer(ilp) :: n 
-                    complex(sp) :: cx(*) 
-                    complex(sp) :: cy(*) 
+                    integer(ilp) :: incx,incy,n 
+                    complex(sp) :: cx(*),cy(*) 
                end subroutine ccopy
 #else
                module procedure stdlib_ccopy
@@ -91,11 +72,8 @@ module stdlib_linalg_blas
                subroutine dcopy(n,dx,incx,dy,incy)
                     import sp,dp,qp,ilp,lk 
                     implicit none(type,external) 
-                    integer(ilp) :: incx 
-                    integer(ilp) :: incy 
-                    integer(ilp) :: n 
-                    real(dp) :: dx(*) 
-                    real(dp) :: dy(*) 
+                    integer(ilp) :: incx,incy,n 
+                    real(dp) :: dx(*),dy(*) 
                end subroutine dcopy
 #else
                module procedure stdlib_dcopy
@@ -104,11 +82,8 @@ module stdlib_linalg_blas
                subroutine scopy(n,sx,incx,sy,incy)
                     import sp,dp,qp,ilp,lk 
                     implicit none(type,external) 
-                    integer(ilp) :: incx 
-                    integer(ilp) :: incy 
-                    integer(ilp) :: n 
-                    real(sp) :: sx(*) 
-                    real(sp) :: sy(*) 
+                    integer(ilp) :: incx,incy,n 
+                    real(sp) :: sx(*),sy(*) 
                end subroutine scopy
 #else
                module procedure stdlib_scopy
@@ -117,11 +92,8 @@ module stdlib_linalg_blas
                subroutine zcopy(n,zx,incx,zy,incy)
                     import sp,dp,qp,ilp,lk 
                     implicit none(type,external) 
-                    integer(ilp) :: incx 
-                    integer(ilp) :: incy 
-                    integer(ilp) :: n 
-                    complex(dp) :: zx(*) 
-                    complex(dp) :: zy(*) 
+                    integer(ilp) :: incx,incy,n 
+                    complex(dp) :: zx(*),zy(*) 
                end subroutine zcopy
 #else
                module procedure stdlib_zcopy
@@ -140,19 +112,9 @@ module stdlib_linalg_blas
                subroutine cgbmv(trans,m,n,kl,ku,alpha,a,lda,x,incx,beta,y,incy)
                     import sp,dp,qp,ilp,lk 
                     implicit none(type,external) 
-                    complex(sp) :: alpha 
-                    complex(sp) :: beta 
-                    integer(ilp) :: incx 
-                    integer(ilp) :: incy 
-                    integer(ilp) :: kl 
-                    integer(ilp) :: ku 
-                    integer(ilp) :: lda 
-                    integer(ilp) :: m 
-                    integer(ilp) :: n 
+                    complex(sp) :: alpha,beta,a(lda,*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,kl,ku,lda,m,n 
                     character :: trans 
-                    complex(sp) :: a(lda,*) 
-                    complex(sp) :: x(*) 
-                    complex(sp) :: y(*) 
                end subroutine cgbmv
 #else
                module procedure stdlib_cgbmv
@@ -161,19 +123,9 @@ module stdlib_linalg_blas
                subroutine dgbmv(trans,m,n,kl,ku,alpha,a,lda,x,incx,beta,y,incy)
                     import sp,dp,qp,ilp,lk 
                     implicit none(type,external) 
-                    real(dp) :: alpha 
-                    real(dp) :: beta 
-                    integer(ilp) :: incx 
-                    integer(ilp) :: incy 
-                    integer(ilp) :: kl 
-                    integer(ilp) :: ku 
-                    integer(ilp) :: lda 
-                    integer(ilp) :: m 
-                    integer(ilp) :: n 
+                    real(dp) :: alpha,beta,a(lda,*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,kl,ku,lda,m,n 
                     character :: trans 
-                    real(dp) :: a(lda,*) 
-                    real(dp) :: x(*) 
-                    real(dp) :: y(*) 
                end subroutine dgbmv
 #else
                module procedure stdlib_dgbmv
@@ -182,19 +134,9 @@ module stdlib_linalg_blas
                subroutine sgbmv(trans,m,n,kl,ku,alpha,a,lda,x,incx,beta,y,incy)
                     import sp,dp,qp,ilp,lk 
                     implicit none(type,external) 
-                    real(sp) :: alpha 
-                    real(sp) :: beta 
-                    integer(ilp) :: incx 
-                    integer(ilp) :: incy 
-                    integer(ilp) :: kl 
-                    integer(ilp) :: ku 
-                    integer(ilp) :: lda 
-                    integer(ilp) :: m 
-                    integer(ilp) :: n 
+                    real(sp) :: alpha,beta,a(lda,*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,kl,ku,lda,m,n 
                     character :: trans 
-                    real(sp) :: a(lda,*) 
-                    real(sp) :: x(*) 
-                    real(sp) :: y(*) 
                end subroutine sgbmv
 #else
                module procedure stdlib_sgbmv
@@ -203,19 +145,9 @@ module stdlib_linalg_blas
                subroutine zgbmv(trans,m,n,kl,ku,alpha,a,lda,x,incx,beta,y,incy)
                     import sp,dp,qp,ilp,lk 
                     implicit none(type,external) 
-                    complex(dp) :: alpha 
-                    complex(dp) :: beta 
-                    integer(ilp) :: incx 
-                    integer(ilp) :: incy 
-                    integer(ilp) :: kl 
-                    integer(ilp) :: ku 
-                    integer(ilp) :: lda 
-                    integer(ilp) :: m 
-                    integer(ilp) :: n 
+                    complex(dp) :: alpha,beta,a(lda,*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,kl,ku,lda,m,n 
                     character :: trans 
-                    complex(dp) :: a(lda,*) 
-                    complex(dp) :: x(*) 
-                    complex(dp) :: y(*) 
                end subroutine zgbmv
 #else
                module procedure stdlib_zgbmv
@@ -235,19 +167,9 @@ module stdlib_linalg_blas
                subroutine cgemm(transa,transb,m,n,k,alpha,a,lda,b,ldb,beta,c,ldc)
                     import sp,dp,qp,ilp,lk 
                     implicit none(type,external) 
-                    complex(sp) :: alpha 
-                    complex(sp) :: beta 
-                    integer(ilp) :: k 
-                    integer(ilp) :: lda 
-                    integer(ilp) :: ldb 
-                    integer(ilp) :: ldc 
-                    integer(ilp) :: m 
-                    integer(ilp) :: n 
-                    character :: transa 
-                    character :: transb 
-                    complex(sp) :: a(lda,*) 
-                    complex(sp) :: b(ldb,*) 
-                    complex(sp) :: c(ldc,*) 
+                    complex(sp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
+                    integer(ilp) :: k,lda,ldb,ldc,m,n 
+                    character :: transa,transb 
                end subroutine cgemm
 #else
                module procedure stdlib_cgemm
@@ -256,19 +178,9 @@ module stdlib_linalg_blas
                subroutine dgemm(transa,transb,m,n,k,alpha,a,lda,b,ldb,beta,c,ldc)
                     import sp,dp,qp,ilp,lk 
                     implicit none(type,external) 
-                    real(dp) :: alpha 
-                    real(dp) :: beta 
-                    integer(ilp) :: k 
-                    integer(ilp) :: lda 
-                    integer(ilp) :: ldb 
-                    integer(ilp) :: ldc 
-                    integer(ilp) :: m 
-                    integer(ilp) :: n 
-                    character :: transa 
-                    character :: transb 
-                    real(dp) :: a(lda,*) 
-                    real(dp) :: b(ldb,*) 
-                    real(dp) :: c(ldc,*) 
+                    real(dp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
+                    integer(ilp) :: k,lda,ldb,ldc,m,n 
+                    character :: transa,transb 
                end subroutine dgemm
 #else
                module procedure stdlib_dgemm
@@ -277,19 +189,9 @@ module stdlib_linalg_blas
                subroutine sgemm(transa,transb,m,n,k,alpha,a,lda,b,ldb,beta,c,ldc)
                     import sp,dp,qp,ilp,lk 
                     implicit none(type,external) 
-                    real(sp) :: alpha 
-                    real(sp) :: beta 
-                    integer(ilp) :: k 
-                    integer(ilp) :: lda 
-                    integer(ilp) :: ldb 
-                    integer(ilp) :: ldc 
-                    integer(ilp) :: m 
-                    integer(ilp) :: n 
-                    character :: transa 
-                    character :: transb 
-                    real(sp) :: a(lda,*) 
-                    real(sp) :: b(ldb,*) 
-                    real(sp) :: c(ldc,*) 
+                    real(sp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
+                    integer(ilp) :: k,lda,ldb,ldc,m,n 
+                    character :: transa,transb 
                end subroutine sgemm
 #else
                module procedure stdlib_sgemm
@@ -298,19 +200,9 @@ module stdlib_linalg_blas
                subroutine zgemm(transa,transb,m,n,k,alpha,a,lda,b,ldb,beta,c,ldc)
                     import sp,dp,qp,ilp,lk 
                     implicit none(type,external) 
-                    complex(dp) :: alpha 
-                    complex(dp) :: beta 
-                    integer(ilp) :: k 
-                    integer(ilp) :: lda 
-                    integer(ilp) :: ldb 
-                    integer(ilp) :: ldc 
-                    integer(ilp) :: m 
-                    integer(ilp) :: n 
-                    character :: transa 
-                    character :: transb 
-                    complex(dp) :: a(lda,*) 
-                    complex(dp) :: b(ldb,*) 
-                    complex(dp) :: c(ldc,*) 
+                    complex(dp) :: alpha,beta,a(lda,*),b(ldb,*),c(ldc,*) 
+                    integer(ilp) :: k,lda,ldb,ldc,m,n 
+                    character :: transa,transb 
                end subroutine zgemm
 #else
                module procedure stdlib_zgemm
@@ -329,17 +221,9 @@ module stdlib_linalg_blas
                subroutine cgemv(trans,m,n,alpha,a,lda,x,incx,beta,y,incy)
                     import sp,dp,qp,ilp,lk 
                     implicit none(type,external) 
-                    complex(sp) :: alpha 
-                    complex(sp) :: beta 
-                    integer(ilp) :: incx 
-                    integer(ilp) :: incy 
-                    integer(ilp) :: lda 
-                    integer(ilp) :: m 
-                    integer(ilp) :: n 
+                    complex(sp) :: alpha,beta,a(lda,*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,lda,m,n 
                     character :: trans 
-                    complex(sp) :: a(lda,*) 
-                    complex(sp) :: x(*) 
-                    complex(sp) :: y(*) 
                end subroutine cgemv
 #else
                module procedure stdlib_cgemv
@@ -348,17 +232,9 @@ module stdlib_linalg_blas
                subroutine dgemv(trans,m,n,alpha,a,lda,x,incx,beta,y,incy)
                     import sp,dp,qp,ilp,lk 
                     implicit none(type,external) 
-                    real(dp) :: alpha 
-                    real(dp) :: beta 
-                    integer(ilp) :: incx 
-                    integer(ilp) :: incy 
-                    integer(ilp) :: lda 
-                    integer(ilp) :: m 
-                    integer(ilp) :: n 
+                    real(dp) :: alpha,beta,a(lda,*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,lda,m,n 
                     character :: trans 
-                    real(dp) :: a(lda,*) 
-                    real(dp) :: x(*) 
-                    real(dp) :: y(*) 
                end subroutine dgemv
 #else
                module procedure stdlib_dgemv
@@ -367,17 +243,9 @@ module stdlib_linalg_blas
                subroutine sgemv(trans,m,n,alpha,a,lda,x,incx,beta,y,incy)
                     import sp,dp,qp,ilp,lk 
                     implicit none(type,external) 
-                    real(sp) :: alpha 
-                    real(sp) :: beta 
-                    integer(ilp) :: incx 
-                    integer(ilp) :: incy 
-                    integer(ilp) :: lda 
-                    integer(ilp) :: m 
-                    integer(ilp) :: n 
+                    real(sp) :: alpha,beta,a(lda,*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,lda,m,n 
                     character :: trans 
-                    real(sp) :: a(lda,*) 
-                    real(sp) :: x(*) 
-                    real(sp) :: y(*) 
                end subroutine sgemv
 #else
                module procedure stdlib_sgemv
@@ -386,17 +254,9 @@ module stdlib_linalg_blas
                subroutine zgemv(trans,m,n,alpha,a,lda,x,incx,beta,y,incy)
                     import sp,dp,qp,ilp,lk 
                     implicit none(type,external) 
-                    complex(dp) :: alpha 
-                    complex(dp) :: beta 
-                    integer(ilp) :: incx 
-                    integer(ilp) :: incy 
-                    integer(ilp) :: lda 
-                    integer(ilp) :: m 
-                    integer(ilp) :: n 
+                    complex(dp) :: alpha,beta,a(lda,*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,lda,m,n 
                     character :: trans 
-                    complex(dp) :: a(lda,*) 
-                    complex(dp) :: x(*) 
-                    complex(dp) :: y(*) 
                end subroutine zgemv
 #else
                module procedure stdlib_zgemv
@@ -414,15 +274,8 @@ module stdlib_linalg_blas
                subroutine dger(m,n,alpha,x,incx,y,incy,a,lda)
                     import sp,dp,qp,ilp,lk 
                     implicit none(type,external) 
-                    real(dp) :: alpha 
-                    integer(ilp) :: incx 
-                    integer(ilp) :: incy 
-                    integer(ilp) :: lda 
-                    integer(ilp) :: m 
-                    integer(ilp) :: n 
-                    real(dp) :: a(lda,*) 
-                    real(dp) :: x(*) 
-                    real(dp) :: y(*) 
+                    real(dp) :: alpha,a(lda,*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,lda,m,n 
                end subroutine dger
 #else
                module procedure stdlib_dger
@@ -431,15 +284,8 @@ module stdlib_linalg_blas
                subroutine sger(m,n,alpha,x,incx,y,incy,a,lda)
                     import sp,dp,qp,ilp,lk 
                     implicit none(type,external) 
-                    real(sp) :: alpha 
-                    integer(ilp) :: incx 
-                    integer(ilp) :: incy 
-                    integer(ilp) :: lda 
-                    integer(ilp) :: m 
-                    integer(ilp) :: n 
-                    real(sp) :: a(lda,*) 
-                    real(sp) :: x(*) 
-                    real(sp) :: y(*) 
+                    real(sp) :: alpha,a(lda,*),x(*),y(*) 
+                    integer(ilp) :: incx,incy,lda,m,n 
                end subroutine sger
 #else
                module procedure stdlib_sger

--- a/src/stdlib_linalg_blas_c.f90
+++ b/src/stdlib_linalg_blas_c.f90
@@ -2,7 +2,6 @@ module stdlib_linalg_blas_c
      use stdlib_linalg_constants
      use stdlib_linalg_blas_aux
      use stdlib_linalg_blas_s
-     use stdlib_linalg_blas_d
      implicit none(type, external)
      private
 

--- a/src/stdlib_linalg_blas_d.f90
+++ b/src/stdlib_linalg_blas_d.f90
@@ -2,6 +2,7 @@ module stdlib_linalg_blas_d
      use stdlib_linalg_constants
      use stdlib_linalg_blas_aux
      use stdlib_linalg_blas_s
+     use stdlib_linalg_blas_c
      implicit none(type, external)
      private
 

--- a/src/stdlib_linalg_blas_q.f90
+++ b/src/stdlib_linalg_blas_q.f90
@@ -2,6 +2,9 @@ module stdlib_linalg_blas_q
      use stdlib_linalg_constants
      use stdlib_linalg_blas_aux
      use stdlib_linalg_blas_s
+     use stdlib_linalg_blas_c
+     use stdlib_linalg_blas_d
+     use stdlib_linalg_blas_z
      implicit none(type, external)
      private
 
@@ -61,7 +64,7 @@ module stdlib_linalg_blas_q
      ! 128-bit scaling constants
      integer, parameter, private :: maxexp = maxexponent(zero)
      integer, parameter, private :: minexp = minexponent(zero)
-     real(qp), parameter, private :: rradix = real(radix(zero), dp)
+     real(qp), parameter, private :: rradix = real(radix(zero), qp)
      real(qp), parameter, private :: ulp = epsilon(zero)
      real(qp), parameter, private :: eps = ulp*half
      real(qp), parameter, private :: safmin = rradix**max(minexp - 1, 1 - maxexp)
@@ -308,7 +311,7 @@ module stdlib_linalg_blas_q
            ! .. array arguments ..
            real(qp) :: a(lda, *), x(*), y(*)
         ! =====================================================================
-
+           
            ! .. local scalars ..
            real(qp) :: temp
            integer(ilp) :: i, info, ix, iy, j, jx, jy, k, kup1, kx, ky, lenx, leny
@@ -471,7 +474,7 @@ module stdlib_linalg_blas_q
            real(qp) :: temp
            integer(ilp) :: i, info, j, l, nrowa, nrowb
            logical(lk) :: nota, notb
-
+           
            ! set  nota  and  notb  as  true if  a  and  b  respectively are not
            ! transposed and set  nrowa and nrowb  as the number of rows of  a
            ! and  b  respectively.
@@ -626,7 +629,7 @@ module stdlib_linalg_blas_q
            ! .. array arguments ..
            real(qp) :: a(lda, *), x(*), y(*)
         ! =====================================================================
-
+           
            ! .. local scalars ..
            real(qp) :: temp
            integer(ilp) :: i, info, ix, iy, j, jx, jy, kx, ky, lenx, leny
@@ -769,7 +772,7 @@ module stdlib_linalg_blas_q
            ! .. array arguments ..
            real(qp) :: a(lda, *), x(*), y(*)
         ! =====================================================================
-
+           
            ! .. local scalars ..
            real(qp) :: temp
            integer(ilp) :: i, info, ix, j, jy, kx
@@ -1044,10 +1047,10 @@ module stdlib_linalg_blas_q
      ! APPLY THE MODIFIED GIVENS TRANSFORMATION, H, TO THE 2 BY N MATRIX
      ! (DX**T) , WHERE **T INDICATES TRANSPOSE. THE ELEMENTS OF DX ARE IN
      ! (DY**T)
-     ! QX(LX+I*INCX), I = 0 TO N-1, WHERE LX = 1 IF INCX >= 0, ELSE
+     ! DX(LX+I*INCX), I = 0 TO N-1, WHERE LX = 1 IF INCX >= 0, ELSE
      ! LX = (-INCX)*N, AND SIMILARLY FOR SY USING LY AND INCY.
      ! WITH DPARAM(1)=DFLAG, H HAS ONE OF THE FOLLOWING FORMS..
-     ! QFLAG=-1._qp     DFLAG=0._qp        DFLAG=1._qp     DFLAG=-2.D0
+     ! DFLAG=-1._qp     DFLAG=0._qp        DFLAG=1._qp     DFLAG=-2.D0
      ! (DH11  DH12)    (1._qp  DH12)    (DH11  1._qp)    (1._qp  0._qp)
      ! H=(          )    (          )    (          )    (          )
      ! (DH21  DH22),   (DH21  1._qp),   (-1._qp DH22),   (0._qp  1._qp).
@@ -1150,7 +1153,7 @@ module stdlib_linalg_blas_q
      ! CONSTRUCT THE MODIFIED GIVENS TRANSFORMATION MATRIX H WHICH ZEROS
      ! THE SECOND COMPONENT OF THE 2-VECTOR  (SQRT(DD1)*DX1,SQRT(DD2)    DY2)**T.
      ! WITH DPARAM(1)=DFLAG, H HAS ONE OF THE FOLLOWING FORMS..
-     ! QFLAG=-1._qp     DFLAG=0._qp        DFLAG=1._qp     DFLAG=-2.D0
+     ! DFLAG=-1._qp     DFLAG=0._qp        DFLAG=1._qp     DFLAG=-2.D0
      ! (DH11  DH12)    (1._qp  DH12)    (DH11  1._qp)    (1._qp  0._qp)
      ! H=(          )    (          )    (          )    (          )
      ! (DH21  DH22),   (DH21  1._qp),   (-1._qp DH22),   (0._qp  1._qp).
@@ -1325,7 +1328,7 @@ module stdlib_linalg_blas_q
            ! .. array arguments ..
            real(qp) :: a(lda, *), x(*), y(*)
         ! =====================================================================
-
+           
            ! .. local scalars ..
            real(qp) :: temp1, temp2
            integer(ilp) :: i, info, ix, iy, j, jx, jy, kplus1, kx, ky, l
@@ -1532,7 +1535,7 @@ module stdlib_linalg_blas_q
            ! .. scalar arguments ..
            integer(ilp) :: incx, incy, n
            ! .. array arguments ..
-           real(sp) :: sx(*), sy(*)
+           real(dp) :: sx(*), sy(*)
         ! authors:
         ! ========
         ! lawson, c. l., (jpl), hanson, r. j., (snla),
@@ -1582,7 +1585,7 @@ module stdlib_linalg_blas_q
            ! .. array arguments ..
            real(qp) :: ap(*), x(*), y(*)
         ! =====================================================================
-
+           
            ! .. local scalars ..
            real(qp) :: temp1, temp2
            integer(ilp) :: i, info, ix, iy, j, jx, jy, k, kk, kx, ky
@@ -1738,7 +1741,7 @@ module stdlib_linalg_blas_q
            ! .. array arguments ..
            real(qp) :: ap(*), x(*)
         ! =====================================================================
-
+           
            ! .. local scalars ..
            real(qp) :: temp
            integer(ilp) :: i, info, ix, j, jx, k, kk, kx
@@ -1845,7 +1848,7 @@ module stdlib_linalg_blas_q
            ! .. array arguments ..
            real(qp) :: ap(*), x(*), y(*)
         ! =====================================================================
-
+           
            ! .. local scalars ..
            real(qp) :: temp1, temp2
            integer(ilp) :: i, info, ix, iy, j, jx, jy, k, kk, kx, ky
@@ -2041,7 +2044,7 @@ module stdlib_linalg_blas_q
            real(qp) :: temp1, temp2
            integer(ilp) :: i, info, j, k, nrowa
            logical(lk) :: upper
-
+           
            ! set nrowa as the number of rows of a.
            if (stdlib_lsame(side, 'l')) then
                nrowa = m
@@ -2180,7 +2183,7 @@ module stdlib_linalg_blas_q
            ! .. array arguments ..
            real(qp) :: a(lda, *), x(*), y(*)
         ! =====================================================================
-
+           
            ! .. local scalars ..
            real(qp) :: temp1, temp2
            integer(ilp) :: i, info, ix, iy, j, jx, jy, kx, ky
@@ -2332,7 +2335,7 @@ module stdlib_linalg_blas_q
            ! .. array arguments ..
            real(qp) :: a(lda, *), x(*)
         ! =====================================================================
-
+           
            ! .. local scalars ..
            real(qp) :: temp
            integer(ilp) :: i, info, ix, j, jx, kx
@@ -2435,7 +2438,7 @@ module stdlib_linalg_blas_q
            ! .. array arguments ..
            real(qp) :: a(lda, *), x(*), y(*)
         ! =====================================================================
-
+           
            ! .. local scalars ..
            real(qp) :: temp1, temp2
            integer(ilp) :: i, info, ix, iy, j, jx, jy, kx, ky
@@ -2567,7 +2570,7 @@ module stdlib_linalg_blas_q
            real(qp) :: temp1, temp2
            integer(ilp) :: i, info, j, l, nrowa
            logical(lk) :: upper
-
+           
            ! test the input parameters.
            if (stdlib_lsame(trans, 'n')) then
                nrowa = n
@@ -2742,7 +2745,7 @@ module stdlib_linalg_blas_q
            real(qp) :: temp
            integer(ilp) :: i, info, j, l, nrowa
            logical(lk) :: upper
-
+           
            ! test the input parameters.
            if (stdlib_lsame(trans, 'n')) then
                nrowa = n
@@ -2899,7 +2902,7 @@ module stdlib_linalg_blas_q
            ! .. array arguments ..
            real(qp) :: a(lda, *), x(*)
         ! =====================================================================
-
+           
            ! .. local scalars ..
            real(qp) :: temp
            integer(ilp) :: i, info, ix, j, jx, kplus1, kx, l
@@ -3085,7 +3088,7 @@ module stdlib_linalg_blas_q
            ! .. array arguments ..
            real(qp) :: a(lda, *), x(*)
         ! =====================================================================
-
+           
            ! .. local scalars ..
            real(qp) :: temp
            integer(ilp) :: i, info, ix, j, jx, kplus1, kx, l
@@ -3268,7 +3271,7 @@ module stdlib_linalg_blas_q
            ! .. array arguments ..
            real(qp) :: ap(*), x(*)
         ! =====================================================================
-
+           
            ! .. local scalars ..
            real(qp) :: temp
            integer(ilp) :: i, info, ix, j, jx, k, kk, kx
@@ -3452,7 +3455,7 @@ module stdlib_linalg_blas_q
            ! .. array arguments ..
            real(qp) :: ap(*), x(*)
         ! =====================================================================
-
+           
            ! .. local scalars ..
            real(qp) :: temp
            integer(ilp) :: i, info, ix, j, jx, k, kk, kx
@@ -3642,7 +3645,7 @@ module stdlib_linalg_blas_q
            real(qp) :: temp
            integer(ilp) :: i, info, j, k, nrowa
            logical(lk) :: lside, nounit, upper
-
+           
            ! test the input parameters.
            lside = stdlib_lsame(side, 'l')
            if (lside) then
@@ -3840,7 +3843,7 @@ module stdlib_linalg_blas_q
            ! .. array arguments ..
            real(qp) :: a(lda, *), x(*)
         ! =====================================================================
-
+           
            ! .. local scalars ..
            real(qp) :: temp
            integer(ilp) :: i, info, ix, j, jx, kx
@@ -4015,7 +4018,7 @@ module stdlib_linalg_blas_q
            real(qp) :: temp
            integer(ilp) :: i, info, j, k, nrowa
            logical(lk) :: lside, nounit, upper
-
+           
            ! test the input parameters.
            lside = stdlib_lsame(side, 'l')
            if (lside) then
@@ -4239,7 +4242,7 @@ module stdlib_linalg_blas_q
            ! .. array arguments ..
            real(qp) :: a(lda, *), x(*)
         ! =====================================================================
-
+           
            ! .. local scalars ..
            real(qp) :: temp
            integer(ilp) :: i, info, ix, j, jx, kx

--- a/src/stdlib_linalg_blas_w.f90
+++ b/src/stdlib_linalg_blas_w.f90
@@ -2,8 +2,10 @@ module stdlib_linalg_blas_w
      use stdlib_linalg_constants
      use stdlib_linalg_blas_aux
      use stdlib_linalg_blas_s
-     use stdlib_linalg_blas_q
      use stdlib_linalg_blas_c
+     use stdlib_linalg_blas_d
+     use stdlib_linalg_blas_z
+     use stdlib_linalg_blas_q
      implicit none(type, external)
      private
 
@@ -62,7 +64,7 @@ module stdlib_linalg_blas_w
      ! 128-bit scaling constants
      integer, parameter, private :: maxexp = maxexponent(zero)
      integer, parameter, private :: minexp = minexponent(zero)
-     real(qp), parameter, private :: rradix = real(radix(zero), dp)
+     real(qp), parameter, private :: rradix = real(radix(zero), qp)
      real(qp), parameter, private :: ulp = epsilon(zero)
      real(qp), parameter, private :: eps = ulp*half
      real(qp), parameter, private :: safmin = rradix**max(minexp - 1, 1 - maxexp)
@@ -334,7 +336,7 @@ module stdlib_linalg_blas_w
            ! .. array arguments ..
            complex(qp) :: a(lda, *), x(*), y(*)
         ! =====================================================================
-
+           
            ! .. local scalars ..
            complex(qp) :: temp
            integer(ilp) :: i, info, ix, iy, j, jx, jy, k, kup1, kx, ky, lenx, leny
@@ -512,7 +514,7 @@ module stdlib_linalg_blas_w
            complex(qp) :: temp
            integer(ilp) :: i, info, j, l, nrowa, nrowb
            logical(lk) :: conja, conjb, nota, notb
-
+           
            ! set  nota  and  notb  as  true if  a  and  b  respectively are not
            ! conjugated or transposed, set  conja and conjb  as true if  a  and
            ! b  respectively are to be  transposed but  not conjugated  and set
@@ -753,7 +755,7 @@ module stdlib_linalg_blas_w
            ! .. array arguments ..
            complex(qp) :: a(lda, *), x(*), y(*)
         ! =====================================================================
-
+           
            ! .. local scalars ..
            complex(qp) :: temp
            integer(ilp) :: i, info, ix, iy, j, jx, jy, kx, ky, lenx, leny
@@ -911,7 +913,7 @@ module stdlib_linalg_blas_w
            ! .. array arguments ..
            complex(qp) :: a(lda, *), x(*), y(*)
         ! =====================================================================
-
+           
            ! .. local scalars ..
            complex(qp) :: temp
            integer(ilp) :: i, info, ix, j, jy, kx
@@ -990,7 +992,7 @@ module stdlib_linalg_blas_w
            ! .. array arguments ..
            complex(qp) :: a(lda, *), x(*), y(*)
         ! =====================================================================
-
+           
            ! .. local scalars ..
            complex(qp) :: temp
            integer(ilp) :: i, info, ix, j, jy, kx
@@ -1070,7 +1072,7 @@ module stdlib_linalg_blas_w
            ! .. array arguments ..
            complex(qp) :: a(lda, *), x(*), y(*)
         ! =====================================================================
-
+           
            ! .. local scalars ..
            complex(qp) :: temp1, temp2
            integer(ilp) :: i, info, ix, iy, j, jx, jy, kplus1, kx, ky, l
@@ -1240,7 +1242,7 @@ module stdlib_linalg_blas_w
            complex(qp) :: temp1, temp2
            integer(ilp) :: i, info, j, k, nrowa
            logical(lk) :: upper
-
+           
            ! set nrowa as the number of rows of a.
            if (stdlib_lsame(side, 'l')) then
                nrowa = m
@@ -1381,7 +1383,7 @@ module stdlib_linalg_blas_w
            ! .. array arguments ..
            complex(qp) :: a(lda, *), x(*), y(*)
         ! =====================================================================
-
+           
            ! .. local scalars ..
            complex(qp) :: temp1, temp2
            integer(ilp) :: i, info, ix, iy, j, jx, jy, kx, ky
@@ -1533,7 +1535,7 @@ module stdlib_linalg_blas_w
            ! .. array arguments ..
            complex(qp) :: a(lda, *), x(*)
         ! =====================================================================
-
+           
            ! .. local scalars ..
            complex(qp) :: temp
            integer(ilp) :: i, info, ix, j, jx, kx
@@ -1648,7 +1650,7 @@ module stdlib_linalg_blas_w
            ! .. array arguments ..
            complex(qp) :: a(lda, *), x(*), y(*)
         ! =====================================================================
-
+           
            ! .. local scalars ..
            complex(qp) :: temp1, temp2
            integer(ilp) :: i, info, ix, iy, j, jx, jy, kx, ky
@@ -1703,7 +1705,7 @@ module stdlib_linalg_blas_w
                                a(i, j) = a(i, j) + x(i)*temp1 + y(i)*temp2
                            end do
                            a(j, j) = real(a(j, j), KIND=qp) + real(x(j)*temp1 + y(j)*temp2, KIND=qp)
-
+                                     
                        else
                            a(j, j) = real(a(j, j), KIND=qp)
                        end if
@@ -1721,7 +1723,7 @@ module stdlib_linalg_blas_w
                                iy = iy + incy
                            end do
                            a(j, j) = real(a(j, j), KIND=qp) + real(x(jx)*temp1 + y(jy)*temp2, KIND=qp)
-
+                                     
                        else
                            a(j, j) = real(a(j, j), KIND=qp)
                        end if
@@ -1737,7 +1739,7 @@ module stdlib_linalg_blas_w
                            temp1 = alpha*conjg(y(j))
                            temp2 = conjg(alpha*x(j))
                            a(j, j) = real(a(j, j), KIND=qp) + real(x(j)*temp1 + y(j)*temp2, KIND=qp)
-
+                                     
                            do i = j + 1, n
                                a(i, j) = a(i, j) + x(i)*temp1 + y(i)*temp2
                            end do
@@ -1751,7 +1753,7 @@ module stdlib_linalg_blas_w
                            temp1 = alpha*conjg(y(jy))
                            temp2 = conjg(alpha*x(jx))
                            a(j, j) = real(a(j, j), KIND=qp) + real(x(jx)*temp1 + y(jy)*temp2, KIND=qp)
-
+                                     
                            ix = jx
                            iy = jy
                            do i = j + 1, n
@@ -1797,7 +1799,7 @@ module stdlib_linalg_blas_w
            complex(qp) :: temp1, temp2
            integer(ilp) :: i, info, j, l, nrowa
            logical(lk) :: upper
-
+           
            ! test the input parameters.
            if (stdlib_lsame(trans, 'n')) then
                nrowa = n
@@ -2005,7 +2007,7 @@ module stdlib_linalg_blas_w
            real(qp) :: rtemp
            integer(ilp) :: i, info, j, l, nrowa
            logical(lk) :: upper
-
+           
            ! test the input parameters.
            if (stdlib_lsame(trans, 'n')) then
                nrowa = n
@@ -2191,7 +2193,7 @@ module stdlib_linalg_blas_w
            ! .. array arguments ..
            complex(qp) :: ap(*), x(*), y(*)
         ! =====================================================================
-
+           
            ! .. local scalars ..
            complex(qp) :: temp1, temp2
            integer(ilp) :: i, info, ix, iy, j, jx, jy, k, kk, kx, ky
@@ -2349,7 +2351,7 @@ module stdlib_linalg_blas_w
            ! .. array arguments ..
            complex(qp) :: ap(*), x(*)
         ! =====================================================================
-
+           
            ! .. local scalars ..
            complex(qp) :: temp
            integer(ilp) :: i, info, ix, j, jx, k, kk, kx
@@ -2407,7 +2409,7 @@ module stdlib_linalg_blas_w
                                ix = ix + incx
                            end do
                            ap(kk + j - 1) = real(ap(kk + j - 1), KIND=qp) + real(x(jx)*temp, KIND=qp)
-
+                                     
                        else
                            ap(kk + j - 1) = real(ap(kk + j - 1), KIND=qp)
                        end if
@@ -2471,7 +2473,7 @@ module stdlib_linalg_blas_w
            ! .. array arguments ..
            complex(qp) :: ap(*), x(*), y(*)
         ! =====================================================================
-
+           
            ! .. local scalars ..
            complex(qp) :: temp1, temp2
            integer(ilp) :: i, info, ix, iy, j, jx, jy, k, kk, kx, ky
@@ -2562,7 +2564,7 @@ module stdlib_linalg_blas_w
                            temp1 = alpha*conjg(y(j))
                            temp2 = conjg(alpha*x(j))
                            ap(kk) = real(ap(kk), KIND=qp) + real(x(j)*temp1 + y(j)*temp2, KIND=qp)
-
+                                     
                            k = kk + 1
                            do i = j + 1, n
                                ap(k) = ap(k) + x(i)*temp1 + y(i)*temp2
@@ -2579,7 +2581,7 @@ module stdlib_linalg_blas_w
                            temp1 = alpha*conjg(y(jy))
                            temp2 = conjg(alpha*x(jx))
                            ap(kk) = real(ap(kk), KIND=qp) + real(x(jx)*temp1 + y(jy)*temp2, KIND=qp)
-
+                                     
                            ix = jx
                            iy = jy
                            do k = kk + 1, kk + n - j
@@ -2821,7 +2823,7 @@ module stdlib_linalg_blas_w
            complex(qp) :: temp1, temp2
            integer(ilp) :: i, info, j, k, nrowa
            logical(lk) :: upper
-
+           
            ! set nrowa as the number of rows of a.
            if (stdlib_lsame(side, 'l')) then
                nrowa = m
@@ -2969,7 +2971,7 @@ module stdlib_linalg_blas_w
            complex(qp) :: temp1, temp2
            integer(ilp) :: i, info, j, l, nrowa
            logical(lk) :: upper
-
+           
            ! test the input parameters.
            if (stdlib_lsame(trans, 'n')) then
                nrowa = n
@@ -3144,7 +3146,7 @@ module stdlib_linalg_blas_w
            complex(qp) :: temp
            integer(ilp) :: i, info, j, l, nrowa
            logical(lk) :: upper
-
+           
            ! test the input parameters.
            if (stdlib_lsame(trans, 'n')) then
                nrowa = n
@@ -3301,7 +3303,7 @@ module stdlib_linalg_blas_w
            ! .. array arguments ..
            complex(qp) :: a(lda, *), x(*)
         ! =====================================================================
-
+           
            ! .. local scalars ..
            complex(qp) :: temp
            integer(ilp) :: i, info, ix, j, jx, kplus1, kx, l
@@ -3518,7 +3520,7 @@ module stdlib_linalg_blas_w
            ! .. array arguments ..
            complex(qp) :: a(lda, *), x(*)
         ! =====================================================================
-
+           
            ! .. local scalars ..
            complex(qp) :: temp
            integer(ilp) :: i, info, ix, j, jx, kplus1, kx, l
@@ -3732,7 +3734,7 @@ module stdlib_linalg_blas_w
            ! .. array arguments ..
            complex(qp) :: ap(*), x(*)
         ! =====================================================================
-
+           
            ! .. local scalars ..
            complex(qp) :: temp
            integer(ilp) :: i, info, ix, j, jx, k, kk, kx
@@ -3951,7 +3953,7 @@ module stdlib_linalg_blas_w
            ! .. array arguments ..
            complex(qp) :: ap(*), x(*)
         ! =====================================================================
-
+           
            ! .. local scalars ..
            complex(qp) :: temp
            integer(ilp) :: i, info, ix, j, jx, k, kk, kx
@@ -4176,7 +4178,7 @@ module stdlib_linalg_blas_w
            complex(qp) :: temp
            integer(ilp) :: i, info, j, k, nrowa
            logical(lk) :: lside, noconj, nounit, upper
-
+           
            ! test the input parameters.
            lside = stdlib_lsame(side, 'l')
            if (lside) then
@@ -4409,7 +4411,7 @@ module stdlib_linalg_blas_w
            ! .. array arguments ..
            complex(qp) :: a(lda, *), x(*)
         ! =====================================================================
-
+           
            ! .. local scalars ..
            complex(qp) :: temp
            integer(ilp) :: i, info, ix, j, jx, kx
@@ -4615,7 +4617,7 @@ module stdlib_linalg_blas_w
            complex(qp) :: temp
            integer(ilp) :: i, info, j, k, nrowa
            logical(lk) :: lside, noconj, nounit, upper
-
+           
            ! test the input parameters.
            lside = stdlib_lsame(side, 'l')
            if (lside) then
@@ -4872,7 +4874,7 @@ module stdlib_linalg_blas_w
            ! .. array arguments ..
            complex(qp) :: a(lda, *), x(*)
         ! =====================================================================
-
+           
            ! .. local scalars ..
            complex(qp) :: temp
            integer(ilp) :: i, info, ix, j, jx, kx

--- a/src/stdlib_linalg_blas_z.f90
+++ b/src/stdlib_linalg_blas_z.f90
@@ -2,8 +2,8 @@ module stdlib_linalg_blas_z
      use stdlib_linalg_constants
      use stdlib_linalg_blas_aux
      use stdlib_linalg_blas_s
-     use stdlib_linalg_blas_d
      use stdlib_linalg_blas_c
+     use stdlib_linalg_blas_d
      implicit none(type, external)
      private
 


### PR DESCRIPTION
- [x] Merge all routines with the same function in the same interface. e.g., `sgemv`, `dgemv`, `cgemv`, `zgemv` -> `gemv`
- [x] employ external BLAS subroutine interface, or internal `module procedure`, depending on `STDLIB_EXTERNAL_BLAS` preprocessor macro
- [x] read all arguments and check their types (both `subroutine`s and `function`s) 
- [x] add header comments on top of each interface 
- [x] resolve some differences between real and complex cases (e.g., `dot` has `cdotu` for vector-vector dot product, and `cdotc` for operation with the complex conjugate) 
- [x] Add quad-precision routines to the interface (all functions)


Comments

- For complex interfaces that use either the direct number or the complex conjugate (e.g., `dotu` and `doth`), I think they're better not mixed with the real number interfaces.

