### PR TITLE
Identity and diagonal matrix input: `eye`, `diag`

### DIFF
--- a/scripts/preprocess.sh
+++ b/scripts/preprocess.sh
@@ -3,7 +3,7 @@
 #
 # preprocess linear algebra sources with fypp
 #
-declare -a linalg_sources=("solve" "inverse" "least_squares" "determinant")
+declare -a linalg_sources=("solve" "inverse" "least_squares" "determinant" "eye")
 
 declare -a operations=("src" "test")
 declare -a oper_prefix=("stdlib" "test")

--- a/src/stdlib_linalg_eye.f90
+++ b/src/stdlib_linalg_eye.f90
@@ -11,13 +11,14 @@ module stdlib_linalg_eye
 
      !> Function interface
      public :: eye
+     public :: diag
 
      ! Numpy: eye(N, M=None, k=0, dtype=<class 'float'>, order='C', *, device=None, like=None)
      ! Numpy: identity(n, dtype=None, *, like=None) --> square matrices only
      ! Scipy: eye(m, n=None, k=0, dtype=<class 'float'>, format=None) --> sparse only
      ! IMSL:  EYE(N)
 
-     ! Function interface
+     ! Identity interface
      interface eye
         module procedure stdlib_linalg_eye_s
         module procedure stdlib_linalg_eye_d
@@ -26,6 +27,22 @@ module stdlib_linalg_eye
         module procedure stdlib_linalg_eye_z
         module procedure stdlib_linalg_eye_w
      end interface eye
+
+     ! Diagonal matrix interface
+     interface diag
+        module procedure stdlib_linalg_diag_s_from_scalar
+        module procedure stdlib_linalg_diag_s_from_array
+        module procedure stdlib_linalg_diag_d_from_scalar
+        module procedure stdlib_linalg_diag_d_from_array
+        module procedure stdlib_linalg_diag_q_from_scalar
+        module procedure stdlib_linalg_diag_q_from_array
+        module procedure stdlib_linalg_diag_c_from_scalar
+        module procedure stdlib_linalg_diag_c_from_array
+        module procedure stdlib_linalg_diag_z_from_scalar
+        module procedure stdlib_linalg_diag_z_from_array
+        module procedure stdlib_linalg_diag_w_from_scalar
+        module procedure stdlib_linalg_diag_w_from_array
+     end interface diag
 
      contains
 
@@ -310,5 +327,509 @@ module stdlib_linalg_eye
 1        call linalg_error_handling(err0,err)
 
      end function stdlib_linalg_eye_w
+
+     ! Return square diagonal matrix with diagonal values equal to the input scalar
+     function stdlib_linalg_diag_s_from_scalar(n,dvalue,err) result(diag)
+         !> Matrix size
+         integer(ilp),intent(in) :: n
+         !> Scalar diagonal value. Used to define the return type.
+         real(sp),intent(in) :: dvalue
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+         !> Return matrix
+         real(sp),allocatable :: diag(:,:)
+
+         !> Local variables
+         integer(ilp) :: i,j
+         type(linalg_state) :: err0
+         character(*),parameter :: this = 'diag::scalar'
+
+         !> Check size
+         if (.not. n >= 0) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid diagonal size: diag[',n,',',n,']')
+            goto 1
+         end if
+
+         ! Allocate array
+         allocate (diag(n,n))
+
+         !> Empty matrix
+         if (n <= 0) return
+
+         !> Fill data
+         do concurrent(i=1:n,j=1:n)
+            if (i == j) then
+               diag(i,j) = dvalue
+            else
+               diag(i,j) = 0.0_sp
+            end if
+         end do
+
+         ! Process output and return
+1        call linalg_error_handling(err0,err)
+
+     end function stdlib_linalg_diag_s_from_scalar
+
+     ! Construct square diagonal matrix from an array of diagonal values
+     function stdlib_linalg_diag_s_from_array(dvalues,err) result(diag)
+         !> Array of diagonal values. Used to define the return type and the matrix size.
+         real(sp),intent(in) :: dvalues(:)
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+         !> Return matrix
+         real(sp),allocatable :: diag(:,:)
+
+         !> Local variables
+         integer(ilp) :: i,j,n
+         type(linalg_state) :: err0
+         character(*),parameter :: this = 'diag::array'
+
+         n = size(dvalues,kind=ilp)
+
+         !> Check size
+         if (.not. n >= 0) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid input array size: diag[',n,',',n,']')
+            goto 1
+         end if
+
+         ! Allocate array
+         allocate (diag(n,n))
+
+         !> Empty matrix
+         if (n <= 0) return
+
+         !> Fill data
+         do concurrent(i=1:n,j=1:n)
+            if (i == j) then
+               diag(i,j) = dvalues(i)
+            else
+               diag(i,j) = 0.0_sp
+            end if
+         end do
+
+         ! Process output and return
+1        call linalg_error_handling(err0,err)
+
+     end function stdlib_linalg_diag_s_from_array
+
+     ! Return square diagonal matrix with diagonal values equal to the input scalar
+     function stdlib_linalg_diag_d_from_scalar(n,dvalue,err) result(diag)
+         !> Matrix size
+         integer(ilp),intent(in) :: n
+         !> Scalar diagonal value. Used to define the return type.
+         real(dp),intent(in) :: dvalue
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+         !> Return matrix
+         real(dp),allocatable :: diag(:,:)
+
+         !> Local variables
+         integer(ilp) :: i,j
+         type(linalg_state) :: err0
+         character(*),parameter :: this = 'diag::scalar'
+
+         !> Check size
+         if (.not. n >= 0) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid diagonal size: diag[',n,',',n,']')
+            goto 1
+         end if
+
+         ! Allocate array
+         allocate (diag(n,n))
+
+         !> Empty matrix
+         if (n <= 0) return
+
+         !> Fill data
+         do concurrent(i=1:n,j=1:n)
+            if (i == j) then
+               diag(i,j) = dvalue
+            else
+               diag(i,j) = 0.0_dp
+            end if
+         end do
+
+         ! Process output and return
+1        call linalg_error_handling(err0,err)
+
+     end function stdlib_linalg_diag_d_from_scalar
+
+     ! Construct square diagonal matrix from an array of diagonal values
+     function stdlib_linalg_diag_d_from_array(dvalues,err) result(diag)
+         !> Array of diagonal values. Used to define the return type and the matrix size.
+         real(dp),intent(in) :: dvalues(:)
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+         !> Return matrix
+         real(dp),allocatable :: diag(:,:)
+
+         !> Local variables
+         integer(ilp) :: i,j,n
+         type(linalg_state) :: err0
+         character(*),parameter :: this = 'diag::array'
+
+         n = size(dvalues,kind=ilp)
+
+         !> Check size
+         if (.not. n >= 0) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid input array size: diag[',n,',',n,']')
+            goto 1
+         end if
+
+         ! Allocate array
+         allocate (diag(n,n))
+
+         !> Empty matrix
+         if (n <= 0) return
+
+         !> Fill data
+         do concurrent(i=1:n,j=1:n)
+            if (i == j) then
+               diag(i,j) = dvalues(i)
+            else
+               diag(i,j) = 0.0_dp
+            end if
+         end do
+
+         ! Process output and return
+1        call linalg_error_handling(err0,err)
+
+     end function stdlib_linalg_diag_d_from_array
+
+     ! Return square diagonal matrix with diagonal values equal to the input scalar
+     function stdlib_linalg_diag_q_from_scalar(n,dvalue,err) result(diag)
+         !> Matrix size
+         integer(ilp),intent(in) :: n
+         !> Scalar diagonal value. Used to define the return type.
+         real(qp),intent(in) :: dvalue
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+         !> Return matrix
+         real(qp),allocatable :: diag(:,:)
+
+         !> Local variables
+         integer(ilp) :: i,j
+         type(linalg_state) :: err0
+         character(*),parameter :: this = 'diag::scalar'
+
+         !> Check size
+         if (.not. n >= 0) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid diagonal size: diag[',n,',',n,']')
+            goto 1
+         end if
+
+         ! Allocate array
+         allocate (diag(n,n))
+
+         !> Empty matrix
+         if (n <= 0) return
+
+         !> Fill data
+         do concurrent(i=1:n,j=1:n)
+            if (i == j) then
+               diag(i,j) = dvalue
+            else
+               diag(i,j) = 0.0_qp
+            end if
+         end do
+
+         ! Process output and return
+1        call linalg_error_handling(err0,err)
+
+     end function stdlib_linalg_diag_q_from_scalar
+
+     ! Construct square diagonal matrix from an array of diagonal values
+     function stdlib_linalg_diag_q_from_array(dvalues,err) result(diag)
+         !> Array of diagonal values. Used to define the return type and the matrix size.
+         real(qp),intent(in) :: dvalues(:)
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+         !> Return matrix
+         real(qp),allocatable :: diag(:,:)
+
+         !> Local variables
+         integer(ilp) :: i,j,n
+         type(linalg_state) :: err0
+         character(*),parameter :: this = 'diag::array'
+
+         n = size(dvalues,kind=ilp)
+
+         !> Check size
+         if (.not. n >= 0) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid input array size: diag[',n,',',n,']')
+            goto 1
+         end if
+
+         ! Allocate array
+         allocate (diag(n,n))
+
+         !> Empty matrix
+         if (n <= 0) return
+
+         !> Fill data
+         do concurrent(i=1:n,j=1:n)
+            if (i == j) then
+               diag(i,j) = dvalues(i)
+            else
+               diag(i,j) = 0.0_qp
+            end if
+         end do
+
+         ! Process output and return
+1        call linalg_error_handling(err0,err)
+
+     end function stdlib_linalg_diag_q_from_array
+
+     ! Return square diagonal matrix with diagonal values equal to the input scalar
+     function stdlib_linalg_diag_c_from_scalar(n,dvalue,err) result(diag)
+         !> Matrix size
+         integer(ilp),intent(in) :: n
+         !> Scalar diagonal value. Used to define the return type.
+         complex(sp),intent(in) :: dvalue
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+         !> Return matrix
+         complex(sp),allocatable :: diag(:,:)
+
+         !> Local variables
+         integer(ilp) :: i,j
+         type(linalg_state) :: err0
+         character(*),parameter :: this = 'diag::scalar'
+
+         !> Check size
+         if (.not. n >= 0) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid diagonal size: diag[',n,',',n,']')
+            goto 1
+         end if
+
+         ! Allocate array
+         allocate (diag(n,n))
+
+         !> Empty matrix
+         if (n <= 0) return
+
+         !> Fill data
+         do concurrent(i=1:n,j=1:n)
+            if (i == j) then
+               diag(i,j) = dvalue
+            else
+               diag(i,j) = 0.0_sp
+            end if
+         end do
+
+         ! Process output and return
+1        call linalg_error_handling(err0,err)
+
+     end function stdlib_linalg_diag_c_from_scalar
+
+     ! Construct square diagonal matrix from an array of diagonal values
+     function stdlib_linalg_diag_c_from_array(dvalues,err) result(diag)
+         !> Array of diagonal values. Used to define the return type and the matrix size.
+         complex(sp),intent(in) :: dvalues(:)
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+         !> Return matrix
+         complex(sp),allocatable :: diag(:,:)
+
+         !> Local variables
+         integer(ilp) :: i,j,n
+         type(linalg_state) :: err0
+         character(*),parameter :: this = 'diag::array'
+
+         n = size(dvalues,kind=ilp)
+
+         !> Check size
+         if (.not. n >= 0) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid input array size: diag[',n,',',n,']')
+            goto 1
+         end if
+
+         ! Allocate array
+         allocate (diag(n,n))
+
+         !> Empty matrix
+         if (n <= 0) return
+
+         !> Fill data
+         do concurrent(i=1:n,j=1:n)
+            if (i == j) then
+               diag(i,j) = dvalues(i)
+            else
+               diag(i,j) = 0.0_sp
+            end if
+         end do
+
+         ! Process output and return
+1        call linalg_error_handling(err0,err)
+
+     end function stdlib_linalg_diag_c_from_array
+
+     ! Return square diagonal matrix with diagonal values equal to the input scalar
+     function stdlib_linalg_diag_z_from_scalar(n,dvalue,err) result(diag)
+         !> Matrix size
+         integer(ilp),intent(in) :: n
+         !> Scalar diagonal value. Used to define the return type.
+         complex(dp),intent(in) :: dvalue
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+         !> Return matrix
+         complex(dp),allocatable :: diag(:,:)
+
+         !> Local variables
+         integer(ilp) :: i,j
+         type(linalg_state) :: err0
+         character(*),parameter :: this = 'diag::scalar'
+
+         !> Check size
+         if (.not. n >= 0) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid diagonal size: diag[',n,',',n,']')
+            goto 1
+         end if
+
+         ! Allocate array
+         allocate (diag(n,n))
+
+         !> Empty matrix
+         if (n <= 0) return
+
+         !> Fill data
+         do concurrent(i=1:n,j=1:n)
+            if (i == j) then
+               diag(i,j) = dvalue
+            else
+               diag(i,j) = 0.0_dp
+            end if
+         end do
+
+         ! Process output and return
+1        call linalg_error_handling(err0,err)
+
+     end function stdlib_linalg_diag_z_from_scalar
+
+     ! Construct square diagonal matrix from an array of diagonal values
+     function stdlib_linalg_diag_z_from_array(dvalues,err) result(diag)
+         !> Array of diagonal values. Used to define the return type and the matrix size.
+         complex(dp),intent(in) :: dvalues(:)
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+         !> Return matrix
+         complex(dp),allocatable :: diag(:,:)
+
+         !> Local variables
+         integer(ilp) :: i,j,n
+         type(linalg_state) :: err0
+         character(*),parameter :: this = 'diag::array'
+
+         n = size(dvalues,kind=ilp)
+
+         !> Check size
+         if (.not. n >= 0) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid input array size: diag[',n,',',n,']')
+            goto 1
+         end if
+
+         ! Allocate array
+         allocate (diag(n,n))
+
+         !> Empty matrix
+         if (n <= 0) return
+
+         !> Fill data
+         do concurrent(i=1:n,j=1:n)
+            if (i == j) then
+               diag(i,j) = dvalues(i)
+            else
+               diag(i,j) = 0.0_dp
+            end if
+         end do
+
+         ! Process output and return
+1        call linalg_error_handling(err0,err)
+
+     end function stdlib_linalg_diag_z_from_array
+
+     ! Return square diagonal matrix with diagonal values equal to the input scalar
+     function stdlib_linalg_diag_w_from_scalar(n,dvalue,err) result(diag)
+         !> Matrix size
+         integer(ilp),intent(in) :: n
+         !> Scalar diagonal value. Used to define the return type.
+         complex(qp),intent(in) :: dvalue
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+         !> Return matrix
+         complex(qp),allocatable :: diag(:,:)
+
+         !> Local variables
+         integer(ilp) :: i,j
+         type(linalg_state) :: err0
+         character(*),parameter :: this = 'diag::scalar'
+
+         !> Check size
+         if (.not. n >= 0) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid diagonal size: diag[',n,',',n,']')
+            goto 1
+         end if
+
+         ! Allocate array
+         allocate (diag(n,n))
+
+         !> Empty matrix
+         if (n <= 0) return
+
+         !> Fill data
+         do concurrent(i=1:n,j=1:n)
+            if (i == j) then
+               diag(i,j) = dvalue
+            else
+               diag(i,j) = 0.0_qp
+            end if
+         end do
+
+         ! Process output and return
+1        call linalg_error_handling(err0,err)
+
+     end function stdlib_linalg_diag_w_from_scalar
+
+     ! Construct square diagonal matrix from an array of diagonal values
+     function stdlib_linalg_diag_w_from_array(dvalues,err) result(diag)
+         !> Array of diagonal values. Used to define the return type and the matrix size.
+         complex(qp),intent(in) :: dvalues(:)
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+         !> Return matrix
+         complex(qp),allocatable :: diag(:,:)
+
+         !> Local variables
+         integer(ilp) :: i,j,n
+         type(linalg_state) :: err0
+         character(*),parameter :: this = 'diag::array'
+
+         n = size(dvalues,kind=ilp)
+
+         !> Check size
+         if (.not. n >= 0) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid input array size: diag[',n,',',n,']')
+            goto 1
+         end if
+
+         ! Allocate array
+         allocate (diag(n,n))
+
+         !> Empty matrix
+         if (n <= 0) return
+
+         !> Fill data
+         do concurrent(i=1:n,j=1:n)
+            if (i == j) then
+               diag(i,j) = dvalues(i)
+            else
+               diag(i,j) = 0.0_qp
+            end if
+         end do
+
+         ! Process output and return
+1        call linalg_error_handling(err0,err)
+
+     end function stdlib_linalg_diag_w_from_array
 
 end module stdlib_linalg_eye

--- a/src/stdlib_linalg_eye.f90
+++ b/src/stdlib_linalg_eye.f90
@@ -1,0 +1,314 @@
+
+! Return a 2-D matrix with ones on the diagonal and zeros everywhere else
+module stdlib_linalg_eye
+     use stdlib_linalg_constants
+     use stdlib_linalg_blas
+     use stdlib_linalg_lapack
+     use stdlib_linalg_state
+     use iso_fortran_env,only:real32,real64,real128,int8,int16,int32,int64,stderr => error_unit
+     implicit none(type,external)
+     private
+
+     !> Function interface
+     public :: eye
+
+     ! Numpy: eye(N, M=None, k=0, dtype=<class 'float'>, order='C', *, device=None, like=None)
+     ! Numpy: identity(n, dtype=None, *, like=None) --> square matrices only
+     ! Scipy: eye(m, n=None, k=0, dtype=<class 'float'>, format=None) --> sparse only
+     ! IMSL:  EYE(N)
+
+     ! Function interface
+     interface eye
+        module procedure stdlib_linalg_eye_s
+        module procedure stdlib_linalg_eye_d
+        module procedure stdlib_linalg_eye_q
+        module procedure stdlib_linalg_eye_c
+        module procedure stdlib_linalg_eye_z
+        module procedure stdlib_linalg_eye_w
+     end interface eye
+
+     contains
+
+     ! Return diagonal eye matrix of size N
+     function stdlib_linalg_eye_s(m,n,dtype,err) result(eye)
+         !> Number of rows
+         integer(ilp),intent(in) :: m
+         !> Number of columns (optional)
+         integer(ilp),optional,intent(in) :: n
+         !> Datatype. Used to define the return type. Defaults to real(real64)
+         real(sp),intent(in) :: dtype
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+         !> Return matrix
+         real(sp),allocatable :: eye(:,:)
+
+         !> Local variables
+         integer(ilp) :: cols
+         type(linalg_state) :: err0
+         character(*),parameter :: this = 'eye'
+
+         !> Determine number of columns
+         if (present(n)) then
+            cols = n
+         else
+            cols = m
+         end if
+
+         !> Check size
+         if (.not. min(m,n) >= 0) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid eye size: eye[',m,',',n,']')
+            goto 1
+         end if
+
+         ! Allocate array
+         allocate (eye(m,n))
+
+         !> Empty matrix
+         if (min(m,n) <= 0) return
+
+         !> Fill data
+         do concurrent(i=1:n,j=1:n)
+            eye(i,j) = merge(1.0_sp,0.0_sp,i == j)
+         end do
+
+         ! Process output and return
+1        call linalg_error_handling(err0,err)
+
+     end function stdlib_linalg_eye_s
+
+     ! Return diagonal eye matrix of size N
+     function stdlib_linalg_eye_d(m,n,dtype,err) result(eye)
+         !> Number of rows
+         integer(ilp),intent(in) :: m
+         !> Number of columns (optional)
+         integer(ilp),optional,intent(in) :: n
+         !> Datatype. Used to define the return type. Defaults to real(real64)
+         real(dp),optional,intent(in) :: dtype
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+         !> Return matrix
+         real(dp),allocatable :: eye(:,:)
+
+         !> Local variables
+         integer(ilp) :: cols
+         type(linalg_state) :: err0
+         character(*),parameter :: this = 'eye'
+
+         !> Determine number of columns
+         if (present(n)) then
+            cols = n
+         else
+            cols = m
+         end if
+
+         !> Check size
+         if (.not. min(m,n) >= 0) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid eye size: eye[',m,',',n,']')
+            goto 1
+         end if
+
+         ! Allocate array
+         allocate (eye(m,n))
+
+         !> Empty matrix
+         if (min(m,n) <= 0) return
+
+         !> Fill data
+         do concurrent(i=1:n,j=1:n)
+            eye(i,j) = merge(1.0_dp,0.0_dp,i == j)
+         end do
+
+         ! Process output and return
+1        call linalg_error_handling(err0,err)
+
+     end function stdlib_linalg_eye_d
+
+     ! Return diagonal eye matrix of size N
+     function stdlib_linalg_eye_q(m,n,dtype,err) result(eye)
+         !> Number of rows
+         integer(ilp),intent(in) :: m
+         !> Number of columns (optional)
+         integer(ilp),optional,intent(in) :: n
+         !> Datatype. Used to define the return type. Defaults to real(real64)
+         real(qp),intent(in) :: dtype
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+         !> Return matrix
+         real(qp),allocatable :: eye(:,:)
+
+         !> Local variables
+         integer(ilp) :: cols
+         type(linalg_state) :: err0
+         character(*),parameter :: this = 'eye'
+
+         !> Determine number of columns
+         if (present(n)) then
+            cols = n
+         else
+            cols = m
+         end if
+
+         !> Check size
+         if (.not. min(m,n) >= 0) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid eye size: eye[',m,',',n,']')
+            goto 1
+         end if
+
+         ! Allocate array
+         allocate (eye(m,n))
+
+         !> Empty matrix
+         if (min(m,n) <= 0) return
+
+         !> Fill data
+         do concurrent(i=1:n,j=1:n)
+            eye(i,j) = merge(1.0_qp,0.0_qp,i == j)
+         end do
+
+         ! Process output and return
+1        call linalg_error_handling(err0,err)
+
+     end function stdlib_linalg_eye_q
+
+     ! Return diagonal eye matrix of size N
+     function stdlib_linalg_eye_c(m,n,dtype,err) result(eye)
+         !> Number of rows
+         integer(ilp),intent(in) :: m
+         !> Number of columns (optional)
+         integer(ilp),optional,intent(in) :: n
+         !> Datatype. Used to define the return type. Defaults to real(real64)
+         complex(sp),intent(in) :: dtype
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+         !> Return matrix
+         complex(sp),allocatable :: eye(:,:)
+
+         !> Local variables
+         integer(ilp) :: cols
+         type(linalg_state) :: err0
+         character(*),parameter :: this = 'eye'
+
+         !> Determine number of columns
+         if (present(n)) then
+            cols = n
+         else
+            cols = m
+         end if
+
+         !> Check size
+         if (.not. min(m,n) >= 0) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid eye size: eye[',m,',',n,']')
+            goto 1
+         end if
+
+         ! Allocate array
+         allocate (eye(m,n))
+
+         !> Empty matrix
+         if (min(m,n) <= 0) return
+
+         !> Fill data
+         do concurrent(i=1:n,j=1:n)
+            eye(i,j) = merge(1.0_sp,0.0_sp,i == j)
+         end do
+
+         ! Process output and return
+1        call linalg_error_handling(err0,err)
+
+     end function stdlib_linalg_eye_c
+
+     ! Return diagonal eye matrix of size N
+     function stdlib_linalg_eye_z(m,n,dtype,err) result(eye)
+         !> Number of rows
+         integer(ilp),intent(in) :: m
+         !> Number of columns (optional)
+         integer(ilp),optional,intent(in) :: n
+         !> Datatype. Used to define the return type. Defaults to real(real64)
+         complex(dp),intent(in) :: dtype
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+         !> Return matrix
+         complex(dp),allocatable :: eye(:,:)
+
+         !> Local variables
+         integer(ilp) :: cols
+         type(linalg_state) :: err0
+         character(*),parameter :: this = 'eye'
+
+         !> Determine number of columns
+         if (present(n)) then
+            cols = n
+         else
+            cols = m
+         end if
+
+         !> Check size
+         if (.not. min(m,n) >= 0) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid eye size: eye[',m,',',n,']')
+            goto 1
+         end if
+
+         ! Allocate array
+         allocate (eye(m,n))
+
+         !> Empty matrix
+         if (min(m,n) <= 0) return
+
+         !> Fill data
+         do concurrent(i=1:n,j=1:n)
+            eye(i,j) = merge(1.0_dp,0.0_dp,i == j)
+         end do
+
+         ! Process output and return
+1        call linalg_error_handling(err0,err)
+
+     end function stdlib_linalg_eye_z
+
+     ! Return diagonal eye matrix of size N
+     function stdlib_linalg_eye_w(m,n,dtype,err) result(eye)
+         !> Number of rows
+         integer(ilp),intent(in) :: m
+         !> Number of columns (optional)
+         integer(ilp),optional,intent(in) :: n
+         !> Datatype. Used to define the return type. Defaults to real(real64)
+         complex(qp),intent(in) :: dtype
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+         !> Return matrix
+         complex(qp),allocatable :: eye(:,:)
+
+         !> Local variables
+         integer(ilp) :: cols
+         type(linalg_state) :: err0
+         character(*),parameter :: this = 'eye'
+
+         !> Determine number of columns
+         if (present(n)) then
+            cols = n
+         else
+            cols = m
+         end if
+
+         !> Check size
+         if (.not. min(m,n) >= 0) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid eye size: eye[',m,',',n,']')
+            goto 1
+         end if
+
+         ! Allocate array
+         allocate (eye(m,n))
+
+         !> Empty matrix
+         if (min(m,n) <= 0) return
+
+         !> Fill data
+         do concurrent(i=1:n,j=1:n)
+            eye(i,j) = merge(1.0_qp,0.0_qp,i == j)
+         end do
+
+         ! Process output and return
+1        call linalg_error_handling(err0,err)
+
+     end function stdlib_linalg_eye_w
+
+end module stdlib_linalg_eye

--- a/src/stdlib_linalg_eye.f90
+++ b/src/stdlib_linalg_eye.f90
@@ -47,13 +47,13 @@ module stdlib_linalg_eye
      contains
 
      ! Return diagonal eye matrix of size N
-     function stdlib_linalg_eye_s(m,n,dtype,err) result(eye)
+     function stdlib_linalg_eye_s(m,n,mold,err) result(eye)
          !> Number of rows
          integer(ilp),intent(in) :: m
          !> Number of columns (optional)
          integer(ilp),optional,intent(in) :: n
          !> Datatype. Used to define the return type. Defaults to real(real64)
-         real(sp),intent(in) :: dtype
+         real(sp),intent(in) :: mold
          !> [optional] state return flag. On error if not requested, the code will stop
          type(linalg_state),optional,intent(out) :: err
          !> Return matrix
@@ -95,13 +95,13 @@ module stdlib_linalg_eye
      end function stdlib_linalg_eye_s
 
      ! Return diagonal eye matrix of size N
-     function stdlib_linalg_eye_d(m,n,dtype,err) result(eye)
+     function stdlib_linalg_eye_d(m,n,mold,err) result(eye)
          !> Number of rows
          integer(ilp),intent(in) :: m
          !> Number of columns (optional)
          integer(ilp),optional,intent(in) :: n
          !> Datatype. Used to define the return type. Defaults to real(real64)
-         real(dp),optional,intent(in) :: dtype
+         real(dp),optional,intent(in) :: mold
          !> [optional] state return flag. On error if not requested, the code will stop
          type(linalg_state),optional,intent(out) :: err
          !> Return matrix
@@ -143,13 +143,13 @@ module stdlib_linalg_eye
      end function stdlib_linalg_eye_d
 
      ! Return diagonal eye matrix of size N
-     function stdlib_linalg_eye_q(m,n,dtype,err) result(eye)
+     function stdlib_linalg_eye_q(m,n,mold,err) result(eye)
          !> Number of rows
          integer(ilp),intent(in) :: m
          !> Number of columns (optional)
          integer(ilp),optional,intent(in) :: n
          !> Datatype. Used to define the return type. Defaults to real(real64)
-         real(qp),intent(in) :: dtype
+         real(qp),intent(in) :: mold
          !> [optional] state return flag. On error if not requested, the code will stop
          type(linalg_state),optional,intent(out) :: err
          !> Return matrix
@@ -191,13 +191,13 @@ module stdlib_linalg_eye
      end function stdlib_linalg_eye_q
 
      ! Return diagonal eye matrix of size N
-     function stdlib_linalg_eye_c(m,n,dtype,err) result(eye)
+     function stdlib_linalg_eye_c(m,n,mold,err) result(eye)
          !> Number of rows
          integer(ilp),intent(in) :: m
          !> Number of columns (optional)
          integer(ilp),optional,intent(in) :: n
          !> Datatype. Used to define the return type. Defaults to real(real64)
-         complex(sp),intent(in) :: dtype
+         complex(sp),intent(in) :: mold
          !> [optional] state return flag. On error if not requested, the code will stop
          type(linalg_state),optional,intent(out) :: err
          !> Return matrix
@@ -239,13 +239,13 @@ module stdlib_linalg_eye
      end function stdlib_linalg_eye_c
 
      ! Return diagonal eye matrix of size N
-     function stdlib_linalg_eye_z(m,n,dtype,err) result(eye)
+     function stdlib_linalg_eye_z(m,n,mold,err) result(eye)
          !> Number of rows
          integer(ilp),intent(in) :: m
          !> Number of columns (optional)
          integer(ilp),optional,intent(in) :: n
          !> Datatype. Used to define the return type. Defaults to real(real64)
-         complex(dp),intent(in) :: dtype
+         complex(dp),intent(in) :: mold
          !> [optional] state return flag. On error if not requested, the code will stop
          type(linalg_state),optional,intent(out) :: err
          !> Return matrix
@@ -287,13 +287,13 @@ module stdlib_linalg_eye
      end function stdlib_linalg_eye_z
 
      ! Return diagonal eye matrix of size N
-     function stdlib_linalg_eye_w(m,n,dtype,err) result(eye)
+     function stdlib_linalg_eye_w(m,n,mold,err) result(eye)
          !> Number of rows
          integer(ilp),intent(in) :: m
          !> Number of columns (optional)
          integer(ilp),optional,intent(in) :: n
          !> Datatype. Used to define the return type. Defaults to real(real64)
-         complex(qp),intent(in) :: dtype
+         complex(qp),intent(in) :: mold
          !> [optional] state return flag. On error if not requested, the code will stop
          type(linalg_state),optional,intent(out) :: err
          !> Return matrix
@@ -335,11 +335,11 @@ module stdlib_linalg_eye
      end function stdlib_linalg_eye_w
 
      ! Return square diagonal matrix with diagonal values equal to the input scalar
-     function stdlib_linalg_diag_s_from_scalar(n,dvalue,err) result(diag)
+     function stdlib_linalg_diag_s_from_scalar(n,source,err) result(diag)
          !> Matrix size
          integer(ilp),intent(in) :: n
          !> Scalar diagonal value. Used to define the return type.
-         real(sp),intent(in) :: dvalue
+         real(sp),intent(in) :: source
          !> [optional] state return flag. On error if not requested, the code will stop
          type(linalg_state),optional,intent(out) :: err
          !> Return matrix
@@ -366,7 +366,7 @@ module stdlib_linalg_eye
          !> Fill data
          do concurrent(i=1:n,j=1:n)
             if (i == j) then
-               diag(i,j) = dvalue
+               diag(i,j) = source
             else
                diag(i,j) = 0.0_sp
             end if
@@ -378,9 +378,9 @@ module stdlib_linalg_eye
      end function stdlib_linalg_diag_s_from_scalar
 
      ! Construct square diagonal matrix from an array of diagonal values
-     function stdlib_linalg_diag_s_from_array(dvalues,err) result(diag)
+     function stdlib_linalg_diag_s_from_array(source,err) result(diag)
          !> Array of diagonal values. Used to define the return type and the matrix size.
-         real(sp),intent(in) :: dvalues(:)
+         real(sp),intent(in) :: source(:)
          !> [optional] state return flag. On error if not requested, the code will stop
          type(linalg_state),optional,intent(out) :: err
          !> Return matrix
@@ -391,7 +391,7 @@ module stdlib_linalg_eye
          type(linalg_state) :: err0
          character(*),parameter :: this = 'diag::array'
 
-         n = size(dvalues,kind=ilp)
+         n = size(source,kind=ilp)
 
          !> Check size
          if (.not. n >= 0) then
@@ -409,7 +409,7 @@ module stdlib_linalg_eye
          !> Fill data
          do concurrent(i=1:n,j=1:n)
             if (i == j) then
-               diag(i,j) = dvalues(i)
+               diag(i,j) = source(i)
             else
                diag(i,j) = 0.0_sp
             end if
@@ -421,11 +421,11 @@ module stdlib_linalg_eye
      end function stdlib_linalg_diag_s_from_array
 
      ! Return square diagonal matrix with diagonal values equal to the input scalar
-     function stdlib_linalg_diag_d_from_scalar(n,dvalue,err) result(diag)
+     function stdlib_linalg_diag_d_from_scalar(n,source,err) result(diag)
          !> Matrix size
          integer(ilp),intent(in) :: n
          !> Scalar diagonal value. Used to define the return type.
-         real(dp),intent(in) :: dvalue
+         real(dp),intent(in) :: source
          !> [optional] state return flag. On error if not requested, the code will stop
          type(linalg_state),optional,intent(out) :: err
          !> Return matrix
@@ -452,7 +452,7 @@ module stdlib_linalg_eye
          !> Fill data
          do concurrent(i=1:n,j=1:n)
             if (i == j) then
-               diag(i,j) = dvalue
+               diag(i,j) = source
             else
                diag(i,j) = 0.0_dp
             end if
@@ -464,9 +464,9 @@ module stdlib_linalg_eye
      end function stdlib_linalg_diag_d_from_scalar
 
      ! Construct square diagonal matrix from an array of diagonal values
-     function stdlib_linalg_diag_d_from_array(dvalues,err) result(diag)
+     function stdlib_linalg_diag_d_from_array(source,err) result(diag)
          !> Array of diagonal values. Used to define the return type and the matrix size.
-         real(dp),intent(in) :: dvalues(:)
+         real(dp),intent(in) :: source(:)
          !> [optional] state return flag. On error if not requested, the code will stop
          type(linalg_state),optional,intent(out) :: err
          !> Return matrix
@@ -477,7 +477,7 @@ module stdlib_linalg_eye
          type(linalg_state) :: err0
          character(*),parameter :: this = 'diag::array'
 
-         n = size(dvalues,kind=ilp)
+         n = size(source,kind=ilp)
 
          !> Check size
          if (.not. n >= 0) then
@@ -495,7 +495,7 @@ module stdlib_linalg_eye
          !> Fill data
          do concurrent(i=1:n,j=1:n)
             if (i == j) then
-               diag(i,j) = dvalues(i)
+               diag(i,j) = source(i)
             else
                diag(i,j) = 0.0_dp
             end if
@@ -507,11 +507,11 @@ module stdlib_linalg_eye
      end function stdlib_linalg_diag_d_from_array
 
      ! Return square diagonal matrix with diagonal values equal to the input scalar
-     function stdlib_linalg_diag_q_from_scalar(n,dvalue,err) result(diag)
+     function stdlib_linalg_diag_q_from_scalar(n,source,err) result(diag)
          !> Matrix size
          integer(ilp),intent(in) :: n
          !> Scalar diagonal value. Used to define the return type.
-         real(qp),intent(in) :: dvalue
+         real(qp),intent(in) :: source
          !> [optional] state return flag. On error if not requested, the code will stop
          type(linalg_state),optional,intent(out) :: err
          !> Return matrix
@@ -538,7 +538,7 @@ module stdlib_linalg_eye
          !> Fill data
          do concurrent(i=1:n,j=1:n)
             if (i == j) then
-               diag(i,j) = dvalue
+               diag(i,j) = source
             else
                diag(i,j) = 0.0_qp
             end if
@@ -550,9 +550,9 @@ module stdlib_linalg_eye
      end function stdlib_linalg_diag_q_from_scalar
 
      ! Construct square diagonal matrix from an array of diagonal values
-     function stdlib_linalg_diag_q_from_array(dvalues,err) result(diag)
+     function stdlib_linalg_diag_q_from_array(source,err) result(diag)
          !> Array of diagonal values. Used to define the return type and the matrix size.
-         real(qp),intent(in) :: dvalues(:)
+         real(qp),intent(in) :: source(:)
          !> [optional] state return flag. On error if not requested, the code will stop
          type(linalg_state),optional,intent(out) :: err
          !> Return matrix
@@ -563,7 +563,7 @@ module stdlib_linalg_eye
          type(linalg_state) :: err0
          character(*),parameter :: this = 'diag::array'
 
-         n = size(dvalues,kind=ilp)
+         n = size(source,kind=ilp)
 
          !> Check size
          if (.not. n >= 0) then
@@ -581,7 +581,7 @@ module stdlib_linalg_eye
          !> Fill data
          do concurrent(i=1:n,j=1:n)
             if (i == j) then
-               diag(i,j) = dvalues(i)
+               diag(i,j) = source(i)
             else
                diag(i,j) = 0.0_qp
             end if
@@ -593,11 +593,11 @@ module stdlib_linalg_eye
      end function stdlib_linalg_diag_q_from_array
 
      ! Return square diagonal matrix with diagonal values equal to the input scalar
-     function stdlib_linalg_diag_c_from_scalar(n,dvalue,err) result(diag)
+     function stdlib_linalg_diag_c_from_scalar(n,source,err) result(diag)
          !> Matrix size
          integer(ilp),intent(in) :: n
          !> Scalar diagonal value. Used to define the return type.
-         complex(sp),intent(in) :: dvalue
+         complex(sp),intent(in) :: source
          !> [optional] state return flag. On error if not requested, the code will stop
          type(linalg_state),optional,intent(out) :: err
          !> Return matrix
@@ -624,7 +624,7 @@ module stdlib_linalg_eye
          !> Fill data
          do concurrent(i=1:n,j=1:n)
             if (i == j) then
-               diag(i,j) = dvalue
+               diag(i,j) = source
             else
                diag(i,j) = 0.0_sp
             end if
@@ -636,9 +636,9 @@ module stdlib_linalg_eye
      end function stdlib_linalg_diag_c_from_scalar
 
      ! Construct square diagonal matrix from an array of diagonal values
-     function stdlib_linalg_diag_c_from_array(dvalues,err) result(diag)
+     function stdlib_linalg_diag_c_from_array(source,err) result(diag)
          !> Array of diagonal values. Used to define the return type and the matrix size.
-         complex(sp),intent(in) :: dvalues(:)
+         complex(sp),intent(in) :: source(:)
          !> [optional] state return flag. On error if not requested, the code will stop
          type(linalg_state),optional,intent(out) :: err
          !> Return matrix
@@ -649,7 +649,7 @@ module stdlib_linalg_eye
          type(linalg_state) :: err0
          character(*),parameter :: this = 'diag::array'
 
-         n = size(dvalues,kind=ilp)
+         n = size(source,kind=ilp)
 
          !> Check size
          if (.not. n >= 0) then
@@ -667,7 +667,7 @@ module stdlib_linalg_eye
          !> Fill data
          do concurrent(i=1:n,j=1:n)
             if (i == j) then
-               diag(i,j) = dvalues(i)
+               diag(i,j) = source(i)
             else
                diag(i,j) = 0.0_sp
             end if
@@ -679,11 +679,11 @@ module stdlib_linalg_eye
      end function stdlib_linalg_diag_c_from_array
 
      ! Return square diagonal matrix with diagonal values equal to the input scalar
-     function stdlib_linalg_diag_z_from_scalar(n,dvalue,err) result(diag)
+     function stdlib_linalg_diag_z_from_scalar(n,source,err) result(diag)
          !> Matrix size
          integer(ilp),intent(in) :: n
          !> Scalar diagonal value. Used to define the return type.
-         complex(dp),intent(in) :: dvalue
+         complex(dp),intent(in) :: source
          !> [optional] state return flag. On error if not requested, the code will stop
          type(linalg_state),optional,intent(out) :: err
          !> Return matrix
@@ -710,7 +710,7 @@ module stdlib_linalg_eye
          !> Fill data
          do concurrent(i=1:n,j=1:n)
             if (i == j) then
-               diag(i,j) = dvalue
+               diag(i,j) = source
             else
                diag(i,j) = 0.0_dp
             end if
@@ -722,9 +722,9 @@ module stdlib_linalg_eye
      end function stdlib_linalg_diag_z_from_scalar
 
      ! Construct square diagonal matrix from an array of diagonal values
-     function stdlib_linalg_diag_z_from_array(dvalues,err) result(diag)
+     function stdlib_linalg_diag_z_from_array(source,err) result(diag)
          !> Array of diagonal values. Used to define the return type and the matrix size.
-         complex(dp),intent(in) :: dvalues(:)
+         complex(dp),intent(in) :: source(:)
          !> [optional] state return flag. On error if not requested, the code will stop
          type(linalg_state),optional,intent(out) :: err
          !> Return matrix
@@ -735,7 +735,7 @@ module stdlib_linalg_eye
          type(linalg_state) :: err0
          character(*),parameter :: this = 'diag::array'
 
-         n = size(dvalues,kind=ilp)
+         n = size(source,kind=ilp)
 
          !> Check size
          if (.not. n >= 0) then
@@ -753,7 +753,7 @@ module stdlib_linalg_eye
          !> Fill data
          do concurrent(i=1:n,j=1:n)
             if (i == j) then
-               diag(i,j) = dvalues(i)
+               diag(i,j) = source(i)
             else
                diag(i,j) = 0.0_dp
             end if
@@ -765,11 +765,11 @@ module stdlib_linalg_eye
      end function stdlib_linalg_diag_z_from_array
 
      ! Return square diagonal matrix with diagonal values equal to the input scalar
-     function stdlib_linalg_diag_w_from_scalar(n,dvalue,err) result(diag)
+     function stdlib_linalg_diag_w_from_scalar(n,source,err) result(diag)
          !> Matrix size
          integer(ilp),intent(in) :: n
          !> Scalar diagonal value. Used to define the return type.
-         complex(qp),intent(in) :: dvalue
+         complex(qp),intent(in) :: source
          !> [optional] state return flag. On error if not requested, the code will stop
          type(linalg_state),optional,intent(out) :: err
          !> Return matrix
@@ -796,7 +796,7 @@ module stdlib_linalg_eye
          !> Fill data
          do concurrent(i=1:n,j=1:n)
             if (i == j) then
-               diag(i,j) = dvalue
+               diag(i,j) = source
             else
                diag(i,j) = 0.0_qp
             end if
@@ -808,9 +808,9 @@ module stdlib_linalg_eye
      end function stdlib_linalg_diag_w_from_scalar
 
      ! Construct square diagonal matrix from an array of diagonal values
-     function stdlib_linalg_diag_w_from_array(dvalues,err) result(diag)
+     function stdlib_linalg_diag_w_from_array(source,err) result(diag)
          !> Array of diagonal values. Used to define the return type and the matrix size.
-         complex(qp),intent(in) :: dvalues(:)
+         complex(qp),intent(in) :: source(:)
          !> [optional] state return flag. On error if not requested, the code will stop
          type(linalg_state),optional,intent(out) :: err
          !> Return matrix
@@ -821,7 +821,7 @@ module stdlib_linalg_eye
          type(linalg_state) :: err0
          character(*),parameter :: this = 'diag::array'
 
-         n = size(dvalues,kind=ilp)
+         n = size(source,kind=ilp)
 
          !> Check size
          if (.not. n >= 0) then
@@ -839,7 +839,7 @@ module stdlib_linalg_eye
          !> Fill data
          do concurrent(i=1:n,j=1:n)
             if (i == j) then
-               diag(i,j) = dvalues(i)
+               diag(i,j) = source(i)
             else
                diag(i,j) = 0.0_qp
             end if

--- a/src/stdlib_linalg_eye.f90
+++ b/src/stdlib_linalg_eye.f90
@@ -74,6 +74,7 @@ module stdlib_linalg_eye
          !> Check size
          if (.not. min(m,cols) >= 0) then
             err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid eye size: eye[',m,',',n,']')
+            allocate (eye(0,0))
             goto 1
          end if
 
@@ -121,6 +122,7 @@ module stdlib_linalg_eye
          !> Check size
          if (.not. min(m,cols) >= 0) then
             err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid eye size: eye[',m,',',n,']')
+            allocate (eye(0,0))
             goto 1
          end if
 
@@ -168,6 +170,7 @@ module stdlib_linalg_eye
          !> Check size
          if (.not. min(m,cols) >= 0) then
             err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid eye size: eye[',m,',',n,']')
+            allocate (eye(0,0))
             goto 1
          end if
 
@@ -215,6 +218,7 @@ module stdlib_linalg_eye
          !> Check size
          if (.not. min(m,cols) >= 0) then
             err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid eye size: eye[',m,',',n,']')
+            allocate (eye(0,0))
             goto 1
          end if
 
@@ -262,6 +266,7 @@ module stdlib_linalg_eye
          !> Check size
          if (.not. min(m,cols) >= 0) then
             err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid eye size: eye[',m,',',n,']')
+            allocate (eye(0,0))
             goto 1
          end if
 
@@ -309,6 +314,7 @@ module stdlib_linalg_eye
          !> Check size
          if (.not. min(m,cols) >= 0) then
             err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid eye size: eye[',m,',',n,']')
+            allocate (eye(0,0))
             goto 1
          end if
 
@@ -347,6 +353,7 @@ module stdlib_linalg_eye
          !> Check size
          if (.not. n >= 0) then
             err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid diagonal size: diag[',n,',',n,']')
+            allocate (diag(0,0))
             goto 1
          end if
 
@@ -389,6 +396,7 @@ module stdlib_linalg_eye
          !> Check size
          if (.not. n >= 0) then
             err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid input array size: diag[',n,',',n,']')
+            allocate (diag(0,0))
             goto 1
          end if
 
@@ -431,6 +439,7 @@ module stdlib_linalg_eye
          !> Check size
          if (.not. n >= 0) then
             err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid diagonal size: diag[',n,',',n,']')
+            allocate (diag(0,0))
             goto 1
          end if
 
@@ -473,6 +482,7 @@ module stdlib_linalg_eye
          !> Check size
          if (.not. n >= 0) then
             err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid input array size: diag[',n,',',n,']')
+            allocate (diag(0,0))
             goto 1
          end if
 
@@ -515,6 +525,7 @@ module stdlib_linalg_eye
          !> Check size
          if (.not. n >= 0) then
             err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid diagonal size: diag[',n,',',n,']')
+            allocate (diag(0,0))
             goto 1
          end if
 
@@ -557,6 +568,7 @@ module stdlib_linalg_eye
          !> Check size
          if (.not. n >= 0) then
             err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid input array size: diag[',n,',',n,']')
+            allocate (diag(0,0))
             goto 1
          end if
 
@@ -599,6 +611,7 @@ module stdlib_linalg_eye
          !> Check size
          if (.not. n >= 0) then
             err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid diagonal size: diag[',n,',',n,']')
+            allocate (diag(0,0))
             goto 1
          end if
 
@@ -641,6 +654,7 @@ module stdlib_linalg_eye
          !> Check size
          if (.not. n >= 0) then
             err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid input array size: diag[',n,',',n,']')
+            allocate (diag(0,0))
             goto 1
          end if
 
@@ -683,6 +697,7 @@ module stdlib_linalg_eye
          !> Check size
          if (.not. n >= 0) then
             err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid diagonal size: diag[',n,',',n,']')
+            allocate (diag(0,0))
             goto 1
          end if
 
@@ -725,6 +740,7 @@ module stdlib_linalg_eye
          !> Check size
          if (.not. n >= 0) then
             err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid input array size: diag[',n,',',n,']')
+            allocate (diag(0,0))
             goto 1
          end if
 
@@ -767,6 +783,7 @@ module stdlib_linalg_eye
          !> Check size
          if (.not. n >= 0) then
             err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid diagonal size: diag[',n,',',n,']')
+            allocate (diag(0,0))
             goto 1
          end if
 
@@ -809,6 +826,7 @@ module stdlib_linalg_eye
          !> Check size
          if (.not. n >= 0) then
             err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid input array size: diag[',n,',',n,']')
+            allocate (diag(0,0))
             goto 1
          end if
 

--- a/src/stdlib_linalg_eye.f90
+++ b/src/stdlib_linalg_eye.f90
@@ -43,7 +43,7 @@ module stdlib_linalg_eye
          real(sp),allocatable :: eye(:,:)
 
          !> Local variables
-         integer(ilp) :: cols
+         integer(ilp) :: i,j,cols
          type(linalg_state) :: err0
          character(*),parameter :: this = 'eye'
 
@@ -55,19 +55,19 @@ module stdlib_linalg_eye
          end if
 
          !> Check size
-         if (.not. min(m,n) >= 0) then
+         if (.not. min(m,cols) >= 0) then
             err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid eye size: eye[',m,',',n,']')
             goto 1
          end if
 
          ! Allocate array
-         allocate (eye(m,n))
+         allocate (eye(m,cols))
 
          !> Empty matrix
-         if (min(m,n) <= 0) return
+         if (min(m,cols) <= 0) return
 
          !> Fill data
-         do concurrent(i=1:n,j=1:n)
+         do concurrent(i=1:m,j=1:cols)
             eye(i,j) = merge(1.0_sp,0.0_sp,i == j)
          end do
 
@@ -90,7 +90,7 @@ module stdlib_linalg_eye
          real(dp),allocatable :: eye(:,:)
 
          !> Local variables
-         integer(ilp) :: cols
+         integer(ilp) :: i,j,cols
          type(linalg_state) :: err0
          character(*),parameter :: this = 'eye'
 
@@ -102,19 +102,19 @@ module stdlib_linalg_eye
          end if
 
          !> Check size
-         if (.not. min(m,n) >= 0) then
+         if (.not. min(m,cols) >= 0) then
             err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid eye size: eye[',m,',',n,']')
             goto 1
          end if
 
          ! Allocate array
-         allocate (eye(m,n))
+         allocate (eye(m,cols))
 
          !> Empty matrix
-         if (min(m,n) <= 0) return
+         if (min(m,cols) <= 0) return
 
          !> Fill data
-         do concurrent(i=1:n,j=1:n)
+         do concurrent(i=1:m,j=1:cols)
             eye(i,j) = merge(1.0_dp,0.0_dp,i == j)
          end do
 
@@ -137,7 +137,7 @@ module stdlib_linalg_eye
          real(qp),allocatable :: eye(:,:)
 
          !> Local variables
-         integer(ilp) :: cols
+         integer(ilp) :: i,j,cols
          type(linalg_state) :: err0
          character(*),parameter :: this = 'eye'
 
@@ -149,19 +149,19 @@ module stdlib_linalg_eye
          end if
 
          !> Check size
-         if (.not. min(m,n) >= 0) then
+         if (.not. min(m,cols) >= 0) then
             err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid eye size: eye[',m,',',n,']')
             goto 1
          end if
 
          ! Allocate array
-         allocate (eye(m,n))
+         allocate (eye(m,cols))
 
          !> Empty matrix
-         if (min(m,n) <= 0) return
+         if (min(m,cols) <= 0) return
 
          !> Fill data
-         do concurrent(i=1:n,j=1:n)
+         do concurrent(i=1:m,j=1:cols)
             eye(i,j) = merge(1.0_qp,0.0_qp,i == j)
          end do
 
@@ -184,7 +184,7 @@ module stdlib_linalg_eye
          complex(sp),allocatable :: eye(:,:)
 
          !> Local variables
-         integer(ilp) :: cols
+         integer(ilp) :: i,j,cols
          type(linalg_state) :: err0
          character(*),parameter :: this = 'eye'
 
@@ -196,19 +196,19 @@ module stdlib_linalg_eye
          end if
 
          !> Check size
-         if (.not. min(m,n) >= 0) then
+         if (.not. min(m,cols) >= 0) then
             err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid eye size: eye[',m,',',n,']')
             goto 1
          end if
 
          ! Allocate array
-         allocate (eye(m,n))
+         allocate (eye(m,cols))
 
          !> Empty matrix
-         if (min(m,n) <= 0) return
+         if (min(m,cols) <= 0) return
 
          !> Fill data
-         do concurrent(i=1:n,j=1:n)
+         do concurrent(i=1:m,j=1:cols)
             eye(i,j) = merge(1.0_sp,0.0_sp,i == j)
          end do
 
@@ -231,7 +231,7 @@ module stdlib_linalg_eye
          complex(dp),allocatable :: eye(:,:)
 
          !> Local variables
-         integer(ilp) :: cols
+         integer(ilp) :: i,j,cols
          type(linalg_state) :: err0
          character(*),parameter :: this = 'eye'
 
@@ -243,19 +243,19 @@ module stdlib_linalg_eye
          end if
 
          !> Check size
-         if (.not. min(m,n) >= 0) then
+         if (.not. min(m,cols) >= 0) then
             err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid eye size: eye[',m,',',n,']')
             goto 1
          end if
 
          ! Allocate array
-         allocate (eye(m,n))
+         allocate (eye(m,cols))
 
          !> Empty matrix
-         if (min(m,n) <= 0) return
+         if (min(m,cols) <= 0) return
 
          !> Fill data
-         do concurrent(i=1:n,j=1:n)
+         do concurrent(i=1:m,j=1:cols)
             eye(i,j) = merge(1.0_dp,0.0_dp,i == j)
          end do
 
@@ -278,7 +278,7 @@ module stdlib_linalg_eye
          complex(qp),allocatable :: eye(:,:)
 
          !> Local variables
-         integer(ilp) :: cols
+         integer(ilp) :: i,j,cols
          type(linalg_state) :: err0
          character(*),parameter :: this = 'eye'
 
@@ -290,19 +290,19 @@ module stdlib_linalg_eye
          end if
 
          !> Check size
-         if (.not. min(m,n) >= 0) then
+         if (.not. min(m,cols) >= 0) then
             err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid eye size: eye[',m,',',n,']')
             goto 1
          end if
 
          ! Allocate array
-         allocate (eye(m,n))
+         allocate (eye(m,cols))
 
          !> Empty matrix
-         if (min(m,n) <= 0) return
+         if (min(m,cols) <= 0) return
 
          !> Fill data
-         do concurrent(i=1:n,j=1:n)
+         do concurrent(i=1:m,j=1:cols)
             eye(i,j) = merge(1.0_qp,0.0_qp,i == j)
          end do
 

--- a/src/stdlib_linalg_eye.fypp
+++ b/src/stdlib_linalg_eye.fypp
@@ -57,7 +57,7 @@ module stdlib_linalg_eye
          ${rt}$, allocatable :: eye(:,:)
 
          !> Local variables
-         integer(ilp) :: cols
+         integer(ilp) :: i,j,cols
          type(linalg_state) :: err0
          character(*), parameter :: this = 'eye'
 
@@ -69,19 +69,19 @@ module stdlib_linalg_eye
          endif
 
          !> Check size
-         if (.not.min(m,n)>=0) then
+         if (.not.min(m,cols)>=0) then
             err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid eye size: eye[',m,',',n,']')
             goto 1
          end if
 
          ! Allocate array
-         allocate(eye(m,n))
+         allocate(eye(m,cols))
 
          !> Empty matrix
-         if (min(m,n)<=0) return
+         if (min(m,cols)<=0) return
 
          !> Fill data
-         do concurrent (i=1:n,j=1:n)
+         do concurrent (i=1:m,j=1:cols)
             eye(i,j) = merge(1.0_${rk}$,0.0_${rk}$,i==j)
          end do
 

--- a/src/stdlib_linalg_eye.fypp
+++ b/src/stdlib_linalg_eye.fypp
@@ -79,6 +79,7 @@ module stdlib_linalg_eye
          !> Check size
          if (.not.min(m,cols)>=0) then
             err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid eye size: eye[',m,',',n,']')
+            allocate(eye(0,0))
             goto 1
          end if
 
@@ -120,6 +121,7 @@ module stdlib_linalg_eye
          !> Check size
          if (.not.n>=0) then
             err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid diagonal size: diag[',n,',',n,']')
+            allocate(diag(0,0))
             goto 1
          end if
 
@@ -162,6 +164,7 @@ module stdlib_linalg_eye
          !> Check size
          if (.not.n>=0) then
             err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid input array size: diag[',n,',',n,']')
+            allocate(diag(0,0))
             goto 1
          end if
 

--- a/src/stdlib_linalg_eye.fypp
+++ b/src/stdlib_linalg_eye.fypp
@@ -22,23 +22,31 @@ module stdlib_linalg_eye
 
      !> Function interface
      public :: eye
+     public :: diag
 
      ! Numpy: eye(N, M=None, k=0, dtype=<class 'float'>, order='C', *, device=None, like=None)
      ! Numpy: identity(n, dtype=None, *, like=None) --> square matrices only
      ! Scipy: eye(m, n=None, k=0, dtype=<class 'float'>, format=None) --> sparse only
      ! IMSL:  EYE(N)
 
-     ! Function interface
+     ! Identity interface
      interface eye
         #:for rk,rt,ri in ALL_KINDS_TYPES
         module procedure stdlib_linalg_eye_${ri}$
         #:endfor
      end interface eye
 
+     ! Diagonal matrix interface
+     interface diag
+        #:for rk,rt,ri in ALL_KINDS_TYPES
+        module procedure stdlib_linalg_diag_${ri}$_from_scalar
+        module procedure stdlib_linalg_diag_${ri}$_from_array
+        #:endfor
+     end interface diag
+
      contains
 
      #:for rk,rt,ri in ALL_KINDS_TYPES
-
      ! Return diagonal eye matrix of size N
      function stdlib_linalg_eye_${ri}$(m,n,dtype,err) result(eye)
          !> Number of rows
@@ -89,6 +97,93 @@ module stdlib_linalg_eye
          1 call linalg_error_handling(err0,err)
 
      end function stdlib_linalg_eye_${ri}$
+
+     #: endfor
+
+     #:for rk,rt,ri in ALL_KINDS_TYPES
+     ! Return square diagonal matrix with diagonal values equal to the input scalar
+     function stdlib_linalg_diag_${ri}$_from_scalar(n,dvalue,err) result(diag)
+         !> Matrix size
+         integer(ilp), intent(in) :: n
+         !> Scalar diagonal value. Used to define the return type.
+         ${rt}$, intent(in) :: dvalue
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state), optional, intent(out) :: err
+         !> Return matrix
+         ${rt}$, allocatable :: diag(:,:)
+
+         !> Local variables
+         integer(ilp) :: i,j
+         type(linalg_state) :: err0
+         character(*), parameter :: this = 'diag::scalar'
+
+         !> Check size
+         if (.not.n>=0) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid diagonal size: diag[',n,',',n,']')
+            goto 1
+         end if
+
+         ! Allocate array
+         allocate(diag(n,n))
+
+         !> Empty matrix
+         if (n<=0) return
+
+         !> Fill data
+         do concurrent (i=1:n,j=1:n)
+            if (i==j) then
+               diag(i,j) = dvalue
+            else
+               diag(i,j) = 0.0_${rk}$
+            endif
+         end do
+
+         ! Process output and return
+         1 call linalg_error_handling(err0,err)
+
+     end function stdlib_linalg_diag_${ri}$_from_scalar
+
+     ! Construct square diagonal matrix from an array of diagonal values
+     function stdlib_linalg_diag_${ri}$_from_array(dvalues,err) result(diag)
+         !> Array of diagonal values. Used to define the return type and the matrix size.
+         ${rt}$, intent(in) :: dvalues(:)
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state), optional, intent(out) :: err
+         !> Return matrix
+         ${rt}$, allocatable :: diag(:,:)
+
+         !> Local variables
+         integer(ilp) :: i,j,n
+         type(linalg_state) :: err0
+         character(*), parameter :: this = 'diag::array'
+
+         n = size(dvalues, kind=ilp)
+
+         !> Check size
+         if (.not.n>=0) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid input array size: diag[',n,',',n,']')
+            goto 1
+         end if
+
+         ! Allocate array
+         allocate(diag(n,n))
+
+         !> Empty matrix
+         if (n<=0) return
+
+         !> Fill data
+         do concurrent (i=1:n,j=1:n)
+            if (i==j) then
+               diag(i,j) = dvalues(i)
+            else
+               diag(i,j) = 0.0_${rk}$
+            endif
+         end do
+
+         ! Process output and return
+         1 call linalg_error_handling(err0,err)
+
+     end function stdlib_linalg_diag_${ri}$_from_array
 
      #:endfor
 

--- a/src/stdlib_linalg_eye.fypp
+++ b/src/stdlib_linalg_eye.fypp
@@ -48,16 +48,16 @@ module stdlib_linalg_eye
 
      #:for rk,rt,ri in ALL_KINDS_TYPES
      ! Return diagonal eye matrix of size N
-     function stdlib_linalg_eye_${ri}$(m,n,dtype,err) result(eye)
+     function stdlib_linalg_eye_${ri}$(m,n,mold,err) result(eye)
          !> Number of rows
          integer(ilp), intent(in) :: m
          !> Number of columns (optional)
          integer(ilp), optional, intent(in) :: n
          !> Datatype. Used to define the return type. Defaults to real(real64)
          #:if rt=='real(dp)'
-         ${rt}$, optional, intent(in) :: dtype
+         ${rt}$, optional, intent(in) :: mold
          #:else
-         ${rt}$, intent(in) :: dtype
+         ${rt}$, intent(in) :: mold
          #:endif
          !> [optional] state return flag. On error if not requested, the code will stop
          type(linalg_state), optional, intent(out) :: err
@@ -103,11 +103,11 @@ module stdlib_linalg_eye
 
      #:for rk,rt,ri in ALL_KINDS_TYPES
      ! Return square diagonal matrix with diagonal values equal to the input scalar
-     function stdlib_linalg_diag_${ri}$_from_scalar(n,dvalue,err) result(diag)
+     function stdlib_linalg_diag_${ri}$_from_scalar(n,source,err) result(diag)
          !> Matrix size
          integer(ilp), intent(in) :: n
          !> Scalar diagonal value. Used to define the return type.
-         ${rt}$, intent(in) :: dvalue
+         ${rt}$, intent(in) :: source
          !> [optional] state return flag. On error if not requested, the code will stop
          type(linalg_state), optional, intent(out) :: err
          !> Return matrix
@@ -134,7 +134,7 @@ module stdlib_linalg_eye
          !> Fill data
          do concurrent (i=1:n,j=1:n)
             if (i==j) then
-               diag(i,j) = dvalue
+               diag(i,j) = source
             else
                diag(i,j) = 0.0_${rk}$
             endif
@@ -146,9 +146,9 @@ module stdlib_linalg_eye
      end function stdlib_linalg_diag_${ri}$_from_scalar
 
      ! Construct square diagonal matrix from an array of diagonal values
-     function stdlib_linalg_diag_${ri}$_from_array(dvalues,err) result(diag)
+     function stdlib_linalg_diag_${ri}$_from_array(source,err) result(diag)
          !> Array of diagonal values. Used to define the return type and the matrix size.
-         ${rt}$, intent(in) :: dvalues(:)
+         ${rt}$, intent(in) :: source(:)
          !> [optional] state return flag. On error if not requested, the code will stop
          type(linalg_state), optional, intent(out) :: err
          !> Return matrix
@@ -159,7 +159,7 @@ module stdlib_linalg_eye
          type(linalg_state) :: err0
          character(*), parameter :: this = 'diag::array'
 
-         n = size(dvalues, kind=ilp)
+         n = size(source, kind=ilp)
 
          !> Check size
          if (.not.n>=0) then
@@ -177,7 +177,7 @@ module stdlib_linalg_eye
          !> Fill data
          do concurrent (i=1:n,j=1:n)
             if (i==j) then
-               diag(i,j) = dvalues(i)
+               diag(i,j) = source(i)
             else
                diag(i,j) = 0.0_${rk}$
             endif

--- a/src/stdlib_linalg_eye.fypp
+++ b/src/stdlib_linalg_eye.fypp
@@ -1,0 +1,95 @@
+#:set REAL_KINDS    = ["sp", "dp", "qp"]
+#:set REAL_INITIALS = ["s","d","q"]
+#:set REAL_TYPES    = ["real({})".format(k) for k in REAL_KINDS]
+#:set REAL_KINDS_TYPES = list(zip(REAL_KINDS, REAL_TYPES, REAL_INITIALS))
+#:set CMPL_INITIALS = ["c","z","w"]
+#:set CMPL_TYPES    = ["complex({})".format(k) for k in REAL_KINDS]
+#:set CMPL_KINDS_TYPES = list(zip(REAL_KINDS, CMPL_TYPES, CMPL_INITIALS))
+#:set ALL_KINDS_TYPES = list(zip(REAL_KINDS+REAL_KINDS,REAL_TYPES+CMPL_TYPES,REAL_INITIALS+CMPL_INITIALS))
+
+#:set RANK_SUFFIX = ["_one","_multiple"]
+#:set RANK_SYMBOL = [":",":,:"]
+#:set ALL_RANKS = list(zip(RANK_SYMBOL,RANK_SUFFIX))
+! Return a 2-D matrix with ones on the diagonal and zeros everywhere else
+module stdlib_linalg_eye
+     use stdlib_linalg_constants
+     use stdlib_linalg_blas
+     use stdlib_linalg_lapack
+     use stdlib_linalg_state
+     use iso_fortran_env,only:real32,real64,real128,int8,int16,int32,int64,stderr => error_unit
+     implicit none(type,external)
+     private
+
+     !> Function interface
+     public :: eye
+
+     ! Numpy: eye(N, M=None, k=0, dtype=<class 'float'>, order='C', *, device=None, like=None)
+     ! Numpy: identity(n, dtype=None, *, like=None) --> square matrices only
+     ! Scipy: eye(m, n=None, k=0, dtype=<class 'float'>, format=None) --> sparse only
+     ! IMSL:  EYE(N)
+
+     ! Function interface
+     interface eye
+        #:for rk,rt,ri in ALL_KINDS_TYPES
+        module procedure stdlib_linalg_eye_${ri}$
+        #:endfor
+     end interface eye
+
+     contains
+
+     #:for rk,rt,ri in ALL_KINDS_TYPES
+
+     ! Return diagonal eye matrix of size N
+     function stdlib_linalg_eye_${ri}$(m,n,dtype,err) result(eye)
+         !> Number of rows
+         integer(ilp), intent(in) :: m
+         !> Number of columns (optional)
+         integer(ilp), optional, intent(in) :: n
+         !> Datatype. Used to define the return type. Defaults to real(real64)
+         #:if rt=='real(dp)'
+         ${rt}$, optional, intent(in) :: dtype
+         #:else
+         ${rt}$, intent(in) :: dtype
+         #:endif
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state), optional, intent(out) :: err
+         !> Return matrix
+         ${rt}$, allocatable :: eye(:,:)
+
+         !> Local variables
+         integer(ilp) :: cols
+         type(linalg_state) :: err0
+         character(*), parameter :: this = 'eye'
+
+         !> Determine number of columns
+         if (present(n)) then
+            cols = n
+         else
+            cols = m
+         endif
+
+         !> Check size
+         if (.not.min(m,n)>=0) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid eye size: eye[',m,',',n,']')
+            goto 1
+         end if
+
+         ! Allocate array
+         allocate(eye(m,n))
+
+         !> Empty matrix
+         if (min(m,n)<=0) return
+
+         !> Fill data
+         do concurrent (i=1:n,j=1:n)
+            eye(i,j) = merge(1.0_${rk}$,0.0_${rk}$,i==j)
+         end do
+
+         ! Process output and return
+         1 call linalg_error_handling(err0,err)
+
+     end function stdlib_linalg_eye_${ri}$
+
+     #:endfor
+
+end module stdlib_linalg_eye

--- a/src/stdlib_linalg_interface.f90
+++ b/src/stdlib_linalg_interface.f90
@@ -1,13 +1,13 @@
 module stdlib_linalg_interface
-     use stdlib_linalg_constants
      use stdlib_linalg_blas
-     use stdlib_linalg_lapack
-     use stdlib_linalg_state
-     use stdlib_linalg_eye
-     use stdlib_linalg_solve
+     use stdlib_linalg_constants
      use stdlib_linalg_determinant
+     use stdlib_linalg_eye
      use stdlib_linalg_inverse
+     use stdlib_linalg_lapack
      use stdlib_linalg_least_squares
+     use stdlib_linalg_solve
+     use stdlib_linalg_state
      implicit none(type,external)
      public
 

--- a/src/stdlib_linalg_interface.f90
+++ b/src/stdlib_linalg_interface.f90
@@ -3,6 +3,7 @@ module stdlib_linalg_interface
      use stdlib_linalg_blas
      use stdlib_linalg_lapack
      use stdlib_linalg_state
+     use stdlib_linalg_eye
      use stdlib_linalg_solve
      use stdlib_linalg_determinant
      use stdlib_linalg_inverse

--- a/test/stdlib_linalg_tests.f90
+++ b/test/stdlib_linalg_tests.f90
@@ -1,5 +1,6 @@
 program stdlib_linalg_tests
     use test_linalg_aux
+    use test_linalg_eye
     use test_linalg_solve
     use test_linalg_inverse
     use test_linalg_least_squares
@@ -22,6 +23,9 @@ program stdlib_linalg_tests
 
     call test_matrix_determinant(error)
     if (error) error stop 'test_determinant'
+
+    call test_eye(error)
+    if (error) error stop 'test_eye'
 
     !> All tests passed
     stop 0

--- a/test/test_linalg_determinant.f90
+++ b/test/test_linalg_determinant.f90
@@ -72,10 +72,7 @@ module test_linalg_determinant
 
         real(sp) :: a(n,n),deta
 
-        a = 0.0_sp
-        do concurrent(i=1:n)
-          a(i,i) = 1.0_sp
-        end do
+        a = eye(n)
 
         !> Determinant function
         deta = det(a,err=state)
@@ -96,7 +93,7 @@ module test_linalg_determinant
         real(sp) :: a(n,n),deta
 
         !> Multiply eye by a very small number
-        a = 0.0_sp
+        a = eye(n)
         do concurrent(i=1:n)
           a(i,i) = coef
         end do
@@ -118,10 +115,7 @@ module test_linalg_determinant
 
         real(dp) :: a(n,n),deta
 
-        a = 0.0_dp
-        do concurrent(i=1:n)
-          a(i,i) = 1.0_dp
-        end do
+        a = eye(n)
 
         !> Determinant function
         deta = det(a,err=state)
@@ -142,7 +136,7 @@ module test_linalg_determinant
         real(dp) :: a(n,n),deta
 
         !> Multiply eye by a very small number
-        a = 0.0_dp
+        a = eye(n)
         do concurrent(i=1:n)
           a(i,i) = coef
         end do
@@ -164,10 +158,7 @@ module test_linalg_determinant
 
         real(qp) :: a(n,n),deta
 
-        a = 0.0_qp
-        do concurrent(i=1:n)
-          a(i,i) = 1.0_qp
-        end do
+        a = eye(n)
 
         !> Determinant function
         deta = det(a,err=state)
@@ -188,7 +179,7 @@ module test_linalg_determinant
         real(qp) :: a(n,n),deta
 
         !> Multiply eye by a very small number
-        a = 0.0_qp
+        a = eye(n)
         do concurrent(i=1:n)
           a(i,i) = coef
         end do
@@ -210,10 +201,7 @@ module test_linalg_determinant
 
         complex(sp) :: a(n,n),deta
 
-        a = 0.0_sp
-        do concurrent(i=1:n)
-          a(i,i) = 1.0_sp
-        end do
+        a = eye(n)
 
         !> Determinant function
         deta = det(a,err=state)
@@ -234,7 +222,7 @@ module test_linalg_determinant
         complex(sp) :: a(n,n),deta
 
         !> Multiply eye by a very small number
-        a = 0.0_sp
+        a = eye(n)
         do concurrent(i=1:n)
           a(i,i) = coef
         end do
@@ -256,10 +244,7 @@ module test_linalg_determinant
 
         complex(dp) :: a(n,n),deta
 
-        a = 0.0_dp
-        do concurrent(i=1:n)
-          a(i,i) = 1.0_dp
-        end do
+        a = eye(n)
 
         !> Determinant function
         deta = det(a,err=state)
@@ -280,7 +265,7 @@ module test_linalg_determinant
         complex(dp) :: a(n,n),deta
 
         !> Multiply eye by a very small number
-        a = 0.0_dp
+        a = eye(n)
         do concurrent(i=1:n)
           a(i,i) = coef
         end do
@@ -302,10 +287,7 @@ module test_linalg_determinant
 
         complex(qp) :: a(n,n),deta
 
-        a = 0.0_qp
-        do concurrent(i=1:n)
-          a(i,i) = 1.0_qp
-        end do
+        a = eye(n)
 
         !> Determinant function
         deta = det(a,err=state)
@@ -326,7 +308,7 @@ module test_linalg_determinant
         complex(qp) :: a(n,n),deta
 
         !> Multiply eye by a very small number
-        a = 0.0_qp
+        a = eye(n)
         do concurrent(i=1:n)
           a(i,i) = coef
         end do
@@ -357,9 +339,9 @@ module test_linalg_determinant
         matrix_size: do n = 1,nmax
 
            ! Put 1+i on each diagonal element
-           allocate (a(n,n))
-           do concurrent(i=1:n,j=1:n)
-             a(i,j) = merge((1.0_sp,1.0_sp), (0.0_sp,0.0_sp),i == j)
+           a = eye(n)
+           do concurrent(i=1:n)
+             a(i,i) = (1.0_sp,1.0_sp)
            end do
 
            ! Expected result
@@ -392,9 +374,9 @@ module test_linalg_determinant
         matrix_size: do n = 1,nmax
 
            ! Put 1+i on each diagonal element
-           allocate (a(n,n))
-           do concurrent(i=1:n,j=1:n)
-             a(i,j) = merge((1.0_dp,1.0_dp), (0.0_dp,0.0_dp),i == j)
+           a = eye(n)
+           do concurrent(i=1:n)
+             a(i,i) = (1.0_dp,1.0_dp)
            end do
 
            ! Expected result
@@ -427,9 +409,9 @@ module test_linalg_determinant
         matrix_size: do n = 1,nmax
 
            ! Put 1+i on each diagonal element
-           allocate (a(n,n))
-           do concurrent(i=1:n,j=1:n)
-             a(i,j) = merge((1.0_qp,1.0_qp), (0.0_qp,0.0_qp),i == j)
+           a = eye(n)
+           do concurrent(i=1:n)
+             a(i,i) = (1.0_qp,1.0_qp)
            end do
 
            ! Expected result

--- a/test/test_linalg_determinant.fypp
+++ b/test/test_linalg_determinant.fypp
@@ -56,10 +56,7 @@ module test_linalg_determinant
 
         ${rt}$ :: a(n,n),deta
 
-        a = 0.0_${rk}$
-        do concurrent (i=1:n)
-          a(i,i) = 1.0_${rk}$
-        end do
+        a = eye(n)
 
         !> Determinant function
         deta = det(a,err=state)
@@ -80,7 +77,7 @@ module test_linalg_determinant
         ${rt}$ :: a(n,n),deta
 
         !> Multiply eye by a very small number
-        a = 0.0_${rk}$
+        a = eye(n)
         do concurrent (i=1:n)
           a(i,i) = coef
         end do
@@ -114,9 +111,9 @@ module test_linalg_determinant
         matrix_size: do n=1,nmax
 
            ! Put 1+i on each diagonal element
-           allocate(a(n,n))
-           do concurrent (i=1:n,j=1:n)
-             a(i,j) = merge((1.0_${ck}$,1.0_${ck}$),(0.0_${ck}$,0.0_${ck}$),i==j)
+           a = eye(n)
+           do concurrent (i=1:n)
+             a(i,i) = (1.0_${ck}$,1.0_${ck}$)
            end do
 
            ! Expected result

--- a/test/test_linalg_eye.f90
+++ b/test/test_linalg_eye.f90
@@ -1,0 +1,208 @@
+
+module test_linalg_eye
+    use stdlib_linalg_interface
+
+    implicit none(type,external)
+
+    contains
+
+    !> Identity matrix tests
+    subroutine test_eye(error)
+        logical,intent(out) :: error
+
+        real :: t0,t1
+
+        call cpu_time(t0)
+
+        call test_s_eye_allocation(error)
+        if (error) return
+        call test_d_eye_allocation(error)
+        if (error) return
+        call test_q_eye_allocation(error)
+        if (error) return
+        call test_c_eye_allocation(error)
+        if (error) return
+        call test_z_eye_allocation(error)
+        if (error) return
+        call test_w_eye_allocation(error)
+        if (error) return
+
+        call cpu_time(t1)
+
+        print 1,1000*(t1 - t0),merge('SUCCESS','ERROR  ',.not. error)
+
+1       format('Identity matrix tests completed in ',f9.4,' milliseconds, result=',a)
+
+    end subroutine test_eye
+
+    !> Determinant of identity matrix
+    subroutine test_s_eye_allocation(error)
+        logical,intent(out) :: error
+
+        type(linalg_state) :: state
+
+        integer(ilp) :: i
+        integer(ilp),parameter :: n = 128_ilp
+
+        real(sp),allocatable :: a(:,:)
+        real(sp) :: dummy
+
+        !> Should be error
+        a = eye(-1,dtype=dummy,err=state)
+        error = .not. state%error()
+        if (error) return
+
+        !> Should be error
+        a = eye(5,-1,dtype=dummy,err=state)
+        error = .not. state%error()
+        if (error) return
+
+        !> Should be ok
+        a = eye(0,5,dtype=dummy,err=state)
+        error = state%error() .or. any(shape(a) /= [0,5])
+        if (error) return
+
+    end subroutine test_s_eye_allocation
+
+    subroutine test_d_eye_allocation(error)
+        logical,intent(out) :: error
+
+        type(linalg_state) :: state
+
+        integer(ilp) :: i
+        integer(ilp),parameter :: n = 128_ilp
+
+        real(dp),allocatable :: a(:,:)
+        real(dp) :: dummy
+
+        !> Should be error
+        a = eye(-1,dtype=dummy,err=state)
+        error = .not. state%error()
+        if (error) return
+
+        !> Should be error
+        a = eye(5,-1,dtype=dummy,err=state)
+        error = .not. state%error()
+        if (error) return
+
+        !> Should be ok
+        a = eye(0,5,dtype=dummy,err=state)
+        error = state%error() .or. any(shape(a) /= [0,5])
+        if (error) return
+
+    end subroutine test_d_eye_allocation
+
+    subroutine test_q_eye_allocation(error)
+        logical,intent(out) :: error
+
+        type(linalg_state) :: state
+
+        integer(ilp) :: i
+        integer(ilp),parameter :: n = 128_ilp
+
+        real(qp),allocatable :: a(:,:)
+        real(qp) :: dummy
+
+        !> Should be error
+        a = eye(-1,dtype=dummy,err=state)
+        error = .not. state%error()
+        if (error) return
+
+        !> Should be error
+        a = eye(5,-1,dtype=dummy,err=state)
+        error = .not. state%error()
+        if (error) return
+
+        !> Should be ok
+        a = eye(0,5,dtype=dummy,err=state)
+        error = state%error() .or. any(shape(a) /= [0,5])
+        if (error) return
+
+    end subroutine test_q_eye_allocation
+
+    subroutine test_c_eye_allocation(error)
+        logical,intent(out) :: error
+
+        type(linalg_state) :: state
+
+        integer(ilp) :: i
+        integer(ilp),parameter :: n = 128_ilp
+
+        complex(sp),allocatable :: a(:,:)
+        complex(sp) :: dummy
+
+        !> Should be error
+        a = eye(-1,dtype=dummy,err=state)
+        error = .not. state%error()
+        if (error) return
+
+        !> Should be error
+        a = eye(5,-1,dtype=dummy,err=state)
+        error = .not. state%error()
+        if (error) return
+
+        !> Should be ok
+        a = eye(0,5,dtype=dummy,err=state)
+        error = state%error() .or. any(shape(a) /= [0,5])
+        if (error) return
+
+    end subroutine test_c_eye_allocation
+
+    subroutine test_z_eye_allocation(error)
+        logical,intent(out) :: error
+
+        type(linalg_state) :: state
+
+        integer(ilp) :: i
+        integer(ilp),parameter :: n = 128_ilp
+
+        complex(dp),allocatable :: a(:,:)
+        complex(dp) :: dummy
+
+        !> Should be error
+        a = eye(-1,dtype=dummy,err=state)
+        error = .not. state%error()
+        if (error) return
+
+        !> Should be error
+        a = eye(5,-1,dtype=dummy,err=state)
+        error = .not. state%error()
+        if (error) return
+
+        !> Should be ok
+        a = eye(0,5,dtype=dummy,err=state)
+        error = state%error() .or. any(shape(a) /= [0,5])
+        if (error) return
+
+    end subroutine test_z_eye_allocation
+
+    subroutine test_w_eye_allocation(error)
+        logical,intent(out) :: error
+
+        type(linalg_state) :: state
+
+        integer(ilp) :: i
+        integer(ilp),parameter :: n = 128_ilp
+
+        complex(qp),allocatable :: a(:,:)
+        complex(qp) :: dummy
+
+        !> Should be error
+        a = eye(-1,dtype=dummy,err=state)
+        error = .not. state%error()
+        if (error) return
+
+        !> Should be error
+        a = eye(5,-1,dtype=dummy,err=state)
+        error = .not. state%error()
+        if (error) return
+
+        !> Should be ok
+        a = eye(0,5,dtype=dummy,err=state)
+        error = state%error() .or. any(shape(a) /= [0,5])
+        if (error) return
+
+    end subroutine test_w_eye_allocation
+
+end module test_linalg_eye
+

--- a/test/test_linalg_eye.f90
+++ b/test/test_linalg_eye.f90
@@ -15,16 +15,28 @@ module test_linalg_eye
         call cpu_time(t0)
 
         call test_s_eye_allocation(error)
+        call test_s_diag_scalar(error)
+        call test_s_diag_array(error)
         if (error) return
         call test_d_eye_allocation(error)
+        call test_d_diag_scalar(error)
+        call test_d_diag_array(error)
         if (error) return
         call test_q_eye_allocation(error)
+        call test_q_diag_scalar(error)
+        call test_q_diag_array(error)
         if (error) return
         call test_c_eye_allocation(error)
+        call test_c_diag_scalar(error)
+        call test_c_diag_array(error)
         if (error) return
         call test_z_eye_allocation(error)
+        call test_z_diag_scalar(error)
+        call test_z_diag_array(error)
         if (error) return
         call test_w_eye_allocation(error)
+        call test_w_diag_scalar(error)
+        call test_w_diag_array(error)
         if (error) return
 
         call cpu_time(t1)
@@ -35,7 +47,7 @@ module test_linalg_eye
 
     end subroutine test_eye
 
-    !> Determinant of identity matrix
+    !> Identity matrix: test allocation
     subroutine test_s_eye_allocation(error)
         logical,intent(out) :: error
 
@@ -63,15 +75,76 @@ module test_linalg_eye
 
         !> Test identity values
         a = eye(5,10,dtype=dummy,err=state)
-        error = state%error() .or. nint(sum(a),kind=ilp) /= 5
+        error = state%error() .or. nint(real(sum(a),kind=sp),kind=ilp) /= 5
         if (error) return
 
         a = eye(10,5,dtype=dummy,err=state)
-        error = state%error() .or. nint(sum(a),kind=ilp) /= 5
+        error = state%error() .or. nint(real(sum(a),kind=sp),kind=ilp) /= 5
         if (error) return
 
     end subroutine test_s_eye_allocation
 
+    !> Identity matrix from scalar
+    subroutine test_s_diag_scalar(error)
+        logical,intent(out) :: error
+
+        type(linalg_state) :: state
+
+        integer(ilp) :: i
+
+        real(sp),allocatable :: a(:,:)
+        real(sp) :: dummy
+
+        dummy = 2.0_sp
+
+        !> Should be error
+        a = diag(-1,dvalue=dummy,err=state)
+        error = .not. state%error()
+        if (error) return
+
+        !> Should be ok
+        a = diag(0,dvalue=dummy,err=state)
+        error = state%error() .or. any(shape(a) /= 0)
+        if (error) return
+
+        !> Test identity values
+        a = diag(5,dvalue=dummy,err=state)
+        error = state%error() .or. nint(real(sum(a),kind=sp),kind=ilp) /= 10
+
+        a = diag(12,dvalue=dummy,err=state)
+        error = state%error() .or. nint(real(sum(a),kind=sp),kind=ilp) /= 24
+        if (error) return
+
+    end subroutine test_s_diag_scalar
+
+    !> Identity matrix from array
+    subroutine test_s_diag_array(error)
+        logical,intent(out) :: error
+
+        type(linalg_state) :: state
+
+        integer(ilp) :: i
+
+        integer(ilp),parameter :: array_sizes(*) = [1,2,5,10,20,50,100]
+        real(sp),allocatable :: a(:,:),darr(:)
+
+        do i = 1,size(array_sizes)
+
+            allocate (darr(array_sizes(i)))
+            darr = 2.0_sp
+
+            !> Test with several sizes
+            a = diag(dvalues=darr,err=state)
+            error = state%error() .or. any(shape(a) /= size(darr)) .or. sum(a) /= sum(darr)
+            if (error) return
+
+            deallocate (darr)
+
+        end do
+
+    end subroutine test_s_diag_array
+
+    !> Identity matrix: test allocation
     subroutine test_d_eye_allocation(error)
         logical,intent(out) :: error
 
@@ -99,15 +172,76 @@ module test_linalg_eye
 
         !> Test identity values
         a = eye(5,10,dtype=dummy,err=state)
-        error = state%error() .or. nint(sum(a),kind=ilp) /= 5
+        error = state%error() .or. nint(real(sum(a),kind=dp),kind=ilp) /= 5
         if (error) return
 
         a = eye(10,5,dtype=dummy,err=state)
-        error = state%error() .or. nint(sum(a),kind=ilp) /= 5
+        error = state%error() .or. nint(real(sum(a),kind=dp),kind=ilp) /= 5
         if (error) return
 
     end subroutine test_d_eye_allocation
 
+    !> Identity matrix from scalar
+    subroutine test_d_diag_scalar(error)
+        logical,intent(out) :: error
+
+        type(linalg_state) :: state
+
+        integer(ilp) :: i
+
+        real(dp),allocatable :: a(:,:)
+        real(dp) :: dummy
+
+        dummy = 2.0_dp
+
+        !> Should be error
+        a = diag(-1,dvalue=dummy,err=state)
+        error = .not. state%error()
+        if (error) return
+
+        !> Should be ok
+        a = diag(0,dvalue=dummy,err=state)
+        error = state%error() .or. any(shape(a) /= 0)
+        if (error) return
+
+        !> Test identity values
+        a = diag(5,dvalue=dummy,err=state)
+        error = state%error() .or. nint(real(sum(a),kind=dp),kind=ilp) /= 10
+
+        a = diag(12,dvalue=dummy,err=state)
+        error = state%error() .or. nint(real(sum(a),kind=dp),kind=ilp) /= 24
+        if (error) return
+
+    end subroutine test_d_diag_scalar
+
+    !> Identity matrix from array
+    subroutine test_d_diag_array(error)
+        logical,intent(out) :: error
+
+        type(linalg_state) :: state
+
+        integer(ilp) :: i
+
+        integer(ilp),parameter :: array_sizes(*) = [1,2,5,10,20,50,100]
+        real(dp),allocatable :: a(:,:),darr(:)
+
+        do i = 1,size(array_sizes)
+
+            allocate (darr(array_sizes(i)))
+            darr = 2.0_dp
+
+            !> Test with several sizes
+            a = diag(dvalues=darr,err=state)
+            error = state%error() .or. any(shape(a) /= size(darr)) .or. sum(a) /= sum(darr)
+            if (error) return
+
+            deallocate (darr)
+
+        end do
+
+    end subroutine test_d_diag_array
+
+    !> Identity matrix: test allocation
     subroutine test_q_eye_allocation(error)
         logical,intent(out) :: error
 
@@ -135,15 +269,76 @@ module test_linalg_eye
 
         !> Test identity values
         a = eye(5,10,dtype=dummy,err=state)
-        error = state%error() .or. nint(sum(a),kind=ilp) /= 5
+        error = state%error() .or. nint(real(sum(a),kind=qp),kind=ilp) /= 5
         if (error) return
 
         a = eye(10,5,dtype=dummy,err=state)
-        error = state%error() .or. nint(sum(a),kind=ilp) /= 5
+        error = state%error() .or. nint(real(sum(a),kind=qp),kind=ilp) /= 5
         if (error) return
 
     end subroutine test_q_eye_allocation
 
+    !> Identity matrix from scalar
+    subroutine test_q_diag_scalar(error)
+        logical,intent(out) :: error
+
+        type(linalg_state) :: state
+
+        integer(ilp) :: i
+
+        real(qp),allocatable :: a(:,:)
+        real(qp) :: dummy
+
+        dummy = 2.0_qp
+
+        !> Should be error
+        a = diag(-1,dvalue=dummy,err=state)
+        error = .not. state%error()
+        if (error) return
+
+        !> Should be ok
+        a = diag(0,dvalue=dummy,err=state)
+        error = state%error() .or. any(shape(a) /= 0)
+        if (error) return
+
+        !> Test identity values
+        a = diag(5,dvalue=dummy,err=state)
+        error = state%error() .or. nint(real(sum(a),kind=qp),kind=ilp) /= 10
+
+        a = diag(12,dvalue=dummy,err=state)
+        error = state%error() .or. nint(real(sum(a),kind=qp),kind=ilp) /= 24
+        if (error) return
+
+    end subroutine test_q_diag_scalar
+
+    !> Identity matrix from array
+    subroutine test_q_diag_array(error)
+        logical,intent(out) :: error
+
+        type(linalg_state) :: state
+
+        integer(ilp) :: i
+
+        integer(ilp),parameter :: array_sizes(*) = [1,2,5,10,20,50,100]
+        real(qp),allocatable :: a(:,:),darr(:)
+
+        do i = 1,size(array_sizes)
+
+            allocate (darr(array_sizes(i)))
+            darr = 2.0_qp
+
+            !> Test with several sizes
+            a = diag(dvalues=darr,err=state)
+            error = state%error() .or. any(shape(a) /= size(darr)) .or. sum(a) /= sum(darr)
+            if (error) return
+
+            deallocate (darr)
+
+        end do
+
+    end subroutine test_q_diag_array
+
+    !> Identity matrix: test allocation
     subroutine test_c_eye_allocation(error)
         logical,intent(out) :: error
 
@@ -171,15 +366,76 @@ module test_linalg_eye
 
         !> Test identity values
         a = eye(5,10,dtype=dummy,err=state)
-        error = state%error() .or. nint(sum(a),kind=ilp) /= 5
+        error = state%error() .or. nint(real(sum(a),kind=sp),kind=ilp) /= 5
         if (error) return
 
         a = eye(10,5,dtype=dummy,err=state)
-        error = state%error() .or. nint(sum(a),kind=ilp) /= 5
+        error = state%error() .or. nint(real(sum(a),kind=sp),kind=ilp) /= 5
         if (error) return
 
     end subroutine test_c_eye_allocation
 
+    !> Identity matrix from scalar
+    subroutine test_c_diag_scalar(error)
+        logical,intent(out) :: error
+
+        type(linalg_state) :: state
+
+        integer(ilp) :: i
+
+        complex(sp),allocatable :: a(:,:)
+        complex(sp) :: dummy
+
+        dummy = 2.0_sp
+
+        !> Should be error
+        a = diag(-1,dvalue=dummy,err=state)
+        error = .not. state%error()
+        if (error) return
+
+        !> Should be ok
+        a = diag(0,dvalue=dummy,err=state)
+        error = state%error() .or. any(shape(a) /= 0)
+        if (error) return
+
+        !> Test identity values
+        a = diag(5,dvalue=dummy,err=state)
+        error = state%error() .or. nint(real(sum(a),kind=sp),kind=ilp) /= 10
+
+        a = diag(12,dvalue=dummy,err=state)
+        error = state%error() .or. nint(real(sum(a),kind=sp),kind=ilp) /= 24
+        if (error) return
+
+    end subroutine test_c_diag_scalar
+
+    !> Identity matrix from array
+    subroutine test_c_diag_array(error)
+        logical,intent(out) :: error
+
+        type(linalg_state) :: state
+
+        integer(ilp) :: i
+
+        integer(ilp),parameter :: array_sizes(*) = [1,2,5,10,20,50,100]
+        complex(sp),allocatable :: a(:,:),darr(:)
+
+        do i = 1,size(array_sizes)
+
+            allocate (darr(array_sizes(i)))
+            darr = 2.0_sp
+
+            !> Test with several sizes
+            a = diag(dvalues=darr,err=state)
+            error = state%error() .or. any(shape(a) /= size(darr)) .or. sum(a) /= sum(darr)
+            if (error) return
+
+            deallocate (darr)
+
+        end do
+
+    end subroutine test_c_diag_array
+
+    !> Identity matrix: test allocation
     subroutine test_z_eye_allocation(error)
         logical,intent(out) :: error
 
@@ -207,15 +463,76 @@ module test_linalg_eye
 
         !> Test identity values
         a = eye(5,10,dtype=dummy,err=state)
-        error = state%error() .or. nint(sum(a),kind=ilp) /= 5
+        error = state%error() .or. nint(real(sum(a),kind=dp),kind=ilp) /= 5
         if (error) return
 
         a = eye(10,5,dtype=dummy,err=state)
-        error = state%error() .or. nint(sum(a),kind=ilp) /= 5
+        error = state%error() .or. nint(real(sum(a),kind=dp),kind=ilp) /= 5
         if (error) return
 
     end subroutine test_z_eye_allocation
 
+    !> Identity matrix from scalar
+    subroutine test_z_diag_scalar(error)
+        logical,intent(out) :: error
+
+        type(linalg_state) :: state
+
+        integer(ilp) :: i
+
+        complex(dp),allocatable :: a(:,:)
+        complex(dp) :: dummy
+
+        dummy = 2.0_dp
+
+        !> Should be error
+        a = diag(-1,dvalue=dummy,err=state)
+        error = .not. state%error()
+        if (error) return
+
+        !> Should be ok
+        a = diag(0,dvalue=dummy,err=state)
+        error = state%error() .or. any(shape(a) /= 0)
+        if (error) return
+
+        !> Test identity values
+        a = diag(5,dvalue=dummy,err=state)
+        error = state%error() .or. nint(real(sum(a),kind=dp),kind=ilp) /= 10
+
+        a = diag(12,dvalue=dummy,err=state)
+        error = state%error() .or. nint(real(sum(a),kind=dp),kind=ilp) /= 24
+        if (error) return
+
+    end subroutine test_z_diag_scalar
+
+    !> Identity matrix from array
+    subroutine test_z_diag_array(error)
+        logical,intent(out) :: error
+
+        type(linalg_state) :: state
+
+        integer(ilp) :: i
+
+        integer(ilp),parameter :: array_sizes(*) = [1,2,5,10,20,50,100]
+        complex(dp),allocatable :: a(:,:),darr(:)
+
+        do i = 1,size(array_sizes)
+
+            allocate (darr(array_sizes(i)))
+            darr = 2.0_dp
+
+            !> Test with several sizes
+            a = diag(dvalues=darr,err=state)
+            error = state%error() .or. any(shape(a) /= size(darr)) .or. sum(a) /= sum(darr)
+            if (error) return
+
+            deallocate (darr)
+
+        end do
+
+    end subroutine test_z_diag_array
+
+    !> Identity matrix: test allocation
     subroutine test_w_eye_allocation(error)
         logical,intent(out) :: error
 
@@ -243,14 +560,74 @@ module test_linalg_eye
 
         !> Test identity values
         a = eye(5,10,dtype=dummy,err=state)
-        error = state%error() .or. nint(sum(a),kind=ilp) /= 5
+        error = state%error() .or. nint(real(sum(a),kind=qp),kind=ilp) /= 5
         if (error) return
 
         a = eye(10,5,dtype=dummy,err=state)
-        error = state%error() .or. nint(sum(a),kind=ilp) /= 5
+        error = state%error() .or. nint(real(sum(a),kind=qp),kind=ilp) /= 5
         if (error) return
 
     end subroutine test_w_eye_allocation
+
+    !> Identity matrix from scalar
+    subroutine test_w_diag_scalar(error)
+        logical,intent(out) :: error
+
+        type(linalg_state) :: state
+
+        integer(ilp) :: i
+
+        complex(qp),allocatable :: a(:,:)
+        complex(qp) :: dummy
+
+        dummy = 2.0_qp
+
+        !> Should be error
+        a = diag(-1,dvalue=dummy,err=state)
+        error = .not. state%error()
+        if (error) return
+
+        !> Should be ok
+        a = diag(0,dvalue=dummy,err=state)
+        error = state%error() .or. any(shape(a) /= 0)
+        if (error) return
+
+        !> Test identity values
+        a = diag(5,dvalue=dummy,err=state)
+        error = state%error() .or. nint(real(sum(a),kind=qp),kind=ilp) /= 10
+
+        a = diag(12,dvalue=dummy,err=state)
+        error = state%error() .or. nint(real(sum(a),kind=qp),kind=ilp) /= 24
+        if (error) return
+
+    end subroutine test_w_diag_scalar
+
+    !> Identity matrix from array
+    subroutine test_w_diag_array(error)
+        logical,intent(out) :: error
+
+        type(linalg_state) :: state
+
+        integer(ilp) :: i
+
+        integer(ilp),parameter :: array_sizes(*) = [1,2,5,10,20,50,100]
+        complex(qp),allocatable :: a(:,:),darr(:)
+
+        do i = 1,size(array_sizes)
+
+            allocate (darr(array_sizes(i)))
+            darr = 2.0_qp
+
+            !> Test with several sizes
+            a = diag(dvalues=darr,err=state)
+            error = state%error() .or. any(shape(a) /= size(darr)) .or. sum(a) /= sum(darr)
+            if (error) return
+
+            deallocate (darr)
+
+        end do
+
+    end subroutine test_w_diag_array
 
 end module test_linalg_eye
 

--- a/test/test_linalg_eye.f90
+++ b/test/test_linalg_eye.f90
@@ -42,7 +42,6 @@ module test_linalg_eye
         type(linalg_state) :: state
 
         integer(ilp) :: i
-        integer(ilp),parameter :: n = 128_ilp
 
         real(sp),allocatable :: a(:,:)
         real(sp) :: dummy
@@ -62,6 +61,15 @@ module test_linalg_eye
         error = state%error() .or. any(shape(a) /= [0,5])
         if (error) return
 
+        !> Test identity values
+        a = eye(5,10,dtype=dummy,err=state)
+        error = state%error() .or. nint(sum(a),kind=ilp) /= 5
+        if (error) return
+
+        a = eye(10,5,dtype=dummy,err=state)
+        error = state%error() .or. nint(sum(a),kind=ilp) /= 5
+        if (error) return
+
     end subroutine test_s_eye_allocation
 
     subroutine test_d_eye_allocation(error)
@@ -70,7 +78,6 @@ module test_linalg_eye
         type(linalg_state) :: state
 
         integer(ilp) :: i
-        integer(ilp),parameter :: n = 128_ilp
 
         real(dp),allocatable :: a(:,:)
         real(dp) :: dummy
@@ -90,6 +97,15 @@ module test_linalg_eye
         error = state%error() .or. any(shape(a) /= [0,5])
         if (error) return
 
+        !> Test identity values
+        a = eye(5,10,dtype=dummy,err=state)
+        error = state%error() .or. nint(sum(a),kind=ilp) /= 5
+        if (error) return
+
+        a = eye(10,5,dtype=dummy,err=state)
+        error = state%error() .or. nint(sum(a),kind=ilp) /= 5
+        if (error) return
+
     end subroutine test_d_eye_allocation
 
     subroutine test_q_eye_allocation(error)
@@ -98,7 +114,6 @@ module test_linalg_eye
         type(linalg_state) :: state
 
         integer(ilp) :: i
-        integer(ilp),parameter :: n = 128_ilp
 
         real(qp),allocatable :: a(:,:)
         real(qp) :: dummy
@@ -118,6 +133,15 @@ module test_linalg_eye
         error = state%error() .or. any(shape(a) /= [0,5])
         if (error) return
 
+        !> Test identity values
+        a = eye(5,10,dtype=dummy,err=state)
+        error = state%error() .or. nint(sum(a),kind=ilp) /= 5
+        if (error) return
+
+        a = eye(10,5,dtype=dummy,err=state)
+        error = state%error() .or. nint(sum(a),kind=ilp) /= 5
+        if (error) return
+
     end subroutine test_q_eye_allocation
 
     subroutine test_c_eye_allocation(error)
@@ -126,7 +150,6 @@ module test_linalg_eye
         type(linalg_state) :: state
 
         integer(ilp) :: i
-        integer(ilp),parameter :: n = 128_ilp
 
         complex(sp),allocatable :: a(:,:)
         complex(sp) :: dummy
@@ -146,6 +169,15 @@ module test_linalg_eye
         error = state%error() .or. any(shape(a) /= [0,5])
         if (error) return
 
+        !> Test identity values
+        a = eye(5,10,dtype=dummy,err=state)
+        error = state%error() .or. nint(sum(a),kind=ilp) /= 5
+        if (error) return
+
+        a = eye(10,5,dtype=dummy,err=state)
+        error = state%error() .or. nint(sum(a),kind=ilp) /= 5
+        if (error) return
+
     end subroutine test_c_eye_allocation
 
     subroutine test_z_eye_allocation(error)
@@ -154,7 +186,6 @@ module test_linalg_eye
         type(linalg_state) :: state
 
         integer(ilp) :: i
-        integer(ilp),parameter :: n = 128_ilp
 
         complex(dp),allocatable :: a(:,:)
         complex(dp) :: dummy
@@ -174,6 +205,15 @@ module test_linalg_eye
         error = state%error() .or. any(shape(a) /= [0,5])
         if (error) return
 
+        !> Test identity values
+        a = eye(5,10,dtype=dummy,err=state)
+        error = state%error() .or. nint(sum(a),kind=ilp) /= 5
+        if (error) return
+
+        a = eye(10,5,dtype=dummy,err=state)
+        error = state%error() .or. nint(sum(a),kind=ilp) /= 5
+        if (error) return
+
     end subroutine test_z_eye_allocation
 
     subroutine test_w_eye_allocation(error)
@@ -182,7 +222,6 @@ module test_linalg_eye
         type(linalg_state) :: state
 
         integer(ilp) :: i
-        integer(ilp),parameter :: n = 128_ilp
 
         complex(qp),allocatable :: a(:,:)
         complex(qp) :: dummy
@@ -200,6 +239,15 @@ module test_linalg_eye
         !> Should be ok
         a = eye(0,5,dtype=dummy,err=state)
         error = state%error() .or. any(shape(a) /= [0,5])
+        if (error) return
+
+        !> Test identity values
+        a = eye(5,10,dtype=dummy,err=state)
+        error = state%error() .or. nint(sum(a),kind=ilp) /= 5
+        if (error) return
+
+        a = eye(10,5,dtype=dummy,err=state)
+        error = state%error() .or. nint(sum(a),kind=ilp) /= 5
         if (error) return
 
     end subroutine test_w_eye_allocation

--- a/test/test_linalg_eye.f90
+++ b/test/test_linalg_eye.f90
@@ -59,32 +59,32 @@ module test_linalg_eye
         real(sp) :: dummy
 
         !> Should be error
-        a = eye(-1,dtype=dummy,err=state)
+        a = eye(-1,mold=dummy,err=state)
         error = .not. state%error()
         if (error) return
 
         !> Should be error
-        a = eye(5,-1,dtype=dummy,err=state)
+        a = eye(5,-1,mold=dummy,err=state)
         error = .not. state%error()
         if (error) return
 
         !> Should be ok
-        a = eye(0,5,dtype=dummy,err=state)
+        a = eye(0,5,mold=dummy,err=state)
         error = state%error() .or. any(shape(a) /= [0,5])
         if (error) return
 
         !> Test identity values
-        a = eye(5,10,dtype=dummy,err=state)
+        a = eye(5,10,mold=dummy,err=state)
         error = state%error() .or. nint(real(sum(a),kind=sp),kind=ilp) /= 5
         if (error) return
 
-        a = eye(10,5,dtype=dummy,err=state)
+        a = eye(10,5,mold=dummy,err=state)
         error = state%error() .or. nint(real(sum(a),kind=sp),kind=ilp) /= 5
         if (error) return
 
     end subroutine test_s_eye_allocation
 
-    !> Identity matrix from scalar
+    !> Diagonal matrix from scalar
     subroutine test_s_diag_scalar(error)
         logical,intent(out) :: error
 
@@ -98,26 +98,26 @@ module test_linalg_eye
         dummy = 2.0_sp
 
         !> Should be error
-        a = diag(-1,dvalue=dummy,err=state)
+        a = diag(-1,source=dummy,err=state)
         error = .not. state%error()
         if (error) return
 
         !> Should be ok
-        a = diag(0,dvalue=dummy,err=state)
+        a = diag(0,source=dummy,err=state)
         error = state%error() .or. any(shape(a) /= 0)
         if (error) return
 
         !> Test identity values
-        a = diag(5,dvalue=dummy,err=state)
+        a = diag(5,source=dummy,err=state)
         error = state%error() .or. nint(real(sum(a),kind=sp),kind=ilp) /= 10
 
-        a = diag(12,dvalue=dummy,err=state)
+        a = diag(12,source=dummy,err=state)
         error = state%error() .or. nint(real(sum(a),kind=sp),kind=ilp) /= 24
         if (error) return
 
     end subroutine test_s_diag_scalar
 
-    !> Identity matrix from array
+    !> Diagonal matrix from array
     subroutine test_s_diag_array(error)
         logical,intent(out) :: error
 
@@ -134,7 +134,7 @@ module test_linalg_eye
             darr = 2.0_sp
 
             !> Test with several sizes
-            a = diag(dvalues=darr,err=state)
+            a = diag(source=darr,err=state)
             error = state%error() .or. any(shape(a) /= size(darr)) .or. sum(a) /= sum(darr)
             if (error) return
 
@@ -156,32 +156,32 @@ module test_linalg_eye
         real(dp) :: dummy
 
         !> Should be error
-        a = eye(-1,dtype=dummy,err=state)
+        a = eye(-1,mold=dummy,err=state)
         error = .not. state%error()
         if (error) return
 
         !> Should be error
-        a = eye(5,-1,dtype=dummy,err=state)
+        a = eye(5,-1,mold=dummy,err=state)
         error = .not. state%error()
         if (error) return
 
         !> Should be ok
-        a = eye(0,5,dtype=dummy,err=state)
+        a = eye(0,5,mold=dummy,err=state)
         error = state%error() .or. any(shape(a) /= [0,5])
         if (error) return
 
         !> Test identity values
-        a = eye(5,10,dtype=dummy,err=state)
+        a = eye(5,10,mold=dummy,err=state)
         error = state%error() .or. nint(real(sum(a),kind=dp),kind=ilp) /= 5
         if (error) return
 
-        a = eye(10,5,dtype=dummy,err=state)
+        a = eye(10,5,mold=dummy,err=state)
         error = state%error() .or. nint(real(sum(a),kind=dp),kind=ilp) /= 5
         if (error) return
 
     end subroutine test_d_eye_allocation
 
-    !> Identity matrix from scalar
+    !> Diagonal matrix from scalar
     subroutine test_d_diag_scalar(error)
         logical,intent(out) :: error
 
@@ -195,26 +195,26 @@ module test_linalg_eye
         dummy = 2.0_dp
 
         !> Should be error
-        a = diag(-1,dvalue=dummy,err=state)
+        a = diag(-1,source=dummy,err=state)
         error = .not. state%error()
         if (error) return
 
         !> Should be ok
-        a = diag(0,dvalue=dummy,err=state)
+        a = diag(0,source=dummy,err=state)
         error = state%error() .or. any(shape(a) /= 0)
         if (error) return
 
         !> Test identity values
-        a = diag(5,dvalue=dummy,err=state)
+        a = diag(5,source=dummy,err=state)
         error = state%error() .or. nint(real(sum(a),kind=dp),kind=ilp) /= 10
 
-        a = diag(12,dvalue=dummy,err=state)
+        a = diag(12,source=dummy,err=state)
         error = state%error() .or. nint(real(sum(a),kind=dp),kind=ilp) /= 24
         if (error) return
 
     end subroutine test_d_diag_scalar
 
-    !> Identity matrix from array
+    !> Diagonal matrix from array
     subroutine test_d_diag_array(error)
         logical,intent(out) :: error
 
@@ -231,7 +231,7 @@ module test_linalg_eye
             darr = 2.0_dp
 
             !> Test with several sizes
-            a = diag(dvalues=darr,err=state)
+            a = diag(source=darr,err=state)
             error = state%error() .or. any(shape(a) /= size(darr)) .or. sum(a) /= sum(darr)
             if (error) return
 
@@ -253,32 +253,32 @@ module test_linalg_eye
         real(qp) :: dummy
 
         !> Should be error
-        a = eye(-1,dtype=dummy,err=state)
+        a = eye(-1,mold=dummy,err=state)
         error = .not. state%error()
         if (error) return
 
         !> Should be error
-        a = eye(5,-1,dtype=dummy,err=state)
+        a = eye(5,-1,mold=dummy,err=state)
         error = .not. state%error()
         if (error) return
 
         !> Should be ok
-        a = eye(0,5,dtype=dummy,err=state)
+        a = eye(0,5,mold=dummy,err=state)
         error = state%error() .or. any(shape(a) /= [0,5])
         if (error) return
 
         !> Test identity values
-        a = eye(5,10,dtype=dummy,err=state)
+        a = eye(5,10,mold=dummy,err=state)
         error = state%error() .or. nint(real(sum(a),kind=qp),kind=ilp) /= 5
         if (error) return
 
-        a = eye(10,5,dtype=dummy,err=state)
+        a = eye(10,5,mold=dummy,err=state)
         error = state%error() .or. nint(real(sum(a),kind=qp),kind=ilp) /= 5
         if (error) return
 
     end subroutine test_q_eye_allocation
 
-    !> Identity matrix from scalar
+    !> Diagonal matrix from scalar
     subroutine test_q_diag_scalar(error)
         logical,intent(out) :: error
 
@@ -292,26 +292,26 @@ module test_linalg_eye
         dummy = 2.0_qp
 
         !> Should be error
-        a = diag(-1,dvalue=dummy,err=state)
+        a = diag(-1,source=dummy,err=state)
         error = .not. state%error()
         if (error) return
 
         !> Should be ok
-        a = diag(0,dvalue=dummy,err=state)
+        a = diag(0,source=dummy,err=state)
         error = state%error() .or. any(shape(a) /= 0)
         if (error) return
 
         !> Test identity values
-        a = diag(5,dvalue=dummy,err=state)
+        a = diag(5,source=dummy,err=state)
         error = state%error() .or. nint(real(sum(a),kind=qp),kind=ilp) /= 10
 
-        a = diag(12,dvalue=dummy,err=state)
+        a = diag(12,source=dummy,err=state)
         error = state%error() .or. nint(real(sum(a),kind=qp),kind=ilp) /= 24
         if (error) return
 
     end subroutine test_q_diag_scalar
 
-    !> Identity matrix from array
+    !> Diagonal matrix from array
     subroutine test_q_diag_array(error)
         logical,intent(out) :: error
 
@@ -328,7 +328,7 @@ module test_linalg_eye
             darr = 2.0_qp
 
             !> Test with several sizes
-            a = diag(dvalues=darr,err=state)
+            a = diag(source=darr,err=state)
             error = state%error() .or. any(shape(a) /= size(darr)) .or. sum(a) /= sum(darr)
             if (error) return
 
@@ -350,32 +350,32 @@ module test_linalg_eye
         complex(sp) :: dummy
 
         !> Should be error
-        a = eye(-1,dtype=dummy,err=state)
+        a = eye(-1,mold=dummy,err=state)
         error = .not. state%error()
         if (error) return
 
         !> Should be error
-        a = eye(5,-1,dtype=dummy,err=state)
+        a = eye(5,-1,mold=dummy,err=state)
         error = .not. state%error()
         if (error) return
 
         !> Should be ok
-        a = eye(0,5,dtype=dummy,err=state)
+        a = eye(0,5,mold=dummy,err=state)
         error = state%error() .or. any(shape(a) /= [0,5])
         if (error) return
 
         !> Test identity values
-        a = eye(5,10,dtype=dummy,err=state)
+        a = eye(5,10,mold=dummy,err=state)
         error = state%error() .or. nint(real(sum(a),kind=sp),kind=ilp) /= 5
         if (error) return
 
-        a = eye(10,5,dtype=dummy,err=state)
+        a = eye(10,5,mold=dummy,err=state)
         error = state%error() .or. nint(real(sum(a),kind=sp),kind=ilp) /= 5
         if (error) return
 
     end subroutine test_c_eye_allocation
 
-    !> Identity matrix from scalar
+    !> Diagonal matrix from scalar
     subroutine test_c_diag_scalar(error)
         logical,intent(out) :: error
 
@@ -389,26 +389,26 @@ module test_linalg_eye
         dummy = 2.0_sp
 
         !> Should be error
-        a = diag(-1,dvalue=dummy,err=state)
+        a = diag(-1,source=dummy,err=state)
         error = .not. state%error()
         if (error) return
 
         !> Should be ok
-        a = diag(0,dvalue=dummy,err=state)
+        a = diag(0,source=dummy,err=state)
         error = state%error() .or. any(shape(a) /= 0)
         if (error) return
 
         !> Test identity values
-        a = diag(5,dvalue=dummy,err=state)
+        a = diag(5,source=dummy,err=state)
         error = state%error() .or. nint(real(sum(a),kind=sp),kind=ilp) /= 10
 
-        a = diag(12,dvalue=dummy,err=state)
+        a = diag(12,source=dummy,err=state)
         error = state%error() .or. nint(real(sum(a),kind=sp),kind=ilp) /= 24
         if (error) return
 
     end subroutine test_c_diag_scalar
 
-    !> Identity matrix from array
+    !> Diagonal matrix from array
     subroutine test_c_diag_array(error)
         logical,intent(out) :: error
 
@@ -425,7 +425,7 @@ module test_linalg_eye
             darr = 2.0_sp
 
             !> Test with several sizes
-            a = diag(dvalues=darr,err=state)
+            a = diag(source=darr,err=state)
             error = state%error() .or. any(shape(a) /= size(darr)) .or. sum(a) /= sum(darr)
             if (error) return
 
@@ -447,32 +447,32 @@ module test_linalg_eye
         complex(dp) :: dummy
 
         !> Should be error
-        a = eye(-1,dtype=dummy,err=state)
+        a = eye(-1,mold=dummy,err=state)
         error = .not. state%error()
         if (error) return
 
         !> Should be error
-        a = eye(5,-1,dtype=dummy,err=state)
+        a = eye(5,-1,mold=dummy,err=state)
         error = .not. state%error()
         if (error) return
 
         !> Should be ok
-        a = eye(0,5,dtype=dummy,err=state)
+        a = eye(0,5,mold=dummy,err=state)
         error = state%error() .or. any(shape(a) /= [0,5])
         if (error) return
 
         !> Test identity values
-        a = eye(5,10,dtype=dummy,err=state)
+        a = eye(5,10,mold=dummy,err=state)
         error = state%error() .or. nint(real(sum(a),kind=dp),kind=ilp) /= 5
         if (error) return
 
-        a = eye(10,5,dtype=dummy,err=state)
+        a = eye(10,5,mold=dummy,err=state)
         error = state%error() .or. nint(real(sum(a),kind=dp),kind=ilp) /= 5
         if (error) return
 
     end subroutine test_z_eye_allocation
 
-    !> Identity matrix from scalar
+    !> Diagonal matrix from scalar
     subroutine test_z_diag_scalar(error)
         logical,intent(out) :: error
 
@@ -486,26 +486,26 @@ module test_linalg_eye
         dummy = 2.0_dp
 
         !> Should be error
-        a = diag(-1,dvalue=dummy,err=state)
+        a = diag(-1,source=dummy,err=state)
         error = .not. state%error()
         if (error) return
 
         !> Should be ok
-        a = diag(0,dvalue=dummy,err=state)
+        a = diag(0,source=dummy,err=state)
         error = state%error() .or. any(shape(a) /= 0)
         if (error) return
 
         !> Test identity values
-        a = diag(5,dvalue=dummy,err=state)
+        a = diag(5,source=dummy,err=state)
         error = state%error() .or. nint(real(sum(a),kind=dp),kind=ilp) /= 10
 
-        a = diag(12,dvalue=dummy,err=state)
+        a = diag(12,source=dummy,err=state)
         error = state%error() .or. nint(real(sum(a),kind=dp),kind=ilp) /= 24
         if (error) return
 
     end subroutine test_z_diag_scalar
 
-    !> Identity matrix from array
+    !> Diagonal matrix from array
     subroutine test_z_diag_array(error)
         logical,intent(out) :: error
 
@@ -522,7 +522,7 @@ module test_linalg_eye
             darr = 2.0_dp
 
             !> Test with several sizes
-            a = diag(dvalues=darr,err=state)
+            a = diag(source=darr,err=state)
             error = state%error() .or. any(shape(a) /= size(darr)) .or. sum(a) /= sum(darr)
             if (error) return
 
@@ -544,32 +544,32 @@ module test_linalg_eye
         complex(qp) :: dummy
 
         !> Should be error
-        a = eye(-1,dtype=dummy,err=state)
+        a = eye(-1,mold=dummy,err=state)
         error = .not. state%error()
         if (error) return
 
         !> Should be error
-        a = eye(5,-1,dtype=dummy,err=state)
+        a = eye(5,-1,mold=dummy,err=state)
         error = .not. state%error()
         if (error) return
 
         !> Should be ok
-        a = eye(0,5,dtype=dummy,err=state)
+        a = eye(0,5,mold=dummy,err=state)
         error = state%error() .or. any(shape(a) /= [0,5])
         if (error) return
 
         !> Test identity values
-        a = eye(5,10,dtype=dummy,err=state)
+        a = eye(5,10,mold=dummy,err=state)
         error = state%error() .or. nint(real(sum(a),kind=qp),kind=ilp) /= 5
         if (error) return
 
-        a = eye(10,5,dtype=dummy,err=state)
+        a = eye(10,5,mold=dummy,err=state)
         error = state%error() .or. nint(real(sum(a),kind=qp),kind=ilp) /= 5
         if (error) return
 
     end subroutine test_w_eye_allocation
 
-    !> Identity matrix from scalar
+    !> Diagonal matrix from scalar
     subroutine test_w_diag_scalar(error)
         logical,intent(out) :: error
 
@@ -583,26 +583,26 @@ module test_linalg_eye
         dummy = 2.0_qp
 
         !> Should be error
-        a = diag(-1,dvalue=dummy,err=state)
+        a = diag(-1,source=dummy,err=state)
         error = .not. state%error()
         if (error) return
 
         !> Should be ok
-        a = diag(0,dvalue=dummy,err=state)
+        a = diag(0,source=dummy,err=state)
         error = state%error() .or. any(shape(a) /= 0)
         if (error) return
 
         !> Test identity values
-        a = diag(5,dvalue=dummy,err=state)
+        a = diag(5,source=dummy,err=state)
         error = state%error() .or. nint(real(sum(a),kind=qp),kind=ilp) /= 10
 
-        a = diag(12,dvalue=dummy,err=state)
+        a = diag(12,source=dummy,err=state)
         error = state%error() .or. nint(real(sum(a),kind=qp),kind=ilp) /= 24
         if (error) return
 
     end subroutine test_w_diag_scalar
 
-    !> Identity matrix from array
+    !> Diagonal matrix from array
     subroutine test_w_diag_array(error)
         logical,intent(out) :: error
 
@@ -619,7 +619,7 @@ module test_linalg_eye
             darr = 2.0_qp
 
             !> Test with several sizes
-            a = diag(dvalues=darr,err=state)
+            a = diag(source=darr,err=state)
             error = state%error() .or. any(shape(a) /= size(darr)) .or. sum(a) /= sum(darr)
             if (error) return
 

--- a/test/test_linalg_eye.fypp
+++ b/test/test_linalg_eye.fypp
@@ -1,0 +1,72 @@
+#:set REAL_KINDS    = ["sp", "dp", "qp"]
+#:set REAL_INITIALS = ["s","d","q"]
+#:set REAL_TYPES    = ["real({})".format(k) for k in REAL_KINDS]
+#:set REAL_KINDS_TYPES = list(zip(REAL_KINDS, REAL_TYPES, REAL_INITIALS))
+#:set CMPL_INITIALS = ["c","z","w"]
+#:set CMPL_TYPES    = ["complex({})".format(k) for k in REAL_KINDS]
+#:set CMPL_KINDS_TYPES = list(zip(REAL_KINDS, CMPL_TYPES, CMPL_INITIALS))
+#:set ALL_KINDS_TYPES = list(zip(REAL_KINDS+REAL_KINDS,REAL_TYPES+CMPL_TYPES,REAL_INITIALS+CMPL_INITIALS))
+
+module test_linalg_eye
+    use stdlib_linalg_interface
+
+    implicit none (type,external)
+
+    contains
+
+    !> Identity matrix tests
+    subroutine test_eye(error)
+        logical, intent(out) :: error
+
+        real :: t0,t1
+
+        call cpu_time(t0)
+
+        #:for rk,rt,ri in ALL_KINDS_TYPES
+        call test_${ri}$_eye_allocation(error)
+        if (error) return
+        #: endfor
+
+        call cpu_time(t1)
+
+        print 1, 1000*(t1-t0), merge('SUCCESS','ERROR  ',.not.error)
+
+        1 format('Identity matrix tests completed in ',f9.4,' milliseconds, result=',a)
+
+    end subroutine test_eye
+
+    !> Determinant of identity matrix
+    #:for rk,rt,ri in ALL_KINDS_TYPES
+    subroutine test_${ri}$_eye_allocation(error)
+        logical, intent(out) :: error
+
+        type(linalg_state) :: state
+
+        integer(ilp) :: i
+        integer(ilp), parameter :: n = 128_ilp
+
+        ${rt}$, allocatable :: a(:,:)
+        ${rt}$ :: dummy
+
+        !> Should be error
+        a = eye(-1,dtype=dummy,err=state)
+        error = .not.state%error()
+        if (error) return
+
+        !> Should be error
+        a = eye(5,-1,dtype=dummy,err=state)
+        error = .not.state%error()
+        if (error) return
+
+        !> Should be ok
+        a = eye(0,5,dtype=dummy,err=state)
+        error = state%error() .or. any(shape(a)/=[0,5])
+        if (error) return
+
+    end subroutine test_${ri}$_eye_allocation
+
+    #:endfor
+
+end module test_linalg_eye
+
+

--- a/test/test_linalg_eye.fypp
+++ b/test/test_linalg_eye.fypp
@@ -50,26 +50,26 @@ module test_linalg_eye
         ${rt}$ :: dummy
 
         !> Should be error
-        a = eye(-1,dtype=dummy,err=state)
+        a = eye(-1,mold=dummy,err=state)
         error = .not.state%error()
         if (error) return
 
         !> Should be error
-        a = eye(5,-1,dtype=dummy,err=state)
+        a = eye(5,-1,mold=dummy,err=state)
         error = .not.state%error()
         if (error) return
 
         !> Should be ok
-        a = eye(0,5,dtype=dummy,err=state)
+        a = eye(0,5,mold=dummy,err=state)
         error = state%error() .or. any(shape(a)/=[0,5])
         if (error) return
 
         !> Test identity values
-        a = eye(5,10,dtype=dummy,err=state)
+        a = eye(5,10,mold=dummy,err=state)
         error = state%error() .or. nint(real(sum(a),kind=${rk}$),kind=ilp)/=5
         if (error) return
 
-        a = eye(10,5,dtype=dummy,err=state)
+        a = eye(10,5,mold=dummy,err=state)
         error = state%error() .or. nint(real(sum(a),kind=${rk}$),kind=ilp)/=5
         if (error) return
 
@@ -89,20 +89,20 @@ module test_linalg_eye
         dummy = 2.0_${rk}$
 
         !> Should be error
-        a = diag(-1,dvalue=dummy,err=state)
+        a = diag(-1,source=dummy,err=state)
         error = .not.state%error()
         if (error) return
 
         !> Should be ok
-        a = diag(0,dvalue=dummy,err=state)
+        a = diag(0,source=dummy,err=state)
         error = state%error() .or. any(shape(a)/=0)
         if (error) return
 
         !> Test identity values
-        a = diag(5,dvalue=dummy,err=state)
+        a = diag(5,source=dummy,err=state)
         error = state%error() .or. nint(real(sum(a),kind=${rk}$),kind=ilp)/=10
 
-        a = diag(12,dvalue=dummy,err=state)
+        a = diag(12,source=dummy,err=state)
         error = state%error() .or. nint(real(sum(a),kind=${rk}$),kind=ilp)/=24
         if (error) return
 
@@ -125,7 +125,7 @@ module test_linalg_eye
             darr = 2.0_${rk}$
 
             !> Test with several sizes
-            a = diag(dvalues=darr,err=state)
+            a = diag(source=darr,err=state)
             error = state%error() .or. any(shape(a)/=size(darr)) .or. sum(a)/=sum(darr)
             if (error) return
 

--- a/test/test_linalg_eye.fypp
+++ b/test/test_linalg_eye.fypp
@@ -43,7 +43,6 @@ module test_linalg_eye
         type(linalg_state) :: state
 
         integer(ilp) :: i
-        integer(ilp), parameter :: n = 128_ilp
 
         ${rt}$, allocatable :: a(:,:)
         ${rt}$ :: dummy
@@ -61,6 +60,15 @@ module test_linalg_eye
         !> Should be ok
         a = eye(0,5,dtype=dummy,err=state)
         error = state%error() .or. any(shape(a)/=[0,5])
+        if (error) return
+
+        !> Test identity values
+        a = eye(5,10,dtype=dummy,err=state)
+        error = state%error() .or. nint(sum(a),kind=ilp)/=5
+        if (error) return
+
+        a = eye(10,5,dtype=dummy,err=state)
+        error = state%error() .or. nint(sum(a),kind=ilp)/=5
         if (error) return
 
     end subroutine test_${ri}$_eye_allocation

--- a/test/test_linalg_eye.fypp
+++ b/test/test_linalg_eye.fypp
@@ -24,6 +24,8 @@ module test_linalg_eye
 
         #:for rk,rt,ri in ALL_KINDS_TYPES
         call test_${ri}$_eye_allocation(error)
+        call test_${ri}$_diag_scalar(error)
+        call test_${ri}$_diag_array(error)
         if (error) return
         #: endfor
 
@@ -35,8 +37,8 @@ module test_linalg_eye
 
     end subroutine test_eye
 
-    !> Determinant of identity matrix
     #:for rk,rt,ri in ALL_KINDS_TYPES
+    !> Identity matrix: test allocation
     subroutine test_${ri}$_eye_allocation(error)
         logical, intent(out) :: error
 
@@ -64,14 +66,74 @@ module test_linalg_eye
 
         !> Test identity values
         a = eye(5,10,dtype=dummy,err=state)
-        error = state%error() .or. nint(sum(a),kind=ilp)/=5
+        error = state%error() .or. nint(real(sum(a),kind=${rk}$),kind=ilp)/=5
         if (error) return
 
         a = eye(10,5,dtype=dummy,err=state)
-        error = state%error() .or. nint(sum(a),kind=ilp)/=5
+        error = state%error() .or. nint(real(sum(a),kind=${rk}$),kind=ilp)/=5
         if (error) return
 
     end subroutine test_${ri}$_eye_allocation
+
+    !> Diagonal matrix from scalar
+    subroutine test_${ri}$_diag_scalar(error)
+        logical, intent(out) :: error
+
+        type(linalg_state) :: state
+
+        integer(ilp) :: i
+
+        ${rt}$, allocatable :: a(:,:)
+        ${rt}$ :: dummy
+
+        dummy = 2.0_${rk}$
+
+        !> Should be error
+        a = diag(-1,dvalue=dummy,err=state)
+        error = .not.state%error()
+        if (error) return
+
+        !> Should be ok
+        a = diag(0,dvalue=dummy,err=state)
+        error = state%error() .or. any(shape(a)/=0)
+        if (error) return
+
+        !> Test identity values
+        a = diag(5,dvalue=dummy,err=state)
+        error = state%error() .or. nint(real(sum(a),kind=${rk}$),kind=ilp)/=10
+
+        a = diag(12,dvalue=dummy,err=state)
+        error = state%error() .or. nint(real(sum(a),kind=${rk}$),kind=ilp)/=24
+        if (error) return
+
+    end subroutine test_${ri}$_diag_scalar
+
+    !> Diagonal matrix from array
+    subroutine test_${ri}$_diag_array(error)
+        logical, intent(out) :: error
+
+        type(linalg_state) :: state
+
+        integer(ilp) :: i
+
+        integer(ilp), parameter :: array_sizes(*) = [1,2,5,10,20,50,100]
+        ${rt}$, allocatable :: a(:,:),darr(:)
+
+        do i=1,size(array_sizes)
+
+            allocate(darr(array_sizes(i)))
+            darr = 2.0_${rk}$
+
+            !> Test with several sizes
+            a = diag(dvalues=darr,err=state)
+            error = state%error() .or. any(shape(a)/=size(darr)) .or. sum(a)/=sum(darr)
+            if (error) return
+
+            deallocate(darr)
+
+        end do
+
+    end subroutine test_${ri}$_diag_array
 
     #:endfor
 


### PR DESCRIPTION
Close #42.

- [x] Implement `eye` for square and non-square identity matrices
- [x] `diag` for square diagonal matrices: scalar input
- [x] `diag` for square diagonal matrices: array input
- [x] test `eye` including invalid allocation sizes
- [x] test `diag`: allocation and results
- [x] `det(A)` tests: replace manual matrix inputs with `eye` interface  