### PR TITLE
Prettify and fully automate library generation

### DIFF
--- a/scripts/align_labelled_continue.py
+++ b/scripts/align_labelled_continue.py
@@ -1,0 +1,43 @@
+# Revert the ugly labelled continue statements created by fprettify
+
+def revert_fprettify_labels(source_folder,file_name):
+
+    import re
+    import os
+
+    # Load whole file; split by lines
+    with open(os.path.join(source_folder,file_name), 'r') as file:
+        # Create an empty list to store the lines
+        file_body = []
+
+        # Iterate over the lines of the file
+        for line in file:
+            file_body.append(line.rstrip())
+
+
+    file.close()
+
+    for i in range(len(file_body)):
+       if 'continue' in file_body[i]:
+           old = file_body[i]
+           nspaces = len(file_body[i-1])-len(file_body[i-1].lstrip())
+           file_body[i] = re.sub(r'(\s*)([0-9]+)(\s*)(continue)(\s*)'," "*nspaces+r'\2 \4',old)
+
+    # Write out
+    fid = open(os.path.join(source_folder,file_name), 'w')
+    for i in range(len(file_body)):
+        fid.write("{}\n".format(file_body[i]))
+    fid.close()
+
+
+# Launch script
+revert_fprettify_labels("../src","stdlib_linalg_lapack_s.f90")
+revert_fprettify_labels("../src","stdlib_linalg_lapack_d.f90")
+revert_fprettify_labels("../src","stdlib_linalg_lapack_q.f90")
+revert_fprettify_labels("../src","stdlib_linalg_lapack_c.f90")
+revert_fprettify_labels("../src","stdlib_linalg_lapack_z.f90")
+revert_fprettify_labels("../src","stdlib_linalg_lapack_w.f90")
+
+
+
+

--- a/scripts/run_fprettify.sh
+++ b/scripts/run_fprettify.sh
@@ -5,3 +5,6 @@ python3 modularize_blas.py
 
 # prettify
 fprettify -i 4 -l 132 -w 2 --disable-indent --strip-comments --c-relations --enable-replacements --enable-decl --whitespace-comma 0 --recursive ../src/
+
+# Revert ugly changes at labelled continue statements
+python3 align_labelled_continue.py

--- a/src/stdlib_linalg_blas_d.f90
+++ b/src/stdlib_linalg_blas_d.f90
@@ -840,7 +840,8 @@ module stdlib_linalg_blas_d
      !> name, so that
      !> DNRM2 := sqrt( x'*x )
 
-     pure real(dp) function stdlib_dnrm2(n,x,incx)
+     pure function stdlib_dnrm2(n,x,incx)
+        real(dp) :: stdlib_dnrm2
         ! -- reference blas level1 routine (version 3.9.1_dp) --
         ! -- reference blas is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--

--- a/src/stdlib_linalg_blas_q.f90
+++ b/src/stdlib_linalg_blas_q.f90
@@ -842,7 +842,8 @@ module stdlib_linalg_blas_q
      !> name, so that
      !> DNRM2 := sqrt( x'*x )
 
-     pure real(qp) function stdlib_qnrm2(n,x,incx)
+     pure function stdlib_qnrm2(n,x,incx)
+        real(qp) :: stdlib_qnrm2
         ! -- reference blas level1 routine (version 3.9.1_qp) --
         ! -- reference blas is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -4414,6 +4415,8 @@ module stdlib_linalg_blas_q
            return
      end function stdlib_qzasum
 
+     !> !
+     !>
      !> DZNRM2: returns the euclidean norm of a vector via the function
      !> name, so that
      !> DZNRM2 := sqrt( x**H*x )

--- a/src/stdlib_linalg_constants.f90
+++ b/src/stdlib_linalg_constants.f90
@@ -1,5 +1,5 @@
 module stdlib_linalg_constants
-     use iso_fortran_env,only:int32,int64
+     use iso_fortran_env,only:real32,real64,real128,int32,int64
      use,intrinsic :: ieee_arithmetic,only:ieee_is_nan
 #if defined(_OPENMP)
      use omp_lib
@@ -7,9 +7,9 @@ module stdlib_linalg_constants
      implicit none(type,external)
      public
 
-     integer,parameter :: sp = selected_real_kind(6)
-     integer,parameter :: dp = selected_real_kind(15)
-     integer,parameter :: qp = selected_real_kind(33)
+     integer,parameter :: sp = real32
+     integer,parameter :: dp = real64
+     integer,parameter :: qp = real128
      integer,parameter :: lk = kind(.true.)
      ! Integer size support for ILP64 builds should be done here
      integer,parameter :: ilp = int32

--- a/src/stdlib_linalg_lapack_c.f90
+++ b/src/stdlib_linalg_lapack_c.f90
@@ -505,7 +505,7 @@ module stdlib_linalg_lapack_c
      !> works well in practice.
 
      pure subroutine stdlib_cgbequ(m,n,kl,ku,ab,ldab,r,c,rowcnd,colcnd,amax,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -517,7 +517,7 @@ module stdlib_linalg_lapack_c
            real(sp),intent(out) :: c(*),r(*)
            complex(sp),intent(in) :: ab(ldab,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,kd
            real(sp) :: bignum,rcmax,rcmin,smlnum
@@ -646,7 +646,7 @@ module stdlib_linalg_lapack_c
      !> between sqrt(radix) and 1/sqrt(radix).
 
      pure subroutine stdlib_cgbequb(m,n,kl,ku,ab,ldab,r,c,rowcnd,colcnd,amax,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -658,7 +658,7 @@ module stdlib_linalg_lapack_c
            real(sp),intent(out) :: c(*),r(*)
            complex(sp),intent(in) :: ab(ldab,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,kd
            real(sp) :: bignum,rcmax,rcmin,smlnum,radix,logrdx
@@ -794,7 +794,7 @@ module stdlib_linalg_lapack_c
            integer(ilp),intent(out) :: ipiv(*)
            complex(sp),intent(inout) :: ab(ldab,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,jp,ju,km,kv
            ! Intrinsic Functions
@@ -881,7 +881,7 @@ module stdlib_linalg_lapack_c
            real(sp),intent(in) :: scale(*)
            complex(sp),intent(inout) :: v(ldv,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: leftv,rightv
            integer(ilp) :: i,ii,k
@@ -936,7 +936,7 @@ module stdlib_linalg_lapack_c
            ! backward permutation
            ! for  i = ilo-1 step -1 until 1,
                     ! ihi+1 step 1 until n do --
-30   continue
+                    30 continue
            if (stdlib_lsame(job,'P') .or. stdlib_lsame(job,'B')) then
               if (rightv) then
                  loop_40: do ii = 1,n
@@ -986,7 +986,7 @@ module stdlib_linalg_lapack_c
            ! Parameters
            real(sp),parameter :: sclfac = 2.0e+0_sp
            real(sp),parameter :: factor = 0.95e+0_sp
-           
+
            ! Local Scalars
            logical(lk) :: noconv
            integer(ilp) :: i,ica,iexc,ira,j,k,l,m
@@ -1020,18 +1020,18 @@ module stdlib_linalg_lapack_c
            ! permutation to isolate eigenvalues if possible
            go to 50
            ! row and column exchange.
-20   continue
+           20 continue
            scale(m) = j
            if (j == m) go to 30
            call stdlib_cswap(l,a(1,j),1,a(1,m),1)
            call stdlib_cswap(n - k + 1,a(j,k),lda,a(m,k),lda)
-30         continue
+           30 continue
            go to(40,80) iexc
            ! search for rows isolating an eigenvalue and push them down.
-40   continue
+           40 continue
            if (l == 1) go to 210
            l = l - 1
-50         continue
+           50 continue
            loop_70: do j = l,1,-1
               loop_60: do i = 1,l
                  if (i == j) cycle loop_60
@@ -1044,9 +1044,9 @@ module stdlib_linalg_lapack_c
            end do loop_70
            go to 90
            ! search for columns isolating an eigenvalue and push them left.
-80   continue
+           80 continue
            k = k + 1
-90         continue
+           90 continue
            loop_110: do j = k,l
               loop_100: do i = k,l
                  if (i == j) cycle loop_100
@@ -1057,7 +1057,7 @@ module stdlib_linalg_lapack_c
               iexc = 2
               go to 20
            end do loop_110
-120        continue
+           120 continue
            do i = k,l
               scale(i) = one
            end do
@@ -1068,7 +1068,7 @@ module stdlib_linalg_lapack_c
            sfmax1 = one/sfmin1
            sfmin2 = sfmin1*sclfac
            sfmax2 = one/sfmin2
-140        continue
+           140 continue
            noconv = .false.
            loop_200: do i = k,l
               c = stdlib_scnrm2(l - k + 1,a(k,i),1)
@@ -1082,7 +1082,7 @@ module stdlib_linalg_lapack_c
               g = r/sclfac
               f = one
               s = c + r
-160           continue
+              160 continue
               if (c >= g .or. max(f,c,ca) >= sfmax2 .or. min(r,g,ra) <= sfmin2) go to 170
                  if (stdlib_sisnan(c + f + ca + r + g + ra)) then
                  ! exit if nan to avoid infinite loop
@@ -1097,9 +1097,9 @@ module stdlib_linalg_lapack_c
               g = g/sclfac
               ra = ra/sclfac
               go to 160
-170           continue
+              170 continue
               g = c/sclfac
-180           continue
+              180 continue
               if (g < r .or. max(r,ra) >= sfmax2 .or. min(f,c,g,ca) <= sfmin2) go to 190
               f = f/sclfac
               c = c/sclfac
@@ -1109,7 +1109,7 @@ module stdlib_linalg_lapack_c
               ra = ra*sclfac
               go to 180
               ! now balance.
-190  continue
+              190 continue
               if ((c + r) >= factor*s) cycle loop_200
               if (f < one .and. scale(i) < one) then
                  if (f*scale(i) <= sfmin1) cycle loop_200
@@ -1124,7 +1124,7 @@ module stdlib_linalg_lapack_c
               call stdlib_csscal(l,f,a(1,i),1)
            end do loop_200
            if (noconv) go to 140
-210        continue
+           210 continue
            ilo = k
            ihi = l
            return
@@ -1152,7 +1152,7 @@ module stdlib_linalg_lapack_c
            real(sp),intent(out) :: c(*),r(*)
            complex(sp),intent(in) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(sp) :: bignum,rcmax,rcmin,smlnum
@@ -1286,7 +1286,7 @@ module stdlib_linalg_lapack_c
            real(sp),intent(out) :: c(*),r(*)
            complex(sp),intent(in) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(sp) :: bignum,rcmax,rcmin,smlnum,radix,logrdx
@@ -1419,7 +1419,7 @@ module stdlib_linalg_lapack_c
            integer(ilp),intent(out) :: ipiv(*),jpiv(*)
            complex(sp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,ip,ipv,j,jp,jpv
            real(sp) :: bignum,eps,smin,smlnum,xmax
@@ -1506,7 +1506,7 @@ module stdlib_linalg_lapack_c
            integer(ilp),intent(out) :: ipiv(*)
            complex(sp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(sp) :: sfmin
            integer(ilp) :: i,j,jp
@@ -1565,7 +1565,7 @@ module stdlib_linalg_lapack_c
      !> CGGBAL.
 
      pure subroutine stdlib_cggbak(job,side,n,ilo,ihi,lscale,rscale,m,v,ldv,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -1632,7 +1632,7 @@ module stdlib_linalg_lapack_c
               end if
            end if
            ! backward permutation
-30   continue
+           30 continue
            if (stdlib_lsame(job,'P') .or. stdlib_lsame(job,'B')) then
               ! backward permutation on right eigenvectors
               if (rightv) then
@@ -1642,7 +1642,7 @@ module stdlib_linalg_lapack_c
                     if (k == i) cycle loop_40
                     call stdlib_cswap(m,v(i,1),ldv,v(k,1),ldv)
                  end do loop_40
-50               continue
+                 50 continue
                  if (ihi == n) go to 70
                  loop_60: do i = ihi + 1,n
                     k = rscale(i)
@@ -1651,7 +1651,7 @@ module stdlib_linalg_lapack_c
                  end do loop_60
               end if
               ! backward permutation on left eigenvectors
-70   continue
+              70 continue
               if (leftv) then
                  if (ilo == 1) go to 90
                  loop_80: do i = ilo - 1,1,-1
@@ -1659,7 +1659,7 @@ module stdlib_linalg_lapack_c
                     if (k == i) cycle loop_80
                     call stdlib_cswap(m,v(i,1),ldv,v(k,1),ldv)
                  end do loop_80
-90               continue
+                 90 continue
                  if (ihi == n) go to 110
                  loop_100: do i = ihi + 1,n
                     k = lscale(i)
@@ -1668,7 +1668,7 @@ module stdlib_linalg_lapack_c
                  end do loop_100
               end if
            end if
-110        continue
+           110 continue
            return
      end subroutine stdlib_cggbak
 
@@ -1683,7 +1683,7 @@ module stdlib_linalg_lapack_c
      !> generalized eigenvalue problem A*x = lambda*B*x.
 
      pure subroutine stdlib_cggbal(job,n,a,lda,b,ldb,ilo,ihi,lscale,rscale,work,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -1697,7 +1697,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: sclfac = 1.0e+1_sp
-           
+
            ! Local Scalars
            integer(ilp) :: i,icab,iflow,ip1,ir,irab,it,j,jc,jp1,k,kount,l,lcab,lm1, &
                      lrab,lsfmax,lsfmin,m,nr,nrp2
@@ -1755,13 +1755,13 @@ module stdlib_linalg_lapack_c
            go to 30
            ! permute the matrices a and b to isolate the eigenvalues.
            ! find row with one nonzero in columns 1 through l
-20   continue
+           20 continue
            l = lm1
            if (l /= 1) go to 30
            rscale(1) = one
            lscale(1) = one
            go to 190
-30         continue
+           30 continue
            lm1 = l - 1
            loop_80: do i = l,1,-1
               do j = 1,lm1
@@ -1770,21 +1770,21 @@ module stdlib_linalg_lapack_c
               end do
               j = l
               go to 70
-50            continue
+              50 continue
               do j = jp1,l
                  if (a(i,j) /= czero .or. b(i,j) /= czero) cycle loop_80
               end do
               j = jp1 - 1
-70            continue
+              70 continue
               m = l
               iflow = 1
               go to 160
            end do loop_80
            go to 100
            ! find column with one nonzero in rows k through n
-90   continue
+           90 continue
            k = k + 1
-100        continue
+           100 continue
            loop_150: do j = k,l
               do i = k,lm1
                  ip1 = i + 1
@@ -1792,32 +1792,32 @@ module stdlib_linalg_lapack_c
               end do
               i = l
               go to 140
-120           continue
+              120 continue
               do i = ip1,l
                  if (a(i,j) /= czero .or. b(i,j) /= czero) cycle loop_150
               end do
               i = ip1 - 1
-140           continue
+              140 continue
               m = k
               iflow = 2
               go to 160
            end do loop_150
            go to 190
            ! permute rows m and i
-160  continue
+           160 continue
            lscale(m) = i
            if (i == m) go to 170
            call stdlib_cswap(n - k + 1,a(i,k),lda,a(m,k),lda)
            call stdlib_cswap(n - k + 1,b(i,k),ldb,b(m,k),ldb)
            ! permute columns m and j
-170  continue
+           170 continue
            rscale(m) = j
            if (j == m) go to 180
            call stdlib_cswap(l,a(1,j),1,a(1,m),1)
            call stdlib_cswap(l,b(1,j),1,b(1,m),1)
-180        continue
+           180 continue
            go to(20,90) iflow
-190        continue
+           190 continue
            ilo = k
            ihi = l
            if (stdlib_lsame(job,'P')) then
@@ -1849,13 +1849,13 @@ module stdlib_linalg_lapack_c
                     go to 210
                  end if
                  ta = log10(cabs1(a(i,j)))/basl
-210              continue
+                 210 continue
                  if (b(i,j) == czero) then
                     tb = zero
                     go to 220
                  end if
                  tb = log10(cabs1(b(i,j)))/basl
-220              continue
+                 220 continue
                  work(i + 4*n) = work(i + 4*n) - ta - tb
                  work(j + 5*n) = work(j + 5*n) - ta - tb
               end do
@@ -1867,7 +1867,7 @@ module stdlib_linalg_lapack_c
            beta = zero
            it = 1
            ! start generalized conjugate gradient iteration
-250  continue
+           250 continue
            gamma = stdlib_sdot(nr,work(ilo + 4*n),1,work(ilo + 4*n),1) + stdlib_sdot(nr, &
                      work(ilo + 5*n),1,work(ilo + 5*n),1)
            ew = zero
@@ -1897,7 +1897,7 @@ module stdlib_linalg_lapack_c
                  if (a(i,j) == czero) go to 280
                  kount = kount + 1
                  sum = sum + work(j)
-280              continue
+                 280 continue
                  if (b(i,j) == czero) cycle loop_290
                  kount = kount + 1
                  sum = sum + work(j)
@@ -1911,7 +1911,7 @@ module stdlib_linalg_lapack_c
                  if (a(i,j) == czero) go to 310
                  kount = kount + 1
                  sum = sum + work(i + n)
-310              continue
+                 310 continue
                  if (b(i,j) == czero) cycle loop_320
                  kount = kount + 1
                  sum = sum + work(i + n)
@@ -1938,7 +1938,7 @@ module stdlib_linalg_lapack_c
            it = it + 1
            if (it <= nrp2) go to 250
            ! end generalized conjugate gradient iteration
-350  continue
+           350 continue
            sfmin = stdlib_slamch('S')
            sfmax = one/sfmin
            lsfmin = int(log10(sfmin)/basl + one,KIND=ilp)
@@ -1991,7 +1991,7 @@ module stdlib_linalg_lapack_c
            ! Array Arguments
            complex(sp),intent(inout) :: b(ldb,*),d(*),dl(*),du(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j,k
            complex(sp) :: mult,temp,zdum
@@ -2060,7 +2060,7 @@ module stdlib_linalg_lapack_c
               if (n > 1) b(n - 1,j) = (b(n - 1,j) - du(n - 1)*b(n,j))/d(n - 1)
               do k = n - 2,1,-1
                  b(k,j) = (b(k,j) - du(k)*b(k + 1,j) - dl(k)*b(k + 2,j))/d(k)
-                           
+
               end do
            end do
            return
@@ -2086,7 +2086,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: d(*),dl(*),du(*)
            complex(sp),intent(out) :: du2(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            complex(sp) :: fact,temp,zdum
@@ -2158,7 +2158,7 @@ module stdlib_linalg_lapack_c
                  go to 50
               end if
            end do
-50         continue
+           50 continue
            return
      end subroutine stdlib_cgttrf
 
@@ -2191,7 +2191,7 @@ module stdlib_linalg_lapack_c
               ! overwriting each right hand side vector with its solution.
               if (nrhs <= 1) then
                  j = 1
-10               continue
+                 10 continue
                  ! solve l*x = b.
                  do i = 1,n - 1
                     if (ipiv(i) == i) then
@@ -2207,7 +2207,7 @@ module stdlib_linalg_lapack_c
                  if (n > 1) b(n - 1,j) = (b(n - 1,j) - du(n - 1)*b(n,j))/d(n - 1)
                  do i = n - 2,1,-1
                     b(i,j) = (b(i,j) - du(i)*b(i + 1,j) - du2(i)*b(i + 2,j))/d(i)
-                              
+
                  end do
                  if (j < nrhs) then
                     j = j + 1
@@ -2230,7 +2230,7 @@ module stdlib_linalg_lapack_c
                     if (n > 1) b(n - 1,j) = (b(n - 1,j) - du(n - 1)*b(n,j))/d(n - 1)
                     do i = n - 2,1,-1
                        b(i,j) = (b(i,j) - du(i)*b(i + 1,j) - du2(i)*b(i + 2,j))/d(i)
-                                 
+
                     end do
                  end do
               end if
@@ -2238,7 +2238,7 @@ module stdlib_linalg_lapack_c
               ! solve a**t * x = b.
               if (nrhs <= 1) then
                  j = 1
-70               continue
+                 70 continue
                  ! solve u**t * x = b.
                  b(1,j) = b(1,j)/d(1)
                  if (n > 1) b(2,j) = (b(2,j) - du(1)*b(1,j))/d(2)
@@ -2285,11 +2285,11 @@ module stdlib_linalg_lapack_c
               ! solve a**h * x = b.
               if (nrhs <= 1) then
                  j = 1
-130              continue
+                 130 continue
                  ! solve u**h * x = b.
                  b(1,j) = b(1,j)/conjg(d(1))
                  if (n > 1) b(2,j) = (b(2,j) - conjg(du(1))*b(1,j))/conjg(d(2))
-                           
+
                  do i = 3,n
                     b(i,j) = (b(i,j) - conjg(du(i - 1))*b(i - 1,j) - conjg(du2(i - 2))*b( &
                               i - 2,j))/conjg(d(i))
@@ -2313,7 +2313,7 @@ module stdlib_linalg_lapack_c
                  ! solve u**h * x = b.
                     b(1,j) = b(1,j)/conjg(d(1))
                     if (n > 1) b(2,j) = (b(2,j) - conjg(du(1))*b(1,j))/conjg(d(2))
-                              
+
                     do i = 3,n
                        b(i,j) = (b(i,j) - conjg(du(i - 1))*b(i - 1,j) - conjg(du2(i - 2)) &
                                  *b(i - 2,j))/conjg(d(i))
@@ -2427,7 +2427,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: sevten = 17.0e+0_sp
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,imax,j,jmax,k,kk,kp,kstep
@@ -2461,7 +2461,7 @@ module stdlib_linalg_lapack_c
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 90
               kstep = 1
@@ -2555,7 +2555,7 @@ module stdlib_linalg_lapack_c
                        ! = a - ( w(k-1) w(k) )*inv(d(k))*( w(k-1) w(k) )**h
                     if (k > 2) then
                        d = stdlib_slapy2(real(a(k - 1,k),KIND=sp),aimag(a(k - 1,k)))
-                                 
+
                        d22 = real(a(k - 1,k - 1),KIND=sp)/d
                        d11 = real(a(k,k),KIND=sp)/d
                        tt = one/(d11*d22 - one)
@@ -2590,7 +2590,7 @@ module stdlib_linalg_lapack_c
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2
               k = 1
-50            continue
+              50 continue
               ! if k > n, exit from loop
               if (k > n) go to 90
               kstep = 1
@@ -2644,7 +2644,7 @@ module stdlib_linalg_lapack_c
                     ! interchange rows and columns kk and kp in the trailing
                     ! submatrix a(k:n,k:n)
                     if (kp < n) call stdlib_cswap(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     do j = kk + 1,kp - 1
                        t = conjg(a(j,kk))
                        a(j,kk) = conjg(a(kp,j))
@@ -2674,7 +2674,7 @@ module stdlib_linalg_lapack_c
                        ! a := a - l(k)*d(k)*l(k)**h = a - w(k)*(1/d(k))*w(k)**h
                        r1 = one/real(a(k,k),KIND=sp)
                        call stdlib_cher(uplo,n - k,-r1,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                 
+
                        ! store l(k) in column k
                        call stdlib_csscal(n - k,r1,a(k + 1,k),1)
                     end if
@@ -2687,7 +2687,7 @@ module stdlib_linalg_lapack_c
                        ! where l(k) and l(k+1) are the k-th and (k+1)-th
                        ! columns of l
                        d = stdlib_slapy2(real(a(k + 1,k),KIND=sp),aimag(a(k + 1,k)))
-                                 
+
                        d11 = real(a(k + 1,k + 1),KIND=sp)/d
                        d22 = real(a(k,k),KIND=sp)/d
                        tt = one/(d11*d22 - one)
@@ -2718,7 +2718,7 @@ module stdlib_linalg_lapack_c
               k = k + kstep
               go to 50
            end if
-90         continue
+           90 continue
            return
      end subroutine stdlib_chetf2
 
@@ -2747,7 +2747,7 @@ module stdlib_linalg_lapack_c
         ! ======================================================================
            ! Parameters
            real(sp),parameter :: sevten = 17.0e+0_sp
-           
+
            ! Local Scalars
            logical(lk) :: done,upper
            integer(ilp) :: i,ii,imax,itemp,j,jmax,k,kk,kp,kstep,p
@@ -2786,7 +2786,7 @@ module stdlib_linalg_lapack_c
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 34
               kstep = 1
@@ -2822,7 +2822,7 @@ module stdlib_linalg_lapack_c
                  else
                     done = .false.
                     ! loop until pivot found
-12   continue
+                    12 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -2971,7 +2971,7 @@ module stdlib_linalg_lapack_c
                     if (k > 2) then
                        ! d = |a12|
                        d = stdlib_slapy2(real(a(k - 1,k),KIND=sp),aimag(a(k - 1,k)))
-                                 
+
                        d11 = real(a(k,k)/d,KIND=sp)
                        d22 = real(a(k - 1,k - 1)/d,KIND=sp)
                        d12 = a(k - 1,k)/d
@@ -3010,7 +3010,7 @@ module stdlib_linalg_lapack_c
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-34            continue
+              34 continue
            else
               ! factorize a as l*d*l**h using the lower triangle of a
               ! initialize the unused last entry of the subdiagonal array e.
@@ -3018,7 +3018,7 @@ module stdlib_linalg_lapack_c
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop
               if (k > n) go to 64
               kstep = 1
@@ -3054,7 +3054,7 @@ module stdlib_linalg_lapack_c
                  else
                     done = .false.
                     ! loop until pivot found
-42   continue
+                    42 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -3132,7 +3132,7 @@ module stdlib_linalg_lapack_c
                  if (kp /= kk) then
                     ! (1) swap columnar parts
                     if (kp < n) call stdlib_cswap(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     ! (2) swap and conjugate middle parts
                     do j = kk + 1,kp - 1
                        t = conjg(a(j,kk))
@@ -3176,7 +3176,7 @@ module stdlib_linalg_lapack_c
                              ! = a - w(k)*(1/d(k))*w(k)**t
                           d11 = one/real(a(k,k),KIND=sp)
                           call stdlib_cher(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                           ! store l(k) in column k
                           call stdlib_csscal(n - k,d11,a(k + 1,k),1)
                        else
@@ -3190,7 +3190,7 @@ module stdlib_linalg_lapack_c
                              ! = a - w(k)*(1/d(k))*w(k)**t
                              ! = a - (w(k)/d(k))*(d(k))*(w(k)/d(k))**t
                           call stdlib_cher(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                        end if
                        ! store the subdiagonal element of d in array e
                        e(k) = czero
@@ -3207,7 +3207,7 @@ module stdlib_linalg_lapack_c
                     if (k < n - 1) then
                        ! d = |a21|
                        d = stdlib_slapy2(real(a(k + 1,k),KIND=sp),aimag(a(k + 1,k)))
-                                 
+
                        d11 = real(a(k + 1,k + 1),KIND=sp)/d
                        d22 = real(a(k,k),KIND=sp)/d
                        d21 = a(k + 1,k)/d
@@ -3246,7 +3246,7 @@ module stdlib_linalg_lapack_c
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 40
-64            continue
+              64 continue
            end if
            return
      end subroutine stdlib_chetf2_rk
@@ -3273,7 +3273,7 @@ module stdlib_linalg_lapack_c
         ! ======================================================================
            ! Parameters
            real(sp),parameter :: sevten = 17.0e+0_sp
-           
+
            ! Local Scalars
            logical(lk) :: done,upper
            integer(ilp) :: i,ii,imax,itemp,j,jmax,k,kk,kp,kstep,p
@@ -3309,7 +3309,7 @@ module stdlib_linalg_lapack_c
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 70
               kstep = 1
@@ -3343,7 +3343,7 @@ module stdlib_linalg_lapack_c
                  else
                     done = .false.
                     ! loop until pivot found
-12   continue
+                    12 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -3484,7 +3484,7 @@ module stdlib_linalg_lapack_c
                     if (k > 2) then
                        ! d = |a12|
                        d = stdlib_slapy2(real(a(k - 1,k),KIND=sp),aimag(a(k - 1,k)))
-                                 
+
                        d11 = real(a(k,k)/d,KIND=sp)
                        d22 = real(a(k - 1,k - 1)/d,KIND=sp)
                        d12 = a(k - 1,k)/d
@@ -3522,7 +3522,7 @@ module stdlib_linalg_lapack_c
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop
               if (k > n) go to 70
               kstep = 1
@@ -3556,7 +3556,7 @@ module stdlib_linalg_lapack_c
                  else
                     done = .false.
                     ! loop until pivot found
-42   continue
+                    42 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -3631,7 +3631,7 @@ module stdlib_linalg_lapack_c
                  if (kp /= kk) then
                     ! (1) swap columnar parts
                     if (kp < n) call stdlib_cswap(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     ! (2) swap and conjugate middle parts
                     do j = kk + 1,kp - 1
                        t = conjg(a(j,kk))
@@ -3672,7 +3672,7 @@ module stdlib_linalg_lapack_c
                              ! = a - w(k)*(1/d(k))*w(k)**t
                           d11 = one/real(a(k,k),KIND=sp)
                           call stdlib_cher(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                           ! store l(k) in column k
                           call stdlib_csscal(n - k,d11,a(k + 1,k),1)
                        else
@@ -3686,7 +3686,7 @@ module stdlib_linalg_lapack_c
                              ! = a - w(k)*(1/d(k))*w(k)**t
                              ! = a - (w(k)/d(k))*(d(k))*(w(k)/d(k))**t
                           call stdlib_cher(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                        end if
                     end if
                  else
@@ -3701,7 +3701,7 @@ module stdlib_linalg_lapack_c
                     if (k < n - 1) then
                        ! d = |a21|
                        d = stdlib_slapy2(real(a(k + 1,k),KIND=sp),aimag(a(k + 1,k)))
-                                 
+
                        d11 = real(a(k + 1,k + 1),KIND=sp)/d
                        d22 = real(a(k,k),KIND=sp)/d
                        d21 = a(k + 1,k)/d
@@ -3735,7 +3735,7 @@ module stdlib_linalg_lapack_c
               k = k + kstep
               go to 40
            end if
-70         continue
+           70 continue
            return
      end subroutine stdlib_chetf2_rook
 
@@ -3756,7 +3756,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kp,kstep
@@ -3799,7 +3799,7 @@ module stdlib_linalg_lapack_c
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-30            continue
+              30 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               if (ipiv(k) > 0) then
@@ -3810,7 +3810,7 @@ module stdlib_linalg_lapack_c
                  if (k > 1) then
                     call stdlib_ccopy(k - 1,a(1,k),1,work,1)
                     call stdlib_chemv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - real(stdlib_cdotc(k - 1,work,1,a(1,k),1), &
                               KIND=sp)
                  end if
@@ -3830,14 +3830,14 @@ module stdlib_linalg_lapack_c
                  if (k > 1) then
                     call stdlib_ccopy(k - 1,a(1,k),1,work,1)
                     call stdlib_chemv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - real(stdlib_cdotc(k - 1,work,1,a(1,k),1), &
                               KIND=sp)
                     a(k,k + 1) = a(k,k + 1) - stdlib_cdotc(k - 1,a(1,k),1,a(1,k + 1),1)
-                              
+
                     call stdlib_ccopy(k - 1,a(1,k + 1),1,work,1)
                     call stdlib_chemv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k + 1),1)
-                              
+
                     a(k + 1,k + 1) = a(k + 1,k + 1) - real(stdlib_cdotc(k - 1,work,1,a(1,k + 1), &
                               1),KIND=sp)
                  end if
@@ -3865,13 +3865,13 @@ module stdlib_linalg_lapack_c
               end if
               k = k + kstep
               go to 30
-50            continue
+              50 continue
            else
               ! compute inv(a) from the factorization a = l*d*l**h.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-60            continue
+              60 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 80
               if (ipiv(k) > 0) then
@@ -3937,7 +3937,7 @@ module stdlib_linalg_lapack_c
               end if
               k = k - kstep
               go to 60
-80            continue
+              80 continue
            end if
            return
      end subroutine stdlib_chetri
@@ -3959,7 +3959,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kp,kstep
@@ -4002,7 +4002,7 @@ module stdlib_linalg_lapack_c
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-30            continue
+              30 continue
               ! if k > n, exit from loop.
               if (k > n) go to 70
               if (ipiv(k) > 0) then
@@ -4013,7 +4013,7 @@ module stdlib_linalg_lapack_c
                  if (k > 1) then
                     call stdlib_ccopy(k - 1,a(1,k),1,work,1)
                     call stdlib_chemv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - real(stdlib_cdotc(k - 1,work,1,a(1,k),1), &
                               KIND=sp)
                  end if
@@ -4033,14 +4033,14 @@ module stdlib_linalg_lapack_c
                  if (k > 1) then
                     call stdlib_ccopy(k - 1,a(1,k),1,work,1)
                     call stdlib_chemv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - real(stdlib_cdotc(k - 1,work,1,a(1,k),1), &
                               KIND=sp)
                     a(k,k + 1) = a(k,k + 1) - stdlib_cdotc(k - 1,a(1,k),1,a(1,k + 1),1)
-                              
+
                     call stdlib_ccopy(k - 1,a(1,k + 1),1,work,1)
                     call stdlib_chemv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k + 1),1)
-                              
+
                     a(k + 1,k + 1) = a(k + 1,k + 1) - real(stdlib_cdotc(k - 1,work,1,a(1,k + 1), &
                               1),KIND=sp)
                  end if
@@ -4100,13 +4100,13 @@ module stdlib_linalg_lapack_c
               end if
               k = k + 1
               go to 30
-70            continue
+              70 continue
            else
               ! compute inv(a) from the factorization a = l*d*l**h.
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-80            continue
+              80 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 120
               if (ipiv(k) > 0) then
@@ -4204,7 +4204,7 @@ module stdlib_linalg_lapack_c
               end if
               k = k - 1
               go to 80
-120           continue
+              120 continue
            end if
            return
      end subroutine stdlib_chetri_rook
@@ -4232,7 +4232,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: a(lda,*),e(*)
            complex(sp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,j,k,kp
@@ -4390,7 +4390,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: a(lda,*)
            complex(sp),intent(inout) :: c(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,normaltransr,nisodd,notrans
            integer(ilp) :: info,nrowa,j,nk,n1,n2
@@ -4463,7 +4463,7 @@ module stdlib_linalg_lapack_c
                     if (notrans) then
                        ! n is odd, transr = 'n', uplo = 'l', and trans = 'n'
                        call stdlib_cherk('L','N',n1,k,alpha,a(1,1),lda,beta,c(1),n)
-                                 
+
                        call stdlib_cherk('U','N',n2,k,alpha,a(n1 + 1,1),lda,beta,c(n + 1) &
                                  ,n)
                        call stdlib_cgemm('N','C',n2,n1,k,calpha,a(n1 + 1,1),lda,a(1,1) &
@@ -4471,7 +4471,7 @@ module stdlib_linalg_lapack_c
                     else
                        ! n is odd, transr = 'n', uplo = 'l', and trans = 'c'
                        call stdlib_cherk('L','C',n1,k,alpha,a(1,1),lda,beta,c(1),n)
-                                 
+
                        call stdlib_cherk('U','C',n2,k,alpha,a(1,n1 + 1),lda,beta,c(n + 1) &
                                  ,n)
                        call stdlib_cgemm('C','N',n2,n1,k,calpha,a(1,n1 + 1),lda,a(1,1) &
@@ -4648,7 +4648,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: ap(*)
            complex(sp),intent(in) :: bp(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,j1,j1j1,jj,k,k1,k1k1,kk
@@ -4685,7 +4685,7 @@ module stdlib_linalg_lapack_c
                     call stdlib_ctpsv(uplo,'CONJUGATE TRANSPOSE','NON-UNIT',j,bp,ap(j1),1 &
                               )
                     call stdlib_chpmv(uplo,j - 1,-cone,ap,bp(j1),1,cone,ap(j1),1)
-                              
+
                     call stdlib_csscal(j - 1,one/bjj,ap(j1),1)
                     ap(jj) = (ap(jj) - stdlib_cdotc(j - 1,ap(j1),1,bp(j1),1))/ &
                               bjj
@@ -4726,7 +4726,7 @@ module stdlib_linalg_lapack_c
                     akk = real(ap(kk),KIND=sp)
                     bkk = real(bp(kk),KIND=sp)
                     call stdlib_ctpmv(uplo,'NO TRANSPOSE','NON-UNIT',k - 1,bp,ap(k1),1)
-                              
+
                     ct = half*akk
                     call stdlib_caxpy(k - 1,ct,bp(k1),1,ap(k1),1)
                     call stdlib_chpr2(uplo,k - 1,cone,ap(k1),1,bp(k1),1,ap)
@@ -4777,7 +4777,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: sevten = 17.0e+0_sp
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,imax,j,jmax,k,kc,kk,knc,kp,kpc,kstep,kx,npp
@@ -4810,7 +4810,7 @@ module stdlib_linalg_lapack_c
               ! 1 or 2
               k = n
               kc = (n - 1)*n/2 + 1
-10            continue
+              10 continue
               knc = kc
               ! if k < 1, exit from loop
               if (k < 1) go to 110
@@ -4925,7 +4925,7 @@ module stdlib_linalg_lapack_c
                           wkm1 = d*(d11*ap(j + (k - 2)*(k - 1)/2) - conjg(d12)*ap(j + (k - 1)*k &
                                     /2))
                           wk = d*(d22*ap(j + (k - 1)*k/2) - d12*ap(j + (k - 2)*(k - 1)/2))
-                                    
+
                           do i = j,1,-1
                              ap(i + (j - 1)*j/2) = ap(i + (j - 1)*j/2) - ap(i + (k - 1)*k/2) &
                                        *conjg(wk) - ap(i + (k - 2)*(k - 1)/2)*conjg(wkm1)
@@ -4956,7 +4956,7 @@ module stdlib_linalg_lapack_c
               k = 1
               kc = 1
               npp = n*(n + 1)/2
-60            continue
+              60 continue
               knc = kc
               ! if k > n, exit from loop
               if (k > n) go to 110
@@ -5018,7 +5018,7 @@ module stdlib_linalg_lapack_c
                     ! interchange rows and columns kk and kp in the trailing
                     ! submatrix a(k:n,k:n)
                     if (kp < n) call stdlib_cswap(n - kp,ap(knc + kp - kk + 1),1,ap(kpc + 1),1)
-                              
+
                     kx = knc + kp - kk
                     do j = kk + 1,kp - 1
                        kx = kx + n - j + 1
@@ -5101,7 +5101,7 @@ module stdlib_linalg_lapack_c
               kc = knc + n - k + 2
               go to 60
            end if
-110        continue
+           110 continue
            return
      end subroutine stdlib_chptrf
 
@@ -5122,7 +5122,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: ap(*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kc,kcnext,kp,kpc,kstep,kx,npp
@@ -5168,7 +5168,7 @@ module stdlib_linalg_lapack_c
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
               kc = 1
-30            continue
+              30 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               kcnext = kc + k
@@ -5205,7 +5205,7 @@ module stdlib_linalg_lapack_c
                               kcnext),1)
                     call stdlib_ccopy(k - 1,ap(kcnext),1,work,1)
                     call stdlib_chpmv(uplo,k - 1,-cone,ap,work,1,czero,ap(kcnext),1)
-                              
+
                     ap(kcnext + k) = ap(kcnext + k) - real(stdlib_cdotc(k - 1,work,1,ap(kcnext &
                               ),1),KIND=sp)
                  end if
@@ -5238,7 +5238,7 @@ module stdlib_linalg_lapack_c
               k = k + kstep
               kc = kcnext
               go to 30
-50            continue
+              50 continue
            else
               ! compute inv(a) from the factorization a = l*d*l**h.
               ! k is the main loop index, increasing from 1 to n in steps of
@@ -5246,7 +5246,7 @@ module stdlib_linalg_lapack_c
               npp = n*(n + 1)/2
               k = n
               kc = npp
-60            continue
+              60 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 80
               kcnext = kc - (n - k + 2)
@@ -5318,7 +5318,7 @@ module stdlib_linalg_lapack_c
               k = k - kstep
               kc = kcnext
               go to 60
-80            continue
+              80 continue
            end if
            return
      end subroutine stdlib_chptri
@@ -5338,7 +5338,7 @@ module stdlib_linalg_lapack_c
      !> in computing that entry have at least one zero multiplicand.
 
      subroutine stdlib_cla_gbamv(trans,m,n,kl,ku,alpha,ab,ldab,x,incx,beta,y,incy)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -5349,7 +5349,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: ab(ldab,*),x(*)
            real(sp),intent(inout) :: y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: symb_zero
            real(sp) :: temp,safe1
@@ -5434,7 +5434,7 @@ module stdlib_linalg_lapack_c
                        do j = max(i - kl,1),min(i + ku,lenx)
                           temp = cabs1(ab(kd + i - j,j))
                           symb_zero = symb_zero .and. (x(j) == czero .or. temp == czero)
-                                    
+
                           y(iy) = y(iy) + alpha*cabs1(x(j))*temp
                        end do
                     end if
@@ -5456,7 +5456,7 @@ module stdlib_linalg_lapack_c
                        do j = max(i - kl,1),min(i + ku,lenx)
                           temp = cabs1(ab(ke - i + j,i))
                           symb_zero = symb_zero .and. (x(j) == czero .or. temp == czero)
-                                    
+
                           y(iy) = y(iy) + alpha*cabs1(x(j))*temp
                        end do
                     end if
@@ -5481,7 +5481,7 @@ module stdlib_linalg_lapack_c
                        do j = max(i - kl,1),min(i + ku,lenx)
                           temp = cabs1(ab(kd + i - j,j))
                           symb_zero = symb_zero .and. (x(jx) == czero .or. temp == czero)
-                                    
+
                           y(iy) = y(iy) + alpha*cabs1(x(jx))*temp
                           jx = jx + incx
                        end do
@@ -5505,7 +5505,7 @@ module stdlib_linalg_lapack_c
                        do j = max(i - kl,1),min(i + ku,lenx)
                           temp = cabs1(ab(ke - i + j,i))
                           symb_zero = symb_zero .and. (x(jx) == czero .or. temp == czero)
-                                    
+
                           y(iy) = y(iy) + alpha*cabs1(x(jx))*temp
                           jx = jx + incx
                        end do
@@ -5589,7 +5589,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: a(lda,*),x(*)
            real(sp),intent(inout) :: y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: symb_zero
            real(sp) :: temp,safe1
@@ -5668,7 +5668,7 @@ module stdlib_linalg_lapack_c
                        do j = 1,lenx
                           temp = cabs1(a(i,j))
                           symb_zero = symb_zero .and. (x(j) == czero .or. temp == czero)
-                                    
+
                           y(iy) = y(iy) + alpha*cabs1(x(j))*temp
                        end do
                     end if
@@ -5690,7 +5690,7 @@ module stdlib_linalg_lapack_c
                        do j = 1,lenx
                           temp = cabs1(a(j,i))
                           symb_zero = symb_zero .and. (x(j) == czero .or. temp == czero)
-                                    
+
                           y(iy) = y(iy) + alpha*cabs1(x(j))*temp
                        end do
                     end if
@@ -5715,7 +5715,7 @@ module stdlib_linalg_lapack_c
                        do j = 1,lenx
                           temp = cabs1(a(i,j))
                           symb_zero = symb_zero .and. (x(jx) == czero .or. temp == czero)
-                                    
+
                           y(iy) = y(iy) + alpha*cabs1(x(jx))*temp
                           jx = jx + incx
                        end do
@@ -5739,7 +5739,7 @@ module stdlib_linalg_lapack_c
                        do j = 1,lenx
                           temp = cabs1(a(j,i))
                           symb_zero = symb_zero .and. (x(jx) == czero .or. temp == czero)
-                                    
+
                           y(iy) = y(iy) + alpha*cabs1(x(jx))*temp
                           jx = jx + incx
                        end do
@@ -5820,7 +5820,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: a(lda,*),x(*)
            real(sp),intent(inout) :: y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: symb_zero
            real(sp) :: temp,safe1
@@ -6154,7 +6154,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: a(lda,*),x(*)
            real(sp),intent(inout) :: y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: symb_zero
            real(sp) :: temp,safe1
@@ -6347,7 +6347,7 @@ module stdlib_linalg_lapack_c
              s = (s + s) - s
              y(i) = ((x(i) - s) + w(i)) + y(i)
              x(i) = s
-10           continue
+             10 continue
            return
      end subroutine stdlib_cla_wwaddw
 
@@ -6400,7 +6400,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            integer(ilp) :: i,jlast
            real(sp) :: absxi,altsgn,estold,safmin,temp
@@ -6419,7 +6419,7 @@ module stdlib_linalg_lapack_c
            go to(20,40,70,90,120) isave(1)
            ! ................ entry   (isave( 1 ) = 1)
            ! first iteration.  x has been overwritten by a*x.
-20   continue
+           20 continue
            if (n == 1) then
               v(1) = x(1)
               est = abs(v(1))
@@ -6431,7 +6431,7 @@ module stdlib_linalg_lapack_c
               absxi = abs(x(i))
               if (absxi > safmin) then
                  x(i) = cmplx(real(x(i),KIND=sp)/absxi,aimag(x(i))/absxi,KIND=sp)
-                           
+
               else
                  x(i) = cone
               end if
@@ -6441,11 +6441,11 @@ module stdlib_linalg_lapack_c
            return
            ! ................ entry   (isave( 1 ) = 2)
            ! first iteration.  x has been overwritten by ctrans(a)*x.
-40   continue
+           40 continue
            isave(2) = stdlib_icmax1(n,x,1)
            isave(3) = 2
            ! main loop - iterations 2,3,...,itmax.
-50   continue
+           50 continue
            do i = 1,n
               x(i) = czero
            end do
@@ -6455,7 +6455,7 @@ module stdlib_linalg_lapack_c
            return
            ! ................ entry   (isave( 1 ) = 3)
            ! x has been overwritten by a*x.
-70   continue
+           70 continue
            call stdlib_ccopy(n,x,1,v,1)
            estold = est
            est = stdlib_scsum1(n,v,1)
@@ -6465,7 +6465,7 @@ module stdlib_linalg_lapack_c
               absxi = abs(x(i))
               if (absxi > safmin) then
                  x(i) = cmplx(real(x(i),KIND=sp)/absxi,aimag(x(i))/absxi,KIND=sp)
-                           
+
               else
                  x(i) = cone
               end if
@@ -6475,7 +6475,7 @@ module stdlib_linalg_lapack_c
            return
            ! ................ entry   (isave( 1 ) = 4)
            ! x has been overwritten by ctrans(a)*x.
-90   continue
+           90 continue
            jlast = isave(2)
            isave(2) = stdlib_icmax1(n,x,1)
            if ((abs(x(jlast)) /= abs(x(isave(2)))) .and. (isave(3) < itmax)) &
@@ -6484,11 +6484,11 @@ module stdlib_linalg_lapack_c
               go to 50
            end if
            ! iteration complete.  final stage.
-100  continue
+           100 continue
            altsgn = one
            do i = 1,n
               x(i) = cmplx(altsgn*(one + real(i - 1,KIND=sp)/real(n - 1,KIND=sp)),KIND=sp)
-                        
+
               altsgn = -altsgn
            end do
            kase = 1
@@ -6496,13 +6496,13 @@ module stdlib_linalg_lapack_c
            return
            ! ................ entry   (isave( 1 ) = 5)
            ! x has been overwritten by a*x.
-120  continue
+           120 continue
            temp = two*(stdlib_scsum1(n,x,1)/real(3*n,KIND=sp))
            if (temp > est) then
               call stdlib_ccopy(n,x,1,v,1)
               est = temp
            end if
-130        continue
+           130 continue
            kase = 0
            return
      end subroutine stdlib_clacn2
@@ -6524,7 +6524,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            integer(ilp) :: i,iter,j,jlast,jump
            real(sp) :: absxi,altsgn,estold,safmin,temp
@@ -6545,7 +6545,7 @@ module stdlib_linalg_lapack_c
            go to(20,40,70,90,120) jump
            ! ................ entry   (jump = 1)
            ! first iteration.  x has been overwritten by a*x.
-20   continue
+           20 continue
            if (n == 1) then
               v(1) = x(1)
               est = abs(v(1))
@@ -6557,7 +6557,7 @@ module stdlib_linalg_lapack_c
               absxi = abs(x(i))
               if (absxi > safmin) then
                  x(i) = cmplx(real(x(i),KIND=sp)/absxi,aimag(x(i))/absxi,KIND=sp)
-                           
+
               else
                  x(i) = cone
               end if
@@ -6567,11 +6567,11 @@ module stdlib_linalg_lapack_c
            return
            ! ................ entry   (jump = 2)
            ! first iteration.  x has been overwritten by ctrans(a)*x.
-40   continue
+           40 continue
            j = stdlib_icmax1(n,x,1)
            iter = 2
            ! main loop - iterations 2,3,...,itmax.
-50   continue
+           50 continue
            do i = 1,n
               x(i) = czero
            end do
@@ -6581,7 +6581,7 @@ module stdlib_linalg_lapack_c
            return
            ! ................ entry   (jump = 3)
            ! x has been overwritten by a*x.
-70   continue
+           70 continue
            call stdlib_ccopy(n,x,1,v,1)
            estold = est
            est = stdlib_scsum1(n,v,1)
@@ -6591,7 +6591,7 @@ module stdlib_linalg_lapack_c
               absxi = abs(x(i))
               if (absxi > safmin) then
                  x(i) = cmplx(real(x(i),KIND=sp)/absxi,aimag(x(i))/absxi,KIND=sp)
-                           
+
               else
                  x(i) = cone
               end if
@@ -6601,7 +6601,7 @@ module stdlib_linalg_lapack_c
            return
            ! ................ entry   (jump = 4)
            ! x has been overwritten by ctrans(a)*x.
-90   continue
+           90 continue
            jlast = j
            j = stdlib_icmax1(n,x,1)
            if ((abs(x(jlast)) /= abs(x(j))) .and. (iter < itmax)) then
@@ -6609,11 +6609,11 @@ module stdlib_linalg_lapack_c
               go to 50
            end if
            ! iteration complete.  final stage.
-100  continue
+           100 continue
            altsgn = one
            do i = 1,n
               x(i) = cmplx(altsgn*(one + real(i - 1,KIND=sp)/real(n - 1,KIND=sp)),KIND=sp)
-                        
+
               altsgn = -altsgn
            end do
            kase = 1
@@ -6621,13 +6621,13 @@ module stdlib_linalg_lapack_c
            return
            ! ................ entry   (jump = 5)
            ! x has been overwritten by a*x.
-120  continue
+           120 continue
            temp = two*(stdlib_scsum1(n,x,1)/real(3*n,KIND=sp))
            if (temp > est) then
               call stdlib_ccopy(n,x,1,v,1)
               est = temp
            end if
-130        continue
+           130 continue
            kase = 0
            return
      end subroutine stdlib_clacon
@@ -6731,7 +6731,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: a(lda,*)
            complex(sp),intent(out) :: c(ldc,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,l
            ! Intrinsic Functions
@@ -6746,7 +6746,7 @@ module stdlib_linalg_lapack_c
            end do
            l = m*n + 1
            call stdlib_sgemm('N','N',m,n,n,one,rwork,m,b,ldb,zero,rwork(l),m)
-                     
+
            do j = 1,n
               do i = 1,m
                  c(i,j) = rwork(l + (j - 1)*m + i - 1)
@@ -6758,11 +6758,11 @@ module stdlib_linalg_lapack_c
               end do
            end do
            call stdlib_sgemm('N','N',m,n,n,one,rwork,m,b,ldb,zero,rwork(l),m)
-                     
+
            do j = 1,n
               do i = 1,m
                  c(i,j) = cmplx(real(c(i,j),KIND=sp),rwork(l + (j - 1)*m + i - 1),KIND=sp)
-                           
+
               end do
            end do
            return
@@ -6803,7 +6803,7 @@ module stdlib_linalg_lapack_c
            end do
            return
            ! code for both increments equal to 1
-20   continue
+           20 continue
            do i = 1,n
               ctemp = c*cx(i) + s*cy(i)
               cy(i) = c*cy(i) - s*cx(i)
@@ -6829,7 +6829,7 @@ module stdlib_linalg_lapack_c
            intrinsic :: aimag,cmplx,real
            ! Executable Statements
            call stdlib_sladiv(real(x,KIND=sp),aimag(x),real(y,KIND=sp),aimag(y),zr,zi)
-                     
+
            stdlib_cladiv = cmplx(zr,zi,KIND=sp)
            return
      end function stdlib_cladiv
@@ -6860,7 +6860,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: mone = -1.0_sp
-           
+
            ! Local Scalars
            integer(ilp) :: i,imax,j,jlam,jmax,jp,k2,n1,n1p1,n2
            real(sp) :: c,eps,s,t,tau,tol
@@ -6954,7 +6954,7 @@ module stdlib_linalg_lapack_c
                  go to 70
               end if
            end do
-70         continue
+           70 continue
            j = j + 1
            if (j > n) go to 90
            if (rho*abs(z(j)) <= tol) then
@@ -6988,7 +6988,7 @@ module stdlib_linalg_lapack_c
                  d(jlam) = t
                  k2 = k2 - 1
                  i = 1
-80               continue
+                 80 continue
                  if (k2 + i <= n) then
                     if (d(jlam) < d(indxp(k2 + i))) then
                        indxp(k2 + i - 1) = indxp(k2 + i)
@@ -7011,13 +7011,13 @@ module stdlib_linalg_lapack_c
               end if
            end if
            go to 70
-90         continue
+           90 continue
            ! record the last eigenvalue.
            k = k + 1
            w(k) = z(jlam)
            dlamda(k) = d(jlam)
            indxp(k) = jlam
-100        continue
+           100 continue
            ! sort the eigenvalues and corresponding eigenvectors into dlamda
            ! and q2 respectively.  the eigenvalues/vectors which were not
            ! deflated go into the first k slots of dlamda and q2 respectively,
@@ -7057,7 +7057,7 @@ module stdlib_linalg_lapack_c
        ! =====================================================================
            ! Parameters
            real(sp),parameter :: thresh = 0.1_sp
-           
+
            ! Local Scalars
            real(sp) :: babs,evnorm,tabs,z
            complex(sp) :: s,t,tmp
@@ -7141,7 +7141,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: a,b,c
            complex(sp),intent(out) :: sn1
        ! =====================================================================
-           
+
            ! Local Scalars
            real(sp) :: t
            complex(sp) :: w
@@ -7154,7 +7154,7 @@ module stdlib_linalg_lapack_c
               w = conjg(b)/abs(b)
            end if
            call stdlib_slaev2(real(a,KIND=sp),abs(b),real(c,KIND=sp),rt1,rt2,cs1,t)
-                     
+
            sn1 = w*t
            return
      end subroutine stdlib_claev2
@@ -7195,7 +7195,7 @@ module stdlib_linalg_lapack_c
      !> 0., 1., or -1.
 
      pure subroutine stdlib_clagtm(trans,n,nrhs,alpha,dl,d,du,x,ldx,beta,b,ldb)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -7207,7 +7207,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: b(ldb,*)
            complex(sp),intent(in) :: d(*),dl(*),du(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            ! Intrinsic Functions
@@ -7353,7 +7353,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: sevten = 17.0e+0_sp
-           
+
            ! Local Scalars
            integer(ilp) :: imax,j,jb,jj,jmax,jp,k,kk,kkw,kp,kstep,kw
            real(sp) :: absakk,alpha,colmax,r1,rowmax,t
@@ -7374,7 +7374,7 @@ module stdlib_linalg_lapack_c
               ! for use in updating a11 (note that conjg(w) is actually stored)
               ! k is the main loop index, decreasing from n in steps of 1 or 2
               k = n
-10            continue
+              10 continue
               ! kw is the column of w which corresponds to column k of a
               kw = nb + k - n
               ! exit from loop
@@ -7418,7 +7418,7 @@ module stdlib_linalg_lapack_c
                     call stdlib_ccopy(imax - 1,a(1,imax),1,w(1,kw - 1),1)
                     w(imax,kw - 1) = real(a(imax,imax),KIND=sp)
                     call stdlib_ccopy(k - imax,a(imax,imax + 1),lda,w(imax + 1,kw - 1),1)
-                              
+
                     call stdlib_clacgv(k - imax,w(imax + 1,kw - 1),1)
                     if (k < n) then
                        call stdlib_cgemv('NO TRANSPOSE',k,n - k,-cone,a(1,k + 1),lda,w(imax, &
@@ -7576,7 +7576,7 @@ module stdlib_linalg_lapack_c
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-30            continue
+              30 continue
               ! update the upper triangle of a11 (= a(1:k,1:k)) as
               ! a11 := a11 - u12*d*u12**h = a11 - u12*w**h
               ! computing blocks of nb columns at a time (note that conjg(w) is
@@ -7597,7 +7597,7 @@ module stdlib_linalg_lapack_c
               ! put u12 in standard form by partially undoing the interchanges
               ! in of rows in columns k+1:n looping backwards from k+1 to n
               j = k + 1
-60            continue
+              60 continue
                  ! undo the interchanges (if any) of rows j and jp
                  ! at each step j
                  ! (here, j is a diagonal index)
@@ -7622,7 +7622,7 @@ module stdlib_linalg_lapack_c
               ! for use in updating a22 (note that conjg(w) is actually stored)
               ! k is the main loop index, increasing from 1 in steps of 1 or 2
               k = 1
-70            continue
+              70 continue
               ! exit from loop
               if ((k >= nb .and. nb < n) .or. k > n) go to 90
               kstep = 1
@@ -7711,7 +7711,7 @@ module stdlib_linalg_lapack_c
                     call stdlib_ccopy(kp - kk - 1,a(kk + 1,kk),1,a(kp,kk + 1),lda)
                     call stdlib_clacgv(kp - kk - 1,a(kp,kk + 1),lda)
                     if (kp < n) call stdlib_ccopy(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     ! interchange rows kk and kp in first k-1 columns of a
                     ! (columns k (or k and k+1 for 2-by-2 pivot) of a will be
                     ! later overwritten). interchange rows kk and kp
@@ -7817,7 +7817,7 @@ module stdlib_linalg_lapack_c
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 70
-90            continue
+              90 continue
               ! update the lower triangle of a22 (= a(k:n,k:n)) as
               ! a22 := a22 - l21*d*l21**h = a22 - l21*w**h
               ! computing blocks of nb columns at a time (note that conjg(w) is
@@ -7838,7 +7838,7 @@ module stdlib_linalg_lapack_c
               ! put l21 in standard form by partially undoing the interchanges
               ! of rows in columns 1:k-1 looping backwards from k-1 to 1
               j = k - 1
-120           continue
+              120 continue
                  ! undo the interchanges (if any) of rows j and jp
                  ! at each step j
                  ! (here, j is a diagonal index)
@@ -7853,7 +7853,7 @@ module stdlib_linalg_lapack_c
                  ! of the rows to swap back doesn't include diagonal element)
                  j = j - 1
                  if (jp /= jj .and. j >= 1) call stdlib_cswap(j,a(jp,1),lda,a(jj,1),lda)
-                           
+
               if (j >= 1) go to 120
               ! set kb to the number of columns factorized
               kb = k - 1
@@ -7889,7 +7889,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: sevten = 17.0e+0_sp
-           
+
            ! Local Scalars
            logical(lk) :: done
            integer(ilp) :: imax,itemp,ii,j,jb,jj,jmax,k,kk,kkw,kp,kstep,kw,p
@@ -7916,7 +7916,7 @@ module stdlib_linalg_lapack_c
               e(1) = czero
               ! k is the main loop index, decreasing from n in steps of 1 or 2
               k = n
-10            continue
+              10 continue
               ! kw is the column of w which corresponds to column k of a
               kw = nb + k - n
               ! exit from loop
@@ -7963,14 +7963,14 @@ module stdlib_linalg_lapack_c
                  else
                     ! lop until pivot found
                     done = .false.
-12                  continue
+                    12 continue
                        ! begin pivot search loop body
                        ! copy column imax to column kw-1 of w and update it
                        if (imax > 1) call stdlib_ccopy(imax - 1,a(1,imax),1,w(1,kw - 1),1)
-                                 
+
                        w(imax,kw - 1) = real(a(imax,imax),KIND=sp)
                        call stdlib_ccopy(k - imax,a(imax,imax + 1),lda,w(imax + 1,kw - 1),1)
-                                 
+
                        call stdlib_clacgv(k - imax,w(imax + 1,kw - 1),1)
                        if (k < n) then
                           call stdlib_cgemv('NO TRANSPOSE',k,n - k,-cone,a(1,k + 1),lda,w( &
@@ -8183,7 +8183,7 @@ module stdlib_linalg_lapack_c
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-30            continue
+              30 continue
               ! update the upper triangle of a11 (= a(1:k,1:k)) as
               ! a11 := a11 - u12*d*u12**h = a11 - u12*w**h
               ! computing blocks of nb columns at a time (note that conjg(w) is
@@ -8211,7 +8211,7 @@ module stdlib_linalg_lapack_c
               e(n) = czero
               ! k is the main loop index, increasing from 1 in steps of 1 or 2
               k = 1
-70            continue
+              70 continue
               ! exit from loop
               if ((k >= nb .and. nb < n) .or. k > n) go to 90
               kstep = 1
@@ -8256,7 +8256,7 @@ module stdlib_linalg_lapack_c
                  else
                     done = .false.
                     ! loop until pivot found
-72   continue
+                    72 continue
                        ! begin pivot search loop body
                        ! copy column imax to column k+1 of w and update it
                        call stdlib_ccopy(imax - k,a(imax,k),lda,w(k,k + 1),1)
@@ -8352,7 +8352,7 @@ module stdlib_linalg_lapack_c
                     call stdlib_ccopy(kp - kk - 1,a(kk + 1,kk),1,a(kp,kk + 1),lda)
                     call stdlib_clacgv(kp - kk - 1,a(kp,kk + 1),lda)
                     if (kp < n) call stdlib_ccopy(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     ! interchange rows kk and kp in first k-1 columns of a
                     ! (column k (or k and k+1 for 2-by-2 pivot) of a will be
                     ! later overwritten). interchange rows kk and kp
@@ -8474,7 +8474,7 @@ module stdlib_linalg_lapack_c
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 70
-90            continue
+              90 continue
               ! update the lower triangle of a22 (= a(k:n,k:n)) as
               ! a22 := a22 - l21*d*l21**h = a22 - l21*w**h
               ! computing blocks of nb columns at a time (note that conjg(w) is
@@ -8527,7 +8527,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: sevten = 17.0e+0_sp
-           
+
            ! Local Scalars
            logical(lk) :: done
            integer(ilp) :: imax,itemp,ii,j,jb,jj,jmax,jp1,jp2,k,kk,kkw,kp,kstep,kw, &
@@ -8552,7 +8552,7 @@ module stdlib_linalg_lapack_c
               ! for use in updating a11 (note that conjg(w) is actually stored)
               ! k is the main loop index, decreasing from n in steps of 1 or 2
               k = n
-10            continue
+              10 continue
               ! kw is the column of w which corresponds to column k of a
               kw = nb + k - n
               ! exit from loop
@@ -8597,14 +8597,14 @@ module stdlib_linalg_lapack_c
                  else
                     ! lop until pivot found
                     done = .false.
-12                  continue
+                    12 continue
                        ! begin pivot search loop body
                        ! copy column imax to column kw-1 of w and update it
                        if (imax > 1) call stdlib_ccopy(imax - 1,a(1,imax),1,w(1,kw - 1),1)
-                                 
+
                        w(imax,kw - 1) = real(a(imax,imax),KIND=sp)
                        call stdlib_ccopy(k - imax,a(imax,imax + 1),lda,w(imax + 1,kw - 1),1)
-                                 
+
                        call stdlib_clacgv(k - imax,w(imax + 1,kw - 1),1)
                        if (k < n) then
                           call stdlib_cgemv('NO TRANSPOSE',k,n - k,-cone,a(1,k + 1),lda,w( &
@@ -8810,7 +8810,7 @@ module stdlib_linalg_lapack_c
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-30            continue
+              30 continue
               ! update the upper triangle of a11 (= a(1:k,1:k)) as
               ! a11 := a11 - u12*d*u12**h = a11 - u12*w**h
               ! computing blocks of nb columns at a time (note that conjg(w) is
@@ -8831,7 +8831,7 @@ module stdlib_linalg_lapack_c
               ! put u12 in standard form by partially undoing the interchanges
               ! in of rows in columns k+1:n looping backwards from k+1 to n
               j = k + 1
-60            continue
+              60 continue
                  ! undo the interchanges (if any) of rows j and jp2
                  ! (or j and jp2, and j+1 and jp1) at each step j
                  kstep = 1
@@ -8863,7 +8863,7 @@ module stdlib_linalg_lapack_c
               ! for use in updating a22 (note that conjg(w) is actually stored)
               ! k is the main loop index, increasing from 1 in steps of 1 or 2
               k = 1
-70            continue
+              70 continue
               ! exit from loop
               if ((k >= nb .and. nb < n) .or. k > n) go to 90
               kstep = 1
@@ -8906,7 +8906,7 @@ module stdlib_linalg_lapack_c
                  else
                     done = .false.
                     ! loop until pivot found
-72   continue
+                    72 continue
                        ! begin pivot search loop body
                        ! copy column imax to column k+1 of w and update it
                        call stdlib_ccopy(imax - k,a(imax,k),lda,w(k,k + 1),1)
@@ -9002,7 +9002,7 @@ module stdlib_linalg_lapack_c
                     call stdlib_ccopy(kp - kk - 1,a(kk + 1,kk),1,a(kp,kk + 1),lda)
                     call stdlib_clacgv(kp - kk - 1,a(kp,kk + 1),lda)
                     if (kp < n) call stdlib_ccopy(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     ! interchange rows kk and kp in first k-1 columns of a
                     ! (column k (or k and k+1 for 2-by-2 pivot) of a will be
                     ! later overwritten). interchange rows kk and kp
@@ -9117,7 +9117,7 @@ module stdlib_linalg_lapack_c
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 70
-90            continue
+              90 continue
               ! update the lower triangle of a22 (= a(k:n,k:n)) as
               ! a22 := a22 - l21*d*l21**h = a22 - l21*w**h
               ! computing blocks of nb columns at a time (note that conjg(w) is
@@ -9138,7 +9138,7 @@ module stdlib_linalg_lapack_c
               ! put l21 in standard form by partially undoing the interchanges
               ! of rows in columns 1:k-1 looping backwards from k-1 to 1
               j = k - 1
-120           continue
+              120 continue
                  ! undo the interchanges (if any) of rows j and jp2
                  ! (or j and jp2, and j-1 and jp1) at each step j
                  kstep = 1
@@ -9157,7 +9157,7 @@ module stdlib_linalg_lapack_c
                  ! of the rows to swap back doesn't include diagonal element)
                  j = j - 1
                  if (jp2 /= jj .and. j >= 1) call stdlib_cswap(j,a(jp2,1),lda,a(jj,1),lda)
-                           
+
                  jj = jj - 1
                  if (kstep == 2 .and. jp1 /= jj .and. j >= 1) call stdlib_cswap(j,a(jp1,1),lda,a( &
                             jj,1),lda)
@@ -9202,7 +9202,7 @@ module stdlib_linalg_lapack_c
            ! Array Arguments
            complex(sp),intent(in) :: w(j),x(j)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(sp) :: absalp,absest,absgam,b,eps,norma,s1,s2,scl,t,test,tmp,zeta1, &
                      zeta2
@@ -9285,7 +9285,7 @@ module stdlib_linalg_lapack_c
                  sine = -(alpha/absest)/t
                  cosine = -(gamma/absest)/(one + t)
                  tmp = real(sqrt(sine*conjg(sine) + cosine*conjg(cosine)),KIND=sp)
-                           
+
                  s = sine/tmp
                  c = cosine/tmp
                  sestpr = sqrt(t + one)*absest
@@ -9374,7 +9374,7 @@ module stdlib_linalg_lapack_c
                     sestpr = sqrt(one + t + four*eps*eps*norma)*absest
                  end if
                  tmp = real(sqrt(sine*conjg(sine) + cosine*conjg(cosine)),KIND=sp)
-                           
+
                  s = sine/tmp
                  c = cosine/tmp
                  return
@@ -9416,7 +9416,7 @@ module stdlib_linalg_lapack_c
                  j = i
                  k(j) = -k(j)
                  in = k(j)
-20               continue
+                 20 continue
                  if (k(in) > 0) go to 40
                  do jj = 1,n
                     temp = x(j,jj)
@@ -9427,7 +9427,7 @@ module stdlib_linalg_lapack_c
                  j = in
                  in = k(in)
                  go to 20
-40               continue
+                 40 continue
               end do
            else
               ! backward permutation
@@ -9435,7 +9435,7 @@ module stdlib_linalg_lapack_c
                  if (k(i) > 0) go to 80
                  k(i) = -k(i)
                  j = k(i)
-60               continue
+                 60 continue
                  if (j == i) go to 80
                  do jj = 1,n
                     temp = x(i,jj)
@@ -9445,7 +9445,7 @@ module stdlib_linalg_lapack_c
                  k(j) = -k(j)
                  j = k(j)
                  go to 60
-80               continue
+                 80 continue
               end do
            end if
            return
@@ -9484,7 +9484,7 @@ module stdlib_linalg_lapack_c
                  j = i
                  k(j) = -k(j)
                  in = k(j)
-20               continue
+                 20 continue
                  if (k(in) > 0) go to 40
                  do ii = 1,m
                     temp = x(ii,j)
@@ -9495,7 +9495,7 @@ module stdlib_linalg_lapack_c
                  j = in
                  in = k(in)
                  go to 20
-40               continue
+                 40 continue
               end do
            else
               ! backward permutation
@@ -9503,7 +9503,7 @@ module stdlib_linalg_lapack_c
                  if (k(i) > 0) go to 100
                  k(i) = -k(i)
                  j = k(i)
-80               continue
+                 80 continue
                  if (j == i) go to 100
                  do ii = 1,m
                     temp = x(ii,i)
@@ -9513,7 +9513,7 @@ module stdlib_linalg_lapack_c
                  k(j) = -k(j)
                  j = k(j)
                  go to 80
-100              continue
+                 100 continue
               end do
            end if
            return
@@ -9524,7 +9524,7 @@ module stdlib_linalg_lapack_c
      !> in the vectors R and C.
 
      pure subroutine stdlib_claqgb(m,n,kl,ku,ab,ldab,r,c,rowcnd,colcnd,amax,equed)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -9538,7 +9538,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: thresh = 0.1e+0_sp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(sp) :: cj,large,small
@@ -9606,7 +9606,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: thresh = 0.1e+0_sp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(sp) :: cj,large,small
@@ -9673,7 +9673,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: thresh = 0.1e+0_sp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(sp) :: cj,large,small
@@ -9735,7 +9735,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: thresh = 0.1e+0_sp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(sp) :: cj,large,small
@@ -9797,7 +9797,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: thresh = 0.1e+0_sp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,jc
            real(sp) :: cj,large,small
@@ -9865,7 +9865,7 @@ module stdlib_linalg_lapack_c
         ! ================================================================
            ! Parameters
            real(sp),parameter :: rzero = 0.0_sp
-           
+
            ! Local Scalars
            complex(sp) :: cdum,h21s,h31s
            real(sp) :: s
@@ -9925,7 +9925,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: thresh = 0.1e+0_sp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(sp) :: cj,large,small
@@ -9985,7 +9985,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: thresh = 0.1e+0_sp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,jc
            real(sp) :: cj,large,small
@@ -10047,7 +10047,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: thresh = 0.1e+0_sp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(sp) :: cj,large,small
@@ -10121,7 +10121,7 @@ module stdlib_linalg_lapack_c
            real(sp),intent(out) :: work(*)
            complex(sp),intent(inout) :: z(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: sawnan1,sawnan2
            integer(ilp) :: i,indlpl,indp,inds,indumn,neg1,neg2,r1,r2
@@ -10169,7 +10169,7 @@ module stdlib_linalg_lapack_c
               s = work(inds + i) - lambda
            end do
            sawnan1 = stdlib_sisnan(s)
-60         continue
+           60 continue
            if (sawnan1) then
               ! runs a slower version of the above loop if a nan is detected
               neg1 = 0
@@ -10254,7 +10254,7 @@ module stdlib_linalg_lapack_c
                  end if
                  ztz = ztz + real(z(i)*z(i),KIND=sp)
               end do
-220           continue
+              220 continue
            else
               ! run slower loop if nan occurred.
               do i = r - 1,b1,-1
@@ -10270,7 +10270,7 @@ module stdlib_linalg_lapack_c
                  end if
                  ztz = ztz + real(z(i)*z(i),KIND=sp)
               end do
-240           continue
+              240 continue
            end if
            ! compute the fp vector downwards from r in blocks of size blksiz
            if (.not. sawnan1 .and. .not. sawnan2) then
@@ -10283,7 +10283,7 @@ module stdlib_linalg_lapack_c
                  end if
                  ztz = ztz + real(z(i + 1)*z(i + 1),KIND=sp)
               end do
-260           continue
+              260 continue
            else
               ! run slower loop if nan occurred.
               do i = r,bn - 1
@@ -10299,7 +10299,7 @@ module stdlib_linalg_lapack_c
                  end if
                  ztz = ztz + real(z(i + 1)*z(i + 1),KIND=sp)
               end do
-280           continue
+              280 continue
            end if
            ! compute quantities for convergence test
            tmp = one/ztz
@@ -10380,7 +10380,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: b(ldb,*)
            complex(sp),intent(out) :: c(ldc,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,l
            ! Intrinsic Functions
@@ -10395,7 +10395,7 @@ module stdlib_linalg_lapack_c
            end do
            l = m*n + 1
            call stdlib_sgemm('N','N',m,n,m,one,a,lda,rwork,m,zero,rwork(l),m)
-                     
+
            do j = 1,n
               do i = 1,m
                  c(i,j) = rwork(l + (j - 1)*m + i - 1)
@@ -10407,11 +10407,11 @@ module stdlib_linalg_lapack_c
               end do
            end do
            call stdlib_sgemm('N','N',m,n,m,one,a,lda,rwork,m,zero,rwork(l),m)
-                     
+
            do j = 1,n
               do i = 1,m
                  c(i,j) = cmplx(real(c(i,j),KIND=sp),rwork(l + (j - 1)*m + i - 1),KIND=sp)
-                           
+
               end do
            end do
            return
@@ -10439,7 +10439,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: v(*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: applyleft
            integer(ilp) :: i,lastv,lastc
@@ -10513,7 +10513,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: t(ldt,*),v(ldv,*)
            complex(sp),intent(out) :: work(ldwork,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            character :: transt
            integer(ilp) :: i,j
@@ -10834,7 +10834,7 @@ module stdlib_linalg_lapack_c
      !> arrays A, B and T. See Further Details section.
 
      pure subroutine stdlib_clarfb_gett(ident,m,n,k,t,ldt,a,lda,b,ldb,work,ldwork)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -10846,7 +10846,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: t(ldt,*)
            complex(sp),intent(out) :: work(ldwork,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lnotident
            integer(ilp) :: i,j
@@ -10870,7 +10870,7 @@ module stdlib_linalg_lapack_c
                  ! v1 is not an identy matrix, but unit lower-triangular
                  ! v1 stored in a1 (diagonal ones are not stored).
                  call stdlib_ctrmm('L','L','C','U',k,n - k,cone,a,lda,work,ldwork)
-                           
+
               end if
               ! col2_(3) compute w2: = w2 + (v2**h) * b2 = w2 + (b1**h) * b2
               ! v2 stored in b1.
@@ -10892,7 +10892,7 @@ module stdlib_linalg_lapack_c
                  ! v1 is not an identity matrix, but unit lower-triangular,
                  ! v1 stored in a1 (diagonal ones are not stored).
                  call stdlib_ctrmm('L','L','N','U',k,n - k,cone,a,lda,work,ldwork)
-                           
+
               end if
               ! col2_(7) compute a2: = a2 - w2 =
                                    ! = a(1:k, k+1:n-k) - work(1:k, 1:n-k),
@@ -10989,7 +10989,7 @@ module stdlib_linalg_lapack_c
            ! Array Arguments
            complex(sp),intent(inout) :: x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j,knt
            real(sp) :: alphi,alphr,beta,rsafmn,safmin,xnorm
@@ -11014,7 +11014,7 @@ module stdlib_linalg_lapack_c
               knt = 0
               if (abs(beta) < safmin) then
                  ! xnorm, beta may be inaccurate; scale x and recompute them
-10   continue
+                 10 continue
                  knt = knt + 1
                  call stdlib_csscal(n - 1,rsafmn,x,incx)
                  beta = beta*rsafmn
@@ -11062,7 +11062,7 @@ module stdlib_linalg_lapack_c
            ! Array Arguments
            complex(sp),intent(inout) :: x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j,knt
            real(sp) :: alphi,alphr,beta,bignum,smlnum,xnorm
@@ -11111,7 +11111,7 @@ module stdlib_linalg_lapack_c
               knt = 0
               if (abs(beta) < smlnum) then
                  ! xnorm, beta may be inaccurate; scale x and recompute them
-10   continue
+                 10 continue
                  knt = knt + 1
                  call stdlib_csscal(n - 1,bignum,x,incx)
                  beta = beta*bignum
@@ -11196,7 +11196,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(out) :: t(ldt,*)
            complex(sp),intent(in) :: tau(*),v(ldv,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,prevlastv,lastv
            ! Executable Statements
@@ -11322,7 +11322,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: v(*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j
            complex(sp) :: sum,t1,t10,t2,t3,t4,t5,t6,t7,t8,t9,v1,v10,v2,v3,v4,v5, &
@@ -11337,14 +11337,14 @@ module stdlib_linalg_lapack_c
               ! code for general m
               call stdlib_clarf(side,m,n,v,1,tau,c,ldc,work)
               go to 410
-10            continue
+              10 continue
               ! special code for 1 x 1 householder
               t1 = cone - tau*v(1)*conjg(v(1))
               do j = 1,n
                  c(1,j) = t1*c(1,j)
               end do
               go to 410
-30            continue
+              30 continue
               ! special code for 2 x 2 householder
               v1 = conjg(v(1))
               t1 = tau*conjg(v1)
@@ -11356,7 +11356,7 @@ module stdlib_linalg_lapack_c
                  c(2,j) = c(2,j) - sum*t2
               end do
               go to 410
-50            continue
+              50 continue
               ! special code for 3 x 3 householder
               v1 = conjg(v(1))
               t1 = tau*conjg(v1)
@@ -11371,7 +11371,7 @@ module stdlib_linalg_lapack_c
                  c(3,j) = c(3,j) - sum*t3
               end do
               go to 410
-70            continue
+              70 continue
               ! special code for 4 x 4 householder
               v1 = conjg(v(1))
               t1 = tau*conjg(v1)
@@ -11389,7 +11389,7 @@ module stdlib_linalg_lapack_c
                  c(4,j) = c(4,j) - sum*t4
               end do
               go to 410
-90            continue
+              90 continue
               ! special code for 5 x 5 householder
               v1 = conjg(v(1))
               t1 = tau*conjg(v1)
@@ -11403,7 +11403,7 @@ module stdlib_linalg_lapack_c
               t5 = tau*conjg(v5)
               do j = 1,n
                  sum = v1*c(1,j) + v2*c(2,j) + v3*c(3,j) + v4*c(4,j) + v5*c(5,j)
-                           
+
                  c(1,j) = c(1,j) - sum*t1
                  c(2,j) = c(2,j) - sum*t2
                  c(3,j) = c(3,j) - sum*t3
@@ -11411,7 +11411,7 @@ module stdlib_linalg_lapack_c
                  c(5,j) = c(5,j) - sum*t5
               end do
               go to 410
-110           continue
+              110 continue
               ! special code for 6 x 6 householder
               v1 = conjg(v(1))
               t1 = tau*conjg(v1)
@@ -11436,7 +11436,7 @@ module stdlib_linalg_lapack_c
                  c(6,j) = c(6,j) - sum*t6
               end do
               go to 410
-130           continue
+              130 continue
               ! special code for 7 x 7 householder
               v1 = conjg(v(1))
               t1 = tau*conjg(v1)
@@ -11464,7 +11464,7 @@ module stdlib_linalg_lapack_c
                  c(7,j) = c(7,j) - sum*t7
               end do
               go to 410
-150           continue
+              150 continue
               ! special code for 8 x 8 householder
               v1 = conjg(v(1))
               t1 = tau*conjg(v1)
@@ -11495,7 +11495,7 @@ module stdlib_linalg_lapack_c
                  c(8,j) = c(8,j) - sum*t8
               end do
               go to 410
-170           continue
+              170 continue
               ! special code for 9 x 9 householder
               v1 = conjg(v(1))
               t1 = tau*conjg(v1)
@@ -11529,7 +11529,7 @@ module stdlib_linalg_lapack_c
                  c(9,j) = c(9,j) - sum*t9
               end do
               go to 410
-190           continue
+              190 continue
               ! special code for 10 x 10 householder
               v1 = conjg(v(1))
               t1 = tau*conjg(v1)
@@ -11572,14 +11572,14 @@ module stdlib_linalg_lapack_c
               ! code for general n
               call stdlib_clarf(side,m,n,v,1,tau,c,ldc,work)
               go to 410
-210           continue
+              210 continue
               ! special code for 1 x 1 householder
               t1 = cone - tau*v(1)*conjg(v(1))
               do j = 1,m
                  c(j,1) = t1*c(j,1)
               end do
               go to 410
-230           continue
+              230 continue
               ! special code for 2 x 2 householder
               v1 = v(1)
               t1 = tau*conjg(v1)
@@ -11591,7 +11591,7 @@ module stdlib_linalg_lapack_c
                  c(j,2) = c(j,2) - sum*t2
               end do
               go to 410
-250           continue
+              250 continue
               ! special code for 3 x 3 householder
               v1 = v(1)
               t1 = tau*conjg(v1)
@@ -11606,7 +11606,7 @@ module stdlib_linalg_lapack_c
                  c(j,3) = c(j,3) - sum*t3
               end do
               go to 410
-270           continue
+              270 continue
               ! special code for 4 x 4 householder
               v1 = v(1)
               t1 = tau*conjg(v1)
@@ -11624,7 +11624,7 @@ module stdlib_linalg_lapack_c
                  c(j,4) = c(j,4) - sum*t4
               end do
               go to 410
-290           continue
+              290 continue
               ! special code for 5 x 5 householder
               v1 = v(1)
               t1 = tau*conjg(v1)
@@ -11638,7 +11638,7 @@ module stdlib_linalg_lapack_c
               t5 = tau*conjg(v5)
               do j = 1,m
                  sum = v1*c(j,1) + v2*c(j,2) + v3*c(j,3) + v4*c(j,4) + v5*c(j,5)
-                           
+
                  c(j,1) = c(j,1) - sum*t1
                  c(j,2) = c(j,2) - sum*t2
                  c(j,3) = c(j,3) - sum*t3
@@ -11646,7 +11646,7 @@ module stdlib_linalg_lapack_c
                  c(j,5) = c(j,5) - sum*t5
               end do
               go to 410
-310           continue
+              310 continue
               ! special code for 6 x 6 householder
               v1 = v(1)
               t1 = tau*conjg(v1)
@@ -11671,7 +11671,7 @@ module stdlib_linalg_lapack_c
                  c(j,6) = c(j,6) - sum*t6
               end do
               go to 410
-330           continue
+              330 continue
               ! special code for 7 x 7 householder
               v1 = v(1)
               t1 = tau*conjg(v1)
@@ -11699,7 +11699,7 @@ module stdlib_linalg_lapack_c
                  c(j,7) = c(j,7) - sum*t7
               end do
               go to 410
-350           continue
+              350 continue
               ! special code for 8 x 8 householder
               v1 = v(1)
               t1 = tau*conjg(v1)
@@ -11730,7 +11730,7 @@ module stdlib_linalg_lapack_c
                  c(j,8) = c(j,8) - sum*t8
               end do
               go to 410
-370           continue
+              370 continue
               ! special code for 9 x 9 householder
               v1 = v(1)
               t1 = tau*conjg(v1)
@@ -11764,7 +11764,7 @@ module stdlib_linalg_lapack_c
                  c(j,9) = c(j,9) - sum*t9
               end do
               go to 410
-390           continue
+              390 continue
               ! special code for 10 x 10 householder
               v1 = v(1)
               t1 = tau*conjg(v1)
@@ -11825,7 +11825,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: v(*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            complex(sp) :: alpha
            ! Executable Statements
@@ -11855,7 +11855,7 @@ module stdlib_linalg_lapack_c
            ! Parameters
            integer(ilp),parameter :: lv = 128
            real(sp),parameter :: twopi = 6.28318530717958647692528676655900576839e+0_sp
-           
+
            ! Local Scalars
            integer(ilp) :: i,il,iv
            ! Local Arrays
@@ -11889,7 +11889,7 @@ module stdlib_linalg_lapack_c
                  ! distributed on the unit disk
                  do i = 1,il
                     x(iv + i - 1) = sqrt(u(2*i - 1))*exp(cmplx(zero,twopi*u(2*i),KIND=sp))
-                              
+
                  end do
               else if (idist == 5) then
                  ! convert generated numbers to complex numbers uniformly
@@ -11898,7 +11898,7 @@ module stdlib_linalg_lapack_c
                     x(iv + i - 1) = exp(cmplx(zero,twopi*u(2*i),KIND=sp))
                  end do
               end if
-60            continue
+              60 continue
            return
      end subroutine stdlib_clarnv
 
@@ -12082,7 +12082,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: v(*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Executable Statements
            if (stdlib_lsame(side,'L')) then
               ! form  h * c
@@ -12134,7 +12134,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: c(ldc,*),t(ldt,*),v(ldv,*)
            complex(sp),intent(out) :: work(ldwork,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            character :: transt
            integer(ilp) :: i,info,j
@@ -12245,7 +12245,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: tau(*)
            complex(sp),intent(inout) :: v(ldv,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,info,j
            ! Executable Statements
@@ -12302,7 +12302,7 @@ module stdlib_linalg_lapack_c
            ! Array Arguments
            complex(sp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: done
            integer(ilp) :: i,itype,j,k1,k2,k3,k4
@@ -12363,7 +12363,7 @@ module stdlib_linalg_lapack_c
            bignum = one/smlnum
            cfromc = cfrom
            ctoc = cto
-10         continue
+           10 continue
            cfrom1 = cfromc*smlnum
            if (cfrom1 == cfromc) then
               ! cfromc is an inf.  multiply by a correctly signed zero for
@@ -12573,7 +12573,7 @@ module stdlib_linalg_lapack_c
            real(sp),intent(in) :: c(*),s(*)
            complex(sp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,info,j
            real(sp) :: ctemp,stemp
@@ -12992,7 +12992,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: sevten = 17.0e+0_sp
-           
+
            ! Local Scalars
            integer(ilp) :: imax,j,jb,jj,jmax,jp,k,kk,kkw,kp,kstep,kw
            real(sp) :: absakk,alpha,colmax,rowmax
@@ -13014,7 +13014,7 @@ module stdlib_linalg_lapack_c
               ! k is the main loop index, decreasing from n in steps of 1 or 2
               ! kw is the column of w which corresponds to column k of a
               k = n
-10            continue
+              10 continue
               kw = nb + k - n
               ! exit from loop
               if ((k <= n - nb + 1 .and. nb < n) .or. k < 1) go to 30
@@ -13047,7 +13047,7 @@ module stdlib_linalg_lapack_c
                     ! copy column imax to column kw-1 of w and update it
                     call stdlib_ccopy(imax,a(1,imax),1,w(1,kw - 1),1)
                     call stdlib_ccopy(k - imax,a(imax,imax + 1),lda,w(imax + 1,kw - 1),1)
-                              
+
                     if (k < n) call stdlib_cgemv('NO TRANSPOSE',k,n - k,-cone,a(1,k + 1),lda,w( &
                                imax,kw + 1),ldw,cone,w(1,kw - 1),1)
                     ! jmax is the column-index of the largest off-diagonal
@@ -13168,7 +13168,7 @@ module stdlib_linalg_lapack_c
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-30            continue
+              30 continue
               ! update the upper triangle of a11 (= a(1:k,1:k)) as
               ! a11 := a11 - u12*d*u12**t = a11 - u12*w**t
               ! computing blocks of nb columns at a time
@@ -13186,7 +13186,7 @@ module stdlib_linalg_lapack_c
               ! put u12 in standard form by partially undoing the interchanges
               ! in columns k+1:n looping backwards from k+1 to n
               j = k + 1
-60            continue
+              60 continue
                  ! undo the interchanges (if any) of rows jj and jp at each
                  ! step j
                  ! (here, j is a diagonal index)
@@ -13211,7 +13211,7 @@ module stdlib_linalg_lapack_c
               ! for use in updating a22
               ! k is the main loop index, increasing from 1 in steps of 1 or 2
               k = 1
-70            continue
+              70 continue
               ! exit from loop
               if ((k >= nb .and. nb < n) .or. k > n) go to 90
               ! copy column k of a to column k of w and update it
@@ -13282,7 +13282,7 @@ module stdlib_linalg_lapack_c
                     a(kp,kp) = a(kk,kk)
                     call stdlib_ccopy(kp - kk - 1,a(kk + 1,kk),1,a(kp,kk + 1),lda)
                     if (kp < n) call stdlib_ccopy(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     ! interchange rows kk and kp in first k-1 columns of a
                     ! (columns k (or k and k+1 for 2-by-2 pivot) of a will be
                     ! later overwritten). interchange rows kk and kp
@@ -13364,7 +13364,7 @@ module stdlib_linalg_lapack_c
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 70
-90            continue
+              90 continue
               ! update the lower triangle of a22 (= a(k:n,k:n)) as
               ! a22 := a22 - l21*d*l21**t = a22 - l21*w**t
               ! computing blocks of nb columns at a time
@@ -13382,7 +13382,7 @@ module stdlib_linalg_lapack_c
               ! put l21 in standard form by partially undoing the interchanges
               ! of rows in columns 1:k-1 looping backwards from k-1 to 1
               j = k - 1
-120           continue
+              120 continue
                  ! undo the interchanges (if any) of rows jj and jp at each
                  ! step j
                  ! (here, j is a diagonal index)
@@ -13397,7 +13397,7 @@ module stdlib_linalg_lapack_c
                  ! of the rows to swap back doesn't include diagonal element)
                  j = j - 1
                  if (jp /= jj .and. j >= 1) call stdlib_cswap(j,a(jp,1),lda,a(jj,1),lda)
-                           
+
               if (j > 1) go to 120
               ! set kb to the number of columns factorized
               kb = k - 1
@@ -13433,7 +13433,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: sevten = 17.0e+0_sp
-           
+
            ! Local Scalars
            logical(lk) :: done
            integer(ilp) :: imax,itemp,j,jb,jj,jmax,k,kk,kw,kkw,kp,kstep,p,ii
@@ -13460,7 +13460,7 @@ module stdlib_linalg_lapack_c
               e(1) = czero
               ! k is the main loop index, decreasing from n in steps of 1 or 2
               k = n
-10            continue
+              10 continue
               ! kw is the column of w which corresponds to column k of a
               kw = nb + k - n
               ! exit from loop
@@ -13501,12 +13501,12 @@ module stdlib_linalg_lapack_c
                  else
                     done = .false.
                     ! loop until pivot found
-12   continue
+                    12 continue
                        ! begin pivot search loop body
                        ! copy column imax to column kw-1 of w and update it
                        call stdlib_ccopy(imax,a(1,imax),1,w(1,kw - 1),1)
                        call stdlib_ccopy(k - imax,a(imax,imax + 1),lda,w(imax + 1,kw - 1),1)
-                                 
+
                        if (k < n) call stdlib_cgemv('NO TRANSPOSE',k,n - k,-cone,a(1,k + 1),lda, &
                                   w(imax,kw + 1),ldw,cone,w(1,kw - 1),1)
                        ! jmax is the column-index of the largest off-diagonal
@@ -13635,7 +13635,7 @@ module stdlib_linalg_lapack_c
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-30            continue
+              30 continue
               ! update the upper triangle of a11 (= a(1:k,1:k)) as
               ! a11 := a11 - u12*d*u12**t = a11 - u12*w**t
               ! computing blocks of nb columns at a time
@@ -13660,7 +13660,7 @@ module stdlib_linalg_lapack_c
               e(n) = czero
               ! k is the main loop index, increasing from 1 in steps of 1 or 2
               k = 1
-70            continue
+              70 continue
               ! exit from loop
               if ((k >= nb .and. nb < n) .or. k > n) go to 90
               kstep = 1
@@ -13699,7 +13699,7 @@ module stdlib_linalg_lapack_c
                  else
                     done = .false.
                     ! loop until pivot found
-72   continue
+                    72 continue
                        ! begin pivot search loop body
                        ! copy column imax to column k+1 of w and update it
                        call stdlib_ccopy(imax - k,a(imax,k),lda,w(k,k + 1),1)
@@ -13828,7 +13828,7 @@ module stdlib_linalg_lapack_c
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 70
-90            continue
+              90 continue
               ! update the lower triangle of a22 (= a(k:n,k:n)) as
               ! a22 := a22 - l21*d*l21**t = a22 - l21*w**t
               ! computing blocks of nb columns at a time
@@ -13877,7 +13877,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: sevten = 17.0e+0_sp
-           
+
            ! Local Scalars
            logical(lk) :: done
            integer(ilp) :: imax,itemp,j,jb,jj,jmax,jp1,jp2,k,kk,kw,kkw,kp,kstep,p, &
@@ -13902,7 +13902,7 @@ module stdlib_linalg_lapack_c
               ! for use in updating a11
               ! k is the main loop index, decreasing from n in steps of 1 or 2
               k = n
-10            continue
+              10 continue
               ! kw is the column of w which corresponds to column k of a
               kw = nb + k - n
               ! exit from loop
@@ -13941,12 +13941,12 @@ module stdlib_linalg_lapack_c
                  else
                     done = .false.
                     ! loop until pivot found
-12   continue
+                    12 continue
                        ! begin pivot search loop body
                        ! copy column imax to column kw-1 of w and update it
                        call stdlib_ccopy(imax,a(1,imax),1,w(1,kw - 1),1)
                        call stdlib_ccopy(k - imax,a(imax,imax + 1),lda,w(imax + 1,kw - 1),1)
-                                 
+
                        if (k < n) call stdlib_cgemv('NO TRANSPOSE',k,n - k,-cone,a(1,k + 1),lda, &
                                   w(imax,kw + 1),ldw,cone,w(1,kw - 1),1)
                        ! jmax is the column-index of the largest off-diagonal
@@ -14068,7 +14068,7 @@ module stdlib_linalg_lapack_c
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-30            continue
+              30 continue
               ! update the upper triangle of a11 (= a(1:k,1:k)) as
               ! a11 := a11 - u12*d*u12**t = a11 - u12*w**t
               ! computing blocks of nb columns at a time
@@ -14086,7 +14086,7 @@ module stdlib_linalg_lapack_c
               ! put u12 in standard form by partially undoing the interchanges
               ! in columns k+1:n
               j = k + 1
-60            continue
+              60 continue
                  kstep = 1
                  jp1 = 1
                  jj = j
@@ -14112,7 +14112,7 @@ module stdlib_linalg_lapack_c
               ! for use in updating a22
               ! k is the main loop index, increasing from 1 in steps of 1 or 2
               k = 1
-70            continue
+              70 continue
               ! exit from loop
               if ((k >= nb .and. nb < n) .or. k > n) go to 90
               kstep = 1
@@ -14149,7 +14149,7 @@ module stdlib_linalg_lapack_c
                  else
                     done = .false.
                     ! loop until pivot found
-72   continue
+                    72 continue
                        ! begin pivot search loop body
                        ! copy column imax to column k+1 of w and update it
                        call stdlib_ccopy(imax - k,a(imax,k),lda,w(k,k + 1),1)
@@ -14271,7 +14271,7 @@ module stdlib_linalg_lapack_c
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 70
-90            continue
+              90 continue
               ! update the lower triangle of a22 (= a(k:n,k:n)) as
               ! a22 := a22 - l21*d*l21**t = a22 - l21*w**t
               ! computing blocks of nb columns at a time
@@ -14289,7 +14289,7 @@ module stdlib_linalg_lapack_c
               ! put l21 in standard form by partially undoing the interchanges
               ! in columns 1:k-1
               j = k - 1
-120           continue
+              120 continue
                  kstep = 1
                  jp1 = 1
                  jj = j
@@ -14302,7 +14302,7 @@ module stdlib_linalg_lapack_c
                  end if
                  j = j - 1
                  if (jp2 /= jj .and. j >= 1) call stdlib_cswap(j,a(jp2,1),lda,a(jj,1),lda)
-                           
+
                  jj = j + 1
                  if (jp1 /= jj .and. kstep == 2) call stdlib_cswap(j,a(jp1,1),lda,a(jj,1), &
                            lda)
@@ -14339,7 +14339,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: ab(ldab,*)
            complex(sp),intent(inout) :: x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            integer(ilp) :: i,imax,j,jfirst,jinc,jlast,jlen,maind
@@ -14480,7 +14480,7 @@ module stdlib_linalg_lapack_c
                     grow = grow*(one/(one + cnorm(j)))
                  end do
               end if
-60            continue
+              60 continue
            else
               ! compute the growth in a**t * x = b  or  a**h * x = b.
               if (upper) then
@@ -14533,7 +14533,7 @@ module stdlib_linalg_lapack_c
                     grow = grow/xj
                  end do
               end if
-90            continue
+              90 continue
            end if
            if ((grow*tscal) > smlnum) then
               ! use the level 2 blas solve if the reciprocal of the bound on
@@ -14603,7 +14603,7 @@ module stdlib_linalg_lapack_c
                           scale = zero
                           xmax = zero
                        end if
-105                    continue
+                       105 continue
                     ! scale x if necessary to avoid overflow when adding a
                     ! multiple of column j of a.
                     if (xj > one) then
@@ -14676,11 +14676,11 @@ module stdlib_linalg_lapack_c
                        if (upper) then
                           jlen = min(kd,j - 1)
                           csumj = stdlib_cdotu(jlen,ab(kd + 1 - jlen,j),1,x(j - jlen),1)
-                                    
+
                        else
                           jlen = min(kd,n - j)
                           if (jlen > 1) csumj = stdlib_cdotu(jlen,ab(2,j),1,x(j + 1),1)
-                                    
+
                        end if
                     else
                        ! otherwise, use in-line code for the dot product.
@@ -14741,7 +14741,7 @@ module stdlib_linalg_lapack_c
                              scale = zero
                              xmax = zero
                           end if
-145                       continue
+                          145 continue
                     else
                        ! compute x(j) := x(j) / a(j,j) - csumj if the dot
                        ! product has already been divided by 1/a(j,j).
@@ -14784,11 +14784,11 @@ module stdlib_linalg_lapack_c
                        if (upper) then
                           jlen = min(kd,j - 1)
                           csumj = stdlib_cdotc(jlen,ab(kd + 1 - jlen,j),1,x(j - jlen),1)
-                                    
+
                        else
                           jlen = min(kd,n - j)
                           if (jlen > 1) csumj = stdlib_cdotc(jlen,ab(2,j),1,x(j + 1),1)
-                                    
+
                        end if
                     else
                        ! otherwise, use in-line code for the dot product.
@@ -14796,7 +14796,7 @@ module stdlib_linalg_lapack_c
                           jlen = min(kd,j - 1)
                           do i = 1,jlen
                              csumj = csumj + (conjg(ab(kd + i - jlen,j))*uscal)*x(j - jlen - 1 + i)
-                                       
+
                           end do
                        else
                           jlen = min(kd,n - j)
@@ -14850,7 +14850,7 @@ module stdlib_linalg_lapack_c
                              scale = zero
                              xmax = zero
                           end if
-185                       continue
+                          185 continue
                     else
                        ! compute x(j) := x(j) / a(j,j) - csumj if the dot
                        ! product has already been divided by 1/a(j,j).
@@ -14881,7 +14881,7 @@ module stdlib_linalg_lapack_c
      !> non-trivial solution to A*x = 0 is returned.
 
      pure subroutine stdlib_clatps(uplo,trans,diag,normin,n,ap,x,scale,cnorm,info)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -14895,7 +14895,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: ap(*)
            complex(sp),intent(inout) :: x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            integer(ilp) :: i,imax,ip,j,jfirst,jinc,jlast,jlen
@@ -15033,7 +15033,7 @@ module stdlib_linalg_lapack_c
                     grow = grow*(one/(one + cnorm(j)))
                  end do
               end if
-60            continue
+              60 continue
            else
               ! compute the growth in a**t * x = b  or  a**h * x = b.
               if (upper) then
@@ -15088,7 +15088,7 @@ module stdlib_linalg_lapack_c
                     grow = grow/xj
                  end do
               end if
-90            continue
+              90 continue
            end if
            if ((grow*tscal) > smlnum) then
               ! use the level 2 blas solve if the reciprocal of the bound on
@@ -15159,7 +15159,7 @@ module stdlib_linalg_lapack_c
                           scale = zero
                           xmax = zero
                        end if
-105                    continue
+                       105 continue
                     ! scale x if necessary to avoid overflow when adding a
                     ! multiple of column j of a.
                     if (xj > one) then
@@ -15189,7 +15189,7 @@ module stdlib_linalg_lapack_c
                           ! compute the update
                              ! x(j+1:n) := x(j+1:n) - x(j) * a(j+1:n,j)
                           call stdlib_caxpy(n - j,-x(j)*tscal,ap(ip + 1),1,x(j + 1),1)
-                                    
+
                           i = j + stdlib_icamax(n - j,x(j + 1),1)
                           xmax = cabs1(x(i))
                        end if
@@ -15292,7 +15292,7 @@ module stdlib_linalg_lapack_c
                              scale = zero
                              xmax = zero
                           end if
-145                       continue
+                          145 continue
                     else
                        ! compute x(j) := x(j) / a(j,j) - csumj if the dot
                        ! product has already been divided by 1/a(j,j).
@@ -15398,7 +15398,7 @@ module stdlib_linalg_lapack_c
                              scale = zero
                              xmax = zero
                           end if
-185                       continue
+                          185 continue
                     else
                        ! compute x(j) := x(j) / a(j,j) - csumj if the dot
                        ! product has already been divided by 1/a(j,j).
@@ -15440,7 +15440,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: tau(*),w(ldw,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,iw
            complex(sp) :: alpha
@@ -15488,7 +15488,7 @@ module stdlib_linalg_lapack_c
                     end if
                     call stdlib_cscal(i - 1,tau(i - 1),w(1,iw),1)
                     alpha = -chalf*tau(i - 1)*stdlib_cdotc(i - 1,w(1,iw),1,a(1,i),1)
-                              
+
                     call stdlib_caxpy(i - 1,alpha,a(1,i),1,w(1,iw),1)
                  end if
               end do loop_10
@@ -15526,7 +15526,7 @@ module stdlib_linalg_lapack_c
                               ,1,cone,w(i + 1,i),1)
                     call stdlib_cscal(n - i,tau(i),w(i + 1,i),1)
                     alpha = -chalf*tau(i)*stdlib_cdotc(n - i,w(i + 1,i),1,a(i + 1,i),1)
-                              
+
                     call stdlib_caxpy(n - i,alpha,a(i + 1,i),1,w(i + 1,i),1)
                  end if
               end do loop_20
@@ -15546,7 +15546,7 @@ module stdlib_linalg_lapack_c
      !> then s is set to 0 and a non-trivial solution to A*x = 0 is returned.
 
      pure subroutine stdlib_clatrs(uplo,trans,diag,normin,n,a,lda,x,scale,cnorm,info)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -15560,7 +15560,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: a(lda,*)
            complex(sp),intent(inout) :: x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            integer(ilp) :: i,imax,j,jfirst,jinc,jlast
@@ -15692,7 +15692,7 @@ module stdlib_linalg_lapack_c
                     grow = grow*(one/(one + cnorm(j)))
                  end do
               end if
-60            continue
+              60 continue
            else
               ! compute the growth in a**t * x = b  or  a**h * x = b.
               if (upper) then
@@ -15743,7 +15743,7 @@ module stdlib_linalg_lapack_c
                     grow = grow/xj
                  end do
               end if
-90            continue
+              90 continue
            end if
            if ((grow*tscal) > smlnum) then
               ! use the level 2 blas solve if the reciprocal of the bound on
@@ -15813,7 +15813,7 @@ module stdlib_linalg_lapack_c
                           scale = zero
                           xmax = zero
                        end if
-105                    continue
+                       105 continue
                     ! scale x if necessary to avoid overflow when adding a
                     ! multiple of column j of a.
                     if (xj > one) then
@@ -15842,7 +15842,7 @@ module stdlib_linalg_lapack_c
                           ! compute the update
                              ! x(j+1:n) := x(j+1:n) - x(j) * a(j+1:n,j)
                           call stdlib_caxpy(n - j,-x(j)*tscal,a(j + 1,j),1,x(j + 1),1)
-                                    
+
                           i = j + stdlib_icamax(n - j,x(j + 1),1)
                           xmax = cabs1(x(i))
                        end if
@@ -15942,7 +15942,7 @@ module stdlib_linalg_lapack_c
                              scale = zero
                              xmax = zero
                           end if
-145                       continue
+                          145 continue
                     else
                        ! compute x(j) := x(j) / a(j,j) - csumj if the dot
                        ! product has already been divided by 1/a(j,j).
@@ -16044,7 +16044,7 @@ module stdlib_linalg_lapack_c
                              scale = zero
                              xmax = zero
                           end if
-185                       continue
+                          185 continue
                     else
                        ! compute x(j) := x(j) / a(j,j) - csumj if the dot
                        ! product has already been divided by 1/a(j,j).
@@ -16077,7 +16077,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            complex(sp) :: alpha
@@ -16168,7 +16168,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: d(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(sp) :: sfmin
            integer(ilp) :: i,iinfo,n1,n2
@@ -16228,17 +16228,17 @@ module stdlib_linalg_lapack_c
               call stdlib_claunhr_col_getrfnp2(n1,n1,a,lda,d,iinfo)
               ! solve for b21
               call stdlib_ctrsm('R','U','N','N',m - n1,n1,cone,a,lda,a(n1 + 1,1),lda)
-                        
+
               ! solve for b12
               call stdlib_ctrsm('L','L','N','U',n1,n2,cone,a,lda,a(1,n1 + 1),lda)
-                        
+
               ! update b22, i.e. compute the schur complement
               ! b22 := b22 - b21*b12
               call stdlib_cgemm('N','N',m - n1,n2,n1,-cone,a(n1 + 1,1),lda,a(1,n1 + 1), &
                         lda,cone,a(n1 + 1,n1 + 1),lda)
               ! factor b22, recursive call
               call stdlib_claunhr_col_getrfnp2(m - n1,n2,a(n1 + 1,n1 + 1),lda,d(n1 + 1),iinfo)
-                        
+
            end if
            return
      end subroutine stdlib_claunhr_col_getrfnp2
@@ -16263,7 +16263,7 @@ module stdlib_linalg_lapack_c
            ! Array Arguments
            complex(sp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i
@@ -16341,7 +16341,7 @@ module stdlib_linalg_lapack_c
            ! Array Arguments
            complex(sp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,ib,nb
@@ -16426,7 +16426,7 @@ module stdlib_linalg_lapack_c
            real(sp),intent(out) :: s(*)
            complex(sp),intent(in) :: ab(ldab,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,j
@@ -16512,7 +16512,7 @@ module stdlib_linalg_lapack_c
            ! Array Arguments
            complex(sp),intent(inout) :: ab(ldab,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,kld,km,m
@@ -16557,7 +16557,7 @@ module stdlib_linalg_lapack_c
                  ! the leading submatrix within the band.
                  call stdlib_csscal(km,one/ajj,ab(kd + 1 - km,j),1)
                  call stdlib_cher('UPPER',km,-one,ab(kd + 1 - km,j),1,ab(kd + 1,j - km),kld)
-                           
+
               end do
               ! factorize the updated submatrix a(1:m,1:m) as u**h*u.
               do j = 1,m
@@ -16576,7 +16576,7 @@ module stdlib_linalg_lapack_c
                     call stdlib_csscal(km,one/ajj,ab(kd,j + 1),kld)
                     call stdlib_clacgv(km,ab(kd,j + 1),kld)
                     call stdlib_cher('UPPER',km,-one,ab(kd,j + 1),kld,ab(kd + 1,j + 1),kld)
-                              
+
                     call stdlib_clacgv(km,ab(kd,j + 1),kld)
                  end if
               end do
@@ -16597,7 +16597,7 @@ module stdlib_linalg_lapack_c
                  call stdlib_csscal(km,one/ajj,ab(km + 1,j - km),kld)
                  call stdlib_clacgv(km,ab(km + 1,j - km),kld)
                  call stdlib_cher('LOWER',km,-one,ab(km + 1,j - km),kld,ab(1,j - km),kld)
-                           
+
                  call stdlib_clacgv(km,ab(km + 1,j - km),kld)
               end do
               ! factorize the updated submatrix a(1:m,1:m) as u**h*u.
@@ -16620,7 +16620,7 @@ module stdlib_linalg_lapack_c
               end do
            end if
            return
-50         continue
+           50 continue
            info = j
            return
      end subroutine stdlib_cpbstf
@@ -16645,7 +16645,7 @@ module stdlib_linalg_lapack_c
            ! Array Arguments
            complex(sp),intent(inout) :: ab(ldab,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,kld,kn
@@ -16690,7 +16690,7 @@ module stdlib_linalg_lapack_c
                     call stdlib_csscal(kn,one/ajj,ab(kd,j + 1),kld)
                     call stdlib_clacgv(kn,ab(kd,j + 1),kld)
                     call stdlib_cher('UPPER',kn,-one,ab(kd,j + 1),kld,ab(kd + 1,j + 1),kld)
-                              
+
                     call stdlib_clacgv(kn,ab(kd,j + 1),kld)
                  end if
               end do
@@ -16715,7 +16715,7 @@ module stdlib_linalg_lapack_c
               end do
            end if
            return
-30         continue
+           30 continue
            info = j
            return
      end subroutine stdlib_cpbtf2
@@ -16809,7 +16809,7 @@ module stdlib_linalg_lapack_c
            real(sp),intent(out) :: s(*)
            complex(sp),intent(in) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(sp) :: smin
@@ -16888,7 +16888,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: a(lda,*)
            real(sp),intent(out) :: s(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(sp) :: smin,base,tmp
@@ -16963,7 +16963,7 @@ module stdlib_linalg_lapack_c
            ! Array Arguments
            complex(sp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j
@@ -17031,9 +17031,9 @@ module stdlib_linalg_lapack_c
               end do
            end if
            go to 40
-30         continue
+           30 continue
            info = j
-40         continue
+           40 continue
            return
      end subroutine stdlib_cpotf2
 
@@ -17062,7 +17062,7 @@ module stdlib_linalg_lapack_c
            ! Array Arguments
            complex(sp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: n1,n2,iinfo
@@ -17153,7 +17153,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: a(lda,*)
            complex(sp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            ! Intrinsic Functions
@@ -17221,7 +17221,7 @@ module stdlib_linalg_lapack_c
            real(sp),intent(out) :: s(*)
            complex(sp),intent(in) :: ap(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,jj
@@ -17310,7 +17310,7 @@ module stdlib_linalg_lapack_c
            ! Array Arguments
            complex(sp),intent(inout) :: ap(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,jc,jj
@@ -17372,9 +17372,9 @@ module stdlib_linalg_lapack_c
               end do
            end if
            go to 40
-30         continue
+           30 continue
            info = j
-40         continue
+           40 continue
            return
      end subroutine stdlib_cpptrf
 
@@ -17426,14 +17426,14 @@ module stdlib_linalg_lapack_c
                            1)
                  ! solve u*x = b, overwriting b with x.
                  call stdlib_ctpsv('UPPER','NO TRANSPOSE','NON-UNIT',n,ap,b(1,i),1)
-                           
+
               end do
            else
               ! solve a*x = b where a = l * l**h.
               do i = 1,nrhs
                  ! solve l*y = b, overwriting b with x.
                  call stdlib_ctpsv('LOWER','NO TRANSPOSE','NON-UNIT',n,ap,b(1,i),1)
-                           
+
                  ! solve l**h *x = y, overwriting b with x.
                  call stdlib_ctpsv('LOWER','CONJUGATE TRANSPOSE','NON-UNIT',n,ap,b(1,i), &
                            1)
@@ -17466,7 +17466,7 @@ module stdlib_linalg_lapack_c
            real(sp),intent(out) :: work(2*n)
            integer(ilp),intent(out) :: piv(n)
         ! =====================================================================
-           
+
            ! Local Scalars
            complex(sp) :: ctemp
            real(sp) :: ajj,sstop,stemp
@@ -17525,7 +17525,7 @@ module stdlib_linalg_lapack_c
                  do i = j,n
                     if (j > 1) then
                        work(i) = work(i) + real(conjg(a(j - 1,i))*a(j - 1,i),KIND=sp)
-                                 
+
                     end if
                     work(n + i) = real(a(i,i),KIND=sp) - work(i)
                  end do
@@ -17543,7 +17543,7 @@ module stdlib_linalg_lapack_c
                     a(pvt,pvt) = a(j,j)
                     call stdlib_cswap(j - 1,a(1,j),1,a(1,pvt),1)
                     if (pvt < n) call stdlib_cswap(n - pvt,a(j,pvt + 1),lda,a(pvt,pvt + 1),lda)
-                              
+
                     do i = j + 1,pvt - 1
                        ctemp = conjg(a(j,i))
                        a(j,i) = conjg(a(i,pvt))
@@ -17578,7 +17578,7 @@ module stdlib_linalg_lapack_c
                  do i = j,n
                     if (j > 1) then
                        work(i) = work(i) + real(conjg(a(i,j - 1))*a(i,j - 1),KIND=sp)
-                                 
+
                     end if
                     work(n + i) = real(a(i,i),KIND=sp) - work(i)
                  end do
@@ -17596,7 +17596,7 @@ module stdlib_linalg_lapack_c
                     a(pvt,pvt) = a(j,j)
                     call stdlib_cswap(j - 1,a(j,1),lda,a(pvt,1),lda)
                     if (pvt < n) call stdlib_cswap(n - pvt,a(pvt + 1,j),1,a(pvt + 1,pvt),1)
-                              
+
                     do i = j + 1,pvt - 1
                        ctemp = conjg(a(i,j))
                        a(i,j) = conjg(a(pvt,i))
@@ -17626,12 +17626,12 @@ module stdlib_linalg_lapack_c
            ! ran to completion, a has full rank
            rank = n
            go to 200
-190        continue
+           190 continue
            ! rank is number of steps completed.  set info = 1 to signal
            ! that the factorization cannot be used to solve a system.
            rank = j - 1
            info = 1
-200        continue
+           200 continue
            return
      end subroutine stdlib_cpstf2
 
@@ -17659,7 +17659,7 @@ module stdlib_linalg_lapack_c
            real(sp),intent(out) :: work(2*n)
            integer(ilp),intent(out) :: piv(n)
         ! =====================================================================
-           
+
            ! Local Scalars
            complex(sp) :: ctemp
            real(sp) :: ajj,sstop,stemp
@@ -17851,12 +17851,12 @@ module stdlib_linalg_lapack_c
            ! ran to completion, a has full rank
            rank = n
            go to 230
-220        continue
+           220 continue
            ! rank is the number of steps completed.  set info = 1 to signal
            ! that the factorization cannot be used to solve a system.
            rank = j - 1
            info = 1
-230        continue
+           230 continue
            return
      end subroutine stdlib_cpstrf
 
@@ -17882,7 +17882,7 @@ module stdlib_linalg_lapack_c
            real(sp),intent(out) :: rwork(*)
            complex(sp),intent(in) :: e(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,ix
            real(sp) :: ainvnm
@@ -17949,7 +17949,7 @@ module stdlib_linalg_lapack_c
            real(sp),intent(inout) :: d(*)
            complex(sp),intent(inout) :: e(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,i4
            real(sp) :: eii,eir,f,g
@@ -18029,7 +18029,7 @@ module stdlib_linalg_lapack_c
            end do loop_110
            ! check d(n) for positive definiteness.
            if (d(n) <= zero) info = n
-20         continue
+           20 continue
            return
      end subroutine stdlib_cpttrf
 
@@ -18066,7 +18066,7 @@ module stdlib_linalg_lapack_c
               ! overwriting each right hand side vector with its solution.
               if (nrhs <= 2) then
                  j = 1
-5                continue
+                 5 continue
                  ! solve u**h * x = b.
                  do i = 2,n
                     b(i,j) = b(i,j) - b(i - 1,j)*conjg(e(i - 1))
@@ -18100,7 +18100,7 @@ module stdlib_linalg_lapack_c
               ! overwriting each right hand side vector with its solution.
               if (nrhs <= 2) then
                  j = 1
-65               continue
+                 65 continue
                  ! solve l * x = b.
                  do i = 2,n
                     b(i,j) = b(i,j) - b(i - 1,j)*e(i - 1)
@@ -18169,7 +18169,7 @@ module stdlib_linalg_lapack_c
            end do
            return
            ! code for both increments equal to 1
-20   continue
+           20 continue
            do i = 1,n
               stemp = c*cx(i) + s*cy(i)
               cy(i) = c*cy(i) - conjg(s)*cx(i)
@@ -18195,7 +18195,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: ap(*),x(*)
            complex(sp),intent(inout) :: y(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,info,ix,iy,j,jx,jy,k,kk,kx,ky
            complex(sp) :: temp1,temp2
@@ -18352,7 +18352,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: ap(*)
            complex(sp),intent(in) :: x(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,info,ix,j,jx,k,kk,kx
            complex(sp) :: temp
@@ -18477,7 +18477,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: sevten = 17.0e+0_sp
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,imax,j,jmax,k,kc,kk,knc,kp,kpc,kstep,kx,npp
@@ -18510,7 +18510,7 @@ module stdlib_linalg_lapack_c
               ! 1 or 2
               k = n
               kc = (n - 1)*n/2 + 1
-10            continue
+              10 continue
               knc = kc
               ! if k < 1, exit from loop
               if (k < 1) go to 110
@@ -18613,9 +18613,9 @@ module stdlib_linalg_lapack_c
                        d12 = t/d12
                        do j = k - 2,1,-1
                           wkm1 = d12*(d11*ap(j + (k - 2)*(k - 1)/2) - ap(j + (k - 1)*k/2))
-                                    
+
                           wk = d12*(d22*ap(j + (k - 1)*k/2) - ap(j + (k - 2)*(k - 1)/2))
-                                    
+
                           do i = j,1,-1
                              ap(i + (j - 1)*j/2) = ap(i + (j - 1)*j/2) - ap(i + (k - 1)*k/2) &
                                        *wk - ap(i + (k - 2)*(k - 1)/2)*wkm1
@@ -18644,7 +18644,7 @@ module stdlib_linalg_lapack_c
               k = 1
               kc = 1
               npp = n*(n + 1)/2
-60            continue
+              60 continue
               knc = kc
               ! if k > n, exit from loop
               if (k > n) go to 110
@@ -18705,7 +18705,7 @@ module stdlib_linalg_lapack_c
                     ! interchange rows and columns kk and kp in the trailing
                     ! submatrix a(k:n,k:n)
                     if (kp < n) call stdlib_cswap(n - kp,ap(knc + kp - kk + 1),1,ap(kpc + 1),1)
-                              
+
                     kx = knc + kp - kk
                     do j = kk + 1,kp - 1
                        kx = kx + n - j + 1
@@ -18753,7 +18753,7 @@ module stdlib_linalg_lapack_c
                        d21 = t/d21
                        do j = k + 2,n
                           wk = d21*(d11*ap(j + (k - 1)*(2*n - k)/2) - ap(j + k*(2*n - k - 1)/2))
-                                    
+
                           wkp1 = d21*(d22*ap(j + k*(2*n - k - 1)/2) - ap(j + (k - 1)*(2*n - k)/2) &
                                      )
                           do i = j,n
@@ -18778,7 +18778,7 @@ module stdlib_linalg_lapack_c
               kc = knc + n - k + 2
               go to 60
            end if
-110        continue
+           110 continue
            return
      end subroutine stdlib_csptrf
 
@@ -18799,7 +18799,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: ap(*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kc,kcnext,kp,kpc,kstep,kx,npp
@@ -18844,7 +18844,7 @@ module stdlib_linalg_lapack_c
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
               kc = 1
-30            continue
+              30 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               kcnext = kc + k
@@ -18879,9 +18879,9 @@ module stdlib_linalg_lapack_c
                               kcnext),1)
                     call stdlib_ccopy(k - 1,ap(kcnext),1,work,1)
                     call stdlib_cspmv(uplo,k - 1,-cone,ap,work,1,czero,ap(kcnext),1)
-                              
+
                     ap(kcnext + k) = ap(kcnext + k) - stdlib_cdotu(k - 1,work,1,ap(kcnext),1)
-                              
+
                  end if
                  kstep = 2
                  kcnext = kcnext + k + 1
@@ -18911,7 +18911,7 @@ module stdlib_linalg_lapack_c
               k = k + kstep
               kc = kcnext
               go to 30
-50            continue
+              50 continue
            else
               ! compute inv(a) from the factorization a = l*d*l**t.
               ! k is the main loop index, increasing from 1 to n in steps of
@@ -18919,7 +18919,7 @@ module stdlib_linalg_lapack_c
               npp = n*(n + 1)/2
               k = n
               kc = npp
-60            continue
+              60 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 80
               kcnext = kc - (n - k + 2)
@@ -18958,7 +18958,7 @@ module stdlib_linalg_lapack_c
                     call stdlib_cspmv(uplo,n - k,-cone,ap(kc + (n - k + 1)),work,1,czero,ap( &
                               kcnext + 2),1)
                     ap(kcnext) = ap(kcnext) - stdlib_cdotu(n - k,work,1,ap(kcnext + 2),1)
-                              
+
                  end if
                  kstep = 2
                  kcnext = kcnext - (n - k + 3)
@@ -18988,7 +18988,7 @@ module stdlib_linalg_lapack_c
               k = k - kstep
               kc = kcnext
               go to 60
-80            continue
+              80 continue
            end if
            return
      end subroutine stdlib_csptri
@@ -19010,7 +19010,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: ap(*)
            complex(sp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kc,kp
@@ -19042,7 +19042,7 @@ module stdlib_linalg_lapack_c
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
               kc = n*(n + 1)/2 + 1
-10            continue
+              10 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 30
               kc = kc - k
@@ -19054,7 +19054,7 @@ module stdlib_linalg_lapack_c
                  ! multiply by inv(u(k)), where u(k) is the transformation
                  ! stored in column k of a.
                  call stdlib_cgeru(k - 1,nrhs,-cone,ap(kc),1,b(k,1),ldb,b(1,1),ldb)
-                           
+
                  ! multiply by the inverse of the diagonal block.
                  call stdlib_cscal(nrhs,cone/ap(kc + k - 1),b(k,1),ldb)
                  k = k - 1
@@ -19066,7 +19066,7 @@ module stdlib_linalg_lapack_c
                  ! multiply by inv(u(k)), where u(k) is the transformation
                  ! stored in columns k-1 and k of a.
                  call stdlib_cgeru(k - 2,nrhs,-cone,ap(kc),1,b(k,1),ldb,b(1,1),ldb)
-                           
+
                  call stdlib_cgeru(k - 2,nrhs,-cone,ap(kc - (k - 1)),1,b(k - 1,1),ldb,b(1, &
                            1),ldb)
                  ! multiply by the inverse of the diagonal block.
@@ -19084,13 +19084,13 @@ module stdlib_linalg_lapack_c
                  k = k - 2
               end if
               go to 10
-30            continue
+              30 continue
               ! next solve u**t*x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
               kc = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               if (ipiv(k) > 0) then
@@ -19119,7 +19119,7 @@ module stdlib_linalg_lapack_c
                  k = k + 2
               end if
               go to 40
-50            continue
+              50 continue
            else
               ! solve a*x = b, where a = l*d*l**t.
               ! first solve l*d*x = b, overwriting b with x.
@@ -19127,7 +19127,7 @@ module stdlib_linalg_lapack_c
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
               kc = 1
-60            continue
+              60 continue
               ! if k > n, exit from loop.
               if (k > n) go to 80
               if (ipiv(k) > 0) then
@@ -19171,13 +19171,13 @@ module stdlib_linalg_lapack_c
                  k = k + 2
               end if
               go to 60
-80            continue
+              80 continue
               ! next solve l**t*x = b, overwriting b with x.
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
               kc = n*(n + 1)/2 + 1
-90            continue
+              90 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 100
               kc = kc - (n - k + 1)
@@ -19208,7 +19208,7 @@ module stdlib_linalg_lapack_c
                  k = k - 2
               end if
               go to 90
-100           continue
+              100 continue
            end if
            return
      end subroutine stdlib_csptrs
@@ -19227,7 +19227,7 @@ module stdlib_linalg_lapack_c
            ! Array Arguments
            complex(sp),intent(inout) :: sx(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: done
            real(sp) :: bignum,cden,cden1,cnum,cnum1,mul,smlnum
@@ -19243,7 +19243,7 @@ module stdlib_linalg_lapack_c
            ! initialize the denominator to sa and the numerator to 1.
            cden = sa
            cnum = one
-10         continue
+           10 continue
            cden1 = cden*smlnum
            cnum1 = cnum/bignum
            if (abs(cden1) > abs(cnum) .and. cnum /= zero) then
@@ -19297,7 +19297,7 @@ module stdlib_linalg_lapack_c
            real(sp),parameter :: odm1 = 1.0e-1_sp
            integer(ilp),parameter :: maxits = 5
            integer(ilp),parameter :: extra = 2
-           
+
            ! Local Scalars
            integer(ilp) :: b1,blksiz,bn,gpind,i,iinfo,indrv1,indrv2,indrv3,indrv4, &
                      indrv5,its,j,j1,jblk,jmax,jr,nblk,nrmchk
@@ -19330,7 +19330,7 @@ module stdlib_linalg_lapack_c
                     go to 30
                  end if
               end do
-30            continue
+              30 continue
            end if
            if (info /= 0) then
               call stdlib_xerbla('CSTEIN',-info)
@@ -19377,7 +19377,7 @@ module stdlib_linalg_lapack_c
               ortol = odm3*onenrm
               stpcrt = sqrt(odm1/blksiz)
               ! loop through eigenvalues of block nblk.
-60   continue
+              60 continue
               jblk = 0
               loop_170: do j = j1,m
                  if (iblock(j) /= nblk) then
@@ -19412,7 +19412,7 @@ module stdlib_linalg_lapack_c
                  call stdlib_slagtf(blksiz,work(indrv4 + 1),xj,work(indrv2 + 2),work(indrv3 + &
                            1),tol,work(indrv5 + 1),iwork,iinfo)
                  ! update iteration count.
-70   continue
+                 70 continue
                  its = its + 1
                  if (its > maxits) go to 120
                  ! normalize and scale the righthand side vector pb.
@@ -19440,7 +19440,7 @@ module stdlib_linalg_lapack_c
                     end do
                  end if
                  ! check the infinity norm of the iterate.
-110  continue
+                 110 continue
                  jmax = stdlib_isamax(blksiz,work(indrv1 + 1),1)
                  nrm = abs(work(indrv1 + jmax))
                  ! continue for additional iterations after norm reaches
@@ -19451,16 +19451,16 @@ module stdlib_linalg_lapack_c
                  go to 130
                  ! if stopping criterion was not satisfied, update info and
                  ! store eigenvector number in array ifail.
-120  continue
+                 120 continue
                  info = info + 1
                  ifail(info) = j
                  ! accept iterate as jth eigenvector.
-130  continue
+                 130 continue
                  scl = one/stdlib_snrm2(blksiz,work(indrv1 + 1),1)
                  jmax = stdlib_isamax(blksiz,work(indrv1 + 1),1)
                  if (work(indrv1 + jmax) < zero) scl = -scl
                  call stdlib_sscal(blksiz,scl,work(indrv1 + 1),1)
-140              continue
+                 140 continue
                  do i = 1,n
                     z(i,j) = czero
                  end do
@@ -19496,7 +19496,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: maxit = 30
-           
+
            ! Local Scalars
            integer(ilp) :: i,icompz,ii,iscale,j,jtot,k,l,l1,lend,lendm1,lendp1,lendsv, &
                       lm1,lsv,m,mm,mm1,nm1,nmaxit
@@ -19550,7 +19550,7 @@ module stdlib_linalg_lapack_c
            ! element is smaller.
            l1 = 1
            nm1 = n - 1
-10         continue
+           10 continue
            if (l1 > n) go to 160
            if (l1 > 1) e(l1 - 1) = zero
            if (l1 <= nm1) then
@@ -19564,7 +19564,7 @@ module stdlib_linalg_lapack_c
               end do
            end if
            m = n
-30         continue
+           30 continue
            l = l1
            lsv = l
            lend = m
@@ -19592,7 +19592,7 @@ module stdlib_linalg_lapack_c
            if (lend > l) then
               ! ql iteration
               ! look for small subdiagonal element.
-40   continue
+              40 continue
               if (l /= lend) then
                  lendm1 = lend - 1
                  do m = l,lendm1
@@ -19601,7 +19601,7 @@ module stdlib_linalg_lapack_c
                  end do
               end if
               m = lend
-60            continue
+              60 continue
               if (m < lend) e(m) = zero
               p = d(l)
               if (m == l) go to 80
@@ -19661,7 +19661,7 @@ module stdlib_linalg_lapack_c
               e(l) = g
               go to 40
               ! eigenvalue found.
-80   continue
+              80 continue
               d(l) = p
               l = l + 1
               if (l <= lend) go to 40
@@ -19669,7 +19669,7 @@ module stdlib_linalg_lapack_c
            else
               ! qr iteration
               ! look for small superdiagonal element.
-90   continue
+              90 continue
               if (l /= lend) then
                  lendp1 = lend + 1
                  do m = l,lendp1,-1
@@ -19678,7 +19678,7 @@ module stdlib_linalg_lapack_c
                  end do
               end if
               m = lend
-110           continue
+              110 continue
               if (m > lend) e(m - 1) = zero
               p = d(l)
               if (m == l) go to 130
@@ -19738,24 +19738,24 @@ module stdlib_linalg_lapack_c
               e(lm1) = g
               go to 90
               ! eigenvalue found.
-130  continue
+              130 continue
               d(l) = p
               l = l - 1
               if (l >= lend) go to 90
               go to 140
            end if
            ! undo scaling if necessary
-140  continue
+           140 continue
            if (iscale == 1) then
               call stdlib_slascl('G',0,0,ssfmax,anorm,lendsv - lsv + 1,1,d(lsv),n,info)
-                        
+
               call stdlib_slascl('G',0,0,ssfmax,anorm,lendsv - lsv,1,e(lsv),n,info)
-                        
+
            else if (iscale == 2) then
               call stdlib_slascl('G',0,0,ssfmin,anorm,lendsv - lsv + 1,1,d(lsv),n,info)
-                        
+
               call stdlib_slascl('G',0,0,ssfmin,anorm,lendsv - lsv,1,e(lsv),n,info)
-                        
+
            end if
            ! check for no convergence to an eigenvalue after a total
            ! of n*maxit iterations.
@@ -19767,7 +19767,7 @@ module stdlib_linalg_lapack_c
            end if
            go to 10
            ! order eigenvalues and eigenvectors.
-160  continue
+           160 continue
            if (icompz == 0) then
               ! use quick sort
               call stdlib_slasrt('I',n,d,info)
@@ -19810,7 +19810,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: e(*)
         ! =====================================================================
-           
+
            ! External Subroutines
            logical(lk) :: upper,convert
            integer(ilp) :: i,ip,j
@@ -20028,7 +20028,7 @@ module stdlib_linalg_lapack_c
            integer(ilp),intent(inout) :: ipiv(*)
            complex(sp),intent(inout) :: a(lda,*),e(*)
         ! =====================================================================
-           
+
            ! External Subroutines
            logical(lk) :: upper,convert
            integer(ilp) :: i,ip
@@ -20092,7 +20092,7 @@ module stdlib_linalg_lapack_c
                        if (i < n) then
                           if (ip /= (i - 1)) then
                              call stdlib_cswap(n - i,a(i - 1,i + 1),lda,a(ip,i + 1),lda)
-                                       
+
                           end if
                        end if
                        ! convert ipiv
@@ -20128,7 +20128,7 @@ module stdlib_linalg_lapack_c
                        if (i < n) then
                           if (ip /= (i - 1)) then
                              call stdlib_cswap(n - i,a(ip,i + 1),lda,a(i - 1,i + 1),lda)
-                                       
+
                           end if
                        end if
                        ! convert ipiv
@@ -20283,7 +20283,7 @@ module stdlib_linalg_lapack_c
            integer(ilp),intent(in) :: ipiv(*)
            complex(sp),intent(inout) :: a(lda,*),e(*)
         ! =====================================================================
-           
+
            ! External Subroutines
            logical(lk) :: upper,convert
            integer(ilp) :: i,ip,ip2
@@ -20352,7 +20352,7 @@ module stdlib_linalg_lapack_c
                           end if
                           if (ip2 /= (i - 1)) then
                              call stdlib_cswap(n - i,a(i - 1,i + 1),lda,a(ip2,i + 1),lda)
-                                       
+
                           end if
                        end if
                        i = i - 1
@@ -20385,7 +20385,7 @@ module stdlib_linalg_lapack_c
                        if (i < n) then
                           if (ip2 /= (i - 1)) then
                              call stdlib_cswap(n - i,a(ip2,i + 1),lda,a(i - 1,i + 1),lda)
-                                       
+
                           end if
                           if (ip /= i) then
                              call stdlib_cswap(n - i,a(ip,i + 1),lda,a(i,i + 1),lda)
@@ -20534,7 +20534,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: max_iter = 100
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,iter
            real(sp) :: avg,std,tol,c0,c1,c2,t,u,si,d,base,smin,smax,smlnum,bignum, &
@@ -20675,7 +20675,7 @@ module stdlib_linalg_lapack_c
                  s(i) = si
               end do
            end do
-999        continue
+           999 continue
            smlnum = stdlib_slamch('SAFEMIN')
            bignum = one/smlnum
            smin = bignum
@@ -20708,7 +20708,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: a(lda,*),x(*)
            complex(sp),intent(inout) :: y(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,info,ix,iy,j,jx,jy,kx,ky
            complex(sp) :: temp1,temp2
@@ -20861,7 +20861,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(in) :: x(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,info,ix,j,jx,kx
            complex(sp) :: temp
@@ -21038,7 +21038,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: sevten = 17.0e+0_sp
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,imax,j,jmax,k,kk,kp,kstep
@@ -21072,7 +21072,7 @@ module stdlib_linalg_lapack_c
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 70
               kstep = 1
@@ -21187,7 +21187,7 @@ module stdlib_linalg_lapack_c
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop
               if (k > n) go to 70
               kstep = 1
@@ -21240,7 +21240,7 @@ module stdlib_linalg_lapack_c
                     ! interchange rows and columns kk and kp in the trailing
                     ! submatrix a(k:n,k:n)
                     if (kp < n) call stdlib_cswap(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     call stdlib_cswap(kp - kk - 1,a(kk + 1,kk),1,a(kp,kk + 1),lda)
                     t = a(kk,kk)
                     a(kk,kk) = a(kp,kp)
@@ -21261,7 +21261,7 @@ module stdlib_linalg_lapack_c
                        ! a := a - l(k)*d(k)*l(k)**t = a - w(k)*(1/d(k))*w(k)**t
                        r1 = cone/a(k,k)
                        call stdlib_csyr(uplo,n - k,-r1,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                 
+
                        ! store l(k) in column k
                        call stdlib_cscal(n - k,r1,a(k + 1,k),1)
                     end if
@@ -21301,7 +21301,7 @@ module stdlib_linalg_lapack_c
               k = k + kstep
               go to 40
            end if
-70         continue
+           70 continue
            return
      end subroutine stdlib_csytf2
 
@@ -21330,7 +21330,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: sevten = 17.0e+0_sp
-           
+
            ! Local Scalars
            logical(lk) :: upper,done
            integer(ilp) :: i,imax,j,jmax,itemp,k,kk,kp,kstep,p,ii
@@ -21369,7 +21369,7 @@ module stdlib_linalg_lapack_c
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 34
               kstep = 1
@@ -21403,7 +21403,7 @@ module stdlib_linalg_lapack_c
                  else
                     done = .false.
                     ! loop until pivot found
-12   continue
+                    12 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -21453,7 +21453,7 @@ module stdlib_linalg_lapack_c
                     ! submatrix a(1:k,1:k) if we have a 2-by-2 pivot
                     if (p > 1) call stdlib_cswap(p - 1,a(1,k),1,a(1,p),1)
                     if (p < (k - 1)) call stdlib_cswap(k - p - 1,a(p + 1,k),1,a(p,p + 1),lda)
-                              
+
                     t = a(k,k)
                     a(k,k) = a(p,p)
                     a(p,p) = t
@@ -21556,7 +21556,7 @@ module stdlib_linalg_lapack_c
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-34            continue
+              34 continue
            else
               ! factorize a as l*d*l**t using the lower triangle of a
               ! initialize the unused last entry of the subdiagonal array e.
@@ -21564,7 +21564,7 @@ module stdlib_linalg_lapack_c
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop
               if (k > n) go to 64
               kstep = 1
@@ -21597,7 +21597,7 @@ module stdlib_linalg_lapack_c
                  else
                     done = .false.
                     ! loop until pivot found
-42   continue
+                    42 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -21647,7 +21647,7 @@ module stdlib_linalg_lapack_c
                     ! submatrix a(k:n,k:n) if we have a 2-by-2 pivot
                     if (p < n) call stdlib_cswap(n - p,a(p + 1,k),1,a(p + 1,p),1)
                     if (p > (k + 1)) call stdlib_cswap(p - k - 1,a(k + 1,k),1,a(p,k + 1),lda)
-                              
+
                     t = a(k,k)
                     a(k,k) = a(p,p)
                     a(p,p) = t
@@ -21661,7 +21661,7 @@ module stdlib_linalg_lapack_c
                     ! interchange rows and columns kk and kp in the trailing
                     ! submatrix a(k:n,k:n)
                     if (kp < n) call stdlib_cswap(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     if ((kk < n) .and. (kp > (kk + 1))) call stdlib_cswap(kp - kk - 1,a(kk + 1,kk), &
                               1,a(kp,kk + 1),lda)
                     t = a(kk,kk)
@@ -21690,7 +21690,7 @@ module stdlib_linalg_lapack_c
                              ! = a - w(k)*(1/d(k))*w(k)**t
                           d11 = cone/a(k,k)
                           call stdlib_csyr(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                           ! store l(k) in column k
                           call stdlib_cscal(n - k,d11,a(k + 1,k),1)
                        else
@@ -21704,7 +21704,7 @@ module stdlib_linalg_lapack_c
                              ! = a - w(k)*(1/d(k))*w(k)**t
                              ! = a - (w(k)/d(k))*(d(k))*(w(k)/d(k))**t
                           call stdlib_csyr(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                        end if
                        ! store the subdiagonal element of d in array e
                        e(k) = czero
@@ -21755,7 +21755,7 @@ module stdlib_linalg_lapack_c
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 40
-64            continue
+              64 continue
            end if
            return
      end subroutine stdlib_csytf2_rk
@@ -21782,7 +21782,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: sevten = 17.0e+0_sp
-           
+
            ! Local Scalars
            logical(lk) :: upper,done
            integer(ilp) :: i,imax,j,jmax,itemp,k,kk,kp,kstep,p,ii
@@ -21818,7 +21818,7 @@ module stdlib_linalg_lapack_c
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 70
               kstep = 1
@@ -21850,7 +21850,7 @@ module stdlib_linalg_lapack_c
                  else
                     done = .false.
                     ! loop until pivot found
-12   continue
+                    12 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -21900,7 +21900,7 @@ module stdlib_linalg_lapack_c
                     ! submatrix a(1:k,1:k) if we have a 2-by-2 pivot
                     if (p > 1) call stdlib_cswap(p - 1,a(1,k),1,a(1,p),1)
                     if (p < (k - 1)) call stdlib_cswap(k - p - 1,a(p + 1,k),1,a(p,p + 1),lda)
-                              
+
                     t = a(k,k)
                     a(k,k) = a(p,p)
                     a(p,p) = t
@@ -21994,7 +21994,7 @@ module stdlib_linalg_lapack_c
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop
               if (k > n) go to 70
               kstep = 1
@@ -22025,7 +22025,7 @@ module stdlib_linalg_lapack_c
                  else
                     done = .false.
                     ! loop until pivot found
-42   continue
+                    42 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -22075,7 +22075,7 @@ module stdlib_linalg_lapack_c
                     ! submatrix a(k:n,k:n) if we have a 2-by-2 pivot
                     if (p < n) call stdlib_cswap(n - p,a(p + 1,k),1,a(p + 1,p),1)
                     if (p > (k + 1)) call stdlib_cswap(p - k - 1,a(k + 1,k),1,a(p,k + 1),lda)
-                              
+
                     t = a(k,k)
                     a(k,k) = a(p,p)
                     a(p,p) = t
@@ -22086,7 +22086,7 @@ module stdlib_linalg_lapack_c
                     ! interchange rows and columns kk and kp in the trailing
                     ! submatrix a(k:n,k:n)
                     if (kp < n) call stdlib_cswap(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     if ((kk < n) .and. (kp > (kk + 1))) call stdlib_cswap(kp - kk - 1,a(kk + 1,kk), &
                               1,a(kp,kk + 1),lda)
                     t = a(kk,kk)
@@ -22112,7 +22112,7 @@ module stdlib_linalg_lapack_c
                              ! = a - w(k)*(1/d(k))*w(k)**t
                           d11 = cone/a(k,k)
                           call stdlib_csyr(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                           ! store l(k) in column k
                           call stdlib_cscal(n - k,d11,a(k + 1,k),1)
                        else
@@ -22126,7 +22126,7 @@ module stdlib_linalg_lapack_c
                              ! = a - w(k)*(1/d(k))*w(k)**t
                              ! = a - (w(k)/d(k))*(d(k))*(w(k)/d(k))**t
                           call stdlib_csyr(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                        end if
                     end if
                  else
@@ -22170,7 +22170,7 @@ module stdlib_linalg_lapack_c
               k = k + kstep
               go to 40
            end if
-70         continue
+           70 continue
            return
      end subroutine stdlib_csytf2_rook
 
@@ -22245,7 +22245,7 @@ module stdlib_linalg_lapack_c
               ! kb, where kb is the number of columns factorized by stdlib_clasyf;
               ! kb is either nb or nb-1, or k for the last block
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 40
               if (k > nb) then
@@ -22268,7 +22268,7 @@ module stdlib_linalg_lapack_c
               ! kb, where kb is the number of columns factorized by stdlib_clasyf;
               ! kb is either nb or nb-1, or n-k+1 for the last block
               k = 1
-20            continue
+              20 continue
               ! if k > n, exit from loop
               if (k > n) go to 40
               if (k <= n - nb) then
@@ -22295,7 +22295,7 @@ module stdlib_linalg_lapack_c
               k = k + kb
               go to 20
            end if
-40         continue
+           40 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_csytrf
@@ -22372,14 +22372,14 @@ module stdlib_linalg_lapack_c
               ! kb, where kb is the number of columns factorized by stdlib_clasyf_rk;
               ! kb is either nb or nb-1, or k for the last block
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 15
               if (k > nb) then
                  ! factorize columns k-kb+1:k of a and use blocked code to
                  ! update columns 1:k-kb
                  call stdlib_clasyf_rk(uplo,k,nb,kb,a,lda,e,ipiv,work,ldwork,iinfo)
-                           
+
               else
                  ! use unblocked code to factorize columns 1:k of a
                  call stdlib_csytf2_rk(uplo,k,a,lda,e,ipiv,iinfo)
@@ -22408,14 +22408,14 @@ module stdlib_linalg_lapack_c
               go to 10
               ! this label is the exit from main loop over k decreasing
               ! from n to 1 in steps of kb
-15   continue
+              15 continue
            else
               ! factorize a as l*d*l**t using the lower triangle of a
               ! k is the main loop index, increasing from 1 to n in steps of
               ! kb, where kb is the number of columns factorized by stdlib_clasyf_rk;
               ! kb is either nb or nb-1, or n-k+1 for the last block
               k = 1
-20            continue
+              20 continue
               ! if k > n, exit from loop
               if (k > n) go to 35
               if (k <= n - nb) then
@@ -22426,7 +22426,7 @@ module stdlib_linalg_lapack_c
               else
                  ! use unblocked code to factorize columns k:n of a
                  call stdlib_csytf2_rk(uplo,n - k + 1,a(k,k),lda,e(k),ipiv(k),iinfo)
-                           
+
                  kb = n - k + 1
               end if
               ! set info on the first occurrence of a zero pivot
@@ -22459,7 +22459,7 @@ module stdlib_linalg_lapack_c
               go to 20
               ! this label is the exit from main loop over k increasing
               ! from 1 to n in steps of kb
-35   continue
+              35 continue
            ! end lower
            end if
            work(1) = lwkopt
@@ -22537,14 +22537,14 @@ module stdlib_linalg_lapack_c
               ! kb, where kb is the number of columns factorized by stdlib_clasyf_rook;
               ! kb is either nb or nb-1, or k for the last block
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 40
               if (k > nb) then
                  ! factorize columns k-kb+1:k of a and use blocked code to
                  ! update columns 1:k-kb
                  call stdlib_clasyf_rook(uplo,k,nb,kb,a,lda,ipiv,work,ldwork,iinfo)
-                           
+
               else
                  ! use unblocked code to factorize columns 1:k of a
                  call stdlib_csytf2_rook(uplo,k,a,lda,ipiv,iinfo)
@@ -22562,7 +22562,7 @@ module stdlib_linalg_lapack_c
               ! kb, where kb is the number of columns factorized by stdlib_clasyf_rook;
               ! kb is either nb or nb-1, or n-k+1 for the last block
               k = 1
-20            continue
+              20 continue
               ! if k > n, exit from loop
               if (k > n) go to 40
               if (k <= n - nb) then
@@ -22589,7 +22589,7 @@ module stdlib_linalg_lapack_c
               k = k + kb
               go to 20
            end if
-40         continue
+           40 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_csytrf_rook
@@ -22611,7 +22611,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: k,kp,kstep
@@ -22653,7 +22653,7 @@ module stdlib_linalg_lapack_c
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-30            continue
+              30 continue
               ! if k > n, exit from loop.
               if (k > n) go to 40
               if (ipiv(k) > 0) then
@@ -22664,7 +22664,7 @@ module stdlib_linalg_lapack_c
                  if (k > 1) then
                     call stdlib_ccopy(k - 1,a(1,k),1,work,1)
                     call stdlib_csymv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - stdlib_cdotu(k - 1,work,1,a(1,k),1)
                  end if
                  kstep = 1
@@ -22683,15 +22683,15 @@ module stdlib_linalg_lapack_c
                  if (k > 1) then
                     call stdlib_ccopy(k - 1,a(1,k),1,work,1)
                     call stdlib_csymv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - stdlib_cdotu(k - 1,work,1,a(1,k),1)
                     a(k,k + 1) = a(k,k + 1) - stdlib_cdotu(k - 1,a(1,k),1,a(1,k + 1),1)
-                              
+
                     call stdlib_ccopy(k - 1,a(1,k + 1),1,work,1)
                     call stdlib_csymv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k + 1),1)
-                              
+
                     a(k + 1,k + 1) = a(k + 1,k + 1) - stdlib_cdotu(k - 1,work,1,a(1,k + 1),1)
-                              
+
                  end if
                  kstep = 2
               end if
@@ -22712,13 +22712,13 @@ module stdlib_linalg_lapack_c
               end if
               k = k + kstep
               go to 30
-40            continue
+              40 continue
            else
               ! compute inv(a) from the factorization a = l*d*l**t.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-50            continue
+              50 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 60
               if (ipiv(k) > 0) then
@@ -22756,7 +22756,7 @@ module stdlib_linalg_lapack_c
                     call stdlib_csymv(uplo,n - k,-cone,a(k + 1,k + 1),lda,work,1,czero,a(k + &
                               1,k - 1),1)
                     a(k - 1,k - 1) = a(k - 1,k - 1) - stdlib_cdotu(n - k,work,1,a(k + 1,k - 1),1)
-                              
+
                  end if
                  kstep = 2
               end if
@@ -22777,7 +22777,7 @@ module stdlib_linalg_lapack_c
               end if
               k = k - kstep
               go to 50
-60            continue
+              60 continue
            end if
            return
      end subroutine stdlib_csytri
@@ -22799,7 +22799,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: k,kp,kstep
@@ -22841,7 +22841,7 @@ module stdlib_linalg_lapack_c
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-30            continue
+              30 continue
               ! if k > n, exit from loop.
               if (k > n) go to 40
               if (ipiv(k) > 0) then
@@ -22852,7 +22852,7 @@ module stdlib_linalg_lapack_c
                  if (k > 1) then
                     call stdlib_ccopy(k - 1,a(1,k),1,work,1)
                     call stdlib_csymv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - stdlib_cdotu(k - 1,work,1,a(1,k),1)
                  end if
                  kstep = 1
@@ -22871,15 +22871,15 @@ module stdlib_linalg_lapack_c
                  if (k > 1) then
                     call stdlib_ccopy(k - 1,a(1,k),1,work,1)
                     call stdlib_csymv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - stdlib_cdotu(k - 1,work,1,a(1,k),1)
                     a(k,k + 1) = a(k,k + 1) - stdlib_cdotu(k - 1,a(1,k),1,a(1,k + 1),1)
-                              
+
                     call stdlib_ccopy(k - 1,a(1,k + 1),1,work,1)
                     call stdlib_csymv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k + 1),1)
-                              
+
                     a(k + 1,k + 1) = a(k + 1,k + 1) - stdlib_cdotu(k - 1,work,1,a(1,k + 1),1)
-                              
+
                  end if
                  kstep = 2
               end if
@@ -22920,13 +22920,13 @@ module stdlib_linalg_lapack_c
               end if
               k = k + 1
               go to 30
-40            continue
+              40 continue
            else
               ! compute inv(a) from the factorization a = l*d*l**t.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-50            continue
+              50 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 60
               if (ipiv(k) > 0) then
@@ -22964,7 +22964,7 @@ module stdlib_linalg_lapack_c
                     call stdlib_csymv(uplo,n - k,-cone,a(k + 1,k + 1),lda,work,1,czero,a(k + 1, &
                                k - 1),1)
                     a(k - 1,k - 1) = a(k - 1,k - 1) - stdlib_cdotu(n - k,work,1,a(k + 1,k - 1),1)
-                              
+
                  end if
                  kstep = 2
               end if
@@ -23005,7 +23005,7 @@ module stdlib_linalg_lapack_c
               end if
               k = k - 1
               go to 50
-60            continue
+              60 continue
            end if
            return
      end subroutine stdlib_csytri_rook
@@ -23027,7 +23027,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: a(lda,*)
            complex(sp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kp
@@ -23060,7 +23060,7 @@ module stdlib_linalg_lapack_c
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 30
               if (ipiv(k) > 0) then
@@ -23100,12 +23100,12 @@ module stdlib_linalg_lapack_c
                  k = k - 2
               end if
               go to 10
-30            continue
+              30 continue
               ! next solve u**t *x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               if (ipiv(k) > 0) then
@@ -23132,14 +23132,14 @@ module stdlib_linalg_lapack_c
                  k = k + 2
               end if
               go to 40
-50            continue
+              50 continue
            else
               ! solve a*x = b, where a = l*d*l**t.
               ! first solve l*d*x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-60            continue
+              60 continue
               ! if k > n, exit from loop.
               if (k > n) go to 80
               if (ipiv(k) > 0) then
@@ -23181,12 +23181,12 @@ module stdlib_linalg_lapack_c
                  k = k + 2
               end if
               go to 60
-80            continue
+              80 continue
               ! next solve l**t *x = b, overwriting b with x.
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-90            continue
+              90 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 100
               if (ipiv(k) > 0) then
@@ -23215,7 +23215,7 @@ module stdlib_linalg_lapack_c
                  k = k - 2
               end if
               go to 90
-100           continue
+              100 continue
            end if
            return
      end subroutine stdlib_csytrs
@@ -23237,7 +23237,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,iinfo,j,k,kp
@@ -23346,7 +23346,7 @@ module stdlib_linalg_lapack_c
                  ! interchange rows k and -ipiv(k+1).
                  kp = -ipiv(k + 1)
                  if (kp == -ipiv(k)) call stdlib_cswap(nrhs,b(k + 1,1),ldb,b(kp,1),ldb)
-                           
+
                  k = k + 2
               end if
              end do
@@ -23421,7 +23421,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: a(lda,*),e(*)
            complex(sp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,j,k,kp
@@ -23560,7 +23560,7 @@ module stdlib_linalg_lapack_c
      !> A = L*T*L**T computed by CSYTRF_AA.
 
      pure subroutine stdlib_csytrs_aa(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -23574,7 +23574,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: b(ldb,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            logical(lk) :: lquery,upper
            integer(ilp) :: k,kp,lwkopt
            ! Intrinsic Functions
@@ -23691,7 +23691,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: a(lda,*)
            complex(sp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kp
@@ -23724,7 +23724,7 @@ module stdlib_linalg_lapack_c
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 30
               if (ipiv(k) > 0) then
@@ -23768,12 +23768,12 @@ module stdlib_linalg_lapack_c
                  k = k - 2
               end if
               go to 10
-30            continue
+              30 continue
               ! next solve u**t *x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               if (ipiv(k) > 0) then
@@ -23804,14 +23804,14 @@ module stdlib_linalg_lapack_c
                  k = k + 2
               end if
               go to 40
-50            continue
+              50 continue
            else
               ! solve a*x = b, where a = l*d*l**t.
               ! first solve l*d*x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-60            continue
+              60 continue
               ! if k > n, exit from loop.
               if (k > n) go to 80
               if (ipiv(k) > 0) then
@@ -23855,12 +23855,12 @@ module stdlib_linalg_lapack_c
                  k = k + 2
               end if
               go to 60
-80            continue
+              80 continue
               ! next solve l**t *x = b, overwriting b with x.
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-90            continue
+              90 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 100
               if (ipiv(k) > 0) then
@@ -23891,7 +23891,7 @@ module stdlib_linalg_lapack_c
                  k = k - 2
               end if
               go to 90
-100           continue
+              100 continue
            end if
            return
      end subroutine stdlib_csytrs_rook
@@ -23917,7 +23917,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: ab(ldab,*),b(ldb,*),x(ldx,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            character :: transn,transt
@@ -24110,7 +24110,7 @@ module stdlib_linalg_lapack_c
                  end if
               end do
               kase = 0
-210           continue
+              210 continue
               call stdlib_clacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -24144,7 +24144,7 @@ module stdlib_linalg_lapack_c
      !> N-by-NRHS matrix.  A check is made to verify that A is nonsingular.
 
      pure subroutine stdlib_ctbtrs(uplo,trans,diag,n,kd,nrhs,ab,ldab,b,ldb,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -24156,7 +24156,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: ab(ldab,*)
            complex(sp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,upper
            integer(ilp) :: j
@@ -24221,7 +24221,7 @@ module stdlib_linalg_lapack_c
      !> The matrix X is overwritten on B.
 
      pure subroutine stdlib_ctfsm(transr,side,uplo,trans,diag,m,n,alpha,a,b,ldb)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -24233,7 +24233,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: a(0:*)
            complex(sp),intent(inout) :: b(0:ldb - 1,0:*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,lside,misodd,nisodd,normaltransr,notrans
            integer(ilp) :: m1,m2,n1,n2,k,info,i,j
@@ -24308,7 +24308,7 @@ module stdlib_linalg_lapack_c
                           ! trans = 'n'
                           if (m == 1) then
                              call stdlib_ctrsm('L','L','N',diag,m1,n,alpha,a,m,b,ldb)
-                                       
+
                           else
                              call stdlib_ctrsm('L','L','N',diag,m1,n,alpha,a(0),m,b, &
                                        ldb)
@@ -24351,7 +24351,7 @@ module stdlib_linalg_lapack_c
                           call stdlib_cgemm('N','N',m1,n,m2,-cone,a(0),m,b(m1,0), &
                                     ldb,alpha,b,ldb)
                           call stdlib_ctrsm('L','L','C',diag,m1,n,cone,a(m2),m,b,ldb)
-                                    
+
                        end if
                     end if
                  else
@@ -24433,7 +24433,7 @@ module stdlib_linalg_lapack_c
                           call stdlib_cgemm('C','N',k,n,k,-cone,a(k + 1),m + 1,b(k,0), &
                                     ldb,alpha,b,ldb)
                           call stdlib_ctrsm('L','L','C',diag,k,n,cone,a(1),m + 1,b,ldb)
-                                    
+
                        end if
                     else
                        ! side  ='l', n is even, transr = 'n', and uplo = 'u'
@@ -24465,7 +24465,7 @@ module stdlib_linalg_lapack_c
                           ! side  ='l', n is even, transr = 'c', uplo = 'l',
                           ! and trans = 'n'
                           call stdlib_ctrsm('L','U','C',diag,k,n,alpha,a(k),k,b,ldb)
-                                    
+
                           call stdlib_cgemm('C','N',k,n,k,-cone,a(k*(k + 1)),k,b,ldb, &
                                     alpha,b(k,0),ldb)
                           call stdlib_ctrsm('L','L','N',diag,k,n,cone,a(0),k,b(k,0), &
@@ -24478,7 +24478,7 @@ module stdlib_linalg_lapack_c
                           call stdlib_cgemm('N','N',k,n,k,-cone,a(k*(k + 1)),k,b(k,0) &
                                     ,ldb,alpha,b,ldb)
                           call stdlib_ctrsm('L','U','N',diag,k,n,cone,a(k),k,b,ldb)
-                                    
+
                        end if
                     else
                        ! side  ='l', n is even, transr = 'c', and uplo = 'u'
@@ -25257,7 +25257,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: vl(ldvl,*),vr(ldvr,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: compl,compr,ilall,ilback,ilbbad,ilcomp,lsa,lsb
            integer(ilp) :: i,ibeg,ieig,iend,ihwmny,im,iside,isrc,j,je,jr
@@ -25412,7 +25412,7 @@ module stdlib_linalg_lapack_c
                     scale = one
                     if (lsa) scale = (small/abs(sbeta))*min(anorm,big)
                     if (lsb) scale = max(scale, (small/abs1(salpha))*min(bnorm,big))
-                              
+
                     if (lsa .or. lsb) then
                        scale = min(scale,one/(safmin*max(one,abs(acoeff),abs1(bcoeff)) &
                                  ))
@@ -25541,7 +25541,7 @@ module stdlib_linalg_lapack_c
                     scale = one
                     if (lsa) scale = (small/abs(sbeta))*min(anorm,big)
                     if (lsb) scale = max(scale, (small/abs1(salpha))*min(bnorm,big))
-                              
+
                     if (lsa .or. lsb) then
                        scale = min(scale,one/(safmin*max(one,abs(acoeff),abs1(bcoeff)) &
                                  ))
@@ -25645,7 +25645,7 @@ module stdlib_linalg_lapack_c
      !> Q(in) * B(in) * Z(in)**H = Q(out) * B(out) * Z(out)**H
 
      pure subroutine stdlib_ctgex2(wantq,wantz,n,a,lda,b,ldb,q,ldq,z,ldz,j1,info)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -25660,7 +25660,7 @@ module stdlib_linalg_lapack_c
            real(sp),parameter :: twenty = 2.0e+1_sp
            integer(ilp),parameter :: ldst = 2
            logical(lk),parameter :: wands = .true.
-           
+
            ! Local Scalars
            logical(lk) :: strong,weak
            integer(ilp) :: i,m
@@ -25760,13 +25760,13 @@ module stdlib_linalg_lapack_c
            b(j1 + 1,j1) = czero
            ! accumulate transformations into q and z if requested.
            if (wantz) call stdlib_crot(n,z(1,j1),1,z(1,j1 + 1),1,cz,conjg(sz))
-                     
+
            if (wantq) call stdlib_crot(n,q(1,j1),1,q(1,j1 + 1),1,cq,conjg(sq))
-                     
+
            ! exit with info = 0 if swap was successfully performed.
            return
            ! exit with info = 1 if swap was rejected.
-20   continue
+           20 continue
            info = 1
            return
      end subroutine stdlib_ctgex2
@@ -25826,10 +25826,10 @@ module stdlib_linalg_lapack_c
            if (ifst == ilst) return
            if (ifst < ilst) then
               here = ifst
-10            continue
+              10 continue
               ! swap with next one below
               call stdlib_ctgex2(wantq,wantz,n,a,lda,b,ldb,q,ldq,z,ldz,here,info)
-                        
+
               if (info /= 0) then
                  ilst = here
                  return
@@ -25839,10 +25839,10 @@ module stdlib_linalg_lapack_c
               here = here - 1
            else
               here = ifst - 1
-20            continue
+              20 continue
               ! swap with next one above
               call stdlib_ctgex2(wantq,wantz,n,a,lda,b,ldb,q,ldq,z,ldz,here,info)
-                        
+
               if (info /= 0) then
                  ilst = here
                  return
@@ -25870,7 +25870,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(sp),intent(out) :: t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,p,mp,np
            complex(sp) :: alpha
@@ -25986,7 +25986,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(sp),intent(out) :: t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,p,mp,np
            complex(sp) :: alpha
@@ -26031,7 +26031,7 @@ module stdlib_linalg_lapack_c
                     a(i,i + j) = a(i,i + j) + alpha*conjg(t(j,n))
                  end do
                  call stdlib_cgerc(p,n - i,alpha,b(1,i),1,t(1,n),1,b(1,i + 1),ldb)
-                           
+
               end if
            end do
            do i = 2,n
@@ -26053,7 +26053,7 @@ module stdlib_linalg_lapack_c
                         np,i),1)
               ! b1
               call stdlib_cgemv('C',m - l,i - 1,alpha,b,ldb,b(1,i),1,cone,t(1,i),1)
-                        
+
               ! t(1:i-1,i) := t(1:i-1,1:i-1) * t(1:i-1,i)
               call stdlib_ctrmv('U','N','N',i - 1,t,ldt,t(1,i),1)
               ! t(i,i) = tau(i)
@@ -26079,7 +26079,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: t(ldt,*),v(ldv,*)
            complex(sp),intent(out) :: work(ldwork,*)
         ! ==========================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,mp,np,kp
            logical(lk) :: left,forward,column,right,backward,row
@@ -26137,9 +26137,9 @@ module stdlib_linalg_lapack_c
                  end do
               end do
               call stdlib_ctrmm('L','U','C','N',l,n,cone,v(mp,1),ldv,work,ldwork)
-                        
+
               call stdlib_cgemm('C','N',l,n,m - l,cone,v,ldv,b,ldb,cone,work,ldwork)
-                        
+
               call stdlib_cgemm('C','N',k - l,n,m,cone,v(1,kp),ldv,b,ldb,czero,work( &
                         kp,1),ldwork)
               do j = 1,n
@@ -26154,11 +26154,11 @@ module stdlib_linalg_lapack_c
                  end do
               end do
               call stdlib_cgemm('N','N',m - l,n,k,-cone,v,ldv,work,ldwork,cone,b,ldb)
-                        
+
               call stdlib_cgemm('N','N',l,n,k - l,-cone,v(mp,kp),ldv,work(kp,1), &
                         ldwork,cone,b(mp,1),ldb)
               call stdlib_ctrmm('L','U','N','N',l,n,cone,v(mp,1),ldv,work,ldwork)
-                        
+
               do j = 1,n
                  do i = 1,l
                     b(m - l + i,j) = b(m - l + i,j) - work(i,j)
@@ -26182,9 +26182,9 @@ module stdlib_linalg_lapack_c
                  end do
               end do
               call stdlib_ctrmm('R','U','N','N',m,l,cone,v(np,1),ldv,work,ldwork)
-                        
+
               call stdlib_cgemm('N','N',m,l,n - l,cone,b,ldb,v,ldv,cone,work,ldwork)
-                        
+
               call stdlib_cgemm('N','N',m,k - l,n,cone,b,ldb,v(1,kp),ldv,czero,work( &
                         1,kp),ldwork)
               do j = 1,k
@@ -26199,11 +26199,11 @@ module stdlib_linalg_lapack_c
                  end do
               end do
               call stdlib_cgemm('N','C',m,n - l,k,-cone,work,ldwork,v,ldv,cone,b,ldb)
-                        
+
               call stdlib_cgemm('N','C',m,l,k - l,-cone,work(1,kp),ldwork,v(np,kp), &
                         ldv,cone,b(1,np),ldb)
               call stdlib_ctrmm('R','U','C','N',m,l,cone,v(np,1),ldv,work,ldwork)
-                        
+
               do j = 1,l
                  do i = 1,m
                     b(i,n - l + j) = b(i,n - l + j) - work(i,j)
@@ -26232,7 +26232,7 @@ module stdlib_linalg_lapack_c
               call stdlib_cgemm('C','N',l,n,m - l,cone,v(mp,kp),ldv,b(mp,1),ldb, &
                         cone,work(kp,1),ldwork)
               call stdlib_cgemm('C','N',k - l,n,m,cone,v,ldv,b,ldb,czero,work,ldwork)
-                        
+
               do j = 1,n
                  do i = 1,k
                     work(i,j) = work(i,j) + a(i,j)
@@ -26247,7 +26247,7 @@ module stdlib_linalg_lapack_c
               call stdlib_cgemm('N','N',m - l,n,k,-cone,v(mp,1),ldv,work,ldwork,cone, &
                         b(mp,1),ldb)
               call stdlib_cgemm('N','N',l,n,k - l,-cone,v,ldv,work,ldwork,cone,b,ldb)
-                        
+
               call stdlib_ctrmm('L','L','N','N',l,n,cone,v(1,kp),ldv,work(kp,1), &
                         ldwork)
               do j = 1,n
@@ -26277,7 +26277,7 @@ module stdlib_linalg_lapack_c
               call stdlib_cgemm('N','N',m,l,n - l,cone,b(1,np),ldb,v(np,kp),ldv, &
                         cone,work(1,kp),ldwork)
               call stdlib_cgemm('N','N',m,k - l,n,cone,b,ldb,v,ldv,czero,work,ldwork)
-                        
+
               do j = 1,k
                  do i = 1,m
                     work(i,j) = work(i,j) + a(i,j)
@@ -26292,7 +26292,7 @@ module stdlib_linalg_lapack_c
               call stdlib_cgemm('N','C',m,n - l,k,-cone,work,ldwork,v(np,1),ldv,cone, &
                         b(1,np),ldb)
               call stdlib_cgemm('N','C',m,l,k - l,-cone,work,ldwork,v,ldv,cone,b,ldb)
-                        
+
               call stdlib_ctrmm('R','L','C','N',m,l,cone,v(1,kp),ldv,work(1,kp), &
                         ldwork)
               do j = 1,l
@@ -26318,9 +26318,9 @@ module stdlib_linalg_lapack_c
                  end do
               end do
               call stdlib_ctrmm('L','L','N','N',l,n,cone,v(1,mp),ldv,work,ldb)
-                        
+
               call stdlib_cgemm('N','N',l,n,m - l,cone,v,ldv,b,ldb,cone,work,ldwork)
-                        
+
               call stdlib_cgemm('N','N',k - l,n,m,cone,v(kp,1),ldv,b,ldb,czero,work( &
                         kp,1),ldwork)
               do j = 1,n
@@ -26335,11 +26335,11 @@ module stdlib_linalg_lapack_c
                  end do
               end do
               call stdlib_cgemm('C','N',m - l,n,k,-cone,v,ldv,work,ldwork,cone,b,ldb)
-                        
+
               call stdlib_cgemm('C','N',l,n,k - l,-cone,v(kp,mp),ldv,work(kp,1), &
                         ldwork,cone,b(mp,1),ldb)
               call stdlib_ctrmm('L','L','C','N',l,n,cone,v(1,mp),ldv,work,ldwork)
-                        
+
               do j = 1,n
                  do i = 1,l
                     b(m - l + i,j) = b(m - l + i,j) - work(i,j)
@@ -26362,9 +26362,9 @@ module stdlib_linalg_lapack_c
                  end do
               end do
               call stdlib_ctrmm('R','L','C','N',m,l,cone,v(1,np),ldv,work,ldwork)
-                        
+
               call stdlib_cgemm('N','C',m,l,n - l,cone,b,ldb,v,ldv,cone,work,ldwork)
-                        
+
               call stdlib_cgemm('N','C',m,k - l,n,cone,b,ldb,v(kp,1),ldv,czero,work( &
                         1,kp),ldwork)
               do j = 1,k
@@ -26379,11 +26379,11 @@ module stdlib_linalg_lapack_c
                  end do
               end do
               call stdlib_cgemm('N','N',m,n - l,k,-cone,work,ldwork,v,ldv,cone,b,ldb)
-                        
+
               call stdlib_cgemm('N','N',m,l,k - l,-cone,work(1,kp),ldwork,v(kp,np), &
                         ldv,cone,b(1,np),ldb)
               call stdlib_ctrmm('R','L','N','N',m,l,cone,v(1,np),ldv,work,ldwork)
-                        
+
               do j = 1,l
                  do i = 1,m
                     b(i,n - l + j) = b(i,n - l + j) - work(i,j)
@@ -26411,7 +26411,7 @@ module stdlib_linalg_lapack_c
               call stdlib_cgemm('N','N',l,n,m - l,cone,v(kp,mp),ldv,b(mp,1),ldb, &
                         cone,work(kp,1),ldwork)
               call stdlib_cgemm('N','N',k - l,n,m,cone,v,ldv,b,ldb,czero,work,ldwork)
-                        
+
               do j = 1,n
                  do i = 1,k
                     work(i,j) = work(i,j) + a(i,j)
@@ -26426,7 +26426,7 @@ module stdlib_linalg_lapack_c
               call stdlib_cgemm('C','N',m - l,n,k,-cone,v(1,mp),ldv,work,ldwork,cone, &
                         b(mp,1),ldb)
               call stdlib_cgemm('C','N',l,n,k - l,-cone,v,ldv,work,ldwork,cone,b,ldb)
-                        
+
               call stdlib_ctrmm('L','U','C','N',l,n,cone,v(kp,1),ldv,work(kp,1), &
                         ldwork)
               do j = 1,n
@@ -26455,7 +26455,7 @@ module stdlib_linalg_lapack_c
               call stdlib_cgemm('N','C',m,l,n - l,cone,b(1,np),ldb,v(kp,np),ldv, &
                         cone,work(1,kp),ldwork)
               call stdlib_cgemm('N','C',m,k - l,n,cone,b,ldb,v,ldv,czero,work,ldwork)
-                        
+
               do j = 1,k
                  do i = 1,m
                     work(i,j) = work(i,j) + a(i,j)
@@ -26470,7 +26470,7 @@ module stdlib_linalg_lapack_c
               call stdlib_cgemm('N','N',m,n - l,k,-cone,work,ldwork,v(1,np),ldv,cone, &
                         b(1,np),ldb)
               call stdlib_cgemm('N','N',m,l,k - l,-cone,work,ldwork,v,ldv,cone,b,ldb)
-                        
+
               call stdlib_ctrmm('R','U','N','N',m,l,cone,v(kp,1),ldv,work(1,kp), &
                         ldwork)
               do j = 1,l
@@ -26503,7 +26503,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: ap(*),b(ldb,*),x(ldx,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            character :: transn,transt
@@ -26704,7 +26704,7 @@ module stdlib_linalg_lapack_c
                  end if
               end do
               kase = 0
-210           continue
+              210 continue
               call stdlib_clacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -26746,7 +26746,7 @@ module stdlib_linalg_lapack_c
            ! Array Arguments
            complex(sp),intent(inout) :: ap(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,upper
            integer(ilp) :: j,jc,jclast,jj
@@ -26840,7 +26840,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: ap(*)
            complex(sp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,upper
            integer(ilp) :: j,jc
@@ -27241,7 +27241,7 @@ module stdlib_linalg_lapack_c
            ! Parameters
            complex(sp),parameter :: cmzero = (0.0e+0_sp,0.0e+0_sp)
            complex(sp),parameter :: cmone = (1.0e+0_sp,0.0e+0_sp)
-           
+
            ! Local Scalars
            logical(lk) :: allv,bothv,leftv,over,rightv,somev
            integer(ilp) :: i,ii,is,j,k,ki
@@ -27441,7 +27441,7 @@ module stdlib_linalg_lapack_c
            ! Parameters
            integer(ilp),parameter :: nbmin = 8
            integer(ilp),parameter :: nbmax = 128
-           
+
            ! Local Scalars
            logical(lk) :: allv,bothv,leftv,lquery,over,rightv,somev
            integer(ilp) :: i,ii,is,j,k,ki,iv,maxwrk,nb
@@ -27768,7 +27768,7 @@ module stdlib_linalg_lapack_c
               call stdlib_clartg(t(k,k + 1),t22 - t11,cs,sn,temp)
               ! apply transformation to the matrix t.
               if (k + 2 <= n) call stdlib_crot(n - k - 1,t(k,k + 2),ldt,t(k + 1,k + 2),ldt,cs,sn)
-                        
+
               call stdlib_crot(k - 1,t(1,k),1,t(1,k + 1),1,cs,conjg(sn))
               t(k,k) = t22
               t(k + 1,k + 1) = t11
@@ -27801,7 +27801,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: a(lda,*),b(ldb,*),x(ldx,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            character :: transn,transt
@@ -27992,7 +27992,7 @@ module stdlib_linalg_lapack_c
                  end if
               end do
               kase = 0
-210           continue
+              210 continue
               call stdlib_clacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -28039,7 +28039,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: t(ldt,*),vl(ldvl,*),vr(ldvr,*)
            complex(sp),intent(out) :: work(ldwork,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: somcon,wantbh,wants,wantsp
            character :: normin
@@ -28138,7 +28138,7 @@ module stdlib_linalg_lapack_c
                  est = zero
                  kase = 0
                  normin = 'N'
-30               continue
+                 30 continue
                  call stdlib_clacn2(n - 1,work(1,n + 1),work,est,kase,isave)
                  if (kase /= 0) then
                     if (kase == 1) then
@@ -28163,7 +28163,7 @@ module stdlib_linalg_lapack_c
                  end if
                  sep(ks) = one/max(est,smlnum)
               end if
-40            continue
+              40 continue
               ks = ks + 1
            end do loop_50
            return
@@ -28184,7 +28184,7 @@ module stdlib_linalg_lapack_c
            ! Array Arguments
            complex(sp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,upper
            integer(ilp) :: j
@@ -28220,7 +28220,7 @@ module stdlib_linalg_lapack_c
                  end if
                  ! compute elements 1:j-1 of j-th column.
                  call stdlib_ctrmv('UPPER','NO TRANSPOSE',diag,j - 1,a,lda,a(1,j),1)
-                           
+
                  call stdlib_cscal(j - 1,ajj,a(1,j),1)
               end do
            else
@@ -28258,7 +28258,7 @@ module stdlib_linalg_lapack_c
            ! Array Arguments
            complex(sp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,upper
            integer(ilp) :: j,jb,nb,nn
@@ -28347,7 +28347,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: a(lda,*)
            complex(sp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit
            ! Intrinsic Functions
@@ -28711,7 +28711,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,iws,ki,kk,ldwork,lwkmin,lwkopt,m1,mu,nb,nbmin, &
@@ -28796,7 +28796,7 @@ module stdlib_linalg_lapack_c
                     ! apply h to a(1:i-1,i:n) from the right
                     call stdlib_clarzb('RIGHT','NO TRANSPOSE','BACKWARD','ROWWISE',i - 1,n - i + 1, &
                      ib,n - m,a(i,m1),lda,work,ldwork,a(1,i),lda,work(ib + 1),ldwork)
-                               
+
                  end if
               end do
               mu = i + nb - 1
@@ -28839,11 +28839,11 @@ module stdlib_linalg_lapack_c
            real(sp),intent(out) :: phi(*),theta(*)
            complex(sp),intent(out) :: taup1(*),taup2(*),tauq1(*),tauq2(*),work(*)
            complex(sp),intent(inout) :: x11(ldx11,*),x12(ldx12,*),x21(ldx21,*),x22(ldx22,*)
-                     
+
         ! ====================================================================
            ! Parameters
            real(sp),parameter :: realone = 1.0_sp
-           
+
            ! Local Scalars
            logical(lk) :: colmajor,lquery
            integer(ilp) :: i,lworkmin,lworkopt
@@ -28978,7 +28978,7 @@ module stdlib_linalg_lapack_c
                        call stdlib_clarfgp(m - q - i + 1,x12(i,i),x12(i,i),ldx12,tauq2(i))
                     else
                        call stdlib_clarfgp(m - q - i + 1,x12(i,i),x12(i,i + 1),ldx12,tauq2(i))
-                                 
+
                     end if
                  end if
                  x12(i,i) = cone
@@ -29002,7 +29002,7 @@ module stdlib_linalg_lapack_c
               ! reduce columns q + 1, ..., p of x12, x22
               do i = q + 1,p
                  call stdlib_cscal(m - q - i + 1,cmplx(-z1*z4,0.0_sp,KIND=sp),x12(i,i),ldx12)
-                           
+
                  call stdlib_clacgv(m - q - i + 1,x12(i,i),ldx12)
                  if (i >= m - q) then
                     call stdlib_clarfgp(m - q - i + 1,x12(i,i),x12(i,i),ldx12,tauq2(i))
@@ -29021,10 +29021,10 @@ module stdlib_linalg_lapack_c
               ! reduce columns p + 1, ..., m - q of x12, x22
               do i = 1,m - p - q
                  call stdlib_cscal(m - p - q - i + 1,cmplx(z2*z4,0.0_sp,KIND=sp),x22(q + i,p + i),ldx22)
-                           
+
                  call stdlib_clacgv(m - p - q - i + 1,x22(q + i,p + i),ldx22)
                  call stdlib_clarfgp(m - p - q - i + 1,x22(q + i,p + i),x22(q + i,p + i + 1),ldx22,tauq2(p + i))
-                           
+
                  x22(q + i,p + i) = cone
                  call stdlib_clarf('R',m - p - q - i,m - p - q - i + 1,x22(q + i,p + i),ldx22,tauq2(p + i),x22( &
                            q + i + 1,p + i),ldx22,work)
@@ -29043,7 +29043,7 @@ module stdlib_linalg_lapack_c
                  end if
                  if (i == 1) then
                     call stdlib_cscal(m - p - i + 1,cmplx(z2,0.0_sp,KIND=sp),x21(i,i),ldx21)
-                              
+
                  else
                     call stdlib_cscal(m - p - i + 1,cmplx(z2*cos(phi(i - 1)),0.0_sp,KIND=sp),x21(i,i), &
                                ldx21)
@@ -29118,9 +29118,9 @@ module stdlib_linalg_lapack_c
               ! reduce columns p + 1, ..., m - q of x12, x22
               do i = 1,m - p - q
                  call stdlib_cscal(m - p - q - i + 1,cmplx(z2*z4,0.0_sp,KIND=sp),x22(p + i,q + i),1)
-                           
+
                  call stdlib_clarfgp(m - p - q - i + 1,x22(p + i,q + i),x22(p + i + 1,q + i),1,tauq2(p + i))
-                           
+
                  x22(p + i,q + i) = cone
                  if (m - p - q /= i) then
                     call stdlib_clarf('L',m - p - q - i + 1,m - p - q - i,x22(p + i,q + i),1,conjg(tauq2(p + i)), &
@@ -29158,7 +29158,7 @@ module stdlib_linalg_lapack_c
            real(sp),parameter :: alphasq = 0.01_sp
            real(sp),parameter :: realone = 1.0_sp
            real(sp),parameter :: realzero = 0.0_sp
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(sp) :: normsq1,normsq2,scl1,scl2,ssq1,ssq2
@@ -29276,7 +29276,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: tau(*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,ii,j,l
            ! Intrinsic Functions
@@ -29311,7 +29311,7 @@ module stdlib_linalg_lapack_c
               ! apply h(i) to a(1:m-k+i,1:n-k+i) from the left
               a(m - n + ii,ii) = cone
               call stdlib_clarf('LEFT',m - n + ii,ii - 1,a(1,ii),1,tau(i),a,lda,work)
-                        
+
               call stdlib_cscal(m - n + ii - 1,-tau(i),a(1,ii),1)
               a(m - n + ii,ii) = cone - tau(i)
               ! set a(m-k+i+1:m,n-k+i) to czero
@@ -29340,7 +29340,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: tau(*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,l
            ! Intrinsic Functions
@@ -29405,7 +29405,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: tau(*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,l
            ! Intrinsic Functions
@@ -29476,7 +29476,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: tau(*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,iinfo,iws,j,ki,kk,l,ldwork,lwkopt,nb,nbmin,nx
@@ -29592,7 +29592,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: tau(*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,iinfo,iws,j,kk,l,ldwork,lwkopt,nb,nbmin,nx
@@ -29678,7 +29678,7 @@ module stdlib_linalg_lapack_c
                     ! apply h to a(1:m-k+i+ib-1,1:n-k+i-1) from the left
                     call stdlib_clarfb('LEFT','NO TRANSPOSE','BACKWARD','COLUMNWISE',m - k + i + ib - &
                     1,n - k + i - 1,ib,a(1,n - k + i),lda,work,ldwork,a,lda,work(ib + 1),ldwork)
-                              
+
                  end if
                  ! apply h to rows 1:m-k+i+ib-1 of current block
                  call stdlib_cung2l(m - k + i + ib - 1,ib,ib,a(1,n - k + i),lda,tau(i),work,iinfo &
@@ -29713,7 +29713,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: tau(*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,iinfo,iws,j,ki,kk,l,ldwork,lwkopt,nb,nbmin,nx
@@ -29829,7 +29829,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: tau(*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,ii,j,l
            ! Intrinsic Functions
@@ -29897,7 +29897,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: tau(*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,ii,iinfo,iws,j,kk,l,ldwork,lwkopt,nb,nbmin,nx
@@ -29984,11 +29984,11 @@ module stdlib_linalg_lapack_c
                     ! apply h**h to a(1:m-k+i-1,1:n-k+i+ib-1) from the right
                     call stdlib_clarfb('RIGHT','CONJUGATE TRANSPOSE','BACKWARD','ROWWISE',ii - &
                     1,n - k + i + ib - 1,ib,a(ii,1),lda,work,ldwork,a,lda,work(ib + 1),ldwork)
-                              
+
                  end if
                  ! apply h**h to columns 1:n-k+i+ib-1 of current block
                  call stdlib_cungr2(ib,n - k + i + ib - 1,ib,a(ii,1),lda,tau(i),work,iinfo)
-                           
+
                  ! set columns n-k+i+ib:n of current block to czero
                  do l = n - k + i + ib,n
                     do j = ii,ii + ib - 1
@@ -30029,7 +30029,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: t(ldt,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: nblocal,mb2,m_plus_one,itmp,ib_bottom,lworkopt, &
@@ -30145,7 +30145,7 @@ module stdlib_linalg_lapack_c
      end subroutine stdlib_cungtsqr_row
 
      pure subroutine stdlib_cunm22(side,trans,m,n,n1,n2,q,ldq,c,ldc,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -30158,7 +30158,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: c(ldc,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            integer(ilp) :: i,ldwork,len,lwkopt,nb,nq,nw
@@ -30217,12 +30217,12 @@ module stdlib_linalg_lapack_c
            ! degenerate cases (n1 = 0 or n2 = 0) are handled using stdlib_ctrmm.
            if (n1 == 0) then
               call stdlib_ctrmm(side,'UPPER',trans,'NON-UNIT',m,n,cone,q,ldq,c,ldc)
-                        
+
               work(1) = cone
               return
            else if (n2 == 0) then
               call stdlib_ctrmm(side,'LOWER',trans,'NON-UNIT',m,n,cone,q,ldq,c,ldc)
-                        
+
               work(1) = cone
               return
            end if
@@ -30242,7 +30242,7 @@ module stdlib_linalg_lapack_c
                               c(1,i),ldc,cone,work,ldwork)
                     ! multiply top part of c by q21.
                     call stdlib_clacpy('ALL',n2,len,c(1,i),ldc,work(n1 + 1),ldwork)
-                              
+
                     call stdlib_ctrmm('LEFT','UPPER','NO TRANSPOSE','NON-UNIT',n2,len,cone, &
                               q(n1 + 1,1),ldq,work(n1 + 1),ldwork)
                     ! multiply bottom part of c by q22.
@@ -30264,7 +30264,7 @@ module stdlib_linalg_lapack_c
                               1,i),ldc,cone,work,ldwork)
                     ! multiply top part of c by q12**h.
                     call stdlib_clacpy('ALL',n1,len,c(1,i),ldc,work(n2 + 1),ldwork)
-                              
+
                     call stdlib_ctrmm('LEFT','LOWER','CONJUGATE','NON-UNIT',n1,len,cone,q( &
                               1,n2 + 1),ldq,work(n2 + 1),ldwork)
                     ! multiply bottom part of c by q22**h.
@@ -30349,7 +30349,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: tau(*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: left,notran
            integer(ilp) :: i,i1,i2,i3,mi,ni,nq
@@ -30448,7 +30448,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: tau(*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: left,notran
            integer(ilp) :: i,i1,i2,i3,ic,jc,mi,ni,nq
@@ -30551,7 +30551,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: tau(*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: left,notran
            integer(ilp) :: i,i1,i2,i3,ic,jc,mi,ni,nq
@@ -30626,7 +30626,7 @@ module stdlib_linalg_lapack_c
               aii = a(i,i)
               a(i,i) = cone
               call stdlib_clarf(side,mi,ni,a(i,i),lda,taui,c(ic,jc),ldc,work)
-                        
+
               a(i,i) = aii
               if (i < nq) call stdlib_clacgv(nq - i,a(i,i + 1),lda)
            end do
@@ -30644,7 +30644,7 @@ module stdlib_linalg_lapack_c
      !> if SIDE = 'R'.
 
      pure subroutine stdlib_cunmlq(side,trans,m,n,k,a,lda,tau,c,ldc,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -30661,7 +30661,7 @@ module stdlib_linalg_lapack_c
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            character :: transt
@@ -30706,7 +30706,7 @@ module stdlib_linalg_lapack_c
                  lwkopt = 1
               else
                  nb = min(nbmax,stdlib_ilaenv(1,'CUNMLQ',side//trans,m,n,k,-1))
-                           
+
                  lwkopt = nw*nb + tsize
               end if
               work(1) = lwkopt
@@ -30792,7 +30792,7 @@ module stdlib_linalg_lapack_c
      !> if SIDE = 'R'.
 
      pure subroutine stdlib_cunmql(side,trans,m,n,k,a,lda,tau,c,ldc,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -30809,7 +30809,7 @@ module stdlib_linalg_lapack_c
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            integer(ilp) :: i,i1,i2,i3,ib,iinfo,iwt,ldwork,lwkopt,mi,nb,nbmin,ni,nq, &
@@ -30853,7 +30853,7 @@ module stdlib_linalg_lapack_c
                  lwkopt = 1
               else
                  nb = min(nbmax,stdlib_ilaenv(1,'CUNMQL',side//trans,m,n,k,-1))
-                           
+
                  lwkopt = nw*nb + tsize
               end if
               work(1) = lwkopt
@@ -30930,7 +30930,7 @@ module stdlib_linalg_lapack_c
      !> if SIDE = 'R'.
 
      pure subroutine stdlib_cunmqr(side,trans,m,n,k,a,lda,tau,c,ldc,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -30947,7 +30947,7 @@ module stdlib_linalg_lapack_c
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            integer(ilp) :: i,i1,i2,i3,ib,ic,iinfo,iwt,jc,ldwork,lwkopt,mi,nb,nbmin, &
@@ -31080,7 +31080,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: tau(*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: left,notran
            integer(ilp) :: i,i1,i2,i3,mi,ni,nq
@@ -31169,7 +31169,7 @@ module stdlib_linalg_lapack_c
      !> if SIDE = 'R'.
 
      pure subroutine stdlib_cunmr3(side,trans,m,n,k,l,a,lda,tau,c,ldc,work,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -31257,7 +31257,7 @@ module stdlib_linalg_lapack_c
                  taui = conjg(tau(i))
               end if
               call stdlib_clarz(side,mi,ni,l,a(i,ja),lda,taui,c(ic,jc),ldc,work)
-                        
+
            end do
            return
      end subroutine stdlib_cunmr3
@@ -31273,7 +31273,7 @@ module stdlib_linalg_lapack_c
      !> if SIDE = 'R'.
 
      pure subroutine stdlib_cunmrq(side,trans,m,n,k,a,lda,tau,c,ldc,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -31290,7 +31290,7 @@ module stdlib_linalg_lapack_c
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            character :: transt
@@ -31335,7 +31335,7 @@ module stdlib_linalg_lapack_c
                  lwkopt = 1
               else
                  nb = min(nbmax,stdlib_ilaenv(1,'CUNMRQ',side//trans,m,n,k,-1))
-                           
+
                  lwkopt = nw*nb + tsize
               end if
               work(1) = lwkopt
@@ -31433,7 +31433,7 @@ module stdlib_linalg_lapack_c
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            character :: transt
@@ -31480,7 +31480,7 @@ module stdlib_linalg_lapack_c
                  lwkopt = 1
               else
                  nb = min(nbmax,stdlib_ilaenv(1,'CUNMRQ',side//trans,m,n,k,-1))
-                           
+
                  lwkopt = nw*nb + tsize
               end if
               work(1) = lwkopt
@@ -31508,7 +31508,7 @@ module stdlib_linalg_lapack_c
            if (nb < nbmin .or. nb >= k) then
               ! use unblocked code
               call stdlib_cunmr3(side,trans,m,n,k,l,a,lda,tau,c,ldc,work,iinfo)
-                        
+
            else
               ! use blocked code
               iwt = 1 + nw*nb
@@ -31596,14 +31596,14 @@ module stdlib_linalg_lapack_c
                       b22e(*),rwork(*)
            real(sp),intent(inout) :: phi(*),theta(*)
            complex(sp),intent(inout) :: u1(ldu1,*),u2(ldu2,*),v1t(ldv1t,*),v2t(ldv2t,*)
-                     
+
         ! ===================================================================
            ! Parameters
            integer(ilp),parameter :: maxitr = 6
            real(sp),parameter :: hundred = 100.0_sp
            real(sp),parameter :: meighth = -0.125_sp
            real(sp),parameter :: piover2 = 1.57079632679489661923132169163975144210_sp
-           
+
            ! Local Scalars
            logical(lk) :: colmajor,lquery,restart11,restart12,restart21,restart22,wantu1, &
                      wantu2,wantv1t,wantv2t
@@ -31753,9 +31753,9 @@ module stdlib_linalg_lapack_c
               else
                  ! compute shifts for b11 and b21 and use the lesser
                  call stdlib_slas2(b11d(imax - 1),b11e(imax - 1),b11d(imax),sigma11,dummy)
-                           
+
                  call stdlib_slas2(b21d(imax - 1),b21e(imax - 1),b21d(imax),sigma21,dummy)
-                           
+
                  if (sigma11 <= sigma21) then
                     mu = sigma11
                     nu = sqrt(one - mu**2)
@@ -31782,13 +31782,13 @@ module stdlib_linalg_lapack_c
               end if
               temp = rwork(iv1tcs + imin - 1)*b11d(imin) + rwork(iv1tsn + imin - 1)*b11e(imin)
               b11e(imin) = rwork(iv1tcs + imin - 1)*b11e(imin) - rwork(iv1tsn + imin - 1)*b11d(imin)
-                        
+
               b11d(imin) = temp
               b11bulge = rwork(iv1tsn + imin - 1)*b11d(imin + 1)
               b11d(imin + 1) = rwork(iv1tcs + imin - 1)*b11d(imin + 1)
               temp = rwork(iv1tcs + imin - 1)*b21d(imin) + rwork(iv1tsn + imin - 1)*b21e(imin)
               b21e(imin) = rwork(iv1tcs + imin - 1)*b21e(imin) - rwork(iv1tsn + imin - 1)*b21d(imin)
-                        
+
               b21d(imin) = temp
               b21bulge = rwork(iv1tsn + imin - 1)*b21d(imin + 1)
               b21d(imin + 1) = rwork(iv1tcs + imin - 1)*b21d(imin + 1)
@@ -31820,7 +31820,7 @@ module stdlib_linalg_lapack_c
               rwork(iu2sn + imin - 1) = -rwork(iu2sn + imin - 1)
               temp = rwork(iu1cs + imin - 1)*b11e(imin) + rwork(iu1sn + imin - 1)*b11d(imin + 1)
               b11d(imin + 1) = rwork(iu1cs + imin - 1)*b11d(imin + 1) - rwork(iu1sn + imin - 1)*b11e(imin)
-                        
+
               b11e(imin) = temp
               if (imax > imin + 1) then
                  b11bulge = rwork(iu1sn + imin - 1)*b11e(imin + 1)
@@ -31833,7 +31833,7 @@ module stdlib_linalg_lapack_c
               b12d(imin + 1) = rwork(iu1cs + imin - 1)*b12d(imin + 1)
               temp = rwork(iu2cs + imin - 1)*b21e(imin) + rwork(iu2sn + imin - 1)*b21d(imin + 1)
               b21d(imin + 1) = rwork(iu2cs + imin - 1)*b21d(imin + 1) - rwork(iu2sn + imin - 1)*b21e(imin)
-                        
+
               b21e(imin) = temp
               if (imax > imin + 1) then
                  b21bulge = rwork(iu2sn + imin - 1)*b21e(imin + 1)
@@ -31882,7 +31882,7 @@ module stdlib_linalg_lapack_c
                  rwork(iv1tsn + i - 1) = -rwork(iv1tsn + i - 1)
                  if (.not. restart12 .and. .not. restart22) then
                     call stdlib_slartgp(y2,y1,rwork(iv2tsn + i - 1 - 1),rwork(iv2tcs + i - 1 - 1),r)
-                              
+
                  else if (.not. restart12 .and. restart22) then
                     call stdlib_slartgp(b12bulge,b12d(i - 1),rwork(iv2tsn + i - 1 - 1),rwork(iv2tcs + i - &
                               1 - 1),r)
@@ -31935,7 +31935,7 @@ module stdlib_linalg_lapack_c
                     call stdlib_slartgp(x2,x1,rwork(iu1sn + i - 1),rwork(iu1cs + i - 1),r)
                  else if (.not. restart11 .and. restart12) then
                     call stdlib_slartgp(b11bulge,b11d(i),rwork(iu1sn + i - 1),rwork(iu1cs + i - 1),r)
-                              
+
                  else if (restart11 .and. .not. restart12) then
                     call stdlib_slartgp(b12bulge,b12e(i - 1),rwork(iu1sn + i - 1),rwork(iu1cs + i - 1), &
                               r)
@@ -31944,13 +31944,13 @@ module stdlib_linalg_lapack_c
                                )
                  else
                     call stdlib_slartgs(b12d(i),b12e(i),nu,rwork(iu1cs + i - 1),rwork(iu1sn + i - 1))
-                              
+
                  end if
                  if (.not. restart21 .and. .not. restart22) then
                     call stdlib_slartgp(y2,y1,rwork(iu2sn + i - 1),rwork(iu2cs + i - 1),r)
                  else if (.not. restart21 .and. restart22) then
                     call stdlib_slartgp(b21bulge,b21d(i),rwork(iu2sn + i - 1),rwork(iu2cs + i - 1),r)
-                              
+
                  else if (restart21 .and. .not. restart22) then
                     call stdlib_slartgp(b22bulge,b22e(i - 1),rwork(iu2sn + i - 1),rwork(iu2cs + i - 1), &
                               r)
@@ -31959,7 +31959,7 @@ module stdlib_linalg_lapack_c
                                )
                  else
                     call stdlib_slartgs(b22d(i),b22e(i),mu,rwork(iu2cs + i - 1),rwork(iu2sn + i - 1))
-                              
+
                  end if
                  rwork(iu2cs + i - 1) = -rwork(iu2cs + i - 1)
                  rwork(iu2sn + i - 1) = -rwork(iu2sn + i - 1)
@@ -31998,7 +31998,7 @@ module stdlib_linalg_lapack_c
               restart22 = b22d(imax - 1)**2 + b22bulge**2 <= thresh**2
               if (.not. restart12 .and. .not. restart22) then
                  call stdlib_slartgp(y2,y1,rwork(iv2tsn + imax - 1 - 1),rwork(iv2tcs + imax - 1 - 1),r)
-                           
+
               else if (.not. restart12 .and. restart22) then
                  call stdlib_slartgp(b12bulge,b12d(imax - 1),rwork(iv2tsn + imax - 1 - 1),rwork(iv2tcs + &
                            imax - 1 - 1),r)
@@ -32013,14 +32013,14 @@ module stdlib_linalg_lapack_c
                            iv2tsn + imax - 1 - 1))
               end if
               temp = rwork(iv2tcs + imax - 1 - 1)*b12e(imax - 1) + rwork(iv2tsn + imax - 1 - 1)*b12d(imax)
-                        
+
               b12d(imax) = rwork(iv2tcs + imax - 1 - 1)*b12d(imax) - rwork(iv2tsn + imax - 1 - 1)*b12e(imax - 1)
-                        
+
               b12e(imax - 1) = temp
               temp = rwork(iv2tcs + imax - 1 - 1)*b22e(imax - 1) + rwork(iv2tsn + imax - 1 - 1)*b22d(imax)
-                        
+
               b22d(imax) = rwork(iv2tcs + imax - 1 - 1)*b22d(imax) - rwork(iv2tsn + imax - 1 - 1)*b22e(imax - 1)
-                        
+
               b22e(imax - 1) = temp
               ! update singular vectors
               if (wantu1) then
@@ -32155,9 +32155,9 @@ module stdlib_linalg_lapack_c
                     if (wantu1) call stdlib_cswap(p,u1(1,i),1,u1(1,mini),1)
                     if (wantu2) call stdlib_cswap(m - p,u2(1,i),1,u2(1,mini),1)
                     if (wantv1t) call stdlib_cswap(q,v1t(i,1),ldv1t,v1t(mini,1),ldv1t)
-                              
+
                     if (wantv2t) call stdlib_cswap(m - q,v2t(i,1),ldv2t,v2t(mini,1),ldv2t)
-                              
+
                  else
                     if (wantu1) call stdlib_cswap(p,u1(i,1),ldu1,u1(mini,1),ldu1)
                     if (wantu2) call stdlib_cswap(m - p,u2(i,1),ldu2,u2(mini,1),ldu2)
@@ -32213,7 +32213,7 @@ module stdlib_linalg_lapack_c
            real(sp),parameter :: hndrd = 100.0_sp
            real(sp),parameter :: meigth = -0.125_sp
            integer(ilp),parameter :: maxitr = 6
-           
+
            ! Local Scalars
            logical(lk) :: lower,rotate
            integer(ilp) :: i,idir,isub,iter,j,ll,lll,m,maxit,nm1,nm12,nm13,oldll, &
@@ -32279,9 +32279,9 @@ module stdlib_linalg_lapack_c
               end do
               ! update singular vectors if desired
               if (nru > 0) call stdlib_clasr('R','V','F',nru,n,rwork(1),rwork(n),u,ldu)
-                        
+
               if (ncc > 0) call stdlib_clasr('L','V','F',n,ncc,rwork(1),rwork(n),c,ldc)
-                        
+
            end if
            ! compute singular values to relative accuracy tol
            ! (by setting tol to be negative, algorithm will compute
@@ -32307,7 +32307,7 @@ module stdlib_linalg_lapack_c
                  sminoa = min(sminoa,mu)
                  if (sminoa == zero) go to 50
               end do
-50            continue
+              50 continue
               sminoa = sminoa/sqrt(real(n,KIND=sp))
               thresh = max(tol*sminoa,maxitr*n*n*unfl)
            else
@@ -32324,7 +32324,7 @@ module stdlib_linalg_lapack_c
            ! m points to last element of unconverged part of matrix
            m = n
            ! begin main iteration loop
-60   continue
+           60 continue
            ! check for convergence or exceeding iteration count
            if (m <= 1) go to 160
            if (iter > maxit) go to 200
@@ -32343,7 +32343,7 @@ module stdlib_linalg_lapack_c
            end do
            ll = 0
            go to 90
-80         continue
+           80 continue
            e(ll) = zero
            ! matrix splits since e(ll) = 0
            if (ll == m - 1) then
@@ -32351,7 +32351,7 @@ module stdlib_linalg_lapack_c
               m = m - 1
               go to 60
            end if
-90         continue
+           90 continue
            ll = ll + 1
            ! e(ll) through e(m-1) are nonzero, e(ll-1) is zero
            if (ll == m - 1) then
@@ -32365,9 +32365,9 @@ module stdlib_linalg_lapack_c
               if (ncvt > 0) call stdlib_csrot(ncvt,vt(m - 1,1),ldvt,vt(m,1),ldvt,cosr, &
                         sinr)
               if (nru > 0) call stdlib_csrot(nru,u(1,m - 1),1,u(1,m),1,cosl,sinl)
-                        
+
               if (ncc > 0) call stdlib_csrot(ncc,c(m - 1,1),ldc,c(m,1),ldc,cosl,sinl)
-                        
+
               m = m - 2
               go to 60
            end if
@@ -32583,7 +32583,7 @@ module stdlib_linalg_lapack_c
            ! qr iteration finished, go back and check convergence
            go to 60
            ! all singular values converged, so make them positive
-160  continue
+           160 continue
            do i = 1,n
               if (d(i) < zero) then
                  d(i) = -d(i)
@@ -32608,20 +32608,20 @@ module stdlib_linalg_lapack_c
                  d(isub) = d(n + 1 - i)
                  d(n + 1 - i) = smin
                  if (ncvt > 0) call stdlib_cswap(ncvt,vt(isub,1),ldvt,vt(n + 1 - i,1),ldvt)
-                           
+
                  if (nru > 0) call stdlib_cswap(nru,u(1,isub),1,u(1,n + 1 - i),1)
                  if (ncc > 0) call stdlib_cswap(ncc,c(isub,1),ldc,c(n + 1 - i,1),ldc)
-                           
+
               end if
            end do
            go to 220
            ! maximum number of iterations exceeded, failure to converge
-200  continue
+           200 continue
            info = 0
            do i = 1,n - 1
               if (e(i) /= zero) info = info + 1
            end do
-220        continue
+           220 continue
            return
      end subroutine stdlib_cbdsqr
 
@@ -32649,7 +32649,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: ab(ldab,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lnoti,onenrm
            character :: normin
@@ -32705,7 +32705,7 @@ module stdlib_linalg_lapack_c
            kd = kl + ku + 1
            lnoti = kl > 0
            kase = 0
-10         continue
+           10 continue
            call stdlib_clacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == kase1) then
@@ -32734,7 +32734,7 @@ module stdlib_linalg_lapack_c
                     do j = n - 1,1,-1
                        lm = min(kl,n - j)
                        work(j) = work(j) - stdlib_cdotc(lm,ab(kd + 1,j),1,work(j + 1),1)
-                                 
+
                        jp = ipiv(j)
                        if (jp /= j) then
                           t = work(jp)
@@ -32755,7 +32755,7 @@ module stdlib_linalg_lapack_c
            end if
            ! compute the estimate of the reciprocal condition number.
            if (ainvnm /= zero) rcond = (one/ainvnm)/anorm
-40         continue
+           40 continue
            return
      end subroutine stdlib_cgbcon
 
@@ -32777,7 +32777,7 @@ module stdlib_linalg_lapack_c
            ! Parameters
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldwork = nbmax + 1
-           
+
            ! Local Scalars
            integer(ilp) :: i,i2,i3,ii,ip,j,j2,j3,jb,jj,jm,jp,ju,k2,km,kv,nb, &
                      nw
@@ -32909,7 +32909,7 @@ module stdlib_linalg_lapack_c
                     ! use stdlib_claswp to apply the row interchanges to a12, a22, and
                     ! a32.
                     call stdlib_claswp(j2,ab(kv + 1 - jb,j + jb),ldab - 1,1,jb,ipiv(j),1)
-                              
+
                     ! adjust the pivot indices.
                     do i = j,j + jb - 1
                        ipiv(i) = ipiv(i) + j - 1
@@ -32961,7 +32961,7 @@ module stdlib_linalg_lapack_c
                           ! update a23
                           call stdlib_cgemm('NO TRANSPOSE','NO TRANSPOSE',i2,j3,jb,-cone,ab( &
                            kv + 1 + jb,j),ldab - 1,work13,ldwork,cone,ab(1 + jb,j + kv),ldab - 1)
-                                     
+
                        end if
                        if (i3 > 0) then
                           ! update a33
@@ -33026,7 +33026,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: ab(ldab,*)
            complex(sp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lnoti,notran
            integer(ilp) :: i,j,kd,l,lm
@@ -33137,7 +33137,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: taup(*),tauq(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            complex(sp) :: alpha
@@ -33241,7 +33241,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: onenrm
            character :: normin
@@ -33291,7 +33291,7 @@ module stdlib_linalg_lapack_c
               kase1 = 2
            end if
            kase = 0
-10         continue
+           10 continue
            call stdlib_clacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == kase1) then
@@ -33321,7 +33321,7 @@ module stdlib_linalg_lapack_c
            end if
            ! compute the estimate of the reciprocal condition number.
            if (ainvnm /= zero) rcond = (one/ainvnm)/anorm
-20         continue
+           20 continue
            return
      end subroutine stdlib_cgecon
 
@@ -33339,7 +33339,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            complex(sp) :: alpha
@@ -33395,7 +33395,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            complex(sp) :: alpha
@@ -33517,7 +33517,7 @@ module stdlib_linalg_lapack_c
                     ! apply h to a(i+ib:m,i:n) from the right
                     call stdlib_clarfb('RIGHT','NO TRANSPOSE','FORWARD','ROWWISE',m - i - ib + 1,n - &
                     i + 1,ib,a(i,i),lda,work,ldwork,a(i + ib,i),lda,work(ib + 1),ldwork)
-                              
+
                  end if
               end do
            else
@@ -33525,7 +33525,7 @@ module stdlib_linalg_lapack_c
            end if
            ! use unblocked code to factor the last or only block.
            if (i <= k) call stdlib_cgelq2(m - i + 1,n - i + 1,a(i,i),lda,tau(i),work,iinfo)
-                     
+
            work(1) = iws
            return
      end subroutine stdlib_cgelqf
@@ -33546,7 +33546,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,i1,j,j1,m1,m2,iinfo
            ! Executable Statements
@@ -33583,15 +33583,15 @@ module stdlib_linalg_lapack_c
                  end do
               end do
               call stdlib_ctrmm('R','U','C','U',m2,m1,cone,a,lda,t(i1,1),ldt)
-                        
+
               call stdlib_cgemm('N','C',m2,m1,n - m1,cone,a(i1,i1),lda,a(1,i1),lda, &
                         cone,t(i1,1),ldt)
               call stdlib_ctrmm('R','U','N','N',m2,m1,cone,t,ldt,t(i1,1),ldt)
-                        
+
               call stdlib_cgemm('N','N',m2,n - m1,m1,-cone,t(i1,1),ldt,a(1,i1),lda, &
                         cone,a(i1,i1),lda)
               call stdlib_ctrmm('R','U','N','U',m2,m1,cone,a,lda,t(i1,1),ldt)
-                        
+
               do i = 1,m2
                  do j = 1,m1
                     a(i + m1,j) = a(i + m1,j) - t(i + m1,j)
@@ -33611,7 +33611,7 @@ module stdlib_linalg_lapack_c
               call stdlib_cgemm('N','C',m1,m2,n - m,cone,a(1,j1),lda,a(i1,j1),lda, &
                         cone,t(1,i1),ldt)
               call stdlib_ctrmm('L','U','N','N',m1,m2,-cone,t,ldt,t(1,i1),ldt)
-                        
+
               call stdlib_ctrmm('R','U','N','N',m1,m2,cone,t(i1,i1),ldt,t(1,i1), &
                         ldt)
               ! y = (y1,y2); l = [ l1            0  ];  t = [t1 t3]
@@ -33631,7 +33631,7 @@ module stdlib_linalg_lapack_c
      !> Q is of order M if SIDE = 'L' and of order N  if SIDE = 'R'.
 
      pure subroutine stdlib_cgemlqt(side,trans,m,n,k,mb,v,ldv,t,ldt,c,ldc,work,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -33729,7 +33729,7 @@ module stdlib_linalg_lapack_c
      !> Q is of order M if SIDE = 'L' and of order N  if SIDE = 'R'.
 
      pure subroutine stdlib_cgemqrt(side,trans,m,n,k,nb,v,ldv,t,ldt,c,ldc,work,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -33830,7 +33830,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            complex(sp) :: alpha
@@ -33947,7 +33947,7 @@ module stdlib_linalg_lapack_c
                  ! compute the ql factorization of the current block
                  ! a(1:m-k+i+ib-1,n-k+i:n-k+i+ib-1)
                  call stdlib_cgeql2(m - k + i + ib - 1,ib,a(1,n - k + i),lda,tau(i),work,iinfo)
-                           
+
                  if (n - k + i > 1) then
                     ! form the triangular factor of the block reflector
                     ! h = h(i+ib-1) . . . h(i+1) h(i)
@@ -33990,7 +33990,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            complex(sp) :: alpha
@@ -34046,7 +34046,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            complex(sp) :: alpha
@@ -34179,7 +34179,7 @@ module stdlib_linalg_lapack_c
            end if
            ! use unblocked code to factor the last or only block.
            if (i <= k) call stdlib_cgeqr2(m - i + 1,n - i + 1,a(i,i),lda,tau(i),work,iinfo)
-                     
+
            work(1) = iws
            return
      end subroutine stdlib_cgeqrf
@@ -34278,7 +34278,7 @@ module stdlib_linalg_lapack_c
            end if
            ! use unblocked code to factor the last or only block.
            if (i <= k) call stdlib_cgeqr2p(m - i + 1,n - i + 1,a(i,i),lda,tau(i),work,iinfo)
-                     
+
            work(1) = iws
            return
      end subroutine stdlib_cgeqrfp
@@ -34297,7 +34297,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            complex(sp) :: aii,alpha
@@ -34367,7 +34367,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,i1,j,j1,n1,n2,iinfo
            ! Executable Statements
@@ -34403,15 +34403,15 @@ module stdlib_linalg_lapack_c
                  end do
               end do
               call stdlib_ctrmm('L','L','C','U',n1,n2,cone,a,lda,t(1,j1),ldt)
-                        
+
               call stdlib_cgemm('C','N',n1,n2,m - n1,cone,a(j1,1),lda,a(j1,j1),lda, &
                         cone,t(1,j1),ldt)
               call stdlib_ctrmm('L','U','C','N',n1,n2,cone,t,ldt,t(1,j1),ldt)
-                        
+
               call stdlib_cgemm('N','N',m - n1,n2,n1,-cone,a(j1,1),lda,t(1,j1),ldt, &
                         cone,a(j1,j1),lda)
               call stdlib_ctrmm('L','L','N','U',n1,n2,cone,a,lda,t(1,j1),ldt)
-                        
+
               do j = 1,n2
                  do i = 1,n1
                     a(i,j + n1) = a(i,j + n1) - t(i,j + n1)
@@ -34430,7 +34430,7 @@ module stdlib_linalg_lapack_c
               call stdlib_cgemm('C','N',n1,n2,m - n,cone,a(i1,1),lda,a(i1,j1),lda, &
                         cone,t(1,j1),ldt)
               call stdlib_ctrmm('L','U','N','N',n1,n2,-cone,t,ldt,t(1,j1),ldt)
-                        
+
               call stdlib_ctrmm('R','U','N','N',n1,n2,cone,t(j1,j1),ldt,t(1,j1), &
                         ldt)
               ! y = (y1,y2); r = [ r1  a(1:n1,j1:n) ];  t = [t1 t3]
@@ -34453,7 +34453,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            complex(sp) :: alpha
@@ -34572,7 +34572,7 @@ module stdlib_linalg_lapack_c
                  ! compute the rq factorization of the current block
                  ! a(m-k+i:m-k+i+ib-1,1:n-k+i+ib-1)
                  call stdlib_cgerq2(ib,n - k + i + ib - 1,a(m - k + i,1),lda,tau(i),work,iinfo)
-                           
+
                  if (m - k + i > 1) then
                     ! form the triangular factor of the block reflector
                     ! h = h(i+ib-1) . . . h(i+1) h(i)
@@ -34581,7 +34581,7 @@ module stdlib_linalg_lapack_c
                     ! apply h to a(1:m-k+i-1,1:n-k+i+ib-1) from the right
                     call stdlib_clarfb('RIGHT','NO TRANSPOSE','BACKWARD','ROWWISE',m - k + i - 1,n - &
                     k + i + ib - 1,ib,a(m - k + i,1),lda,work,ldwork,a,lda,work(ib + 1),ldwork)
-                              
+
                  end if
               end do
               mu = m - k + i + nb - 1
@@ -34613,7 +34613,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: a(lda,*)
            complex(sp),intent(inout) :: rhs(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(sp) :: bignum,eps,smlnum
@@ -34686,7 +34686,7 @@ module stdlib_linalg_lapack_c
            integer(ilp),intent(out) :: ipiv(*)
            complex(sp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(sp) :: sfmin
            complex(sp) :: temp
@@ -34754,7 +34754,7 @@ module stdlib_linalg_lapack_c
               call stdlib_claswp(n2,a(1,n1 + 1),lda,1,n1,ipiv,1)
               ! solve a12
               call stdlib_ctrsm('L','L','N','U',n1,n2,cone,a,lda,a(1,n1 + 1),lda)
-                        
+
               ! update a22
               call stdlib_cgemm('N','N',m - n1,n2,n1,-cone,a(n1 + 1,1),lda,a(1,n1 + 1), &
                         lda,cone,a(n1 + 1,n1 + 1),lda)
@@ -34788,7 +34788,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,iws,j,jb,jj,jp,ldwork,lwkopt,nb,nbmin,nn
@@ -34891,7 +34891,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: a(lda,*)
            complex(sp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran
            ! Intrinsic Functions
@@ -34935,7 +34935,7 @@ module stdlib_linalg_lapack_c
                         )
               ! solve l**t *x = b, or l**h *x = b overwriting b with x.
               call stdlib_ctrsm('LEFT','LOWER',trans,'UNIT',n,nrhs,cone,a,lda,b,ldb)
-                        
+
               ! apply row interchanges to the solution vectors.
               call stdlib_claswp(nrhs,b,ldb,1,n,ipiv,-1)
            end if
@@ -34978,7 +34978,7 @@ module stdlib_linalg_lapack_c
            ! Array Arguments
            complex(sp),intent(inout) :: a(lda,*),b(ldb,*),q(ldq,*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: ilq,ilz
            integer(ilp) :: icompq,icompz,jcol,jrow
@@ -35057,11 +35057,11 @@ module stdlib_linalg_lapack_c
                  call stdlib_clartg(ctemp,a(jrow,jcol),c,s,a(jrow - 1,jcol))
                  a(jrow,jcol) = czero
                  call stdlib_crot(n - jcol,a(jrow - 1,jcol + 1),lda,a(jrow,jcol + 1),lda,c,s)
-                           
+
                  call stdlib_crot(n + 2 - jrow,b(jrow - 1,jrow - 1),ldb,b(jrow,jrow - 1),ldb,c, &
                            s)
                  if (ilq) call stdlib_crot(n,q(1,jrow - 1),1,q(1,jrow),1,c,conjg(s))
-                           
+
                  ! step 2: rotate columns jrow, jrow-1 to kill b(jrow,jrow-1)
                  ctemp = b(jrow,jrow)
                  call stdlib_clartg(ctemp,b(jrow,jrow - 1),c,s,b(jrow,jrow))
@@ -35094,7 +35094,7 @@ module stdlib_linalg_lapack_c
      !> conjugate transpose of matrix Z.
 
      pure subroutine stdlib_cggqrf(n,m,p,a,lda,taua,b,ldb,taub,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -35172,7 +35172,7 @@ module stdlib_linalg_lapack_c
      !> conjugate transpose of the matrix Z.
 
      pure subroutine stdlib_cggrqf(m,p,n,a,lda,taua,b,ldb,taub,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -35312,7 +35312,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: v(*),tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,j1,j2,lm,ln,vpos,taupos,dpos,ofdpos,ajeter
@@ -35401,7 +35401,7 @@ module stdlib_linalg_lapack_c
                        a(ofdpos + i,st - 1) = czero
                    end do
                    call stdlib_clarfg(lm,a(ofdpos,st - 1),v(vpos + 1),1,tau(taupos))
-                             
+
                    lm = ed - st + 1
                    call stdlib_clarfy(uplo,lm,v(vpos),1,conjg(tau(taupos)),a(dpos,st) &
                              ,lda - 1,work)
@@ -35432,7 +35432,7 @@ module stdlib_linalg_lapack_c
                            a(dpos + nb + i,st) = czero
                        end do
                        call stdlib_clarfg(lm,a(dpos + nb,st),v(vpos + 1),1,tau(taupos))
-                                 
+
                        call stdlib_clarfx('LEFT',lm,ln - 1,v(vpos),conjg(tau(taupos)),a( &
                                  dpos + nb - 1,st + 1),lda - 1,work)
                    end if
@@ -35465,7 +35465,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: max_iter = 100
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,iter
            real(sp) :: avg,std,tol,c0,c1,c2,t,u,si,d,base,smin,smax,smlnum,bignum, &
@@ -35606,7 +35606,7 @@ module stdlib_linalg_lapack_c
                  s(i) = si
               end do
            end do
-999        continue
+           999 continue
            smlnum = stdlib_slamch('SAFEMIN')
            bignum = one/smlnum
            smin = bignum
@@ -35641,7 +35641,7 @@ module stdlib_linalg_lapack_c
            ! Array Arguments
            complex(sp),intent(inout) :: a(lda,*),b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: k
@@ -35724,7 +35724,7 @@ module stdlib_linalg_lapack_c
                     ct = half*akk
                     call stdlib_caxpy(k - 1,ct,b(1,k),1,a(1,k),1)
                     call stdlib_cher2(uplo,k - 1,cone,a(1,k),1,b(1,k),1,a,lda)
-                              
+
                     call stdlib_caxpy(k - 1,ct,b(1,k),1,a(1,k),1)
                     call stdlib_csscal(k - 1,bkk,a(1,k),1)
                     a(k,k) = akk*bkk**2
@@ -35742,7 +35742,7 @@ module stdlib_linalg_lapack_c
                     call stdlib_clacgv(k - 1,b(k,1),ldb)
                     call stdlib_caxpy(k - 1,ct,b(k,1),ldb,a(k,1),lda)
                     call stdlib_cher2(uplo,k - 1,cone,a(k,1),lda,b(k,1),ldb,a,lda)
-                              
+
                     call stdlib_caxpy(k - 1,ct,b(k,1),ldb,a(k,1),lda)
                     call stdlib_clacgv(k - 1,b(k,1),ldb)
                     call stdlib_csscal(k - 1,bkk,a(k,1),lda)
@@ -35773,7 +35773,7 @@ module stdlib_linalg_lapack_c
            ! Array Arguments
            complex(sp),intent(inout) :: a(lda,*),b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: k,kb,nb
@@ -35814,7 +35814,7 @@ module stdlib_linalg_lapack_c
                        kb = min(n - k + 1,nb)
                        ! update the upper triangle of a(k:n,k:n)
                        call stdlib_chegs2(itype,uplo,kb,a(k,k),lda,b(k,k),ldb,info)
-                                 
+
                        if (k + kb <= n) then
                           call stdlib_ctrsm('LEFT',uplo,'CONJUGATE TRANSPOSE','NON-UNIT',kb, &
                                     n - k - kb + 1,cone,b(k,k),ldb,a(k,k + kb),lda)
@@ -35834,7 +35834,7 @@ module stdlib_linalg_lapack_c
                        kb = min(n - k + 1,nb)
                        ! update the lower triangle of a(k:n,k:n)
                        call stdlib_chegs2(itype,uplo,kb,a(k,k),lda,b(k,k),ldb,info)
-                                 
+
                        if (k + kb <= n) then
                           call stdlib_ctrsm('RIGHT',uplo,'CONJUGATE TRANSPOSE','NON-UNIT',n - k - &
                                     kb + 1,kb,cone,b(k,k),ldb,a(k + kb,k),lda)
@@ -35866,7 +35866,7 @@ module stdlib_linalg_lapack_c
                        call stdlib_ctrmm('RIGHT',uplo,'CONJUGATE TRANSPOSE','NON-UNIT',k - 1, &
                                  kb,cone,b(k,k),ldb,a(1,k),lda)
                        call stdlib_chegs2(itype,uplo,kb,a(k,k),lda,b(k,k),ldb,info)
-                                 
+
                     end do
                  else
                     ! compute l**h*a*l
@@ -35884,7 +35884,7 @@ module stdlib_linalg_lapack_c
                        call stdlib_ctrmm('LEFT',uplo,'CONJUGATE TRANSPOSE','NON-UNIT',kb,k - 1, &
                                   cone,b(k,k),ldb,a(k,1),lda)
                        call stdlib_chegs2(itype,uplo,kb,a(k,k),lda,b(k,k),ldb,info)
-                                 
+
                     end do
                  end if
               end if
@@ -35909,7 +35909,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: tau(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i
@@ -35947,7 +35947,7 @@ module stdlib_linalg_lapack_c
                     a(i,i + 1) = cone
                     ! compute  x := tau * a * v  storing x in tau(1:i)
                     call stdlib_chemv(uplo,i,taui,a,lda,a(1,i + 1),1,czero,tau,1)
-                              
+
                     ! compute  w := x - 1/2 * tau * (x**h * v) * v
                     alpha = -chalf*taui*stdlib_cdotc(i,tau,1,a(1,i + 1),1)
                     call stdlib_caxpy(i,alpha,a(1,i + 1),1,tau,1)
@@ -36013,7 +36013,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper
            integer(ilp) :: i,iinfo,iws,j,kk,ldwork,lwkopt,nb,nbmin,nx
@@ -36117,7 +36117,7 @@ module stdlib_linalg_lapack_c
               end do
               ! use unblocked code to reduce the last or only block
               call stdlib_chetd2(uplo,n - i + 1,a(i,i),lda,d(i),e(i),tau(i),iinfo)
-                        
+
            end if
            work(1) = lwkopt
            return
@@ -36145,7 +36145,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: rzero = 0.0e+0_sp
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wantq,upper,afters1
            integer(ilp) :: i,m,k,ib,sweepid,myid,shift,stt,st,ed,stind,edind, &
@@ -36412,7 +36412,7 @@ module stdlib_linalg_lapack_c
      !> Q**H * A * Q = AB.
 
      pure subroutine stdlib_chetrd_he2hb(uplo,n,kd,a,lda,ab,ldab,tau,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -36426,7 +36426,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: rone = 1.0e+0_sp
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper
            integer(ilp) :: i,j,iinfo,lwmin,pn,pk,lk,ldt,ldw,lds2,lds1,ls2,ls1,lw,lt, &
@@ -36569,7 +36569,7 @@ module stdlib_linalg_lapack_c
                    ! do 45 j = i, i+pk-1
                       ! lk = min( kd, n-j ) + 1
                       ! call stdlib_ccopy( lk, ab( 1, j ), 1, a( j, j ), 1 )
-45   continue
+                      45 continue
                   ! ==================================================================
                end do loop_40
               ! copy the lower band to ab which is the band storage matrix
@@ -36653,7 +36653,7 @@ module stdlib_linalg_lapack_c
               ! kb, where kb is the number of columns factorized by stdlib_clahef;
               ! kb is either nb or nb-1, or k for the last block
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 40
               if (k > nb) then
@@ -36676,7 +36676,7 @@ module stdlib_linalg_lapack_c
               ! kb, where kb is the number of columns factorized by stdlib_clahef;
               ! kb is either nb or nb-1, or n-k+1 for the last block
               k = 1
-20            continue
+              20 continue
               ! if k > n, exit from loop
               if (k > n) go to 40
               if (k <= n - nb) then
@@ -36703,7 +36703,7 @@ module stdlib_linalg_lapack_c
               k = k + kb
               go to 20
            end if
-40         continue
+           40 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_chetrf
@@ -36780,14 +36780,14 @@ module stdlib_linalg_lapack_c
               ! kb, where kb is the number of columns factorized by stdlib_clahef_rk;
               ! kb is either nb or nb-1, or k for the last block
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 15
               if (k > nb) then
                  ! factorize columns k-kb+1:k of a and use blocked code to
                  ! update columns 1:k-kb
                  call stdlib_clahef_rk(uplo,k,nb,kb,a,lda,e,ipiv,work,ldwork,iinfo)
-                           
+
               else
                  ! use unblocked code to factorize columns 1:k of a
                  call stdlib_chetf2_rk(uplo,k,a,lda,e,ipiv,iinfo)
@@ -36816,14 +36816,14 @@ module stdlib_linalg_lapack_c
               go to 10
               ! this label is the exit from main loop over k decreasing
               ! from n to 1 in steps of kb
-15   continue
+              15 continue
            else
               ! factorize a as l*d*l**t using the lower triangle of a
               ! k is the main loop index, increasing from 1 to n in steps of
               ! kb, where kb is the number of columns factorized by stdlib_clahef_rk;
               ! kb is either nb or nb-1, or n-k+1 for the last block
               k = 1
-20            continue
+              20 continue
               ! if k > n, exit from loop
               if (k > n) go to 35
               if (k <= n - nb) then
@@ -36834,7 +36834,7 @@ module stdlib_linalg_lapack_c
               else
                  ! use unblocked code to factorize columns k:n of a
                  call stdlib_chetf2_rk(uplo,n - k + 1,a(k,k),lda,e(k),ipiv(k),iinfo)
-                           
+
                  kb = n - k + 1
               end if
               ! set info on the first occurrence of a zero pivot
@@ -36867,7 +36867,7 @@ module stdlib_linalg_lapack_c
               go to 20
               ! this label is the exit from main loop over k increasing
               ! from 1 to n in steps of kb
-35   continue
+              35 continue
            ! end lower
            end if
            work(1) = lwkopt
@@ -36945,14 +36945,14 @@ module stdlib_linalg_lapack_c
               ! kb, where kb is the number of columns factorized by stdlib_clahef_rook;
               ! kb is either nb or nb-1, or k for the last block
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 40
               if (k > nb) then
                  ! factorize columns k-kb+1:k of a and use blocked code to
                  ! update columns 1:k-kb
                  call stdlib_clahef_rook(uplo,k,nb,kb,a,lda,ipiv,work,ldwork,iinfo)
-                           
+
               else
                  ! use unblocked code to factorize columns 1:k of a
                  call stdlib_chetf2_rook(uplo,k,a,lda,ipiv,iinfo)
@@ -36970,7 +36970,7 @@ module stdlib_linalg_lapack_c
               ! kb, where kb is the number of columns factorized by stdlib_clahef_rook;
               ! kb is either nb or nb-1, or n-k+1 for the last block
               k = 1
-20            continue
+              20 continue
               ! if k > n, exit from loop
               if (k > n) go to 40
               if (k <= n - nb) then
@@ -36997,7 +36997,7 @@ module stdlib_linalg_lapack_c
               k = k + kb
               go to 20
            end if
-40         continue
+           40 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_chetrf_rook
@@ -37019,7 +37019,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: a(lda,*)
            complex(sp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kp
@@ -37053,7 +37053,7 @@ module stdlib_linalg_lapack_c
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 30
               if (ipiv(k) > 0) then
@@ -37094,12 +37094,12 @@ module stdlib_linalg_lapack_c
                  k = k - 2
               end if
               go to 10
-30            continue
+              30 continue
               ! next solve u**h *x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               if (ipiv(k) > 0) then
@@ -37136,14 +37136,14 @@ module stdlib_linalg_lapack_c
                  k = k + 2
               end if
               go to 40
-50            continue
+              50 continue
            else
               ! solve a*x = b, where a = l*d*l**h.
               ! first solve l*d*x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-60            continue
+              60 continue
               ! if k > n, exit from loop.
               if (k > n) go to 80
               if (ipiv(k) > 0) then
@@ -37186,12 +37186,12 @@ module stdlib_linalg_lapack_c
                  k = k + 2
               end if
               go to 60
-80            continue
+              80 continue
               ! next solve l**h *x = b, overwriting b with x.
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-90            continue
+              90 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 100
               if (ipiv(k) > 0) then
@@ -37228,7 +37228,7 @@ module stdlib_linalg_lapack_c
                  k = k - 2
               end if
               go to 90
-100           continue
+              100 continue
            end if
            return
      end subroutine stdlib_chetrs
@@ -37250,7 +37250,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,iinfo,j,k,kp
@@ -37361,7 +37361,7 @@ module stdlib_linalg_lapack_c
                  ! interchange rows k and -ipiv(k+1).
                  kp = -ipiv(k + 1)
                  if (kp == -ipiv(k)) call stdlib_cswap(nrhs,b(k + 1,1),ldb,b(kp,1),ldb)
-                           
+
                  k = k + 2
               end if
              end do
@@ -37419,7 +37419,7 @@ module stdlib_linalg_lapack_c
      !> A = L*T*L**H computed by CHETRF_AA.
 
      pure subroutine stdlib_chetrs_aa(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -37433,7 +37433,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: b(ldb,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            logical(lk) :: lquery,upper
            integer(ilp) :: k,kp,lwkopt
            ! Intrinsic Functions
@@ -37560,7 +37560,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: a(lda,*)
            complex(sp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kp
@@ -37594,7 +37594,7 @@ module stdlib_linalg_lapack_c
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 30
               if (ipiv(k) > 0) then
@@ -37637,12 +37637,12 @@ module stdlib_linalg_lapack_c
                  k = k - 2
               end if
               go to 10
-30            continue
+              30 continue
               ! next solve u**h *x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               if (ipiv(k) > 0) then
@@ -37681,14 +37681,14 @@ module stdlib_linalg_lapack_c
                  k = k + 2
               end if
               go to 40
-50            continue
+              50 continue
            else
               ! solve a*x = b, where a = l*d*l**h.
               ! first solve l*d*x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-60            continue
+              60 continue
               ! if k > n, exit from loop.
               if (k > n) go to 80
               if (ipiv(k) > 0) then
@@ -37733,12 +37733,12 @@ module stdlib_linalg_lapack_c
                  k = k + 2
               end if
               go to 60
-80            continue
+              80 continue
               ! next solve l**h *x = b, overwriting b with x.
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-90            continue
+              90 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 100
               if (ipiv(k) > 0) then
@@ -37777,7 +37777,7 @@ module stdlib_linalg_lapack_c
                  k = k - 2
               end if
               go to 90
-100           continue
+              100 continue
            end if
            return
      end subroutine stdlib_chetrs_rook
@@ -37799,7 +37799,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: ap(*)
            complex(sp),intent(out) :: tau(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,i1,i1i1,ii
@@ -37874,7 +37874,7 @@ module stdlib_linalg_lapack_c
                     ! apply the transformation as a rank-2 update:
                        ! a := a - v * w**h - w * v**h
                     call stdlib_chpr2(uplo,n - i,-cone,ap(ii + 1),1,tau(i),1,ap(i1i1))
-                              
+
                  end if
                  ap(ii + 1) = e(i)
                  d(i) = real(ap(ii),KIND=sp)
@@ -37903,7 +37903,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: ap(*)
            complex(sp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kc,kp
@@ -37936,7 +37936,7 @@ module stdlib_linalg_lapack_c
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
               kc = n*(n + 1)/2 + 1
-10            continue
+              10 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 30
               kc = kc - k
@@ -37948,7 +37948,7 @@ module stdlib_linalg_lapack_c
                  ! multiply by inv(u(k)), where u(k) is the transformation
                  ! stored in column k of a.
                  call stdlib_cgeru(k - 1,nrhs,-cone,ap(kc),1,b(k,1),ldb,b(1,1),ldb)
-                           
+
                  ! multiply by the inverse of the diagonal block.
                  s = real(cone,KIND=sp)/real(ap(kc + k - 1),KIND=sp)
                  call stdlib_csscal(nrhs,s,b(k,1),ldb)
@@ -37961,7 +37961,7 @@ module stdlib_linalg_lapack_c
                  ! multiply by inv(u(k)), where u(k) is the transformation
                  ! stored in columns k-1 and k of a.
                  call stdlib_cgeru(k - 2,nrhs,-cone,ap(kc),1,b(k,1),ldb,b(1,1),ldb)
-                           
+
                  call stdlib_cgeru(k - 2,nrhs,-cone,ap(kc - (k - 1)),1,b(k - 1,1),ldb,b(1, &
                            1),ldb)
                  ! multiply by the inverse of the diagonal block.
@@ -37979,13 +37979,13 @@ module stdlib_linalg_lapack_c
                  k = k - 2
               end if
               go to 10
-30            continue
+              30 continue
               ! next solve u**h *x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
               kc = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               if (ipiv(k) > 0) then
@@ -38024,7 +38024,7 @@ module stdlib_linalg_lapack_c
                  k = k + 2
               end if
               go to 40
-50            continue
+              50 continue
            else
               ! solve a*x = b, where a = l*d*l**h.
               ! first solve l*d*x = b, overwriting b with x.
@@ -38032,7 +38032,7 @@ module stdlib_linalg_lapack_c
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
               kc = 1
-60            continue
+              60 continue
               ! if k > n, exit from loop.
               if (k > n) go to 80
               if (ipiv(k) > 0) then
@@ -38077,13 +38077,13 @@ module stdlib_linalg_lapack_c
                  k = k + 2
               end if
               go to 60
-80            continue
+              80 continue
               ! next solve l**h *x = b, overwriting b with x.
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
               kc = n*(n + 1)/2 + 1
-90            continue
+              90 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 100
               kc = kc - (n - k + 1)
@@ -38122,7 +38122,7 @@ module stdlib_linalg_lapack_c
                  k = k - 2
               end if
               go to 90
-100           continue
+              100 continue
            end if
            return
      end subroutine stdlib_chptrs
@@ -38228,7 +38228,7 @@ module stdlib_linalg_lapack_c
            ! estimate the norm of inv(op(a)).
            ainvnm = zero
            kase = 0
-10         continue
+           10 continue
            call stdlib_clacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == 2) then
@@ -38369,7 +38369,7 @@ module stdlib_linalg_lapack_c
            ! estimate the norm of inv(op(a)).
            ainvnm = zero
            kase = 0
-10         continue
+           10 continue
            call stdlib_clacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == 2) then
@@ -38379,7 +38379,7 @@ module stdlib_linalg_lapack_c
                  end do
                  if (notrans) then
                     call stdlib_cgetrs('NO TRANSPOSE',n,1,af,ldaf,ipiv,work,n,info)
-                              
+
                  else
                     call stdlib_cgetrs('CONJUGATE TRANSPOSE',n,1,af,ldaf,ipiv,work,n,info &
                               )
@@ -38402,7 +38402,7 @@ module stdlib_linalg_lapack_c
                               )
                  else
                     call stdlib_cgetrs('NO TRANSPOSE',n,1,af,ldaf,ipiv,work,n,info)
-                              
+
                  end if
                  ! multiply by r.
                  do i = 1,n
@@ -38523,7 +38523,7 @@ module stdlib_linalg_lapack_c
            ! estimate the norm of inv(op(a)).
            ainvnm = zero
            kase = 0
-10         continue
+           10 continue
            call stdlib_clacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == 2) then
@@ -38862,7 +38862,7 @@ module stdlib_linalg_lapack_c
            ! estimate the norm of inv(op(a)).
            ainvnm = zero
            kase = 0
-10         continue
+           10 continue
            call stdlib_clacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == 2) then
@@ -39013,7 +39013,7 @@ module stdlib_linalg_lapack_c
            ! estimate the norm of inv(op(a)).
            ainvnm = zero
            kase = 0
-10         continue
+           10 continue
            call stdlib_clacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == 2) then
@@ -39264,7 +39264,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: taup(*),tauq(*),x(ldx,*),y(ldy,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            complex(sp) :: alpha
@@ -39431,7 +39431,7 @@ module stdlib_linalg_lapack_c
            real(sp),intent(inout) :: rho
            ! Array Arguments
            integer(ilp),intent(inout) :: givcol(2,*),givptr(*),perm(*),prmptr(*),qptr(*)
-                     
+
            integer(ilp),intent(out) :: indxq(*),iwork(*)
            real(sp),intent(inout) :: d(*),givnum(2,*),qstore(*)
            real(sp),intent(out) :: rwork(*)
@@ -39496,7 +39496,7 @@ module stdlib_linalg_lapack_c
            call stdlib_claed8(k,n,qsiz,q,ldq,d,rho,cutpnt,rwork(iz),rwork(idlmda), &
            work,qsiz,rwork(iw),iwork(indxp),iwork(indx),indxq,perm(prmptr(curr)), &
            givptr(curr + 1),givcol(1,givptr(curr)),givnum(1,givptr(curr)),info)
-                     
+
            prmptr(curr + 1) = prmptr(curr) + n
            givptr(curr + 1) = givptr(curr + 1) + givptr(curr)
            ! solve secular equation.
@@ -39545,7 +39545,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: tenth = 1.0e-1_sp
-           
+
            ! Local Scalars
            character :: normin,trans
            integer(ilp) :: i,ierr,its,j
@@ -39658,7 +39658,7 @@ module stdlib_linalg_lapack_c
            end do
            ! failure to find eigenvector in n iterations.
            info = 1
-120        continue
+           120 continue
            ! normalize eigenvector.
            i = stdlib_icamax(n,v,1)
            call stdlib_csscal(n,one/cabs1(v(i)),v,1)
@@ -39691,7 +39691,7 @@ module stdlib_linalg_lapack_c
      !> zero.
 
      pure subroutine stdlib_clags2(upper,a1,a2,a3,b1,b2,b3,csu,snu,csv,snv,csq,snq)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -39702,7 +39702,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: a2,b2
            complex(sp),intent(out) :: snq,snu,snv
         ! =====================================================================
-           
+
            ! Local Scalars
            real(sp) :: a,aua11,aua12,aua21,aua22,avb11,avb12,avb21,avb22,csl,csr,d,fb, &
                       fc,s1,s2,snl,snr,ua11r,ua22r,vb11r,vb22r
@@ -39742,17 +39742,17 @@ module stdlib_linalg_lapack_c
                  ! zero (1,2) elements of u**h *a and v**h *b
                  if ((abs(ua11r) + abs1(ua12)) == zero) then
                     call stdlib_clartg(-cmplx(vb11r,KIND=sp),conjg(vb12),csq,snq,r)
-                              
+
                  else if ((abs(vb11r) + abs1(vb12)) == zero) then
                     call stdlib_clartg(-cmplx(ua11r,KIND=sp),conjg(ua12),csq,snq,r)
-                              
+
                  else if (aua12/(abs(ua11r) + abs1(ua12)) <= avb12/(abs(vb11r) + abs1(vb12 &
                            ))) then
                     call stdlib_clartg(-cmplx(ua11r,KIND=sp),conjg(ua12),csq,snq,r)
-                              
+
                  else
                     call stdlib_clartg(-cmplx(vb11r,KIND=sp),conjg(vb12),csq,snq,r)
-                              
+
                  end if
                  csu = csl
                  snu = -d1*snl
@@ -39875,7 +39875,7 @@ module stdlib_linalg_lapack_c
            real(sp),parameter :: rone = 1.0_sp
            real(sp),parameter :: dat1 = 3.0_sp/4.0_sp
            integer(ilp),parameter :: kexsh = 10
-           
+
            ! Local Scalars
            complex(sp) :: cdum,h11,h11s,h22,sc,sum,t,t1,temp,u,v2,x,y
            real(sp) :: aa,ab,ba,bb,h10,h21,rtemp,s,safmax,safmin,smlnum,sx,t2,tst, &
@@ -39949,7 +39949,7 @@ module stdlib_linalg_lapack_c
            ! eigenvalues i+1 to ihi have already converged. either l = ilo, or
            ! h(l,l-1) is negligible so that the matrix splits.
            i = ihi
-30         continue
+           30 continue
            if (i < ilo) go to 150
            ! perform qr iterations on rows and columns ilo to i until a
            ! submatrix of order 1 splits off at the bottom because a
@@ -39977,7 +39977,7 @@ module stdlib_linalg_lapack_c
                     if (ba*(ab/s) <= max(smlnum,ulp*(bb*(aa/s)))) go to 50
                  end if
               end do
-50            continue
+              50 continue
               l = k
               if (l > ilo) then
                  ! h(l,l-1) is negligible
@@ -40045,7 +40045,7 @@ module stdlib_linalg_lapack_c
               h21 = h21/s
               v(1) = h11s
               v(2) = h21
-70            continue
+              70 continue
               ! single-shift qr step
               loop_120: do k = m,i - 1
                  ! the first iteration of this loop determines a reflection g
@@ -40123,7 +40123,7 @@ module stdlib_linalg_lapack_c
            ! failure to converge in remaining number of iterations
            info = i
            return
-140        continue
+           140 continue
            ! h(i,i-1) is negligible: cone eigenvalue has converged.
            w(i) = h(i,i)
            ! reset deflation counter
@@ -40131,7 +40131,7 @@ module stdlib_linalg_lapack_c
            ! return to start of the main loop with new value of i.
            i = l - 1
            go to 30
-150        continue
+           150 continue
            return
      end subroutine stdlib_clahqr
 
@@ -40152,7 +40152,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: t(ldt,nb),tau(nb),y(ldy,nb)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            complex(sp) :: ei
@@ -40196,7 +40196,7 @@ module stdlib_linalg_lapack_c
               ! generate the elementary reflector h(i) to annihilate
               ! a(k+i+1:n,i)
               call stdlib_clarfg(n - k - i + 1,a(k + i,i),a(min(k + i + 1,n),i),1,tau(i))
-                        
+
               ei = a(k + i,i)
               a(k + i,i) = cone
               ! compute  y(k+1:n,i)
@@ -40210,7 +40210,7 @@ module stdlib_linalg_lapack_c
               ! compute t(1:i,i)
               call stdlib_cscal(i - 1,-tau(i),t(1,i),1)
               call stdlib_ctrmv('UPPER','NO TRANSPOSE','NON-UNIT',i - 1,t,ldt,t(1,i),1)
-                        
+
               t(i,i) = tau(i)
            end do loop_10
            a(k + nb,nb) = ei
@@ -40264,7 +40264,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: b(ldb,*)
            complex(sp),intent(out) :: bx(ldbx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,jcol,jrow,m,n,nlp1
            real(sp) :: diflj,difrj,dj,dsigj,dsigjp,temp
@@ -40380,7 +40380,7 @@ module stdlib_linalg_lapack_c
                        b(j,jcol) = cmplx(rwork(jcol + k),rwork(jcol + k + nrhs),KIND=sp)
                     end do
                     call stdlib_clascl('G',0,0,temp,one,1,nrhs,b(j,1),ldb,info)
-                              
+
                  end do loop_100
               end if
               ! move the deflated rows of bx to b also.
@@ -40399,7 +40399,7 @@ module stdlib_linalg_lapack_c
                        rwork(j) = zero
                     else
                        rwork(j) = -z(j)/difl(j)/(dsigj + poles(j,1))/difr(j,2)
-                                 
+
                     end if
                     do i = 1,j - 1
                        if (z(j) == zero) then
@@ -40441,7 +40441,7 @@ module stdlib_linalg_lapack_c
                               zero,rwork(1 + k + nrhs),1)
                     do jcol = 1,nrhs
                        bx(j,jcol) = cmplx(rwork(jcol + k),rwork(jcol + k + nrhs),KIND=sp)
-                                 
+
                     end do
                  end do loop_180
               end if
@@ -40497,7 +40497,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: b(ldb,*)
            complex(sp),intent(out) :: bx(ldbx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,i1,ic,im1,inode,j,jcol,jimag,jreal,jrow,lf,ll,lvl,lvl2, &
                      nd,ndb1,ndiml,ndimr,nl,nlf,nlp1,nlvl,nr,nrf,nrp1,sqre
@@ -40655,7 +40655,7 @@ module stdlib_linalg_lapack_c
            end do
            go to 330
            ! icompq = 1: applying back the right singular vector factors.
-170  continue
+           170 continue
            ! first now go through the right singular vector matrices of all
            ! the tree nodes top-down.
            j = 0
@@ -40769,7 +40769,7 @@ module stdlib_linalg_lapack_c
                  end do
               end do
            end do loop_320
-330        continue
+           330 continue
            return
      end subroutine stdlib_clalsa
 
@@ -40805,7 +40805,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: b(ldb,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: bx,bxst,c,difl,difr,givcol,givnum,givptr,i,icmpq1,icmpq2, &
            irwb,irwib,irwrb,irwu,irwvt,irwwrk,iwk,j,jcol,jimag,jreal,jrow,k,nlvl, &
@@ -40934,7 +40934,7 @@ module stdlib_linalg_lapack_c
                     call stdlib_claset('A',1,nrhs,czero,czero,b(i,1),ldb)
                  else
                     call stdlib_clascl('G',0,0,d(i),one,1,nrhs,b(i,1),ldb,info)
-                              
+
                     rank = rank + 1
                  end if
               end do
@@ -41046,7 +41046,7 @@ module stdlib_linalg_lapack_c
                     call stdlib_slaset('A',nsize,nsize,zero,one,rwork(u + st1),n)
                     call stdlib_slasdq('U',0,nsize,nsize,nsize,0,d(st),e(st),rwork( &
                     vt + st1),n,rwork(u + st1),n,rwork(nrwork),1,rwork(nrwork),info)
-                              
+
                     if (info /= 0) then
                        return
                     end if
@@ -41081,7 +41081,7 @@ module stdlib_linalg_lapack_c
                        end do
                     end do
                     call stdlib_clacpy('A',nsize,nrhs,b(st,1),ldb,work(bx + st1),n)
-                              
+
                  else
                     ! a large problem. solve it using divide and conquer.
                     call stdlib_slasda(icmpq1,smlsiz,nsize,sqre,d(st),e(st),rwork(u + &
@@ -41115,7 +41115,7 @@ module stdlib_linalg_lapack_c
               else
                  rank = rank + 1
                  call stdlib_clascl('G',0,0,d(i),one,1,nrhs,work(bx + i - 1),n,info)
-                           
+
               end if
               d(i) = abs(d(i))
            end do
@@ -41198,7 +41198,7 @@ module stdlib_linalg_lapack_c
            real(sp),intent(out) :: work(*)
            complex(sp),intent(in) :: ab(ldab,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,k,l
            real(sp) :: scale,sum,value,temp
@@ -41273,7 +41273,7 @@ module stdlib_linalg_lapack_c
            real(sp),intent(out) :: work(*)
            complex(sp),intent(in) :: a(lda,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(sp) :: scale,sum,value,temp
@@ -41344,7 +41344,7 @@ module stdlib_linalg_lapack_c
            ! Array Arguments
            complex(sp),intent(in) :: d(*),dl(*),du(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(sp) :: anorm,scale,sum,temp
@@ -41358,11 +41358,11 @@ module stdlib_linalg_lapack_c
               anorm = abs(d(n))
               do i = 1,n - 1
                  if (anorm < abs(dl(i)) .or. stdlib_sisnan(abs(dl(i)))) anorm = abs(dl(i))
-                           
+
                  if (anorm < abs(d(i)) .or. stdlib_sisnan(abs(d(i)))) anorm = abs(d(i))
-                           
+
                  if (anorm < abs(du(i)) .or. stdlib_sisnan(abs(du(i)))) anorm = abs(du(i))
-                           
+
               end do
            else if (stdlib_lsame(norm,'O') .or. norm == '1') then
               ! find norm1(a).
@@ -41421,7 +41421,7 @@ module stdlib_linalg_lapack_c
            real(sp),intent(out) :: work(*)
            complex(sp),intent(in) :: ab(ldab,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,l
            real(sp) :: absa,scale,sum,value
@@ -41495,7 +41495,7 @@ module stdlib_linalg_lapack_c
                  if (stdlib_lsame(uplo,'U')) then
                     do j = 2,n
                        call stdlib_classq(min(j - 1,k),ab(max(k + 2 - j,1),j),1,scale,sum)
-                                 
+
                     end do
                     l = k + 1
                  else
@@ -41540,7 +41540,7 @@ module stdlib_linalg_lapack_c
            real(sp),intent(out) :: work(*)
            complex(sp),intent(in) :: a(lda,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(sp) :: absa,scale,sum,value
@@ -41650,7 +41650,7 @@ module stdlib_linalg_lapack_c
            real(sp),intent(out) :: work(0:*)
            complex(sp),intent(in) :: a(0:*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,ifm,ilu,noe,n1,k,l,lda
            real(sp) :: scale,s,value,aa,temp
@@ -42022,7 +42022,7 @@ module stdlib_linalg_lapack_c
                           end do
                           work(j) = work(j) + s
                        end do
-10                     continue
+                       10 continue
                        value = work(0)
                        do i = 1,n - 1
                           temp = work(i)
@@ -42870,7 +42870,7 @@ module stdlib_linalg_lapack_c
            real(sp),intent(out) :: work(*)
            complex(sp),intent(in) :: ap(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,k
            real(sp) :: absa,scale,sum,value
@@ -42998,7 +42998,7 @@ module stdlib_linalg_lapack_c
            real(sp),intent(out) :: work(*)
            complex(sp),intent(in) :: a(lda,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(sp) :: scale,sum,value
@@ -43070,7 +43070,7 @@ module stdlib_linalg_lapack_c
            real(sp),intent(in) :: d(*)
            complex(sp),intent(in) :: e(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(sp) :: anorm,scale,sum
@@ -43133,7 +43133,7 @@ module stdlib_linalg_lapack_c
            real(sp),intent(out) :: work(*)
            complex(sp),intent(in) :: ab(ldab,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,l
            real(sp) :: absa,scale,sum,value
@@ -43203,7 +43203,7 @@ module stdlib_linalg_lapack_c
                  if (stdlib_lsame(uplo,'U')) then
                     do j = 2,n
                        call stdlib_classq(min(j - 1,k),ab(max(k + 2 - j,1),j),1,scale,sum)
-                                 
+
                     end do
                     l = k + 1
                  else
@@ -43238,7 +43238,7 @@ module stdlib_linalg_lapack_c
            real(sp),intent(out) :: work(*)
            complex(sp),intent(in) :: ap(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,k
            real(sp) :: absa,scale,sum,value
@@ -43371,7 +43371,7 @@ module stdlib_linalg_lapack_c
            real(sp),intent(out) :: work(*)
            complex(sp),intent(in) :: a(lda,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(sp) :: absa,scale,sum,value
@@ -43467,7 +43467,7 @@ module stdlib_linalg_lapack_c
            real(sp),intent(out) :: work(*)
            complex(sp),intent(in) :: ab(ldab,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: udiag
            integer(ilp) :: i,j,l
@@ -43619,7 +43619,7 @@ module stdlib_linalg_lapack_c
                     sum = one
                     do j = 1,n
                        call stdlib_classq(min(j,k + 1),ab(max(k + 2 - j,1),j),1,scale,sum)
-                                 
+
                     end do
                  end if
               else
@@ -43660,7 +43660,7 @@ module stdlib_linalg_lapack_c
            real(sp),intent(out) :: work(*)
            complex(sp),intent(in) :: ap(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: udiag
            integer(ilp) :: i,j,k
@@ -43866,7 +43866,7 @@ module stdlib_linalg_lapack_c
            real(sp),intent(out) :: work(*)
            complex(sp),intent(in) :: a(lda,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: udiag
            integer(ilp) :: i,j
@@ -44054,7 +44054,7 @@ module stdlib_linalg_lapack_c
            ! Array Arguments
            complex(sp),intent(inout) :: x(*),y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(sp) :: ssmax
            complex(sp) :: a11,a12,a22,c,tau
@@ -44096,7 +44096,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,itemp,j,mn,offpi,pvt
            real(sp) :: temp,temp2,tol3z
@@ -44122,7 +44122,7 @@ module stdlib_linalg_lapack_c
               ! generate elementary reflector h(i).
               if (offpi < m) then
                  call stdlib_clarfg(m - offpi + 1,a(offpi,i),a(offpi + 1,i),1,tau(i))
-                           
+
               else
                  call stdlib_clarfg(1,a(m,i),a(m,i),1,tau(i))
               end if
@@ -44182,7 +44182,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*),auxv(*),f(ldf,*)
            complex(sp),intent(out) :: tau(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: itemp,j,k,lastrk,lsticc,pvt,rk
            real(sp) :: temp,temp2,tol3z
@@ -44195,7 +44195,7 @@ module stdlib_linalg_lapack_c
            k = 0
            tol3z = sqrt(stdlib_slamch('EPSILON'))
            ! beginning of while loop.
-10   continue
+           10 continue
            if ((k < nb) .and. (lsticc == 0)) then
               k = k + 1
               rk = offset + k
@@ -44287,7 +44287,7 @@ module stdlib_linalg_lapack_c
                         rk + 1,1),lda,f(kb + 1,1),ldf,cone,a(rk + 1,kb + 1),lda)
            end if
            ! recomputation of difficult columns.
-60   continue
+           60 continue
            if (lsticc > 0) then
               itemp = nint(vn2(lsticc),KIND=ilp)
               vn1(lsticc) = stdlib_scnrm2(m - rk,a(rk + 1,lsticc),1)
@@ -44320,7 +44320,7 @@ module stdlib_linalg_lapack_c
            ! Parameters
            real(sp),parameter :: rzero = 0.0_sp
            real(sp),parameter :: rone = 1.0_sp
-           
+
            ! Local Scalars
            complex(sp) :: alpha,beta,cdum,refsum
            real(sp) :: h11,h12,h21,h22,safmax,safmin,scl,smlnum,tst1,tst2,ulp
@@ -44456,9 +44456,9 @@ module stdlib_linalg_lapack_c
                              h12 = max(cabs1(h(k + 1,k)),cabs1(h(k,k + 1)))
                              h21 = min(cabs1(h(k + 1,k)),cabs1(h(k,k + 1)))
                              h11 = max(cabs1(h(k + 1,k + 1)),cabs1(h(k,k) - h(k + 1,k + 1)))
-                                       
+
                              h22 = min(cabs1(h(k + 1,k + 1)),cabs1(h(k,k) - h(k + 1,k + 1)))
-                                       
+
                              scl = h11 + h12
                              tst2 = h22*(h11/scl)
                              if (tst2 == rzero .or. h21*(h12/scl) <= max(smlnum,ulp*tst2)) h( &
@@ -44521,11 +44521,11 @@ module stdlib_linalg_lapack_c
                           ! .    reflector is too large, then abandon it.
                           ! .    otherwise, use the new cone. ====
                           call stdlib_claqr1(3,h(k + 1,k + 1),ldh,s(2*m - 1),s(2*m),vt)
-                                    
+
                           alpha = vt(1)
                           call stdlib_clarfg(3,alpha,vt(2),1,vt(1))
                           refsum = conjg(vt(1))*(h(k + 1,k) + conjg(vt(2))*h(k + 2,k))
-                                    
+
                           if (cabs1(h(k + 2,k) - refsum*vt(2)) + cabs1(refsum*vt(3)) > ulp*( &
                           cabs1(h(k,k)) + cabs1(h(k + 1,k + 1)) + cabs1(h(k + 2,k + 2)))) &
                                     then
@@ -44591,9 +44591,9 @@ module stdlib_linalg_lapack_c
                           h12 = max(cabs1(h(k + 1,k)),cabs1(h(k,k + 1)))
                           h21 = min(cabs1(h(k + 1,k)),cabs1(h(k,k + 1)))
                           h11 = max(cabs1(h(k + 1,k + 1)),cabs1(h(k,k) - h(k + 1,k + 1)))
-                                    
+
                           h22 = min(cabs1(h(k + 1,k + 1)),cabs1(h(k,k) - h(k + 1,k + 1)))
-                                    
+
                           scl = h11 + h12
                           tst2 = h22*(h11/scl)
                           if (tst2 == rzero .or. h21*(h12/scl) <= max(smlnum,ulp*tst2)) h(k + 1, &
@@ -44674,7 +44674,7 @@ module stdlib_linalg_lapack_c
                     call stdlib_cgemm('C','N',nu,jlen,nu,cone,u(k1,k1),ldu,h(incol + k1, &
                                jcol),ldh,czero,wh,ldwh)
                     call stdlib_clacpy('ALL',nu,jlen,wh,ldwh,h(incol + k1,jcol),ldh)
-                              
+
                  end do
                  ! ==== vertical multiply ====
                  do jrow = jtop,max(ktop,incol) - 1,nv
@@ -44682,7 +44682,7 @@ module stdlib_linalg_lapack_c
                     call stdlib_cgemm('N','N',jlen,nu,nu,cone,h(jrow,incol + k1),ldh,u( &
                               k1,k1),ldu,czero,wv,ldwv)
                     call stdlib_clacpy('ALL',jlen,nu,wv,ldwv,h(jrow,incol + k1),ldh)
-                              
+
                  end do
                  ! ==== z multiply (also vertical) ====
                  if (wantz) then
@@ -44691,7 +44691,7 @@ module stdlib_linalg_lapack_c
                        call stdlib_cgemm('N','N',jlen,nu,nu,cone,z(jrow,incol + k1),ldz, &
                                  u(k1,k1),ldu,czero,wv,ldwv)
                        call stdlib_clacpy('ALL',jlen,nu,wv,ldwv,z(jrow,incol + k1),ldz)
-                                 
+
                     end do
                  end if
               end if
@@ -44707,7 +44707,7 @@ module stdlib_linalg_lapack_c
            integer(ilp),intent(in) :: k,lda,ldb,ldq,ldz,istartm,istopm,nq,nz,qstart, &
                      zstart,ihi
            complex(sp),intent(inout) :: a(lda,*),b(ldb,*),q(ldq,*),z(ldz,*)
-           
+
            ! local variables
            real(sp) :: c
            complex(sp) :: s,temp
@@ -44717,12 +44717,12 @@ module stdlib_linalg_lapack_c
               b(ihi,ihi) = temp
               b(ihi,ihi - 1) = czero
               call stdlib_crot(ihi - istartm,b(istartm,ihi),1,b(istartm,ihi - 1),1,c,s)
-                        
+
               call stdlib_crot(ihi - istartm + 1,a(istartm,ihi),1,a(istartm,ihi - 1),1,c,s)
-                        
+
               if (ilz) then
                  call stdlib_crot(nz,z(1,ihi - zstart + 1),1,z(1,ihi - 1 - zstart + 1),1,c,s)
-                           
+
               end if
            else
               ! normal operation, move bulge down
@@ -44731,12 +44731,12 @@ module stdlib_linalg_lapack_c
               b(k + 1,k + 1) = temp
               b(k + 1,k) = czero
               call stdlib_crot(k + 2 - istartm + 1,a(istartm,k + 1),1,a(istartm,k),1,c,s)
-                        
+
               call stdlib_crot(k - istartm + 1,b(istartm,k + 1),1,b(istartm,k),1,c,s)
-                        
+
               if (ilz) then
                  call stdlib_crot(nz,z(1,k + 1 - zstart + 1),1,z(1,k - zstart + 1),1,c,s)
-                           
+
               end if
               ! apply transformation from the left
               call stdlib_clartg(a(k + 1,k),a(k + 2,k),c,s,temp)
@@ -44762,7 +44762,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*),b(ldb,*),q(ldq,*),z(ldz,*),qc( &
                      ldqc,*),zc(ldzc,*),work(*),alpha(*),beta(*)
            integer(ilp),intent(out) :: info
-           
+
            ! local scalars
            integer(ilp) :: i,j,ns,istartm,istopm,sheight,swidth,k,np,istartb,istopb, &
                      ishift,nblock,npos
@@ -44838,11 +44838,11 @@ module stdlib_linalg_lapack_c
               call stdlib_cgemm('C','N',sheight,swidth,sheight,cone,qc,ldqc,a(ilo,ilo + &
                         ns),lda,czero,work,sheight)
               call stdlib_clacpy('ALL',sheight,swidth,work,sheight,a(ilo,ilo + ns),lda)
-                        
+
               call stdlib_cgemm('C','N',sheight,swidth,sheight,cone,qc,ldqc,b(ilo,ilo + &
                         ns),ldb,czero,work,sheight)
               call stdlib_clacpy('ALL',sheight,swidth,work,sheight,b(ilo,ilo + ns),ldb)
-                        
+
            end if
            if (ilq) then
              call stdlib_cgemm('N','N',n,sheight,sheight,cone,q(1,ilo),ldq,qc,ldqc, &
@@ -44857,11 +44857,11 @@ module stdlib_linalg_lapack_c
               call stdlib_cgemm('N','N',sheight,swidth,swidth,cone,a(istartm,ilo),lda, &
                         zc,ldzc,czero,work,sheight)
               call stdlib_clacpy('ALL',sheight,swidth,work,sheight,a(istartm,ilo),lda)
-                        
+
               call stdlib_cgemm('N','N',sheight,swidth,swidth,cone,b(istartm,ilo),ldb, &
                         zc,ldzc,czero,work,sheight)
               call stdlib_clacpy('ALL',sheight,swidth,work,sheight,b(istartm,ilo),ldb)
-                        
+
            end if
            if (ilz) then
               call stdlib_cgemm('N','N',n,swidth,swidth,cone,z(1,ilo),ldz,zc,ldzc, &
@@ -44921,11 +44921,11 @@ module stdlib_linalg_lapack_c
                  call stdlib_cgemm('N','N',sheight,swidth,swidth,cone,a(istartm,k),lda, &
                            zc,ldzc,czero,work,sheight)
                  call stdlib_clacpy('ALL',sheight,swidth,work,sheight,a(istartm,k),lda)
-                           
+
                  call stdlib_cgemm('N','N',sheight,swidth,swidth,cone,b(istartm,k),ldb, &
                            zc,ldzc,czero,work,sheight)
                  call stdlib_clacpy('ALL',sheight,swidth,work,sheight,b(istartm,k),ldb)
-                           
+
               end if
               if (ilz) then
                  call stdlib_cgemm('N','N',n,nblock,nblock,cone,z(1,k),ldz,zc,ldzc, &
@@ -45011,7 +45011,7 @@ module stdlib_linalg_lapack_c
            real(sp),intent(out) :: c(*)
            complex(sp),intent(inout) :: x(*),y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            ! logical            first
            integer(ilp) :: count,i,ic,ix,iy,j
@@ -45049,7 +45049,7 @@ module stdlib_linalg_lapack_c
               gs = g
               count = 0
               if (scale >= safmx2) then
-10            continue
+              10 continue
                  count = count + 1
                  fs = fs*safmn2
                  gs = gs*safmn2
@@ -45062,7 +45062,7 @@ module stdlib_linalg_lapack_c
                     r = f
                     go to 50
                  end if
-20               continue
+                 20 continue
                  count = count - 1
                  fs = fs*safmx2
                  gs = gs*safmx2
@@ -45132,7 +45132,7 @@ module stdlib_linalg_lapack_c
                     end if
                  end if
               end if
-50            continue
+              50 continue
               c(ic) = cs
               y(iy) = sn
               x(ix) = r
@@ -45167,7 +45167,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: maxitr = 10
-           
+
            ! Local Scalars
            logical(lk) :: eskip,needbs,stp2ii,tryrqc,usedbs,usedrq
            integer(ilp) :: done,i,ibegin,idone,iend,ii,iindc1,iindc2,iindr,iindwk,iinfo, &
@@ -45250,7 +45250,7 @@ module stdlib_linalg_lapack_c
               ! find the eigenvectors of the submatrix indexed ibegin
               ! through iend.
               wend = wbegin - 1
-15            continue
+              15 continue
               if (wend < m) then
                  if (iblock(wend + 1) == jblk) then
                     wend = wend + 1
@@ -45318,7 +45318,7 @@ module stdlib_linalg_lapack_c
               ! loop while( idone<im )
               ! generate the representation tree for the current block and
               ! compute the eigenvectors
-40   continue
+              40 continue
               if (idone < im) then
                  ! this is a crude protection against infinitely deep trees
                  if (ndepth > m) then
@@ -45374,7 +45374,7 @@ module stdlib_linalg_lapack_c
                        sigma = real(z(iend,j + 1),KIND=sp)
                        ! set the corresponding entries in z to zero
                        call stdlib_claset('FULL',in,2,czero,czero,z(ibegin,j),ldz)
-                                 
+
                     end if
                     ! compute dl and dll of current rrr
                     do j = ibegin,iend - 1
@@ -45410,7 +45410,7 @@ module stdlib_linalg_lapack_c
                        if (oldfst > 1) then
                           wgap(wbegin + oldfst - 2) = max(wgap(wbegin + oldfst - 2),w(wbegin + oldfst - 1) - &
                           werr(wbegin + oldfst - 1) - w(wbegin + oldfst - 2) - werr(wbegin + oldfst - 2))
-                                    
+
                        end if
                        if (wbegin + oldlst - 1 < wend) then
                           wgap(wbegin + oldlst - 1) = max(wgap(wbegin + oldlst - 1),w(wbegin + oldlst) - &
@@ -45506,15 +45506,15 @@ module stdlib_linalg_lapack_c
                           call stdlib_slarrf(in,d(ibegin),l(ibegin),work(indld + ibegin - 1), &
                           newfst,newlst,work(wbegin),wgap(wbegin),werr(wbegin),spdiam,lgap, &
                           rgap,pivmin,tau,work(indin1),work(indin2),work(indwrk),iinfo)
-                                    
+
                           ! in the complex case, stdlib_slarrf cannot write
                           ! the new rrr directly into z and needs an intermediate
                           ! workspace
                           do k = 1,in - 1
                              z(ibegin + k - 1,newftt) = cmplx(work(indin1 + k - 1),zero,KIND=sp)
-                                       
+
                              z(ibegin + k - 1,newftt + 1) = cmplx(work(indin2 + k - 1),zero,KIND=sp)
-                                       
+
                           end do
                           z(iend,newftt) = cmplx(work(indin1 + in - 1),zero,KIND=sp)
                           if (iinfo == 0) then
@@ -45621,7 +45621,7 @@ module stdlib_linalg_lapack_c
                           usedrq = .false.
                           ! bisection is initially turned off unless it is forced
                           needbs = .not. tryrqc
-120                       continue
+                          120 continue
                           ! check if bisection should be used to refine eigenvalue
                           if (needbs) then
                              ! take the bisection as new iterate
@@ -45755,7 +45755,7 @@ module stdlib_linalg_lapack_c
                              end do
                           end if
                           call stdlib_csscal(zto - zfrom + 1,nrminv,z(zfrom,windex),1)
-125                       continue
+                          125 continue
                           ! update w
                           w(windex) = lambda + sigma
                           ! recompute the gaps on the left and right
@@ -45777,7 +45777,7 @@ module stdlib_linalg_lapack_c
                           idone = idone + 1
                        end if
                        ! here ends the code for the current child
-139  continue
+                       139 continue
                        ! proceed to any remaining child nodes
                        newfst = j + 1
                     end do loop_140
@@ -45813,7 +45813,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: maxdim = 2
-           
+
            ! Local Scalars
            integer(ilp) :: i,info,j,k
            real(sp) :: rtemp,scale,sminu,splus
@@ -45836,7 +45836,7 @@ module stdlib_linalg_lapack_c
                  ! lockahead for l- part rhs(1:n-1) = +-1
                  ! splus and smin computed more efficiently than in bsolve[1].
                  splus = splus + real(stdlib_cdotc(n - j,z(j + 1,j),1,z(j + 1,j),1),KIND=sp)
-                           
+
                  sminu = real(stdlib_cdotc(n - j,z(j + 1,j),1,rhs(j + 1),1),KIND=sp)
                  splus = splus*real(rhs(j),KIND=sp)
                  if (splus > sminu) then
@@ -45948,7 +45948,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: d(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: iinfo,j,jb,nb
            ! Intrinsic Functions
@@ -45980,7 +45980,7 @@ module stdlib_linalg_lapack_c
                  jb = min(min(m,n) - j + 1,nb)
                  ! factor diagonal and subdiagonal blocks.
                  call stdlib_claunhr_col_getrfnp2(m - j + 1,jb,a(j,j),lda,d(j),iinfo)
-                           
+
                  if (j + jb <= n) then
                     ! compute block row of u.
                     call stdlib_ctrsm('LEFT','LOWER','NO TRANSPOSE','UNIT',jb,n - j - jb + 1,cone, &
@@ -45989,7 +45989,7 @@ module stdlib_linalg_lapack_c
                        ! update trailing submatrix.
                        call stdlib_cgemm('NO TRANSPOSE','NO TRANSPOSE',m - j - jb + 1,n - j - jb + 1,jb,- &
                        cone,a(j + jb,j),lda,a(j,j + jb),lda,cone,a(j + jb,j + jb),lda)
-                                 
+
                     end if
                  end if
               end do
@@ -46005,7 +46005,7 @@ module stdlib_linalg_lapack_c
      !> condition number is computed as RCOND = 1 / (ANORM * norm(inv(A))).
 
      pure subroutine stdlib_cpbcon(uplo,n,kd,ab,ldab,anorm,rcond,work,rwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -46020,7 +46020,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: ab(ldab,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            character :: normin
@@ -46066,7 +46066,7 @@ module stdlib_linalg_lapack_c
            ! estimate the 1-norm of the inverse.
            kase = 0
            normin = 'N'
-10         continue
+           10 continue
            call stdlib_clacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               if (upper) then
@@ -46097,7 +46097,7 @@ module stdlib_linalg_lapack_c
            end if
            ! compute the estimate of the reciprocal condition number.
            if (ainvnm /= zero) rcond = (one/ainvnm)/anorm
-20         continue
+           20 continue
            return
      end subroutine stdlib_cpbcon
 
@@ -46123,7 +46123,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,j,k,kase,l,nz
@@ -46180,12 +46180,12 @@ module stdlib_linalg_lapack_c
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_ccopy(n,b(1,j),1,work,1)
               call stdlib_chbmv(uplo,n,kd,-cone,ab,ldab,x(1,j),1,cone,work,1)
-                        
+
               ! compute componentwise relative backward error from formula
               ! max(i) ( abs(r(i)) / ( abs(a)*abs(x) + abs(b) )(i) )
               ! where abs(z) is the componentwise absolute value of the matrix
@@ -46267,7 +46267,7 @@ module stdlib_linalg_lapack_c
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_clacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -46316,7 +46316,7 @@ module stdlib_linalg_lapack_c
            ! Parameters
            integer(ilp),parameter :: nbmax = 32
            integer(ilp),parameter :: ldwork = nbmax + 1
-           
+
            ! Local Scalars
            integer(ilp) :: i,i2,i3,ib,ii,j,jj,nb
            ! Local Arrays
@@ -46489,7 +46489,7 @@ module stdlib_linalg_lapack_c
               end if
            end if
            return
-150        continue
+           150 continue
            return
      end subroutine stdlib_cpbtrf
 
@@ -46509,7 +46509,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: a(0:*)
            complex(sp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,normaltransr
            ! Intrinsic Functions
@@ -46568,7 +46568,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            character :: normin
@@ -46612,7 +46612,7 @@ module stdlib_linalg_lapack_c
            ! estimate the 1-norm of inv(a).
            kase = 0
            normin = 'N'
-10         continue
+           10 continue
            call stdlib_clacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               if (upper) then
@@ -46643,7 +46643,7 @@ module stdlib_linalg_lapack_c
            end if
            ! compute the estimate of the reciprocal condition number.
            if (ainvnm /= zero) rcond = (one/ainvnm)/anorm
-20         continue
+           20 continue
            return
      end subroutine stdlib_cpocon
 
@@ -46669,7 +46669,7 @@ module stdlib_linalg_lapack_c
         ! ====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,j,k,kase,nz
@@ -46724,7 +46724,7 @@ module stdlib_linalg_lapack_c
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_ccopy(n,b(1,j),1,work,1)
@@ -46808,7 +46808,7 @@ module stdlib_linalg_lapack_c
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_clacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -46855,7 +46855,7 @@ module stdlib_linalg_lapack_c
            ! Array Arguments
            complex(sp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,jb,nb
@@ -46924,9 +46924,9 @@ module stdlib_linalg_lapack_c
               end if
            end if
            go to 40
-30         continue
+           30 continue
            info = info + j - 1
-40         continue
+           40 continue
            return
      end subroutine stdlib_cpotrf
 
@@ -46993,7 +46993,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: ap(*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            character :: normin
@@ -47035,7 +47035,7 @@ module stdlib_linalg_lapack_c
            ! estimate the 1-norm of the inverse.
            kase = 0
            normin = 'N'
-10         continue
+           10 continue
            call stdlib_clacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               if (upper) then
@@ -47066,7 +47066,7 @@ module stdlib_linalg_lapack_c
            end if
            ! compute the estimate of the reciprocal condition number.
            if (ainvnm /= zero) rcond = (one/ainvnm)/anorm
-20         continue
+           20 continue
            return
      end subroutine stdlib_cppcon
 
@@ -47092,7 +47092,7 @@ module stdlib_linalg_lapack_c
         ! ====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,ik,j,k,kase,kk,nz
@@ -47143,7 +47143,7 @@ module stdlib_linalg_lapack_c
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_ccopy(n,b(1,j),1,work,1)
@@ -47234,7 +47234,7 @@ module stdlib_linalg_lapack_c
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_clacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -47336,7 +47336,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: afp(*),ap(*),b(ldb,*)
            complex(sp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: equil,nofact,rcequ
            integer(ilp) :: i,infequ,j
@@ -47466,7 +47466,7 @@ module stdlib_linalg_lapack_c
            ! Array Arguments
            complex(sp),intent(inout) :: ap(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,jc,jj,jjn
@@ -47544,7 +47544,7 @@ module stdlib_linalg_lapack_c
            real(sp),intent(out) :: work(*)
            complex(sp),intent(inout) :: z(ldz,*)
         ! ====================================================================
-           
+
            ! Local Arrays
            complex(sp) :: c(1,1),vt(1,1)
            ! Local Scalars
@@ -47598,7 +47598,7 @@ module stdlib_linalg_lapack_c
               nru = 0
            end if
            call stdlib_cbdsqr('LOWER',n,0,nru,0,d,e,vt,1,z,ldz,c,1,work,info)
-                     
+
            ! square the singular values.
            if (info == 0) then
               do i = 1,n
@@ -47698,7 +47698,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: ap(*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,ip,kase
@@ -47746,7 +47746,7 @@ module stdlib_linalg_lapack_c
            end if
            ! estimate the 1-norm of the inverse.
            kase = 0
-30         continue
+           30 continue
            call stdlib_clacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               ! multiply by inv(l*d*l**t) or inv(u*d*u**t).
@@ -47781,7 +47781,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,ik,j,k,kase,kk,nz
@@ -47832,7 +47832,7 @@ module stdlib_linalg_lapack_c
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_ccopy(n,b(1,j),1,work,1)
@@ -47923,7 +47923,7 @@ module stdlib_linalg_lapack_c
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_clacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -48026,7 +48026,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: ap(*),b(ldb,*)
            complex(sp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nofact
            real(sp) :: anorm
@@ -48159,7 +48159,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: minrgp = 3.0e-3_sp
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,lquery,valeig,wantz,zquery
            integer(ilp) :: i,ibegin,iend,ifirst,iil,iindbl,iindw,iindwk,iinfo,iinspl, &
@@ -48238,7 +48238,7 @@ module stdlib_linalg_lapack_c
                  nzcmin = n
               else if (wantz .and. valeig) then
                  call stdlib_slarrc('T',n,vl,vu,d,e,safmin,nzcmin,itmp,itmp2,info)
-                           
+
               else if (wantz .and. indeig) then
                  nzcmin = iiu - iil + 1
               else
@@ -48408,7 +48408,7 @@ module stdlib_linalg_lapack_c
               call stdlib_slarre(range,n,wl,wu,iil,iiu,d,e,work(inde2),rtol1,rtol2, &
               thresh,nsplit,iwork(iinspl),m,w,work(inderr),work(indgp),iwork(iindbl), &
               iwork(iindw),work(indgrs),pivmin,work(indwrk),iwork(iindwk),iinfo)
-                        
+
               if (iinfo /= 0) then
                  info = 10 + abs(iinfo)
                  return
@@ -48447,7 +48447,7 @@ module stdlib_linalg_lapack_c
                     in = iend - ibegin + 1
                     wend = wbegin - 1
                     ! check if any eigenvalues have to be refined in this block
-36   continue
+                    36 continue
                     if (wend < m) then
                        if (iwork(iindbl + wend) == jblk) then
                           wend = wend + 1
@@ -48535,7 +48535,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: a(lda,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,kase
@@ -48583,7 +48583,7 @@ module stdlib_linalg_lapack_c
            end if
            ! estimate the 1-norm of the inverse.
            kase = 0
-30         continue
+           30 continue
            call stdlib_clacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               ! multiply by inv(l*d*l**t) or inv(u*d*u**t).
@@ -48616,7 +48616,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: a(lda,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,kase
@@ -48664,7 +48664,7 @@ module stdlib_linalg_lapack_c
            end if
            ! estimate the 1-norm of the inverse.
            kase = 0
-30         continue
+           30 continue
            call stdlib_clacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               ! multiply by inv(l*d*l**t) or inv(u*d*u**t).
@@ -48698,7 +48698,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,j,k,kase,nz
@@ -48753,7 +48753,7 @@ module stdlib_linalg_lapack_c
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_ccopy(n,b(1,j),1,work,1)
@@ -48837,7 +48837,7 @@ module stdlib_linalg_lapack_c
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_clacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -48959,7 +48959,7 @@ module stdlib_linalg_lapack_c
      !> the system of equations A * X = B by calling BLAS3 routine CSYTRS_3.
 
      pure subroutine stdlib_csysv_rk(uplo,n,nrhs,a,lda,e,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -49037,7 +49037,7 @@ module stdlib_linalg_lapack_c
      !> of equations A * X = B by calling CSYTRS_ROOK.
 
      pure subroutine stdlib_csysv_rook(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -49122,7 +49122,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: af(ldaf,*)
            complex(sp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,nofact
            integer(ilp) :: lwkopt,nb
@@ -49203,7 +49203,7 @@ module stdlib_linalg_lapack_c
      !> RCOND = 1 / ( norm(A) * norm(inv(A)) ).
 
      subroutine stdlib_ctbcon(norm,uplo,diag,n,kd,ab,ldab,rcond,work,rwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -49217,7 +49217,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: ab(ldab,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,onenrm,upper
            character :: normin
@@ -49275,7 +49275,7 @@ module stdlib_linalg_lapack_c
                  kase1 = 2
               end if
               kase = 0
-10            continue
+              10 continue
               call stdlib_clacn2(n,work(n + 1),work,ainvnm,kase,isave)
               if (kase /= 0) then
                  if (kase == kase1) then
@@ -49300,7 +49300,7 @@ module stdlib_linalg_lapack_c
               ! compute the estimate of the reciprocal condition number.
               if (ainvnm /= zero) rcond = (one/anorm)/ainvnm
            end if
-20         continue
+           20 continue
            return
      end subroutine stdlib_ctbcon
 
@@ -49319,7 +49319,7 @@ module stdlib_linalg_lapack_c
            ! Array Arguments
            complex(sp),intent(inout) :: a(0:*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,nisodd,normaltransr
            integer(ilp) :: n1,n2,k
@@ -49374,12 +49374,12 @@ module stdlib_linalg_lapack_c
                     call stdlib_ctrtri('L',diag,n1,a(0),n,info)
                     if (info > 0) return
                     call stdlib_ctrmm('R','L','N',diag,n2,n1,-cone,a(0),n,a(n1),n)
-                              
+
                     call stdlib_ctrtri('U',diag,n2,a(n),n,info)
                     if (info > 0) info = info + n1
                     if (info > 0) return
                     call stdlib_ctrmm('L','U','C',diag,n2,n1,cone,a(n),n,a(n1),n)
-                              
+
                  else
                    ! srpa for upper, normal and n is odd ( a(0:n-1,0:n2-1)
                    ! t1 -> a(n1+1,0), t2 -> a(n1,0), s -> a(0,0)
@@ -49387,12 +49387,12 @@ module stdlib_linalg_lapack_c
                     call stdlib_ctrtri('L',diag,n1,a(n2),n,info)
                     if (info > 0) return
                     call stdlib_ctrmm('L','L','C',diag,n1,n2,-cone,a(n2),n,a(0),n)
-                              
+
                     call stdlib_ctrtri('U',diag,n2,a(n1),n,info)
                     if (info > 0) info = info + n1
                     if (info > 0) return
                     call stdlib_ctrmm('R','U','N',diag,n1,n2,cone,a(n1),n,a(0),n)
-                              
+
                  end if
               else
                  ! n is odd and transr = 'c'
@@ -49451,7 +49451,7 @@ module stdlib_linalg_lapack_c
                     if (info > 0) info = info + k
                     if (info > 0) return
                     call stdlib_ctrmm('R','U','N',diag,k,k,cone,a(k),n + 1,a(0),n + 1)
-                              
+
                  end if
               else
                  ! n is even and transr = 'c'
@@ -49480,7 +49480,7 @@ module stdlib_linalg_lapack_c
                     if (info > 0) info = info + k
                     if (info > 0) return
                     call stdlib_ctrmm('L','L','N',diag,k,k,cone,a(k*k),k,a(0),k)
-                              
+
                  end if
               end if
            end if
@@ -49568,7 +49568,7 @@ module stdlib_linalg_lapack_c
            ! Parameters
            integer(ilp),parameter :: maxit = 40
            real(sp),parameter :: hugenum = huge(zero)
-           
+
            ! Local Scalars
            logical(lk) :: initq,initu,initv,upper,wantq,wantu,wantv
            integer(ilp) :: i,j,kcycle
@@ -49647,7 +49647,7 @@ module stdlib_linalg_lapack_c
                     ! update (n-l+i)-th and (n-l+j)-th columns of matrices
                     ! a and b: a*q and b*q
                     call stdlib_crot(min(k + l,m),a(1,n - l + j),1,a(1,n - l + i),1,csq,snq)
-                              
+
                     call stdlib_crot(l,b(1,n - l + j),1,b(1,n - l + i),1,csq,snq)
                     if (upper) then
                        if (k + i <= m) a(k + i,n - l + j) = czero
@@ -49666,7 +49666,7 @@ module stdlib_linalg_lapack_c
                               csu,snu)
                     if (wantv) call stdlib_crot(p,v(1,j),1,v(1,i),1,csv,snv)
                     if (wantq) call stdlib_crot(n,q(1,n - l + j),1,q(1,n - l + i),1,csq,snq)
-                              
+
                  end do loop_10
               end do loop_20
               if (.not. upper) then
@@ -49688,7 +49688,7 @@ module stdlib_linalg_lapack_c
            ! the algorithm has not converged after maxit cycles.
            info = 1
            go to 100
-50         continue
+           50 continue
            ! if error <= min(tola,tolb), then the algorithm has converged.
            ! compute the generalized singular value pairs (alpha, beta), and
            ! set the triangular matrix r to array a.
@@ -49729,7 +49729,7 @@ module stdlib_linalg_lapack_c
                  beta(i) = zero
               end do
            end if
-100        continue
+           100 continue
            ncycle = kcycle
            return
      end subroutine stdlib_ctgsja
@@ -49777,7 +49777,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: ldz = 2
-           
+
            ! Local Scalars
            logical(lk) :: notran
            integer(ilp) :: i,ierr,j,k
@@ -49848,15 +49848,15 @@ module stdlib_linalg_lapack_c
                        if (scaloc /= one) then
                           do k = 1,n
                              call stdlib_cscal(m,cmplx(scaloc,zero,KIND=sp),c(1,k),1)
-                                       
+
                              call stdlib_cscal(m,cmplx(scaloc,zero,KIND=sp),f(1,k),1)
-                                       
+
                           end do
                           scale = scale*scaloc
                        end if
                     else
                        call stdlib_clatdf(ijob,ldz,z,ldz,rhs,rdsum,rdscal,ipiv,jpiv)
-                                 
+
                     end if
                     ! unpack solution vector(s)
                     c(i,j) = rhs(1)
@@ -49869,9 +49869,9 @@ module stdlib_linalg_lapack_c
                     end if
                     if (j < n) then
                        call stdlib_caxpy(n - j,rhs(2),b(j,j + 1),ldb,c(i,j + 1),ldc)
-                                 
+
                        call stdlib_caxpy(n - j,rhs(2),e(j,j + 1),lde,f(i,j + 1),ldf)
-                                 
+
                     end if
                  end do loop_20
               end do loop_30
@@ -49899,9 +49899,9 @@ module stdlib_linalg_lapack_c
                     if (scaloc /= one) then
                        do k = 1,n
                           call stdlib_cscal(m,cmplx(scaloc,zero,KIND=sp),c(1,k),1)
-                                    
+
                           call stdlib_cscal(m,cmplx(scaloc,zero,KIND=sp),f(1,k),1)
-                                    
+
                        end do
                        scale = scale*scaloc
                     end if
@@ -49969,7 +49969,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
         ! replaced various illegal calls to stdlib_ccopy by calls to stdlib_claset.
         ! sven hammarling, 1/5/02.
-           
+
            ! Local Scalars
            logical(lk) :: lquery,notran
            integer(ilp) :: i,ie,ifunc,iround,is,isolve,j,je,js,k,linfo,lwmin,mb,nb, &
@@ -50089,27 +50089,27 @@ module stdlib_linalg_lapack_c
            ! determine block structure of a
            p = 0
            i = 1
-40         continue
+           40 continue
            if (i > m) go to 50
            p = p + 1
            iwork(p) = i
            i = i + mb
            if (i >= m) go to 50
            go to 40
-50         continue
+           50 continue
            iwork(p + 1) = m + 1
            if (iwork(p) == iwork(p + 1)) p = p - 1
            ! determine block structure of b
            q = p + 1
            j = 1
-60         continue
+           60 continue
            if (j > n) go to 70
            q = q + 1
            iwork(q) = j
            j = j + nb
            if (j >= n) go to 70
            go to 60
-70         continue
+           70 continue
            iwork(q + 1) = n + 1
            if (iwork(q) == iwork(q + 1)) q = q - 1
            if (notran) then
@@ -50138,15 +50138,15 @@ module stdlib_linalg_lapack_c
                        if (scaloc /= one) then
                           do k = 1,js - 1
                              call stdlib_cscal(m,cmplx(scaloc,zero,KIND=sp),c(1,k),1)
-                                       
+
                              call stdlib_cscal(m,cmplx(scaloc,zero,KIND=sp),f(1,k),1)
-                                       
+
                           end do
                           do k = js,je
                              call stdlib_cscal(is - 1,cmplx(scaloc,zero,KIND=sp),c(1,k),1)
-                                       
+
                              call stdlib_cscal(is - 1,cmplx(scaloc,zero,KIND=sp),f(1,k),1)
-                                       
+
                           end do
                           do k = js,je
                              call stdlib_cscal(m - ie,cmplx(scaloc,zero,KIND=sp),c(ie + 1,k), &
@@ -50156,9 +50156,9 @@ module stdlib_linalg_lapack_c
                           end do
                           do k = je + 1,n
                              call stdlib_cscal(m,cmplx(scaloc,zero,KIND=sp),c(1,k),1)
-                                       
+
                              call stdlib_cscal(m,cmplx(scaloc,zero,KIND=sp),f(1,k),1)
-                                       
+
                           end do
                           scale = scale*scaloc
                        end if
@@ -50224,27 +50224,27 @@ module stdlib_linalg_lapack_c
                     if (scaloc /= one) then
                        do k = 1,js - 1
                           call stdlib_cscal(m,cmplx(scaloc,zero,KIND=sp),c(1,k),1)
-                                    
+
                           call stdlib_cscal(m,cmplx(scaloc,zero,KIND=sp),f(1,k),1)
-                                    
+
                        end do
                        do k = js,je
                           call stdlib_cscal(is - 1,cmplx(scaloc,zero,KIND=sp),c(1,k),1)
-                                    
+
                           call stdlib_cscal(is - 1,cmplx(scaloc,zero,KIND=sp),f(1,k),1)
-                                    
+
                        end do
                        do k = js,je
                           call stdlib_cscal(m - ie,cmplx(scaloc,zero,KIND=sp),c(ie + 1,k),1)
-                                    
+
                           call stdlib_cscal(m - ie,cmplx(scaloc,zero,KIND=sp),f(ie + 1,k),1)
-                                    
+
                        end do
                        do k = je + 1,n
                           call stdlib_cscal(m,cmplx(scaloc,zero,KIND=sp),c(1,k),1)
-                                    
+
                           call stdlib_cscal(m,cmplx(scaloc,zero,KIND=sp),f(1,k),1)
-                                    
+
                        end do
                        scale = scale*scaloc
                     end if
@@ -50252,10 +50252,10 @@ module stdlib_linalg_lapack_c
                     if (j > p + 2) then
                        call stdlib_cgemm('N','C',mb,js - 1,nb,cmplx(one,zero,KIND=sp),c(is, &
                         js),ldc,b(1,js),ldb,cmplx(one,zero,KIND=sp),f(is,1),ldf)
-                                  
+
                        call stdlib_cgemm('N','C',mb,js - 1,nb,cmplx(one,zero,KIND=sp),f(is, &
                         js),ldf,e(1,js),lde,cmplx(one,zero,KIND=sp),f(is,1),ldf)
-                                  
+
                     end if
                     if (i < p) then
                        call stdlib_cgemm('C','N',m - ie,nb,mb,cmplx(-one,zero,KIND=sp),a( &
@@ -50293,7 +50293,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: ap(*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,onenrm,upper
            character :: normin
@@ -50347,7 +50347,7 @@ module stdlib_linalg_lapack_c
                  kase1 = 2
               end if
               kase = 0
-10            continue
+              10 continue
               call stdlib_clacn2(n,work(n + 1),work,ainvnm,kase,isave)
               if (kase /= 0) then
                  if (kase == kase1) then
@@ -50372,7 +50372,7 @@ module stdlib_linalg_lapack_c
               ! compute the estimate of the reciprocal condition number.
               if (ainvnm /= zero) rcond = (one/anorm)/ainvnm
            end if
-20         continue
+           20 continue
            return
      end subroutine stdlib_ctpcon
 
@@ -50428,7 +50428,7 @@ module stdlib_linalg_lapack_c
                  lb = nb - n + l - i + 1
               end if
               call stdlib_ctplqt2(ib,nb,lb,a(i,i),lda,b(i,1),ldb,t(1,i),ldt,iinfo)
-                        
+
            ! update by applying h**t to b(i+ib:m,:) from the right
               if (i + ib <= m) then
                  call stdlib_ctprfb('R','N','F','R',m - i - ib + 1,nb,ib,lb,b(i,1),ldb,t( &
@@ -50728,7 +50728,7 @@ module stdlib_linalg_lapack_c
                  lb = mb - m + l - i + 1
               end if
               call stdlib_ctpqrt2(mb,ib,lb,a(i,i),lda,b(1,i),ldb,t(1,i),ldt,iinfo)
-                        
+
            ! update by applying h**h to b(:,i+ib:n) from the left
               if (i + ib <= n) then
                  call stdlib_ctprfb('L','C','F','C',mb,n - i - ib + 1,ib,lb,b(1,i),ldb,t( &
@@ -50759,7 +50759,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: a(lda,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,onenrm,upper
            character :: normin
@@ -50815,7 +50815,7 @@ module stdlib_linalg_lapack_c
                  kase1 = 2
               end if
               kase = 0
-10            continue
+              10 continue
               call stdlib_clacn2(n,work(n + 1),work,ainvnm,kase,isave)
               if (kase /= 0) then
                  if (kase == kase1) then
@@ -50840,7 +50840,7 @@ module stdlib_linalg_lapack_c
               ! compute the estimate of the reciprocal condition number.
               if (ainvnm /= zero) rcond = (one/anorm)/ainvnm
            end if
-20         continue
+           20 continue
            return
      end subroutine stdlib_ctrcon
 
@@ -50853,7 +50853,7 @@ module stdlib_linalg_lapack_c
      !> overflow in X.
 
      subroutine stdlib_ctrsyl(trana,tranb,isgn,m,n,a,lda,b,ldb,c,ldc,scale,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -50866,7 +50866,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: a(lda,*),b(ldb,*)
            complex(sp),intent(inout) :: c(ldc,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notrna,notrnb
            integer(ilp) :: j,k,l
@@ -51095,7 +51095,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(out) :: work(*)
            complex(sp),intent(inout) :: x1(*),x2(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: childinfo,i,j
            ! Intrinsic Function
@@ -51199,11 +51199,11 @@ module stdlib_linalg_lapack_c
            real(sp),intent(out) :: theta(*)
            real(sp),intent(out) :: rwork(*)
            complex(sp),intent(out) :: u1(ldu1,*),u2(ldu2,*),v1t(ldv1t,*),v2t(ldv2t,*),work(*)
-                     
+
            complex(sp),intent(inout) :: x11(ldx11,*),x12(ldx12,*),x21(ldx21,*),x22(ldx22,*)
-                     
+
         ! ===================================================================
-           
+
            ! Local Scalars
            character :: transt,signst
            integer(ilp) :: childinfo,i,ib11d,ib11e,ib12d,ib12e,ib21d,ib21e,ib22d,ib22e, &
@@ -51414,7 +51414,7 @@ module stdlib_linalg_lapack_c
                  call stdlib_clacpy('L',m - q,p,x12,ldx12,v2t,ldv2t)
                  if (m > p + q) then
                     call stdlib_clacpy('L',m - p - q,m - p - q,x22(p1,q1),ldx22,v2t(p + 1,p + 1),ldv2t)
-                              
+
                  end if
                  call stdlib_cungqr(m - q,m - q,m - q,v2t,ldv2t,work(itauq2),work(iorgqr), &
                            lorgqrwork,info)
@@ -51476,7 +51476,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: tau(*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,iinfo,j,lwkopt,nb,nh
@@ -51568,7 +51568,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: tau(*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper
            integer(ilp) :: i,iinfo,j,lwkopt,nb
@@ -51643,7 +51643,7 @@ module stdlib_linalg_lapack_c
               if (n > 1) then
                  ! generate q(2:n,2:n)
                  call stdlib_cungqr(n - 1,n - 1,n - 1,a(2,2),lda,tau,work,lwork,iinfo)
-                           
+
               end if
            end if
            work(1) = lwkopt
@@ -51671,7 +51671,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: d(*),t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,iinfo,j,jb,jbtemp1,jbtemp2,jnb,nplusone
            ! Intrinsic Functions
@@ -51711,7 +51711,7 @@ module stdlib_linalg_lapack_c
            ! (1-2) solve for v2.
            if (m > n) then
               call stdlib_ctrsm('R','U','N','N',m - n,n,cone,a,lda,a(n + 1,1),lda)
-                        
+
            end if
            ! (2) reconstruct the block reflector t stored in t(1:nb, 1:n)
            ! as a sequence of upper-triangular blocks with nb-size column
@@ -52020,7 +52020,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: ap(*),tau(*)
            complex(sp),intent(out) :: q(ldq,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,iinfo,ij,j
@@ -52113,7 +52113,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: tau(*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: forwrd,left,notran,upper
            integer(ilp) :: i,i1,i2,i3,ic,ii,jc,mi,ni,nq
@@ -52234,7 +52234,7 @@ module stdlib_linalg_lapack_c
                     taui = conjg(tau(i))
                  end if
                  call stdlib_clarf(side,mi,ni,ap(ii),1,taui,c(ic,jc),ldc,work)
-                           
+
                  ap(ii) = aii
                  if (forwrd) then
                     ii = ii + nq - i + 1
@@ -52265,7 +52265,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: ab(ldab,*),c(ldc,*)
            complex(sp),intent(out) :: pt(ldpt,*),q(ldq,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: wantb,wantc,wantpt,wantq
            integer(ilp) :: i,inca,j,j1,j2,kb,kb1,kk,klm,klu1,kun,l,minmn,ml,ml0,mu, &
@@ -52461,9 +52461,9 @@ module stdlib_linalg_lapack_c
                     ab(1,i + 1) = rc*ab(1,i + 1)
                  end if
                  if (wantq) call stdlib_crot(m,q(1,i),1,q(1,i + 1),1,rc,conjg(rs))
-                           
+
                  if (wantc) call stdlib_crot(ncc,c(i,1),ldc,c(i + 1,1),ldc,rc,rs)
-                           
+
               end do
            else
               ! a has been reduced to complex upper bidiagonal form or is
@@ -52544,7 +52544,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: notran
            character :: transn,transt
@@ -52612,7 +52612,7 @@ module stdlib_linalg_lapack_c
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - op(a) * x,
               ! where op(a) = a, a**t, or a**h, depending on trans.
@@ -52694,13 +52694,13 @@ module stdlib_linalg_lapack_c
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_clacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(op(a)**h).
                     call stdlib_cgbtrs(transt,n,kl,ku,1,afb,ldafb,ipiv,work,n,info)
-                              
+
                     do i = 1,n
                        work(i) = rwork(i)*work(i)
                     end do
@@ -52710,7 +52710,7 @@ module stdlib_linalg_lapack_c
                        work(i) = rwork(i)*work(i)
                     end do
                     call stdlib_cgbtrs(transn,n,kl,ku,1,afb,ldafb,ipiv,work,n,info)
-                              
+
                  end if
                  go to 100
               end if
@@ -52771,7 +52771,7 @@ module stdlib_linalg_lapack_c
            if (info == 0) then
               ! solve the system a*x = b, overwriting b with x.
               call stdlib_cgbtrs('NO TRANSPOSE',n,kl,ku,nrhs,ab,ldab,ipiv,b,ldb,info)
-                        
+
            end if
            return
      end subroutine stdlib_cgbsv
@@ -52804,7 +52804,7 @@ module stdlib_linalg_lapack_c
         ! moved setting of info = n+1 so info does not subsequently get
         ! overwritten.  sven, 17 mar 05.
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: colequ,equil,nofact,notran,rowequ
            character :: norm
@@ -52894,11 +52894,11 @@ module stdlib_linalg_lapack_c
            if (equil) then
               ! compute row and column scalings to equilibrate the matrix a.
               call stdlib_cgbequ(n,n,kl,ku,ab,ldab,r,c,rowcnd,colcnd,amax,infequ)
-                        
+
               if (infequ == 0) then
                  ! equilibrate the matrix.
                  call stdlib_claqgb(n,n,kl,ku,ab,ldab,r,c,rowcnd,colcnd,amax,equed)
-                           
+
                  rowequ = stdlib_lsame(equed,'R') .or. stdlib_lsame(equed,'B')
                  colequ = stdlib_lsame(equed,'C') .or. stdlib_lsame(equed,'B')
               end if
@@ -52925,7 +52925,7 @@ module stdlib_linalg_lapack_c
                  j1 = max(j - ku,1)
                  j2 = min(j + kl,n)
                  call stdlib_ccopy(j2 - j1 + 1,ab(ku + 1 - j + j1,j),1,afb(kl + ku + 1 - j + j1,j),1)
-                           
+
               end do
               call stdlib_cgbtrf(n,n,kl,ku,afb,ldafb,ipiv,info)
               ! return if info is non-zero.
@@ -52966,7 +52966,7 @@ module stdlib_linalg_lapack_c
            end if
            ! compute the reciprocal of the condition number of a.
            call stdlib_cgbcon(norm,n,kl,ku,afb,ldafb,ipiv,anorm,rcond,work,rwork,info)
-                     
+
            ! compute the solution matrix x.
            call stdlib_clacpy('FULL',n,nrhs,b,ldb,x,ldx)
            call stdlib_cgbtrs(trans,n,kl,ku,nrhs,afb,ldafb,ipiv,x,ldx,info)
@@ -53019,7 +53019,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: taup(*),tauq(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,iinfo,j,ldwrkx,ldwrky,lwkopt,minmn,nb,nbmin,nx,ws
@@ -53087,7 +53087,7 @@ module stdlib_linalg_lapack_c
               ! an update of the form  a := a - v*y**h - x*u**h
               call stdlib_cgemm('NO TRANSPOSE','CONJUGATE TRANSPOSE',m - i - nb + 1,n - i - nb + 1,nb,- &
               cone,a(i + nb,i),lda,work(ldwrkx*nb + nb + 1),ldwrky,cone,a(i + nb,i + nb),lda)
-                        
+
               call stdlib_cgemm('NO TRANSPOSE','NO TRANSPOSE',m - i - nb + 1,n - i - nb + 1,nb,-cone, &
                         work(nb + 1),ldwrkx,a(i,i + nb),lda,cone,a(i + nb,i + nb),lda)
               ! copy diagonal and off-diagonal elements of b back into a
@@ -53128,7 +53128,7 @@ module stdlib_linalg_lapack_c
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,iinfo,iwt,j,ldwork,lwkopt,nb,nbmin,nh,nx
@@ -53321,7 +53321,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,tpsd
            integer(ilp) :: brow,i,iascl,ibscl,j,mn,nb,scllen,wsize
@@ -53502,7 +53502,7 @@ module stdlib_linalg_lapack_c
            else if (ibscl == 2) then
               call stdlib_clascl('G',0,0,bignum,bnrm,scllen,nrhs,b,ldb,info)
            end if
-50         continue
+           50 continue
            work(1) = real(wsize,KIND=sp)
            return
      end subroutine stdlib_cgels
@@ -53527,7 +53527,7 @@ module stdlib_linalg_lapack_c
            integer(ilp),parameter :: inb = 1
            integer(ilp),parameter :: inbmin = 2
            integer(ilp),parameter :: ixover = 3
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: fjb,iws,j,jb,lwkopt,minmn,minws,na,nb,nbmin,nfxd,nx,sm, &
@@ -53624,7 +53624,7 @@ module stdlib_linalg_lapack_c
                        ! determine the minimum value of nb.
                        nb = lwork/(sn + 1)
                        nbmin = max(2,stdlib_ilaenv(inbmin,'CGEQRF',' ',sm,sn,-1,-1))
-                                 
+
                     end if
                  end if
               end if
@@ -53639,7 +53639,7 @@ module stdlib_linalg_lapack_c
                  j = nfxd + 1
                  ! compute factorization: while loop.
                  topbmn = minmn - nx
-30               continue
+                 30 continue
                  if (j <= topbmn) then
                     jb = min(nb,topbmn - j + 1)
                     ! factorize jb columns among columns j:n.
@@ -53676,7 +53676,7 @@ module stdlib_linalg_lapack_c
            ! Local Scalars
            logical(lk),parameter :: use_recursive_qr = .true.
            integer(ilp) :: i,ib,iinfo,k
-           
+
            ! Executable Statements
            ! test the input arguments
            info = 0
@@ -53738,7 +53738,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: notran
            character :: transn,transt
@@ -53802,7 +53802,7 @@ module stdlib_linalg_lapack_c
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - op(a) * x,
               ! where op(a) = a, a**t, or a**h, depending on trans.
@@ -53881,7 +53881,7 @@ module stdlib_linalg_lapack_c
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_clacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -53929,7 +53929,7 @@ module stdlib_linalg_lapack_c
            integer(ilp),intent(out) :: ipiv(*)
            complex(sp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,iinfo,j,jb,nb
            ! Intrinsic Functions
@@ -53979,7 +53979,7 @@ module stdlib_linalg_lapack_c
                        ! update trailing submatrix.
                        call stdlib_cgemm('NO TRANSPOSE','NO TRANSPOSE',m - j - jb + 1,n - j - jb + 1,jb,- &
                        cone,a(j + jb,j),lda,a(j,j + jb),lda,cone,a(j + jb,j + jb),lda)
-                                 
+
                     end if
                  end if
               end do
@@ -54017,7 +54017,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*),b(ldb,*),d(*)
            complex(sp),intent(out) :: work(*),x(*),y(*)
         ! ===================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,lopt,lwkmin,lwkopt,nb,nb1,nb2,nb3,nb4,np
@@ -54108,7 +54108,7 @@ module stdlib_linalg_lapack_c
            ! solve triangular system: r11*x = d1
            if (m > 0) then
               call stdlib_ctrtrs('UPPER','NO TRANSPOSE','NON UNIT',m,1,a,lda,d,m,info)
-                        
+
               if (info > 0) then
                  info = 2
                  return
@@ -54162,7 +54162,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*),b(ldb,*),q(ldq,*),z(ldz,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: blk22,initq,initz,lquery,wantq,wantz
            character :: compq2,compz2
@@ -54261,7 +54261,7 @@ module stdlib_linalg_lapack_c
                  pw = nblst*nblst + 1
                  do i = 1,n2nb
                     call stdlib_claset('ALL',2*nnb,2*nnb,czero,cone,work(pw),2*nnb)
-                              
+
                     pw = pw + 4*nnb*nnb
                  end do
                  ! reduce columns jcol:jcol+nnb-1 of a to hessenberg form.
@@ -54331,7 +54331,7 @@ module stdlib_linalg_lapack_c
                           call stdlib_clartg(temp,b(jj + 1,jj),c,s,b(jj + 1,jj + 1))
                           b(jj + 1,jj) = czero
                           call stdlib_crot(jj - top,b(top + 1,jj + 1),1,b(top + 1,jj),1,c,s)
-                                    
+
                           a(jj + 1,j) = cmplx(c,KIND=sp)
                           b(jj + 1,j) = -conjg(s)
                        end if
@@ -54387,7 +54387,7 @@ module stdlib_linalg_lapack_c
                                  len*nblst + 1),nblst,work(pw + len),1)
                        call stdlib_cgemv('CONJUGATE',len,nblst - len,cone,work((len + 1)*nblst - &
                        len + 1),nblst,a(jrow + nblst - len,j + 1),1,cone,work(pw + len),1)
-                                 
+
                        ppw = pw
                        do i = jrow,jrow + nblst - 1
                           a(i,j + 1) = work(ppw)
@@ -54439,7 +54439,7 @@ module stdlib_linalg_lapack_c
                  call stdlib_cgemm('CONJUGATE','NO TRANSPOSE',nblst,cola,nblst,cone,work, &
                            nblst,a(j,jcol + nnb),lda,czero,work(pw),nblst)
                  call stdlib_clacpy('ALL',nblst,cola,work(pw),nblst,a(j,jcol + nnb),lda)
-                           
+
                  ppwo = nblst*nblst + 1
                  j0 = j - nnb
                  do j = j0,jcol + 1,-nnb
@@ -54456,7 +54456,7 @@ module stdlib_linalg_lapack_c
                        ! ignore the structure of u.
                        call stdlib_cgemm('CONJUGATE','NO TRANSPOSE',2*nnb,cola,2*nnb,cone, &
                        work(ppwo),2*nnb,a(j,jcol + nnb),lda,czero,work(pw),2*nnb)
-                                 
+
                        call stdlib_clacpy('ALL',2*nnb,cola,work(pw),2*nnb,a(j,jcol + nnb), &
                                   lda)
                     end if
@@ -54475,7 +54475,7 @@ module stdlib_linalg_lapack_c
                     call stdlib_cgemm('NO TRANSPOSE','NO TRANSPOSE',nh,nblst,nblst,cone,q( &
                               topq,j),ldq,work,nblst,czero,work(pw),nh)
                     call stdlib_clacpy('ALL',nh,nblst,work(pw),nh,q(topq,j),ldq)
-                              
+
                     ppwo = nblst*nblst + 1
                     j0 = j - nnb
                     do j = j0,jcol + 1,-nnb
@@ -54491,9 +54491,9 @@ module stdlib_linalg_lapack_c
                           ! ignore the structure of u.
                           call stdlib_cgemm('NO TRANSPOSE','NO TRANSPOSE',nh,2*nnb,2*nnb, &
                           cone,q(topq,j),ldq,work(ppwo),2*nnb,czero,work(pw),nh)
-                                    
+
                           call stdlib_clacpy('ALL',nh,2*nnb,work(pw),nh,q(topq,j),ldq)
-                                    
+
                        end if
                        ppwo = ppwo + 4*nnb*nnb
                     end do
@@ -54506,7 +54506,7 @@ module stdlib_linalg_lapack_c
                     pw = nblst*nblst + 1
                     do i = 1,n2nb
                        call stdlib_claset('ALL',2*nnb,2*nnb,czero,cone,work(pw),2*nnb)
-                                 
+
                        pw = pw + 4*nnb*nnb
                     end do
                     ! accumulate givens rotations into workspace array.
@@ -54560,7 +54560,7 @@ module stdlib_linalg_lapack_c
                     call stdlib_cgemm('NO TRANSPOSE','NO TRANSPOSE',top,nblst,nblst,cone,a( &
                               1,j),lda,work,nblst,czero,work(pw),top)
                     call stdlib_clacpy('ALL',top,nblst,work(pw),top,a(1,j),lda)
-                              
+
                     ppwo = nblst*nblst + 1
                     j0 = j - nnb
                     do j = j0,jcol + 1,-nnb
@@ -54572,9 +54572,9 @@ module stdlib_linalg_lapack_c
                           ! ignore the structure of u.
                           call stdlib_cgemm('NO TRANSPOSE','NO TRANSPOSE',top,2*nnb,2*nnb, &
                           cone,a(1,j),lda,work(ppwo),2*nnb,czero,work(pw),top)
-                                    
+
                           call stdlib_clacpy('ALL',top,2*nnb,work(pw),top,a(1,j),lda)
-                                    
+
                        end if
                        ppwo = ppwo + 4*nnb*nnb
                     end do
@@ -54582,7 +54582,7 @@ module stdlib_linalg_lapack_c
                     call stdlib_cgemm('NO TRANSPOSE','NO TRANSPOSE',top,nblst,nblst,cone,b( &
                               1,j),ldb,work,nblst,czero,work(pw),top)
                     call stdlib_clacpy('ALL',top,nblst,work(pw),top,b(1,j),ldb)
-                              
+
                     ppwo = nblst*nblst + 1
                     j0 = j - nnb
                     do j = j0,jcol + 1,-nnb
@@ -54594,9 +54594,9 @@ module stdlib_linalg_lapack_c
                           ! ignore the structure of u.
                           call stdlib_cgemm('NO TRANSPOSE','NO TRANSPOSE',top,2*nnb,2*nnb, &
                           cone,b(1,j),ldb,work(ppwo),2*nnb,czero,work(pw),top)
-                                    
+
                           call stdlib_clacpy('ALL',top,2*nnb,work(pw),top,b(1,j),ldb)
-                                    
+
                        end if
                        ppwo = ppwo + 4*nnb*nnb
                     end do
@@ -54614,7 +54614,7 @@ module stdlib_linalg_lapack_c
                     call stdlib_cgemm('NO TRANSPOSE','NO TRANSPOSE',nh,nblst,nblst,cone,z( &
                               topq,j),ldz,work,nblst,czero,work(pw),nh)
                     call stdlib_clacpy('ALL',nh,nblst,work(pw),nh,z(topq,j),ldz)
-                              
+
                     ppwo = nblst*nblst + 1
                     j0 = j - nnb
                     do j = j0,jcol + 1,-nnb
@@ -54630,9 +54630,9 @@ module stdlib_linalg_lapack_c
                           ! ignore the structure of u.
                           call stdlib_cgemm('NO TRANSPOSE','NO TRANSPOSE',nh,2*nnb,2*nnb, &
                           cone,z(topq,j),ldz,work(ppwo),2*nnb,czero,work(pw),nh)
-                                    
+
                           call stdlib_clacpy('ALL',nh,2*nnb,work(pw),nh,z(topq,j),ldz)
-                                    
+
                        end if
                        ppwo = ppwo + 4*nnb*nnb
                     end do
@@ -54677,7 +54677,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*),b(ldb,*),c(*),d(*)
            complex(sp),intent(out) :: work(*),x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: lopt,lwkmin,lwkopt,mn,nb,nb1,nb2,nb3,nb4,nr
@@ -54792,7 +54792,7 @@ module stdlib_linalg_lapack_c
      !> condition number is computed as RCOND = 1 / (ANORM * norm(inv(A))).
 
      pure subroutine stdlib_cgtcon(norm,n,dl,d,du,du2,ipiv,anorm,rcond,work,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -54807,7 +54807,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: d(*),dl(*),du(*),du2(*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: onenrm
            integer(ilp) :: i,kase,kase1
@@ -54850,13 +54850,13 @@ module stdlib_linalg_lapack_c
               kase1 = 2
            end if
            kase = 0
-20         continue
+           20 continue
            call stdlib_clacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == kase1) then
                  ! multiply by inv(u)*inv(l).
                  call stdlib_cgttrs('NO TRANSPOSE',n,1,dl,d,du,du2,ipiv,work,n,info)
-                           
+
               else
                  ! multiply by inv(l**h)*inv(u**h).
                  call stdlib_cgttrs('CONJUGATE TRANSPOSE',n,1,dl,d,du,du2,ipiv,work,n, &
@@ -54886,13 +54886,13 @@ module stdlib_linalg_lapack_c
            integer(ilp),intent(in) :: ipiv(*)
            real(sp),intent(out) :: berr(*),ferr(*),rwork(*)
            complex(sp),intent(in) :: b(ldb,*),d(*),df(*),dl(*),dlf(*),du(*),du2(*),duf(*)
-                     
+
            complex(sp),intent(out) :: work(*)
            complex(sp),intent(inout) :: x(ldx,*)
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: notran
            character :: transn,transt
@@ -54952,13 +54952,13 @@ module stdlib_linalg_lapack_c
            loop_110: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - op(a) * x,
               ! where op(a) = a, a**t, or a**h, depending on trans.
               call stdlib_ccopy(n,b(1,j),1,work,1)
               call stdlib_clagtm(trans,n,1,-one,dl,d,du,x(1,j),ldx,one,work,n)
-                        
+
               ! compute abs(op(a))*abs(x) + abs(b) for use in the backward
               ! error bound.
               if (notran) then
@@ -54970,7 +54970,7 @@ module stdlib_linalg_lapack_c
                     do i = 2,n - 1
                        rwork(i) = cabs1(b(i,j)) + cabs1(dl(i - 1))*cabs1(x(i - 1,j)) + &
                        cabs1(d(i))*cabs1(x(i,j)) + cabs1(du(i))*cabs1(x(i + 1,j))
-                                 
+
                     end do
                     rwork(n) = cabs1(b(n,j)) + cabs1(dl(n - 1))*cabs1(x(n - 1,j)) + &
                               cabs1(d(n))*cabs1(x(n,j))
@@ -54984,7 +54984,7 @@ module stdlib_linalg_lapack_c
                     do i = 2,n - 1
                        rwork(i) = cabs1(b(i,j)) + cabs1(du(i - 1))*cabs1(x(i - 1,j)) + &
                        cabs1(d(i))*cabs1(x(i,j)) + cabs1(dl(i))*cabs1(x(i + 1,j))
-                                 
+
                     end do
                     rwork(n) = cabs1(b(n,j)) + cabs1(du(n - 1))*cabs1(x(n - 1,j)) + &
                               cabs1(d(n))*cabs1(x(n,j))
@@ -55043,13 +55043,13 @@ module stdlib_linalg_lapack_c
                  end if
               end do
               kase = 0
-70            continue
+              70 continue
               call stdlib_clacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(op(a)**h).
                     call stdlib_cgttrs(transt,n,1,dlf,df,duf,du2,ipiv,work,n,info)
-                              
+
                     do i = 1,n
                        work(i) = rwork(i)*work(i)
                     end do
@@ -55059,7 +55059,7 @@ module stdlib_linalg_lapack_c
                        work(i) = rwork(i)*work(i)
                     end do
                     call stdlib_cgttrs(transn,n,1,dlf,df,duf,du2,ipiv,work,n,info)
-                              
+
                  end if
                  go to 70
               end if
@@ -55097,7 +55097,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: df(*),dlf(*),du2(*),duf(*)
            complex(sp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nofact,notran
            character :: norm
@@ -55184,7 +55184,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: bb(ldbb,*)
            complex(sp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: update,upper,wantx
            integer(ilp) :: i,i0,i1,i2,inca,j,j1,j1t,j2,j2t,k,ka1,kb1,kbt,l,m,nr, &
@@ -55275,7 +55275,7 @@ module stdlib_linalg_lapack_c
            ! to avoid duplicating code, the two loops are merged.
            update = .true.
            i = n + 1
-10         continue
+           10 continue
            if (update) then
               i = i - 1
               kbt = min(kb,i - 1)
@@ -55319,7 +55319,7 @@ module stdlib_linalg_lapack_c
                  do j = i,i1
                     do k = max(j - ka,i - kbt),i - 1
                        ab(k - j + ka1,j) = ab(k - j + ka1,j) - bb(k - i + kb1,i)*ab(i - j + ka1,j)
-                                 
+
                     end do
                  end do
                  if (wantx) then
@@ -55348,7 +55348,7 @@ module stdlib_linalg_lapack_c
                        work(i - k) = rwork(i - k + ka - m)*t - conjg(work(i - k + ka - m))*ab(1,i - k + ka &
                                  )
                        ab(1,i - k + ka) = work(i - k + ka - m)*t + rwork(i - k + ka - m)*ab(1,i - k + ka)
-                                 
+
                        ra1 = ra
                     end if
                  end if
@@ -55440,7 +55440,7 @@ module stdlib_linalg_lapack_c
                     ! generate rotations in 2nd set to annihilate elements
                     ! which have been created outside the band
                     call stdlib_clargv(nr,ab(1,j2),inca,work(j2),ka1,rwork(j2),ka1)
-                              
+
                     ! apply rotations in 2nd set from the right
                     do l = 1,ka - 1
                        call stdlib_clartv(nr,ab(ka1 - l,j2),inca,ab(ka - l,j2 + 1),inca, &
@@ -55501,7 +55501,7 @@ module stdlib_linalg_lapack_c
                     end do
                     do j = max(1,i - ka),i - kbt - 1
                        ab(k - j + 1,j) = ab(k - j + 1,j) - conjg(bb(i - k + 1,k))*ab(i - j + 1,j)
-                                 
+
                     end do
                  end do
                  do j = i,i1
@@ -55533,9 +55533,9 @@ module stdlib_linalg_lapack_c
                        ! band and store it in work(i-k)
                        t = -bb(k + 1,i - k)*ra1
                        work(i - k) = rwork(i - k + ka - m)*t - conjg(work(i - k + ka - m))*ab(ka1,i - k)
-                                 
+
                        ab(ka1,i - k) = work(i - k + ka - m)*t + rwork(i - k + ka - m)*ab(ka1,i - k)
-                                 
+
                        ra1 = ra
                     end if
                  end if
@@ -55670,7 +55670,7 @@ module stdlib_linalg_lapack_c
               end if
            end if
            go to 10
-480        continue
+           480 continue
            ! **************************** phase 2 *****************************
            ! the logical structure of this phase is:
            ! update = .true.
@@ -55685,7 +55685,7 @@ module stdlib_linalg_lapack_c
            ! to avoid duplicating code, the two loops are merged.
            update = .true.
            i = 0
-490        continue
+           490 continue
            if (update) then
               i = i + 1
               kbt = min(kb,m - i)
@@ -55734,7 +55734,7 @@ module stdlib_linalg_lapack_c
                  do j = i1,i
                     do k = i + 1,min(j + ka,i + kbt)
                        ab(j - k + ka1,k) = ab(j - k + ka1,k) - bb(i - k + kb1,k)*ab(j - i + ka1,i)
-                                 
+
                     end do
                  end do
                  if (wantx) then
@@ -55755,12 +55755,12 @@ module stdlib_linalg_lapack_c
                     if (i + k - ka1 > 0 .and. i + k < m) then
                        ! generate rotation to annihilate a(i+k-ka-1,i)
                        call stdlib_clartg(ab(k + 1,i),ra1,rwork(i + k - ka),work(i + k - ka),ra)
-                                 
+
                        ! create nonzero element a(i+k-ka-1,i+k) outside the
                        ! band and store it in work(m-kb+i+k)
                        t = -bb(kb1 - k,i + k)*ra1
                        work(m - kb + i + k) = rwork(i + k - ka)*t - conjg(work(i + k - ka))*ab(1,i + k)
-                                 
+
                        ab(1,i + k) = work(i + k - ka)*t + rwork(i + k - ka)*ab(1,i + k)
                        ra1 = ra
                     end if
@@ -55807,7 +55807,7 @@ module stdlib_linalg_lapack_c
                     ! post-multiply x by product of rotations in 1st set
                     do j = j1,j2,ka1
                        call stdlib_crot(nx,x(1,j),1,x(1,j - 1),1,rwork(j),work(j))
-                                 
+
                     end do
                  end if
               end do loop_610
@@ -55918,7 +55918,7 @@ module stdlib_linalg_lapack_c
                     end do
                     do j = i + kbt + 1,min(n,i + ka)
                        ab(j - k + 1,k) = ab(j - k + 1,k) - conjg(bb(k - i + 1,i))*ab(j - i + 1,i)
-                                 
+
                     end do
                  end do
                  do j = i1,i
@@ -55951,7 +55951,7 @@ module stdlib_linalg_lapack_c
                        work(m - kb + i + k) = rwork(i + k - ka)*t - conjg(work(i + k - ka))*ab(ka1,i + k - &
                                  ka)
                        ab(ka1,i + k - ka) = work(i + k - ka)*t + rwork(i + k - ka)*ab(ka1,i + k - ka)
-                                 
+
                        ra1 = ra
                     end if
                  end if
@@ -56109,7 +56109,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: ab(ldab,*),q(ldq,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: initq,upper,wantq
            integer(ilp) :: i,i2,ibl,inca,incx,iqaend,iqb,iqend,j,j1,j1end,j1inc,j2, &
@@ -56476,7 +56476,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: a(lda,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,kase
@@ -56524,7 +56524,7 @@ module stdlib_linalg_lapack_c
            end if
            ! estimate the 1-norm of the inverse.
            kase = 0
-30         continue
+           30 continue
            call stdlib_clacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               ! multiply by inv(l*d*l**h) or inv(u*d*u**h).
@@ -56557,7 +56557,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: a(lda,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,kase
@@ -56605,7 +56605,7 @@ module stdlib_linalg_lapack_c
            end if
            ! estimate the 1-norm of the inverse.
            kase = 0
-30         continue
+           30 continue
            call stdlib_clacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               ! multiply by inv(l*d*l**h) or inv(u*d*u**h).
@@ -56633,7 +56633,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,lquery,wantz
            integer(ilp) :: iinfo,imax,inde,indtau,indwrk,iscale,llwork,lwkopt,nb
@@ -56708,10 +56708,10 @@ module stdlib_linalg_lapack_c
               call stdlib_ssterf(n,w,rwork(inde),info)
            else
               call stdlib_cungtr(uplo,n,a,lda,work(indtau),work(indwrk),llwork,iinfo)
-                        
+
               indwrk = inde + n
               call stdlib_csteqr(jobz,n,w,rwork(inde),a,lda,rwork(indwrk),info)
-                        
+
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
            if (iscale == 1) then
@@ -56794,7 +56794,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: work(*),z(ldz,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,lower,lquery,test,valeig,wantz,tryrac
            character :: order
@@ -56991,7 +56991,7 @@ module stdlib_linalg_lapack_c
                  end if
                  call stdlib_cstemr(jobz,'A',n,rwork(indrdd),rwork(indree),vl,vu,il, &
                  iu,m,w,z,ldz,n,isuppz,tryrac,rwork(indrwk),llrwork,iwork,liwork,info)
-                           
+
                  ! apply unitary matrix used in reduction to tridiagonal
                  ! form to eigenvectors returned by stdlib_cstemr.
                  if (wantz .and. info == 0) then
@@ -57028,7 +57028,7 @@ module stdlib_linalg_lapack_c
                         indwkn),llwrkn,iinfo)
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
-30   continue
+           30 continue
            if (iscale == 1) then
               if (info == 0) then
                  imax = m
@@ -57087,7 +57087,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,lower,lquery,test,valeig,wantz
            character :: order
@@ -57237,7 +57237,7 @@ module stdlib_linalg_lapack_c
                            iinfo)
                  call stdlib_scopy(n - 1,rwork(inde),1,rwork(indee),1)
                  call stdlib_csteqr(jobz,n,w,rwork(indee),z,ldz,rwork(indrwk),info)
-                           
+
                  if (info == 0) then
                     do i = 1,n
                        ifail(i) = 0
@@ -57271,7 +57271,7 @@ module stdlib_linalg_lapack_c
                         indwrk),llwork,iinfo)
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
-40   continue
+           40 continue
            if (iscale == 1) then
               if (info == 0) then
                  imax = m
@@ -57319,7 +57319,7 @@ module stdlib_linalg_lapack_c
      !> positive definite.
 
      subroutine stdlib_chegv(itype,jobz,uplo,n,a,lda,b,ldb,w,work,lwork,rwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -57332,7 +57332,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper,wantz
            character :: trans
@@ -57436,7 +57436,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(sp),intent(out) :: work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,lquery,upper,valeig,wantz
            character :: trans
@@ -57523,7 +57523,7 @@ module stdlib_linalg_lapack_c
                     trans = 'C'
                  end if
                  call stdlib_ctrsm('LEFT',uplo,trans,'NON-UNIT',n,m,cone,b,ldb,z,ldz)
-                           
+
               else if (itype == 3) then
                  ! for b*a*x=(lambda)*x;
                  ! backtransform eigenvectors: x = l*y or u**h*y
@@ -57533,7 +57533,7 @@ module stdlib_linalg_lapack_c
                     trans = 'N'
                  end if
                  call stdlib_ctrmm('LEFT',uplo,trans,'NON-UNIT',n,m,cone,b,ldb,z,ldz)
-                           
+
               end if
            end if
            ! set work(1) to optimal complex workspace size.
@@ -57563,7 +57563,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,j,k,kase,nz
@@ -57618,7 +57618,7 @@ module stdlib_linalg_lapack_c
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_ccopy(n,b(1,j),1,work,1)
@@ -57702,7 +57702,7 @@ module stdlib_linalg_lapack_c
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_clacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -57824,7 +57824,7 @@ module stdlib_linalg_lapack_c
      !> the system of equations A * X = B by calling BLAS3 routine CHETRS_3.
 
      pure subroutine stdlib_chesv_rk(uplo,n,nrhs,a,lda,e,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -57902,7 +57902,7 @@ module stdlib_linalg_lapack_c
      !> of equations A * X = B by calling CHETRS_ROOK (uses BLAS 2).
 
      pure subroutine stdlib_chesv_rook(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -57987,7 +57987,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: af(ldaf,*)
            complex(sp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,nofact
            integer(ilp) :: lwkopt,nb
@@ -58108,7 +58108,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(out) :: alpha(*),beta(*),work(*)
            complex(sp),intent(inout) :: h(ldh,*),q(ldq,*),t(ldt,*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: ilazr2,ilazro,ilq,ilschr,ilz,lquery
            integer(ilp) :: icompq,icompz,ifirst,ifrstm,iiter,ilast,ilastm,in,ischur, &
@@ -58338,7 +58338,7 @@ module stdlib_linalg_lapack_c
                        do jch = j,ilast - 1
                           ctemp = t(jch,jch + 1)
                           call stdlib_clartg(ctemp,t(jch + 1,jch + 1),c,s,t(jch,jch + 1))
-                                    
+
                           t(jch + 1,jch + 1) = czero
                           if (jch < ilastm - 1) call stdlib_crot(ilastm - jch - 1,t(jch,jch + 2),ldt, &
                                     t(jch + 1,jch + 2),ldt,c,s)
@@ -58348,14 +58348,14 @@ module stdlib_linalg_lapack_c
                                      s))
                           ctemp = h(jch + 1,jch)
                           call stdlib_clartg(ctemp,h(jch + 1,jch - 1),c,s,h(jch + 1,jch))
-                                    
+
                           h(jch + 1,jch - 1) = czero
                           call stdlib_crot(jch + 1 - ifrstm,h(ifrstm,jch),1,h(ifrstm,jch - 1), &
                                     1,c,s)
                           call stdlib_crot(jch - ifrstm,t(ifrstm,jch),1,t(ifrstm,jch - 1),1, &
                                      c,s)
                           if (ilz) call stdlib_crot(n,z(1,jch),1,z(1,jch - 1),1,c,s)
-                                    
+
                        end do
                        go to 50
                     end if
@@ -58371,7 +58371,7 @@ module stdlib_linalg_lapack_c
               go to 210
               ! t(ilast,ilast)=0 -- clear h(ilast,ilast-1) to split off a
               ! 1x1 block.
-50   continue
+              50 continue
               ctemp = h(ilast,ilast)
               call stdlib_clartg(ctemp,h(ilast,ilast - 1),c,s,h(ilast,ilast))
               h(ilast,ilast - 1) = czero
@@ -58381,7 +58381,7 @@ module stdlib_linalg_lapack_c
                         )
               if (ilz) call stdlib_crot(n,z(1,ilast),1,z(1,ilast - 1),1,c,s)
               ! h(ilast,ilast-1)=0 -- standardize b, set alpha and beta
-60   continue
+              60 continue
               absb = abs(t(ilast,ilast))
               if (absb > safmin) then
                  signbc = conjg(t(ilast,ilast)/absb)
@@ -58412,7 +58412,7 @@ module stdlib_linalg_lapack_c
               ! qz step
               ! this iteration only involves rows/columns ifirst:ilast.  we
               ! assume ifirst < ilast, and that the diagonal of b is non-zero.
-70   continue
+              70 continue
               iiter = iiter + 1
               if (.not. ilschr) then
                  ifrstm = ifirst
@@ -58453,7 +58453,7 @@ module stdlib_linalg_lapack_c
                  if ((iiter/20)*20 == iiter .and. bscale*abs1(t(ilast,ilast)) > safmin) &
                            then
                     eshift = eshift + (ascale*h(ilast,ilast))/(bscale*t(ilast,ilast))
-                              
+
                  else
                     eshift = eshift + (ascale*h(ilast,ilast - 1))/(bscale*t(ilast - 1,ilast - 1) &
                                )
@@ -58475,7 +58475,7 @@ module stdlib_linalg_lapack_c
               end do
               istart = ifirst
               ctemp = ascale*h(ifirst,ifirst) - shift*(bscale*t(ifirst,ifirst))
-90            continue
+              90 continue
               ! do an implicit-shift qz sweep.
               ! initial q
               ctemp2 = ascale*h(istart + 1,istart)
@@ -58523,14 +58523,14 @@ module stdlib_linalg_lapack_c
                     end do
                  end if
               end do loop_150
-160           continue
+              160 continue
            end do loop_170
            ! drop-through = non-convergence
-180  continue
+           180 continue
            info = ilast
            go to 210
            ! successful completion of all qz steps
-190  continue
+           190 continue
            ! set eigenvalues 1:ilo-1
            do j = 1,ilo - 1
               absb = abs(t(j,j))
@@ -58553,7 +58553,7 @@ module stdlib_linalg_lapack_c
            ! normal termination
            info = 0
            ! exit (other than argument error) -- return optimal workspace size
-210  continue
+           210 continue
            work(1) = cmplx(n,KIND=sp)
            return
      end subroutine stdlib_chgeqz
@@ -58579,7 +58579,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: ap(*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,ip,kase
@@ -58627,7 +58627,7 @@ module stdlib_linalg_lapack_c
            end if
            ! estimate the 1-norm of the inverse.
            kase = 0
-30         continue
+           30 continue
            call stdlib_clacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               ! multiply by inv(l*d*l**h) or inv(u*d*u**h).
@@ -58655,7 +58655,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: ap(*)
            complex(sp),intent(out) :: work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: wantz
            integer(ilp) :: iinfo,imax,inde,indrwk,indtau,indwrk,iscale
@@ -58719,10 +58719,10 @@ module stdlib_linalg_lapack_c
            else
               indwrk = indtau + n
               call stdlib_cupgtr(uplo,n,ap,work(indtau),z,ldz,work(indwrk),iinfo)
-                        
+
               indrwk = inde + n
               call stdlib_csteqr(jobz,n,w,rwork(inde),z,ldz,rwork(indrwk),info)
-                        
+
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
            if (iscale == 1) then
@@ -58757,7 +58757,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: ap(*)
            complex(sp),intent(out) :: work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,test,valeig,wantz
            character :: order
@@ -58857,7 +58857,7 @@ module stdlib_linalg_lapack_c
            indtau = 1
            indwrk = indtau + n
            call stdlib_chptrd(uplo,n,ap,rwork(indd),rwork(inde),work(indtau),iinfo)
-                     
+
            ! if all eigenvalues are desired and abstol is less than or equal
            ! to zero, then call stdlib_ssterf or stdlib_cupgtr and stdlib_csteqr.  if this fails
            ! for some eigenvalue, then try stdlib_sstebz.
@@ -58875,10 +58875,10 @@ module stdlib_linalg_lapack_c
                  call stdlib_ssterf(n,w,rwork(indee),info)
               else
                  call stdlib_cupgtr(uplo,n,ap,work(indtau),z,ldz,work(indwrk),iinfo)
-                           
+
                  call stdlib_scopy(n - 1,rwork(inde),1,rwork(indee),1)
                  call stdlib_csteqr(jobz,n,w,rwork(indee),z,ldz,rwork(indrwk),info)
-                           
+
                  if (info == 0) then
                     do i = 1,n
                        ifail(i) = 0
@@ -58913,7 +58913,7 @@ module stdlib_linalg_lapack_c
                          iinfo)
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
-20   continue
+           20 continue
            if (iscale == 1) then
               if (info == 0) then
                  imax = m
@@ -59172,7 +59172,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,ik,j,k,kase,kk,nz
@@ -59223,7 +59223,7 @@ module stdlib_linalg_lapack_c
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_ccopy(n,b(1,j),1,work,1)
@@ -59314,7 +59314,7 @@ module stdlib_linalg_lapack_c
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_clacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -59417,7 +59417,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: ap(*),b(ldb,*)
            complex(sp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nofact
            real(sp) :: anorm
@@ -59497,7 +59497,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: rzero = 0.0e+0_sp
-           
+
            ! Local Scalars
            logical(lk) :: bothv,fromqr,leftv,noinit,rightv
            integer(ilp) :: i,iinfo,k,kl,kln,kr,ks,ldwork
@@ -59574,13 +59574,13 @@ module stdlib_linalg_lapack_c
                     do i = k,kl + 1,-1
                        if (h(i,i - 1) == czero) go to 30
                     end do
-30                  continue
+                    30 continue
                     kl = i
                     if (k > kr) then
                        do i = k,n - 1
                           if (h(i + 1,i) == czero) go to 50
                        end do
-50                     continue
+                       50 continue
                        kr = i
                     end if
                  end if
@@ -59602,7 +59602,7 @@ module stdlib_linalg_lapack_c
                  ! selected eigenvalues affiliated to the submatrix
                  ! h(kl:kr,kl:kr). close roots are modified by eps3.
                  wk = w(k)
-60               continue
+                 60 continue
                  do i = k - 1,kl,-1
                     if (select(i) .and. cabs1(w(i) - wk) < eps3) then
                        wk = wk + eps3
@@ -59650,7 +59650,7 @@ module stdlib_linalg_lapack_c
      !> corresponding eigenvectors of the dense or band matrix.
 
      pure subroutine stdlib_claed0(qsiz,n,d,e,q,ldq,qstore,ldqs,rwork,iwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -59665,7 +59665,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(out) :: qstore(ldqs,*)
         ! =====================================================================
         ! warning:      n could be as big as qsiz!
-           
+
            ! Local Scalars
            integer(ilp) :: curlvl,curprb,curr,i,igivcl,igivnm,igivpt,indxq,iperm,iprmpt, &
            iq,iqptr,iwrem,j,k,lgn,ll,matsiz,msd2,smlsiz,smm1,spm1,spm2,submat, &
@@ -59701,7 +59701,7 @@ module stdlib_linalg_lapack_c
            iwork(1) = n
            subpbs = 1
            tlvls = 0
-10         continue
+           10 continue
            if (iwork(subpbs) > smlsiz) then
               do j = subpbs,1,-1
                  iwork(2*j) = (iwork(j) + 1)/2
@@ -59776,7 +59776,7 @@ module stdlib_linalg_lapack_c
            ! into eigensystem for the corresponding larger matrix.
            ! while ( subpbs > 1 )
            curlvl = 1
-80         continue
+           80 continue
            if (subpbs > 1) then
               spm2 = subpbs - 2
               do i = 0,spm2,2
@@ -59896,7 +59896,7 @@ module stdlib_linalg_lapack_c
            end if
            if ((nb <= k) .or. (nb >= max(m,n,k))) then
              call stdlib_cgemlqt(side,trans,m,n,k,mb,a,lda,t,ldt,c,ldc,work,info)
-                       
+
              return
            end if
            if (left .and. tran) then
@@ -60058,7 +60058,7 @@ module stdlib_linalg_lapack_c
            end if
            if ((mb <= k) .or. (mb >= max(m,n,k))) then
              call stdlib_cgemqrt(side,trans,m,n,k,nb,a,lda,t,ldt,c,ldc,work,info)
-                       
+
              return
             end if
            if (left .and. notran) then
@@ -60171,7 +60171,7 @@ module stdlib_linalg_lapack_c
            ! Parameters
            real(sp),parameter :: rzero = 0.0_sp
            real(sp),parameter :: rone = 1.0_sp
-           
+
            ! Local Scalars
            complex(sp) :: beta,cdum,s,tau
            real(sp) :: foo,safmax,safmin,smlnum,ulp
@@ -60194,7 +60194,7 @@ module stdlib_linalg_lapack_c
               lwk1 = int(work(1),KIND=ilp)
               ! ==== workspace query call to stdlib_cunmhr ====
               call stdlib_cunmhr('R','N',jw,jw,1,jw - 1,t,ldt,work,v,ldv,work,-1,info)
-                        
+
               lwk2 = int(work(1),KIND=ilp)
               ! ==== optimal workspace ====
               lwkopt = jw + max(lwk1,lwk2)
@@ -60279,7 +60279,7 @@ module stdlib_linalg_lapack_c
                  end do
                  ilst = i
                  if (ifst /= ilst) call stdlib_ctrexc('V',jw,t,ldt,v,ldv,ifst,ilst,info)
-                           
+
               end do
            end if
            ! ==== restore shift/eigenvalue array from t ====
@@ -60298,11 +60298,11 @@ module stdlib_linalg_lapack_c
                  work(1) = cone
                  call stdlib_claset('L',jw - 2,jw - 2,czero,czero,t(3,1),ldt)
                  call stdlib_clarf('L',ns,jw,work,1,conjg(tau),t,ldt,work(jw + 1))
-                           
+
                  call stdlib_clarf('R',ns,ns,work,1,tau,t,ldt,work(jw + 1))
                  call stdlib_clarf('R',jw,ns,work,1,tau,v,ldv,work(jw + 1))
                  call stdlib_cgehrd(jw,1,ns,t,ldt,work,work(jw + 1),lwork - jw,info)
-                           
+
               end if
               ! ==== copy updated reduced window into place ====
               if (kwtop > 1) h(kwtop,kwtop - 1) = s*conjg(v(1,1))
@@ -60603,7 +60603,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: ab(ldab,*),afb(ldafb,*),b(ldb,*)
            complex(sp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: equil,nofact,rcequ,upper
            integer(ilp) :: i,infequ,j,j1,j2
@@ -60692,7 +60692,7 @@ module stdlib_linalg_lapack_c
                  do j = 1,n
                     j1 = max(j - kd,1)
                     call stdlib_ccopy(j - j1 + 1,ab(kd + 1 - j + j1,j),1,afb(kd + 1 - j + j1,j),1)
-                              
+
                  end do
               else
                  do j = 1,n
@@ -60754,7 +60754,7 @@ module stdlib_linalg_lapack_c
            ! Array Arguments
            complex(sp),intent(inout) :: a(0:*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,nisodd,normaltransr
            integer(ilp) :: n1,n2,k
@@ -60806,7 +60806,7 @@ module stdlib_linalg_lapack_c
                     call stdlib_cpotrf('L',n1,a(0),n,info)
                     if (info > 0) return
                     call stdlib_ctrsm('R','L','C','N',n2,n1,cone,a(0),n,a(n1),n)
-                              
+
                     call stdlib_cherk('U','N',n2,n1,-one,a(n1),n,one,a(n),n)
                     call stdlib_cpotrf('U',n2,a(n),n,info)
                     if (info > 0) info = info + n1
@@ -60817,7 +60817,7 @@ module stdlib_linalg_lapack_c
                     call stdlib_cpotrf('L',n1,a(n2),n,info)
                     if (info > 0) return
                     call stdlib_ctrsm('L','L','N','N',n1,n2,cone,a(n2),n,a(0),n)
-                              
+
                     call stdlib_cherk('U','C',n2,n1,-one,a(0),n,one,a(n1),n)
                     call stdlib_cpotrf('U',n2,a(n1),n,info)
                     if (info > 0) info = info + n1
@@ -60833,7 +60833,7 @@ module stdlib_linalg_lapack_c
                     call stdlib_ctrsm('L','U','C','N',n1,n2,cone,a(0),n1,a(n1*n1), &
                               n1)
                     call stdlib_cherk('L','C',n2,n1,-one,a(n1*n1),n1,one,a(1),n1)
-                              
+
                     call stdlib_cpotrf('L',n2,a(1),n1,info)
                     if (info > 0) info = info + n1
                  else
@@ -60845,7 +60845,7 @@ module stdlib_linalg_lapack_c
                     call stdlib_ctrsm('R','U','N','N',n2,n1,cone,a(n2*n2),n2,a(0), &
                               n2)
                     call stdlib_cherk('L','N',n2,n1,-one,a(0),n2,one,a(n1*n2),n2)
-                              
+
                     call stdlib_cpotrf('L',n2,a(n1*n2),n2,info)
                     if (info > 0) info = info + n1
                  end if
@@ -60861,9 +60861,9 @@ module stdlib_linalg_lapack_c
                     call stdlib_cpotrf('L',k,a(1),n + 1,info)
                     if (info > 0) return
                     call stdlib_ctrsm('R','L','C','N',k,k,cone,a(1),n + 1,a(k + 1),n + 1)
-                              
+
                     call stdlib_cherk('U','N',k,k,-one,a(k + 1),n + 1,one,a(0),n + 1)
-                              
+
                     call stdlib_cpotrf('U',k,a(0),n + 1,info)
                     if (info > 0) info = info + k
                  else
@@ -60873,9 +60873,9 @@ module stdlib_linalg_lapack_c
                     call stdlib_cpotrf('L',k,a(k + 1),n + 1,info)
                     if (info > 0) return
                     call stdlib_ctrsm('L','L','N','N',k,k,cone,a(k + 1),n + 1,a(0),n + 1)
-                              
+
                     call stdlib_cherk('U','C',k,k,-one,a(0),n + 1,one,a(k),n + 1)
-                              
+
                     call stdlib_cpotrf('U',k,a(k),n + 1,info)
                     if (info > 0) info = info + k
                  end if
@@ -60890,7 +60890,7 @@ module stdlib_linalg_lapack_c
                     call stdlib_ctrsm('L','U','C','N',k,k,cone,a(k),n1,a(k*(k + 1)), &
                               k)
                     call stdlib_cherk('L','C',k,k,-one,a(k*(k + 1)),k,one,a(0),k)
-                              
+
                     call stdlib_cpotrf('L',k,a(0),k,info)
                     if (info > 0) info = info + k
                  else
@@ -60925,7 +60925,7 @@ module stdlib_linalg_lapack_c
            ! Array Arguments
            complex(sp),intent(inout) :: a(0:*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,nisodd,normaltransr
            integer(ilp) :: n1,n2,k
@@ -60981,7 +60981,7 @@ module stdlib_linalg_lapack_c
                     call stdlib_clauum('L',n1,a(0),n,info)
                     call stdlib_cherk('L','C',n1,n2,one,a(n1),n,one,a(0),n)
                     call stdlib_ctrmm('L','U','N','N',n2,n1,cone,a(n),n,a(n1),n)
-                              
+
                     call stdlib_clauum('U',n2,a(n),n,info)
                  else
                     ! srpa for upper, normal and n is odd ( a(0:n-1,0:n2-1)
@@ -60990,7 +60990,7 @@ module stdlib_linalg_lapack_c
                     call stdlib_clauum('L',n1,a(n2),n,info)
                     call stdlib_cherk('L','N',n1,n2,one,a(0),n,one,a(n2),n)
                     call stdlib_ctrmm('R','U','C','N',n1,n2,cone,a(n1),n,a(0),n)
-                              
+
                     call stdlib_clauum('U',n2,a(n1),n,info)
                  end if
               else
@@ -61000,7 +61000,7 @@ module stdlib_linalg_lapack_c
                     ! t1 -> a(0), t2 -> a(1), s -> a(0+n1*n1)
                     call stdlib_clauum('U',n1,a(0),n1,info)
                     call stdlib_cherk('U','N',n1,n2,one,a(n1*n1),n1,one,a(0),n1)
-                              
+
                     call stdlib_ctrmm('R','L','N','N',n1,n2,cone,a(1),n1,a(n1*n1), &
                               n1)
                     call stdlib_clauum('L',n2,a(1),n1,info)
@@ -61009,7 +61009,7 @@ module stdlib_linalg_lapack_c
                     ! t1 -> a(0+n2*n2), t2 -> a(0+n1*n2), s -> a(0)
                     call stdlib_clauum('U',n1,a(n2*n2),n2,info)
                     call stdlib_cherk('U','C',n1,n2,one,a(0),n2,one,a(n2*n2),n2)
-                              
+
                     call stdlib_ctrmm('L','L','C','N',n2,n1,cone,a(n1*n2),n2,a(0), &
                               n2)
                     call stdlib_clauum('L',n2,a(n1*n2),n2,info)
@@ -61025,9 +61025,9 @@ module stdlib_linalg_lapack_c
                     ! t1 -> a(1), t2 -> a(0), s -> a(k+1)
                     call stdlib_clauum('L',k,a(1),n + 1,info)
                     call stdlib_cherk('L','C',k,k,one,a(k + 1),n + 1,one,a(1),n + 1)
-                              
+
                     call stdlib_ctrmm('L','U','N','N',k,k,cone,a(0),n + 1,a(k + 1),n + 1)
-                              
+
                     call stdlib_clauum('U',k,a(0),n + 1,info)
                  else
                     ! srpa for upper, normal, and n is even ( a(0:n,0:k-1) )
@@ -61035,9 +61035,9 @@ module stdlib_linalg_lapack_c
                     ! t1 -> a(k+1), t2 -> a(k), s -> a(0)
                     call stdlib_clauum('L',k,a(k + 1),n + 1,info)
                     call stdlib_cherk('L','N',k,k,one,a(0),n + 1,one,a(k + 1),n + 1)
-                              
+
                     call stdlib_ctrmm('R','U','C','N',k,k,cone,a(k),n + 1,a(0),n + 1)
-                              
+
                     call stdlib_clauum('U',k,a(k),n + 1,info)
                  end if
               else
@@ -61048,7 +61048,7 @@ module stdlib_linalg_lapack_c
                     ! t1 -> a(0+k), t2 -> a(0+0), s -> a(0+k*(k+1)); lda=k
                     call stdlib_clauum('U',k,a(k),k,info)
                     call stdlib_cherk('U','N',k,k,one,a(k*(k + 1)),k,one,a(k),k)
-                              
+
                     call stdlib_ctrmm('R','L','N','N',k,k,cone,a(0),k,a(k*(k + 1)), &
                               k)
                     call stdlib_clauum('L',k,a(0),k,info)
@@ -61058,9 +61058,9 @@ module stdlib_linalg_lapack_c
                     ! t1 -> a(0+k*(k+1)), t2 -> a(0+k*k), s -> a(0+0)); lda=k
                     call stdlib_clauum('U',k,a(k*(k + 1)),k,info)
                     call stdlib_cherk('U','C',k,k,one,a(0),k,one,a(k*(k + 1)),k)
-                              
+
                     call stdlib_ctrmm('L','L','C','N',k,k,cone,a(k*k),k,a(0),k)
-                              
+
                     call stdlib_clauum('L',k,a(k*k),k,info)
                  end if
               end if
@@ -61144,7 +61144,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*),af(ldaf,*),b(ldb,*)
            complex(sp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: equil,nofact,rcequ
            integer(ilp) :: i,infequ,j
@@ -61286,7 +61286,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,ix,j,nz
@@ -61335,7 +61335,7 @@ module stdlib_linalg_lapack_c
            loop_100: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x.  also compute
               ! abs(a)*abs(x) + abs(b) for use in the backward error bound.
@@ -61351,7 +61351,7 @@ module stdlib_linalg_lapack_c
                     ex = e(1)*x(2,j)
                     work(1) = bi - dx - ex
                     rwork(1) = cabs1(bi) + cabs1(dx) + cabs1(e(1))*cabs1(x(2,j))
-                              
+
                     do i = 2,n - 1
                        bi = b(i,j)
                        cx = conjg(e(i - 1))*x(i - 1,j)
@@ -61380,7 +61380,7 @@ module stdlib_linalg_lapack_c
                     ex = conjg(e(1))*x(2,j)
                     work(1) = bi - dx - ex
                     rwork(1) = cabs1(bi) + cabs1(dx) + cabs1(e(1))*cabs1(x(2,j))
-                              
+
                     do i = 2,n - 1
                        bi = b(i,j)
                        cx = e(i - 1)*x(i - 1,j)
@@ -61544,7 +61544,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: ef(*)
            complex(sp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nofact
            real(sp) :: anorm
@@ -61624,7 +61624,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(out) :: work(*)
            complex(sp),intent(inout) :: z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: finish,i,icompz,ii,j,k,lgn,liwmin,ll,lrwmin,lwmin,m,smlsiz, &
@@ -61737,7 +61737,7 @@ module stdlib_linalg_lapack_c
               eps = stdlib_slamch('EPSILON')
               start = 1
               ! while ( start <= n )
-30   continue
+              30 continue
               if (start <= n) then
                  ! let finish be the position of the next subdiagonal entry
                  ! such that e( finish ) <= tiny or finish = n if no such
@@ -61745,7 +61745,7 @@ module stdlib_linalg_lapack_c
                  ! between start and finish constitutes an independent
                  ! sub-problem.
                  finish = start
-40               continue
+                 40 continue
                  if (finish < n) then
                     tiny = eps*sqrt(abs(d(finish)))*sqrt(abs(d(finish + 1)))
                     if (abs(e(finish)) > tiny) then
@@ -61760,7 +61760,7 @@ module stdlib_linalg_lapack_c
                     orgnrm = stdlib_slanst('M',m,d(start),e(start))
                     call stdlib_slascl('G',0,0,orgnrm,one,m,1,d(start),m,info)
                     call stdlib_slascl('G',0,0,orgnrm,one,m - 1,1,e(start),m - 1,info)
-                              
+
                     call stdlib_claed0(n,m,d(start),e(start),z(1,start),ldz,work,n, &
                               rwork,iwork,info)
                     if (info > 0) then
@@ -61803,7 +61803,7 @@ module stdlib_linalg_lapack_c
                 end if
               end do
            end if
-70         continue
+           70 continue
            work(1) = lwmin
            rwork(1) = lrwmin
            iwork(1) = liwmin
@@ -61890,7 +61890,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: idifjb = 3
-           
+
            ! Local Scalars
            logical(lk) :: lquery,swap,wantd,wantd1,wantd2,wantp
            integer(ilp) :: i,ierr,ijb,k,kase,ks,liwmin,lwmin,mn2,n1,n2
@@ -62069,7 +62069,7 @@ module stdlib_linalg_lapack_c
                  ijb = 0
                  mn2 = 2*n1*n2
                  ! 1-norm-based estimate of difu.
-40   continue
+                 40 continue
                  call stdlib_clacn2(mn2,work(mn2 + 1),work,dif(1),kase,isave)
                  if (kase /= 0) then
                     if (kase == 1) then
@@ -62087,7 +62087,7 @@ module stdlib_linalg_lapack_c
                  end if
                  dif(1) = dscale/dif(1)
                  ! 1-norm-based estimate of difl.
-50   continue
+                 50 continue
                  call stdlib_clacn2(mn2,work(mn2 + 1),work,dif(2),kase,isave)
                  if (kase /= 0) then
                     if (kase == 1) then
@@ -62124,7 +62124,7 @@ module stdlib_linalg_lapack_c
               alpha(k) = a(k,k)
               beta(k) = b(k,k)
            end do
-70         continue
+           70 continue
            work(1) = lwmin
            iwork(1) = liwmin
            return
@@ -62153,7 +62153,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: idifjb = 3
-           
+
            ! Local Scalars
            logical(lk) :: lquery,somcon,wantbh,wantdf,wants
            integer(ilp) :: i,ierr,ifst,ilst,k,ks,lwmin,n1,n2
@@ -62309,7 +62309,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: q(ldq,*),t(ldt,*)
            complex(sp),intent(out) :: w(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wantbh,wantq,wants,wantsp
            integer(ilp) :: ierr,k,kase,ks,lwmin,n1,n2,nn
@@ -62398,7 +62398,7 @@ module stdlib_linalg_lapack_c
               ! estimate sep(t11,t22).
               est = zero
               kase = 0
-30            continue
+              30 continue
               call stdlib_clacn2(nn,work(nn + 1),work,est,kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -62414,7 +62414,7 @@ module stdlib_linalg_lapack_c
               end if
               sep = scale/est
            end if
-40         continue
+           40 continue
            ! copy reordered eigenvalues to w.
            do k = 1,n
               w(k) = t(k,k)
@@ -62452,7 +62452,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(out) :: taup1(*),taup2(*),tauq1(*),work(*)
            complex(sp),intent(inout) :: x11(ldx11,*),x21(ldx21,*)
         ! ====================================================================
-           
+
            ! Local Scalars
            real(sp) :: c,s
            integer(ilp) :: childinfo,i,ilarf,iorbdb5,llarf,lorbdb5,lworkmin, &
@@ -62557,7 +62557,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(out) :: taup1(*),taup2(*),tauq1(*),work(*)
            complex(sp),intent(inout) :: x11(ldx11,*),x21(ldx21,*)
         ! ====================================================================
-           
+
            ! Local Scalars
            real(sp) :: c,s
            integer(ilp) :: childinfo,i,ilarf,iorbdb5,llarf,lorbdb5,lworkmin, &
@@ -62672,7 +62672,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(out) :: taup1(*),taup2(*),tauq1(*),work(*)
            complex(sp),intent(inout) :: x11(ldx11,*),x21(ldx21,*)
         ! ====================================================================
-           
+
            ! Local Scalars
            real(sp) :: c,s
            integer(ilp) :: childinfo,i,ilarf,iorbdb5,llarf,lorbdb5,lworkmin, &
@@ -62786,7 +62786,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(out) :: phantom(*),taup1(*),taup2(*),tauq1(*),work(*)
            complex(sp),intent(inout) :: x11(ldx11,*),x21(ldx21,*)
         ! ====================================================================
-           
+
            ! Local Scalars
            real(sp) :: c,s
            integer(ilp) :: childinfo,i,ilarf,iorbdb5,j,llarf,lorbdb5,lworkmin, &
@@ -62841,7 +62841,7 @@ module stdlib_linalg_lapack_c
                  call stdlib_clarfgp(p,phantom(1),phantom(2),1,taup1(1))
                  call stdlib_clarfgp(m - p,phantom(p + 1),phantom(p + 2),1,taup2(1))
                  theta(i) = atan2(real(phantom(1),KIND=sp),real(phantom(p + 1),KIND=sp))
-                           
+
                  c = cos(theta(i))
                  s = sin(theta(i))
                  phantom(1) = cone
@@ -62897,7 +62897,7 @@ module stdlib_linalg_lapack_c
            do i = p + 1,q
               call stdlib_clacgv(q - i + 1,x21(m - q + i - p,i),ldx21)
               call stdlib_clarfgp(q - i + 1,x21(m - q + i - p,i),x21(m - q + i - p,i + 1),ldx21,tauq1(i))
-                        
+
               x21(m - q + i - p,i) = cone
               call stdlib_clarf('R',q - i,q - i + 1,x21(m - q + i - p,i),ldx21,tauq1(i),x21(m - q + i - p + 1,i) &
                         ,ldx21,work(ilarf))
@@ -62940,7 +62940,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: x11(ldx11,*),x21(ldx21,*)
            integer(ilp),intent(out) :: iwork(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: childinfo,i,ib11d,ib11e,ib12d,ib12e,ib21d,ib21e,ib22d,ib22e, &
            ibbcsd,iorbdb,iorglq,iorgqr,iphi,itaup1,itaup2,itauq1,j,lbbcsd,lorbdb, &
@@ -63040,13 +63040,13 @@ module stdlib_linalg_lapack_c
                  end if
                  if (wantu2 .and. m - p > 0) then
                     call stdlib_cungqr(m - p,m - p,q,u2,ldu2,cdum,work(1),-1,childinfo)
-                              
+
                     lorgqrmin = max(lorgqrmin,m - p)
                     lorgqropt = max(lorgqropt,int(work(1),KIND=ilp))
                  end if
                  if (wantv1t .and. q > 0) then
                     call stdlib_cunglq(q - 1,q - 1,q - 1,v1t,ldv1t,cdum,work(1),-1,childinfo)
-                              
+
                     lorglqmin = max(lorglqmin,q - 1)
                     lorglqopt = max(lorglqopt,int(work(1),KIND=ilp))
                  end if
@@ -63066,7 +63066,7 @@ module stdlib_linalg_lapack_c
                  end if
                  if (wantu2 .and. m - p > 0) then
                     call stdlib_cungqr(m - p,m - p,q,u2,ldu2,cdum,work(1),-1,childinfo)
-                              
+
                     lorgqrmin = max(lorgqrmin,m - p)
                     lorgqropt = max(lorgqropt,int(work(1),KIND=ilp))
                  end if
@@ -63114,7 +63114,7 @@ module stdlib_linalg_lapack_c
                  end if
                  if (wantu2 .and. m - p > 0) then
                     call stdlib_cungqr(m - p,m - p,m - q,u2,ldu2,cdum,work(1),-1,childinfo)
-                              
+
                     lorgqrmin = max(lorgqrmin,m - p)
                     lorgqropt = max(lorgqropt,int(work(1),KIND=ilp))
                  end if
@@ -63314,7 +63314,7 @@ module stdlib_linalg_lapack_c
                  call stdlib_clacpy('U',p - (m - q),q - (m - q),x11(m - q + 1,m - q + 1),ldx11,v1t(m - q + 1,m - q + &
                            1),ldv1t)
                  call stdlib_clacpy('U',-p + q,q - p,x21(m - q + 1,p + 1),ldx21,v1t(p + 1,p + 1),ldv1t)
-                           
+
                  call stdlib_cunglq(q,q,q,v1t,ldv1t,work(itauq1),work(iorglq),lorglq, &
                            childinfo)
               end if
@@ -63373,7 +63373,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: tau(*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wantq
            integer(ilp) :: i,iinfo,j,lwkopt,mn
@@ -63457,7 +63457,7 @@ module stdlib_linalg_lapack_c
                  if (m > 1) then
                     ! form q(2:m,2:m)
                     call stdlib_cungqr(m - 1,m - 1,m - 1,a(2,2),lda,tau,work,lwork,iinfo)
-                              
+
                  end if
               end if
            else
@@ -63484,7 +63484,7 @@ module stdlib_linalg_lapack_c
                  if (n > 1) then
                     ! form p**h(2:n,2:n)
                     call stdlib_cunglq(n - 1,n - 1,n - 1,a(2,2),lda,tau,work,lwork,iinfo)
-                              
+
                  end if
               end if
            end if
@@ -63510,7 +63510,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(in) :: t(ldt,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: iinfo,ldc,lworkopt,lc,lw,nblocal,j
@@ -63917,7 +63917,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: iascl,ibscl,ie,il,itau,itaup,itauq,ldwork,liwork,lrwork, &
@@ -63965,9 +63965,9 @@ module stdlib_linalg_lapack_c
                               ! columns.
                     mm = n
                     maxwrk = max(maxwrk,n*stdlib_ilaenv(1,'CGEQRF',' ',m,n,-1,-1))
-                              
+
                     maxwrk = max(maxwrk,nrhs*stdlib_ilaenv(1,'CUNMQR','LC',m,nrhs,n,-1))
-                              
+
                  end if
                  if (m >= n) then
                     ! path 1 - overdetermined or exactly determined.
@@ -64007,7 +64007,7 @@ module stdlib_linalg_lapack_c
                     else
                        ! path 2 - underdetermined.
                        maxwrk = 2*m + (n + m)*stdlib_ilaenv(1,'CGEBRD',' ',m,n,-1,-1)
-                                 
+
                        maxwrk = max(maxwrk,2*m + nrhs*stdlib_ilaenv(1,'CUNMBR','QLC',m,nrhs, &
                                   m,-1))
                        maxwrk = max(maxwrk,2*m + m*stdlib_ilaenv(1,'CUNMBR','PLN',n,nrhs,m, &
@@ -64132,7 +64132,7 @@ module stdlib_linalg_lapack_c
               ! compute a=l*q.
               ! (cworkspace: need 2*m, prefer m+m*nb)
               call stdlib_cgelqf(m,n,a,lda,work(itau),work(nwork),lwork - nwork + 1,info)
-                        
+
               il = nwork
               ! copy l to work(il), zeroing out above its diagonal.
               call stdlib_clacpy('L',m,m,a,lda,work(il),ldwork)
@@ -64206,7 +64206,7 @@ module stdlib_linalg_lapack_c
            else if (ibscl == 2) then
               call stdlib_clascl('G',0,0,bignum,bnrm,n,nrhs,b,ldb,info)
            end if
-10         continue
+           10 continue
            work(1) = maxwrk
            iwork(1) = liwork
            rwork(1) = lrwork
@@ -64240,7 +64240,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: bl,chunk,i,iascl,ibscl,ie,il,irwork,itau,itaup,itauq,iwork, &
@@ -64294,7 +64294,7 @@ module stdlib_linalg_lapack_c
                     lwork_cunmqr = real(dum(1),KIND=sp)
                     mm = n
                     maxwrk = max(maxwrk,n + n*stdlib_ilaenv(1,'CGEQRF',' ',m,n,-1,-1))
-                              
+
                     maxwrk = max(maxwrk,n + nrhs*stdlib_ilaenv(1,'CUNMQR','LC',m,nrhs,n,- &
                               1))
                  end if
@@ -64302,7 +64302,7 @@ module stdlib_linalg_lapack_c
                     ! path 1 - overdetermined or exactly determined
                     ! compute space needed for stdlib_cgebrd
                     call stdlib_cgebrd(mm,n,a,lda,s,s,dum(1),dum(1),dum(1),-1,info)
-                              
+
                     lwork_cgebrd = real(dum(1),KIND=sp)
                     ! compute space needed for stdlib_cunmbr
                     call stdlib_cunmbr('Q','L','C',mm,nrhs,n,a,lda,dum(1),b,ldb,dum(1), &
@@ -64328,7 +64328,7 @@ module stdlib_linalg_lapack_c
                        lwork_cgelqf = real(dum(1),KIND=sp)
                        ! compute space needed for stdlib_cgebrd
                        call stdlib_cgebrd(m,m,a,lda,s,s,dum(1),dum(1),dum(1),-1,info)
-                                 
+
                        lwork_cgebrd = real(dum(1),KIND=sp)
                        ! compute space needed for stdlib_cunmbr
                        call stdlib_cunmbr('Q','L','C',m,nrhs,n,a,lda,dum(1),b,ldb,dum( &
@@ -64356,7 +64356,7 @@ module stdlib_linalg_lapack_c
                        ! path 2 - underdetermined
                        ! compute space needed for stdlib_cgebrd
                        call stdlib_cgebrd(m,n,a,lda,s,s,dum(1),dum(1),dum(1),-1,info)
-                                 
+
                        lwork_cgebrd = real(dum(1),KIND=sp)
                        ! compute space needed for stdlib_cunmbr
                        call stdlib_cunmbr('Q','L','C',m,nrhs,m,a,lda,dum(1),b,ldb,dum( &
@@ -64490,7 +64490,7 @@ module stdlib_linalg_lapack_c
               ! (rworkspace: none)
               if (lwork >= ldb*nrhs .and. nrhs > 1) then
                  call stdlib_cgemm('C','N',n,nrhs,n,cone,a,lda,b,ldb,czero,work,ldb)
-                           
+
                  call stdlib_clacpy('G',n,nrhs,work,ldb,b,ldb)
               else if (nrhs > 1) then
                  chunk = lwork/n
@@ -64516,7 +64516,7 @@ module stdlib_linalg_lapack_c
               ! (cworkspace: need 2*m, prefer m+m*nb)
               ! (rworkspace: none)
               call stdlib_cgelqf(m,n,a,lda,work(itau),work(iwork),lwork - iwork + 1,info)
-                        
+
               il = iwork
               ! copy l to work(il), zeroing out above it
               call stdlib_clacpy('L',m,m,a,lda,work(il),ldwork)
@@ -64637,7 +64637,7 @@ module stdlib_linalg_lapack_c
               ! (rworkspace: none)
               if (lwork >= ldb*nrhs .and. nrhs > 1) then
                  call stdlib_cgemm('C','N',n,nrhs,m,cone,a,lda,b,ldb,czero,work,ldb)
-                           
+
                  call stdlib_clacpy('G',n,nrhs,work,ldb,b,ldb)
               else if (nrhs > 1) then
                  chunk = lwork/n
@@ -64665,7 +64665,7 @@ module stdlib_linalg_lapack_c
            else if (ibscl == 2) then
               call stdlib_clascl('G',0,0,bignum,bnrm,n,nrhs,b,ldb,info)
            end if
-70         continue
+           70 continue
            work(1) = maxwrk
            return
      end subroutine stdlib_cgelss
@@ -64721,7 +64721,7 @@ module stdlib_linalg_lapack_c
            ! Parameters
            integer(ilp),parameter :: imax = 1
            integer(ilp),parameter :: imin = 2
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,iascl,ibscl,ismax,ismin,j,lwkopt,mn,nb,nb1,nb2,nb3, &
@@ -64803,7 +64803,7 @@ module stdlib_linalg_lapack_c
            ! compute qr factorization with column pivoting of a:
               ! a * p = q * r
            call stdlib_cgeqp3(m,n,a,lda,jpvt,work(1),work(mn + 1),lwork - mn,rwork,info)
-                     
+
            wsize = mn + real(work(mn + 1),KIND=sp)
            ! complex workspace: mn+nb*(n+1). real workspace 2*n.
            ! details of householder rotations stored in work(1:mn).
@@ -64819,7 +64819,7 @@ module stdlib_linalg_lapack_c
            else
               rank = 1
            end if
-10         continue
+           10 continue
            if (rank < mn) then
               i = rank + 1
               call stdlib_claic1(imin,rank,work(ismin),smin,a(1,i),a(i,i),sminpr, &
@@ -64888,7 +64888,7 @@ module stdlib_linalg_lapack_c
            else if (ibscl == 2) then
               call stdlib_clascl('G',0,0,bignum,bnrm,n,nrhs,b,ldb,info)
            end if
-70         continue
+           70 continue
            work(1) = cmplx(lwkopt,KIND=sp)
            return
      end subroutine stdlib_cgelsy
@@ -65235,7 +65235,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: u(ldu,*),vt(ldvt,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wntqa,wntqas,wntqn,wntqo,wntqs
            integer(ilp) :: blk,chunk,i,ie,ierr,il,ir,iru,irvt,iscl,itau,itaup,itauq, &
@@ -65660,7 +65660,7 @@ module stdlib_linalg_lapack_c
                        call stdlib_cgemm('N','N',chunk,n,n,cone,a(i,1),lda,work(iu), &
                                  ldwrku,czero,work(ir),ldwrkr)
                        call stdlib_clacpy('F',chunk,n,work(ir),ldwrkr,a(i,1),lda)
-                                 
+
                     end do
                  else if (wntqs) then
                     ! path 3 (m >> n, jobz='s')
@@ -65874,7 +65874,7 @@ module stdlib_linalg_lapack_c
                        call stdlib_clacrm(chunk,n,a(i,1),lda,rwork(iru),n,work(iu), &
                                  ldwrku,rwork(nrwork))
                        call stdlib_clacpy('F',chunk,n,work(iu),ldwrku,a(i,1),lda)
-                                 
+
                     end do
                  else if (wntqs) then
                     ! path 5s (m >> n, jobz='s')
@@ -65907,7 +65907,7 @@ module stdlib_linalg_lapack_c
                     ! cworkspace: need   0
                     ! rworkspace: need   n [e] + n*n [ru] + n*n [rvt] + 2*n*n [rwork]
                     call stdlib_clarcm(n,n,rwork(irvt),n,vt,ldvt,a,lda,rwork(nrwork))
-                              
+
                     call stdlib_clacpy('F',n,n,a,lda,vt,ldvt)
                     ! multiply q in u by realmatrix rwork(iru,KIND=sp), storing the
                     ! result in a, copying to u
@@ -65915,7 +65915,7 @@ module stdlib_linalg_lapack_c
                     ! rworkspace: need   n [e] + n*n [ru] + 2*m*n [rwork] < n + 5*n*n since m < 2*n here
                     nrwork = irvt
                     call stdlib_clacrm(m,n,u,ldu,rwork(iru),n,a,lda,rwork(nrwork))
-                              
+
                     call stdlib_clacpy('F',m,n,a,lda,u,ldu)
                  else
                     ! path 5a (m >> n, jobz='a')
@@ -65948,7 +65948,7 @@ module stdlib_linalg_lapack_c
                     ! cworkspace: need   0
                     ! rworkspace: need   n [e] + n*n [ru] + n*n [rvt] + 2*n*n [rwork]
                     call stdlib_clarcm(n,n,rwork(irvt),n,vt,ldvt,a,lda,rwork(nrwork))
-                              
+
                     call stdlib_clacpy('F',n,n,a,lda,vt,ldvt)
                     ! multiply q in u by realmatrix rwork(iru,KIND=sp), storing the
                     ! result in a, copying to u
@@ -65956,7 +65956,7 @@ module stdlib_linalg_lapack_c
                     ! rworkspace: need   n [e] + n*n [ru] + 2*m*n [rwork] < n + 5*n*n since m < 2*n here
                     nrwork = irvt
                     call stdlib_clacrm(m,n,u,ldu,rwork(iru),n,a,lda,rwork(nrwork))
-                              
+
                     call stdlib_clacpy('F',m,n,a,lda,u,ldu)
                  end if
               else
@@ -66044,7 +66044,7 @@ module stdlib_linalg_lapack_c
                           call stdlib_clacrm(chunk,n,a(i,1),lda,rwork(iru),n,work(iu) &
                                     ,ldwrku,rwork(nrwork))
                           call stdlib_clacpy('F',chunk,n,work(iu),ldwrku,a(i,1),lda)
-                                    
+
                        end do
                     end if
                  else if (wntqs) then
@@ -66173,7 +66173,7 @@ module stdlib_linalg_lapack_c
                     ! copy l to work(il), zeroing about above it
                     call stdlib_clacpy('L',m,m,a,lda,work(il),ldwrkl)
                     call stdlib_claset('U',m - 1,m - 1,czero,czero,work(il + ldwrkl),ldwrkl)
-                              
+
                     ! generate q in a
                     ! cworkspace: need   m*m [vt] + m*m [l] + m [tau] + m    [work]
                     ! cworkspace: prefer m*m [vt] + m*m [l] + m [tau] + m*nb [work]
@@ -66226,7 +66226,7 @@ module stdlib_linalg_lapack_c
                        call stdlib_cgemm('N','N',m,blk,m,cone,work(ivt),m,a(1,i), &
                                  lda,czero,work(il),ldwrkl)
                        call stdlib_clacpy('F',m,blk,work(il),ldwrkl,a(1,i),lda)
-                                 
+
                     end do
                  else if (wntqs) then
                     ! path 3t (n >> m, jobz='s')
@@ -66246,7 +66246,7 @@ module stdlib_linalg_lapack_c
                     ! copy l to work(il), zeroing out above it
                     call stdlib_clacpy('L',m,m,a,lda,work(il),ldwrkl)
                     call stdlib_claset('U',m - 1,m - 1,czero,czero,work(il + ldwrkl),ldwrkl)
-                              
+
                     ! generate q in a
                     ! cworkspace: need   m*m [l] + m [tau] + m    [work]
                     ! cworkspace: prefer m*m [l] + m [tau] + m*nb [work]
@@ -66443,7 +66443,7 @@ module stdlib_linalg_lapack_c
                        call stdlib_clarcm(m,blk,rwork(irvt),m,a(1,i),lda,work(ivt), &
                                  ldwkvt,rwork(nrwork))
                        call stdlib_clacpy('F',m,blk,work(ivt),ldwkvt,a(1,i),lda)
-                                 
+
                     end do
                  else if (wntqs) then
                     ! path 5ts (n >> m, jobz='s')
@@ -66476,7 +66476,7 @@ module stdlib_linalg_lapack_c
                     ! cworkspace: need   0
                     ! rworkspace: need   m [e] + m*m [rvt] + m*m [ru] + 2*m*m [rwork]
                     call stdlib_clacrm(m,m,u,ldu,rwork(iru),m,a,lda,rwork(nrwork))
-                              
+
                     call stdlib_clacpy('F',m,m,a,lda,u,ldu)
                     ! multiply realmatrix rwork(irvt,KIND=sp) by p**h in vt,
                     ! storing the result in a, copying to vt
@@ -66484,7 +66484,7 @@ module stdlib_linalg_lapack_c
                     ! rworkspace: need   m [e] + m*m [rvt] + 2*m*n [rwork] < m + 5*m*m since n < 2*m here
                     nrwork = iru
                     call stdlib_clarcm(m,n,rwork(irvt),m,vt,ldvt,a,lda,rwork(nrwork))
-                              
+
                     call stdlib_clacpy('F',m,n,a,lda,vt,ldvt)
                  else
                     ! path 5ta (n >> m, jobz='a')
@@ -66517,7 +66517,7 @@ module stdlib_linalg_lapack_c
                     ! cworkspace: need   0
                     ! rworkspace: need   m [e] + m*m [rvt] + m*m [ru] + 2*m*m [rwork]
                     call stdlib_clacrm(m,m,u,ldu,rwork(iru),m,a,lda,rwork(nrwork))
-                              
+
                     call stdlib_clacpy('F',m,m,a,lda,u,ldu)
                     ! multiply realmatrix rwork(irvt,KIND=sp) by p**h in vt,
                     ! storing the result in a, copying to vt
@@ -66525,7 +66525,7 @@ module stdlib_linalg_lapack_c
                     ! rworkspace: need   m [e] + m*m [rvt] + 2*m*n [rwork] < m + 5*m*m since n < 2*m here
                     nrwork = iru
                     call stdlib_clarcm(m,n,rwork(irvt),m,vt,ldvt,a,lda,rwork(nrwork))
-                              
+
                     call stdlib_clacpy('F',m,n,a,lda,vt,ldvt)
                  end if
               else
@@ -66591,7 +66591,7 @@ module stdlib_linalg_lapack_c
                        ! cworkspace: prefer 2*m [tauq, taup] + m*n [vt] + m*nb [work]
                        ! rworkspace: need   m [e] + m*m [rvt]
                        call stdlib_clacp2('F',m,m,rwork(irvt),m,work(ivt),ldwkvt)
-                                 
+
                        call stdlib_cunmbr('P','R','C',m,n,m,a,lda,work(itaup),work( &
                                  ivt),ldwkvt,work(nwork),lwork - nwork + 1,ierr)
                        call stdlib_clacpy('F',m,n,work(ivt),ldwkvt,a,lda)
@@ -66615,7 +66615,7 @@ module stdlib_linalg_lapack_c
                           call stdlib_clarcm(m,blk,rwork(irvt),m,a(1,i),lda,work(ivt) &
                                     ,ldwkvt,rwork(nrwork))
                           call stdlib_clacpy('F',m,blk,work(ivt),ldwkvt,a(1,i),lda)
-                                    
+
                        end do
                     end if
                  else if (wntqs) then
@@ -66770,7 +66770,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: u(ldu,*),vt(ldvt,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wntua,wntuas,wntun,wntuo,wntus,wntva,wntvas,wntvn,wntvo, &
                       wntvs
@@ -66840,7 +66840,7 @@ module stdlib_linalg_lapack_c
                  lwork_cungqr_m = int(cdum(1),KIND=ilp)
                  ! compute space needed for stdlib_cgebrd
                  call stdlib_cgebrd(n,n,a,lda,s,dum(1),cdum(1),cdum(1),cdum(1),-1,ierr)
-                           
+
                  lwork_cgebrd = int(cdum(1),KIND=ilp)
                  ! compute space needed for stdlib_cungbr
                  call stdlib_cungbr('P',n,n,n,a,lda,cdum(1),cdum(1),-1,ierr)
@@ -66936,13 +66936,13 @@ module stdlib_linalg_lapack_c
                     maxwrk = 2*n + lwork_cgebrd
                     if (wntus .or. wntuo) then
                        call stdlib_cungbr('Q',m,n,n,a,lda,cdum(1),cdum(1),-1,ierr)
-                                 
+
                        lwork_cungbr_q = int(cdum(1),KIND=ilp)
                        maxwrk = max(maxwrk,2*n + lwork_cungbr_q)
                     end if
                     if (wntua) then
                        call stdlib_cungbr('Q',m,m,n,a,lda,cdum(1),cdum(1),-1,ierr)
-                                 
+
                        lwork_cungbr_q = int(cdum(1),KIND=ilp)
                        maxwrk = max(maxwrk,2*n + lwork_cungbr_q)
                     end if
@@ -66964,7 +66964,7 @@ module stdlib_linalg_lapack_c
                  lwork_cunglq_m = int(cdum(1),KIND=ilp)
                  ! compute space needed for stdlib_cgebrd
                  call stdlib_cgebrd(m,m,a,lda,s,dum(1),cdum(1),cdum(1),cdum(1),-1,ierr)
-                           
+
                  lwork_cgebrd = int(cdum(1),KIND=ilp)
                   ! compute space needed for stdlib_cungbr p
                  call stdlib_cungbr('P',m,m,m,a,n,cdum(1),cdum(1),-1,ierr)
@@ -67181,7 +67181,7 @@ module stdlib_linalg_lapack_c
                        ! copy r to work(ir) and zero out below it
                        call stdlib_clacpy('U',n,n,a,lda,work(ir),ldwrkr)
                        call stdlib_claset('L',n - 1,n - 1,czero,czero,work(ir + 1),ldwrkr)
-                                 
+
                        ! generate q in a
                        ! (cworkspace: need n*n+2*n, prefer n*n+n+n*nb)
                        ! (rworkspace: 0)
@@ -67218,7 +67218,7 @@ module stdlib_linalg_lapack_c
                           call stdlib_cgemm('N','N',chunk,n,n,cone,a(i,1),lda,work(ir &
                                     ),ldwrkr,czero,work(iu),ldwrku)
                           call stdlib_clacpy('F',chunk,n,work(iu),ldwrku,a(i,1),lda)
-                                    
+
                        end do
                     else
                        ! insufficient workspace for a fast algorithm
@@ -67274,7 +67274,7 @@ module stdlib_linalg_lapack_c
                        ! copy r to vt, zeroing out below it
                        call stdlib_clacpy('U',n,n,a,lda,vt,ldvt)
                        if (n > 1) call stdlib_claset('L',n - 1,n - 1,czero,czero,vt(2,1),ldvt)
-                                 
+
                        ! generate q in a
                        ! (cworkspace: need n*n+2*n, prefer n*n+n+n*nb)
                        ! (rworkspace: 0)
@@ -67318,7 +67318,7 @@ module stdlib_linalg_lapack_c
                           call stdlib_cgemm('N','N',chunk,n,n,cone,a(i,1),lda,work(ir &
                                     ),ldwrkr,czero,work(iu),ldwrku)
                           call stdlib_clacpy('F',chunk,n,work(iu),ldwrku,a(i,1),lda)
-                                    
+
                        end do
                     else
                        ! insufficient workspace for a fast algorithm
@@ -67332,7 +67332,7 @@ module stdlib_linalg_lapack_c
                        ! copy r to vt, zeroing out below it
                        call stdlib_clacpy('U',n,n,a,lda,vt,ldvt)
                        if (n > 1) call stdlib_claset('L',n - 1,n - 1,czero,czero,vt(2,1),ldvt)
-                                 
+
                        ! generate q in a
                        ! (cworkspace: need 2*n, prefer n+n*nb)
                        ! (rworkspace: 0)
@@ -67391,7 +67391,7 @@ module stdlib_linalg_lapack_c
                           ! copy r to work(ir), zeroing out below it
                           call stdlib_clacpy('U',n,n,a,lda,work(ir),ldwrkr)
                           call stdlib_claset('L',n - 1,n - 1,czero,czero,work(ir + 1),ldwrkr)
-                                    
+
                           ! generate q in a
                           ! (cworkspace: need n*n+2*n, prefer n*n+n+n*nb)
                           ! (rworkspace: 0)
@@ -67446,7 +67446,7 @@ module stdlib_linalg_lapack_c
                           ! zero out below r in a
                           if (n > 1) then
                              call stdlib_claset('L',n - 1,n - 1,czero,czero,a(2,1),lda)
-                                       
+
                           end if
                           ! bidiagonalize r in a
                           ! (cworkspace: need 3*n, prefer 2*n+2*n*nb)
@@ -67499,7 +67499,7 @@ module stdlib_linalg_lapack_c
                           ! copy r to work(iu), zeroing out below it
                           call stdlib_clacpy('U',n,n,a,lda,work(iu),ldwrku)
                           call stdlib_claset('L',n - 1,n - 1,czero,czero,work(iu + 1),ldwrku)
-                                    
+
                           ! generate q in a
                           ! (cworkspace: need 2*n*n+2*n, prefer 2*n*n+n+n*nb)
                           ! (rworkspace: 0)
@@ -67517,7 +67517,7 @@ module stdlib_linalg_lapack_c
                           call stdlib_cgebrd(n,n,work(iu),ldwrku,s,rwork(ie),work( &
                                     itauq),work(itaup),work(iwork),lwork - iwork + 1,ierr)
                           call stdlib_clacpy('U',n,n,work(iu),ldwrku,work(ir),ldwrkr)
-                                    
+
                           ! generate left bidiagonalizing vectors in work(iu)
                           ! (cworkspace: need 2*n*n+3*n, prefer 2*n*n+2*n+n*nb)
                           ! (rworkspace: 0)
@@ -67569,7 +67569,7 @@ module stdlib_linalg_lapack_c
                           ! zero out below r in a
                           if (n > 1) then
                              call stdlib_claset('L',n - 1,n - 1,czero,czero,a(2,1),lda)
-                                       
+
                           end if
                           ! bidiagonalize r in a
                           ! (cworkspace: need 3*n, prefer 2*n+2*n*nb)
@@ -67620,7 +67620,7 @@ module stdlib_linalg_lapack_c
                           ! copy r to work(iu), zeroing out below it
                           call stdlib_clacpy('U',n,n,a,lda,work(iu),ldwrku)
                           call stdlib_claset('L',n - 1,n - 1,czero,czero,work(iu + 1),ldwrku)
-                                    
+
                           ! generate q in a
                           ! (cworkspace: need n*n+2*n, prefer n*n+n+n*nb)
                           ! (rworkspace: 0)
@@ -67736,7 +67736,7 @@ module stdlib_linalg_lapack_c
                           ! copy r to work(ir), zeroing out below it
                           call stdlib_clacpy('U',n,n,a,lda,work(ir),ldwrkr)
                           call stdlib_claset('L',n - 1,n - 1,czero,czero,work(ir + 1),ldwrkr)
-                                    
+
                           ! generate q in u
                           ! (cworkspace: need n*n+n+m, prefer n*n+n+m*nb)
                           ! (rworkspace: 0)
@@ -67793,7 +67793,7 @@ module stdlib_linalg_lapack_c
                           ! zero out below r in a
                           if (n > 1) then
                              call stdlib_claset('L',n - 1,n - 1,czero,czero,a(2,1),lda)
-                                       
+
                           end if
                           ! bidiagonalize r in a
                           ! (cworkspace: need 3*n, prefer 2*n+2*n*nb)
@@ -67853,7 +67853,7 @@ module stdlib_linalg_lapack_c
                           ! copy r to work(iu), zeroing out below it
                           call stdlib_clacpy('U',n,n,a,lda,work(iu),ldwrku)
                           call stdlib_claset('L',n - 1,n - 1,czero,czero,work(iu + 1),ldwrku)
-                                    
+
                           ie = 1
                           itauq = itau
                           itaup = itauq + n
@@ -67866,7 +67866,7 @@ module stdlib_linalg_lapack_c
                           call stdlib_cgebrd(n,n,work(iu),ldwrku,s,rwork(ie),work( &
                                     itauq),work(itaup),work(iwork),lwork - iwork + 1,ierr)
                           call stdlib_clacpy('U',n,n,work(iu),ldwrku,work(ir),ldwrkr)
-                                    
+
                           ! generate left bidiagonalizing vectors in work(iu)
                           ! (cworkspace: need 2*n*n+3*n, prefer 2*n*n+2*n+n*nb)
                           ! (rworkspace: 0)
@@ -67918,7 +67918,7 @@ module stdlib_linalg_lapack_c
                           ! zero out below r in a
                           if (n > 1) then
                              call stdlib_claset('L',n - 1,n - 1,czero,czero,a(2,1),lda)
-                                       
+
                           end if
                           ! bidiagonalize r in a
                           ! (cworkspace: need 3*n, prefer 2*n+2*n*nb)
@@ -67976,7 +67976,7 @@ module stdlib_linalg_lapack_c
                           ! copy r to work(iu), zeroing out below it
                           call stdlib_clacpy('U',n,n,a,lda,work(iu),ldwrku)
                           call stdlib_claset('L',n - 1,n - 1,czero,czero,work(iu + 1),ldwrku)
-                                    
+
                           ie = 1
                           itauq = itau
                           itaup = itauq + n
@@ -68221,7 +68221,7 @@ module stdlib_linalg_lapack_c
                        ! copy l to work(ir) and zero out above it
                        call stdlib_clacpy('L',m,m,a,lda,work(ir),ldwrkr)
                        call stdlib_claset('U',m - 1,m - 1,czero,czero,work(ir + ldwrkr),ldwrkr)
-                                 
+
                        ! generate q in a
                        ! (cworkspace: need m*m+2*m, prefer m*m+m+m*nb)
                        ! (rworkspace: 0)
@@ -68258,7 +68258,7 @@ module stdlib_linalg_lapack_c
                           call stdlib_cgemm('N','N',m,blk,m,cone,work(ir),ldwrkr,a(1, &
                                     i),lda,czero,work(iu),ldwrku)
                           call stdlib_clacpy('F',m,blk,work(iu),ldwrku,a(1,i),lda)
-                                    
+
                        end do
                     else
                        ! insufficient workspace for a fast algorithm
@@ -68360,7 +68360,7 @@ module stdlib_linalg_lapack_c
                           call stdlib_cgemm('N','N',m,blk,m,cone,work(ir),ldwrkr,a(1, &
                                     i),lda,czero,work(iu),ldwrku)
                           call stdlib_clacpy('F',m,blk,work(iu),ldwrku,a(1,i),lda)
-                                    
+
                        end do
                     else
                        ! insufficient workspace for a fast algorithm
@@ -68557,7 +68557,7 @@ module stdlib_linalg_lapack_c
                           call stdlib_cgebrd(m,m,work(iu),ldwrku,s,rwork(ie),work( &
                                     itauq),work(itaup),work(iwork),lwork - iwork + 1,ierr)
                           call stdlib_clacpy('L',m,m,work(iu),ldwrku,work(ir),ldwrkr)
-                                    
+
                           ! generate right bidiagonalizing vectors in work(iu)
                           ! (cworkspace: need   2*m*m+3*m-1,
                                        ! prefer 2*m*m+2*m+(m-1)*nb)
@@ -68900,7 +68900,7 @@ module stdlib_linalg_lapack_c
                           call stdlib_cgebrd(m,m,work(iu),ldwrku,s,rwork(ie),work( &
                                     itauq),work(itaup),work(iwork),lwork - iwork + 1,ierr)
                           call stdlib_clacpy('L',m,m,work(iu),ldwrku,work(ir),ldwrkr)
-                                    
+
                           ! generate right bidiagonalizing vectors in work(iu)
                           ! (cworkspace: need   2*m*m+3*m-1,
                                        ! prefer 2*m*m+2*m+(m-1)*nb)
@@ -69213,7 +69213,7 @@ module stdlib_linalg_lapack_c
            real(sp),intent(out) :: s(*),rwork(*)
            integer(ilp),intent(out) :: iwork(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: ierr,nr,n1,optratio,p,q
            integer(ilp) :: lwcon,lwqp3,lwrk_cgelqf,lwrk_cgesvd,lwrk_cgesvd2,lwrk_cgeqp3, &
@@ -69302,7 +69302,7 @@ module stdlib_linalg_lapack_c
               lwsvd = max(3*n,1)
               if (lquery) then
                   call stdlib_cgeqp3(m,n,a,lda,iwork,cdummy,cdummy,-1,rdummy,ierr)
-                            
+
                   lwrk_cgeqp3 = int(cdummy(1),KIND=ilp)
                   if (wntus .or. wntur) then
                       call stdlib_cunmqr('L','N',m,n,n,a,lda,cdummy,u,ldu,cdummy,-1, &
@@ -69539,7 +69539,7 @@ module stdlib_linalg_lapack_c
                      ! .. to prevent overflow in the qr factorization, scale the
                      ! matrix by 1/sqrt(m) if too large entry detected
                      call stdlib_clascl('G',0,0,sqrt(real(m,KIND=sp)),one,m,n,a,lda,ierr)
-                               
+
                      ascaled = .true.
                  end if
                  call stdlib_claswp(n,a,lda,1,m - 1,iwork(n + 1),1)
@@ -69559,7 +69559,7 @@ module stdlib_linalg_lapack_c
                    ! .. to prevent overflow in the qr factorization, scale the
                    ! matrix by 1/sqrt(m) if too large entry detected
                    call stdlib_clascl('G',0,0,sqrt(real(m,KIND=sp)),one,m,n,a,lda,ierr)
-                             
+
                    ascaled = .true.
                end if
            end if
@@ -69571,7 +69571,7 @@ module stdlib_linalg_lapack_c
               iwork(p) = 0
            end do
            call stdlib_cgeqp3(m,n,a,lda,iwork,cwork,cwork(n + 1),lcwork - n,rwork,ierr)
-                     
+
           ! if the user requested accuracy level allows truncation in the
           ! computed upper triangular factor, the matrix r is examined and,
           ! if possible, replaced with its leading upper trapezoidal part.
@@ -69590,7 +69590,7 @@ module stdlib_linalg_lapack_c
                  if (abs(a(p,p)) < (rtmp*abs(a(1,1)))) go to 3002
                     nr = nr + 1
               end do
-3002          continue
+              3002 continue
            elseif (acclm) then
               ! .. similarly as above, only slightly more gentle (less aggressive).
               ! sudden drop on the diagonal of r is used as the criterion for being
@@ -69604,7 +69604,7 @@ module stdlib_linalg_lapack_c
                            to 3402
                  nr = nr + 1
               end do
-3402          continue
+              3402 continue
            else
               ! Rrqr Not Authorized To Determine Numerical Rank Except In The
               ! obvious case of zero pivots.
@@ -69615,7 +69615,7 @@ module stdlib_linalg_lapack_c
                  if (abs(a(p,p)) == zero) go to 3502
                  nr = nr + 1
               end do
-3502          continue
+              3502 continue
               if (conda) then
                  ! estimate the scaled condition number of a. use the fact that it is
                  ! the same as the scaled condition number of r.
@@ -69632,10 +69632,10 @@ module stdlib_linalg_lapack_c
                     end do
                     if (.not. (lsvec .or. rsvec)) then
                         call stdlib_cpocon('U',nr,v,ldv,one,rtmp,cwork,rwork,ierr)
-                                  
+
                     else
                         call stdlib_cpocon('U',nr,v,ldv,one,rtmp,cwork(n + 1),rwork,ierr)
-                                  
+
                     end if
                     sconda = one/sqrt(rtmp)
                  ! for nr=n, sconda is an estimate of sqrt(||(r^* * r)^(-1)||_1),
@@ -69670,7 +69670,7 @@ module stdlib_linalg_lapack_c
               else
                  ! .. compute the singular values of r = [a](1:nr,1:n)
                  if (nr > 1) call stdlib_claset('L',nr - 1,nr - 1,czero,czero,a(2,1),lda)
-                           
+
                  call stdlib_cgesvd('N','N',nr,n,a,lda,s,u,ldu,v,ldv,cwork,lcwork, &
                            rwork,info)
               end if
@@ -69688,7 +69688,7 @@ module stdlib_linalg_lapack_c
                     end do
                  end do
                  if (nr > 1) call stdlib_claset('U',nr - 1,nr - 1,czero,czero,u(1,2),ldu)
-                           
+
                  ! .. the left singular vectors not computed, the nr right singular
                  ! vectors overwrite [u](1:nr,1:nr) as conjugate transposed. these
                  ! will be pre-multiplied by q to build the left singular vectors of a.
@@ -69707,7 +69707,7 @@ module stdlib_linalg_lapack_c
                   ! .. copy r into [u] and overwrite [u] with the left singular vectors
                   call stdlib_clacpy('U',nr,n,a,lda,u,ldu)
                   if (nr > 1) call stdlib_claset('L',nr - 1,nr - 1,czero,czero,u(2,1),ldu)
-                            
+
                   ! .. the right singular vectors not computed, the nr left singular
                   ! vectors overwrite [u](1:nr,1:nr)
                      call stdlib_cgesvd('O','N',nr,n,u,ldu,s,u,ldu,v,ldv,cwork(n + 1), &
@@ -69744,7 +69744,7 @@ module stdlib_linalg_lapack_c
                     end do
                  end do
                  if (nr > 1) call stdlib_claset('U',nr - 1,nr - 1,czero,czero,v(1,2),ldv)
-                           
+
                  ! .. the left singular vectors of r**h overwrite v, the right singular
                  ! vectors not computed
                  if (wntvr .or. (nr == n)) then
@@ -69790,7 +69790,7 @@ module stdlib_linalg_lapack_c
                   ! Copy R Into V And Overwrite V With The Right Singular Vectors
                   call stdlib_clacpy('U',nr,n,a,lda,v,ldv)
                   if (nr > 1) call stdlib_claset('L',nr - 1,nr - 1,czero,czero,v(2,1),ldv)
-                            
+
                   ! .. the right singular vectors overwrite v, the nr left singular
                   ! vectors stored in u(1:nr,1:nr)
                   if (wntvr .or. (nr == n)) then
@@ -69827,7 +69827,7 @@ module stdlib_linalg_lapack_c
                     end do
                  end do
                  if (nr > 1) call stdlib_claset('U',nr - 1,nr - 1,czero,czero,v(1,2),ldv)
-                           
+
                  ! .. the left singular vectors of r**h overwrite [v], the nr right
                  ! singular vectors of r**h stored in [u](1:nr,1:nr) as conjugate
                  ! transposed
@@ -69863,7 +69863,7 @@ module stdlib_linalg_lapack_c
                        if (nr < n1) then
                           call stdlib_claset('A',nr,n1 - nr,czero,czero,u(1,nr + 1),ldu)
                           call stdlib_claset('A',m - nr,n1 - nr,czero,cone,u(nr + 1,nr + 1),ldu)
-                                    
+
                        end if
                     end if
                  else
@@ -69883,7 +69883,7 @@ module stdlib_linalg_lapack_c
                            end do
                         end do
                         if (nr > 1) call stdlib_claset('U',nr - 1,nr - 1,czero,czero,v(1,2),ldv)
-                                  
+
                         call stdlib_claset('A',n,n - nr,czero,czero,v(1,nr + 1),ldv)
                         call stdlib_cgesvd('O','A',n,n,v,ldv,s,v,ldv,u,ldu,cwork(n + 1), &
                                   lcwork - n,rwork,info)
@@ -69922,7 +69922,7 @@ module stdlib_linalg_lapack_c
                            end do
                         end do
                         if (nr > 1) call stdlib_claset('U',nr - 1,nr - 1,czero,czero,u(1,nr + 2),ldu)
-                                  
+
                         call stdlib_cgeqrf(n,nr,u(1,nr + 1),ldu,cwork(n + 1),cwork(n + nr + 1), &
                                   lcwork - n - nr,ierr)
                         do p = 1,nr
@@ -69956,7 +69956,7 @@ module stdlib_linalg_lapack_c
                       ! .. copy r into [v] and overwrite v with the right singular vectors
                       call stdlib_clacpy('U',nr,n,a,lda,v,ldv)
                      if (nr > 1) call stdlib_claset('L',nr - 1,nr - 1,czero,czero,v(2,1),ldv)
-                               
+
                      ! .. the right singular vectors of r overwrite [v], the nr left
                      ! singular vectors of r stored in [u](1:nr,1:nr)
                      call stdlib_cgesvd('S','O',nr,n,v,ldv,s,u,ldu,v,ldv,cwork(n + 1), &
@@ -69970,7 +69970,7 @@ module stdlib_linalg_lapack_c
                        if (nr < n1) then
                           call stdlib_claset('A',nr,n1 - nr,czero,czero,u(1,nr + 1),ldu)
                           call stdlib_claset('A',m - nr,n1 - nr,czero,cone,u(nr + 1,nr + 1),ldu)
-                                    
+
                        end if
                     end if
                   else
@@ -69986,7 +69986,7 @@ module stdlib_linalg_lapack_c
                     if (optratio*nr > n) then
                        call stdlib_clacpy('U',nr,n,a,lda,v,ldv)
                        if (nr > 1) call stdlib_claset('L',nr - 1,nr - 1,czero,czero,v(2,1),ldv)
-                                 
+
                     ! .. the right singular vectors of r overwrite [v], the nr left
                        ! singular vectors of r stored in [u](1:nr,1:nr)
                        call stdlib_claset('A',n - nr,n,czero,czero,v(nr + 1,1),ldv)
@@ -70008,12 +70008,12 @@ module stdlib_linalg_lapack_c
                     else
                        call stdlib_clacpy('U',nr,n,a,lda,u(nr + 1,1),ldu)
                        if (nr > 1) call stdlib_claset('L',nr - 1,nr - 1,czero,czero,u(nr + 2,1),ldu)
-                                 
+
                        call stdlib_cgelqf(nr,n,u(nr + 1,1),ldu,cwork(n + 1),cwork(n + nr + 1), &
                                  lcwork - n - nr,ierr)
                        call stdlib_clacpy('L',nr,nr,u(nr + 1,1),ldu,v,ldv)
                        if (nr > 1) call stdlib_claset('U',nr - 1,nr - 1,czero,czero,v(1,2),ldv)
-                                 
+
                        call stdlib_cgesvd('S','O',nr,nr,v,ldv,s,u,ldu,v,ldv,cwork(n + nr + &
                                  1),lcwork - n - nr,rwork,info)
                        call stdlib_claset('A',n - nr,nr,czero,czero,v(nr + 1,1),ldv)
@@ -70029,7 +70029,7 @@ module stdlib_linalg_lapack_c
                           if (nr < n1) then
                           call stdlib_claset('A',nr,n1 - nr,czero,czero,u(1,nr + 1),ldu)
                           call stdlib_claset('A',m - nr,n1 - nr,czero,cone,u(nr + 1,nr + 1),ldu)
-                                    
+
                           end if
                        end if
                     end if
@@ -70051,7 +70051,7 @@ module stdlib_linalg_lapack_c
                if (s(q) > zero) go to 4002
                nr = nr - 1
            end do
-4002       continue
+           4002 continue
            ! .. if numerical rank deficiency is detected, the truncated
            ! singular values are set to zero.
            if (nr < n) call stdlib_slaset('G',n - nr,1,zero,zero,s(nr + 1),n)
@@ -70093,7 +70093,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*),af(ldaf,*),b(ldb,*)
            complex(sp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: colequ,equil,nofact,notran,rowequ
            character :: norm
@@ -70304,7 +70304,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,tran
            integer(ilp) :: i,iascl,ibscl,j,maxmn,brow,scllen,tszo,tszm,lwo,lwm,lw1, &
@@ -70504,7 +70504,7 @@ module stdlib_linalg_lapack_c
            else if (ibscl == 2) then
              call stdlib_clascl('G',0,0,bignum,bnrm,scllen,nrhs,b,ldb,info)
            end if
-50         continue
+           50 continue
            work(1) = real(tszo + lwo,KIND=sp)
            return
      end subroutine stdlib_cgetsls
@@ -70523,7 +70523,7 @@ module stdlib_linalg_lapack_c
      !> of CGEQRT for more details on the format.
 
      pure subroutine stdlib_cgetsqrhrt(m,n,mb1,nb1,nb2,a,lda,t,ldt,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -70534,7 +70534,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: t(ldt,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,iinfo,j,lw1,lw2,lwt,ldwt,lworkopt,nb1local,nb2local, &
@@ -70603,7 +70603,7 @@ module stdlib_linalg_lapack_c
            nb2local = min(nb2,n)
            ! (1) perform tsqr-factorization of the m-by-n matrix a.
            call stdlib_clatsqr(m,n,mb1,nb1local,a,lda,work,ldwt,work(lwt + 1),lw1,iinfo)
-                     
+
            ! (2) copy the factor r_tsqr stored in the upper-triangular part
                ! of a into the square matrix in the work array
                ! work(lwt+1:lwt+n*n) column-by-column.
@@ -70617,7 +70617,7 @@ module stdlib_linalg_lapack_c
            ! (4) perform the reconstruction of householder vectors from
            ! the matrix q (stored in a) in place.
            call stdlib_cunhr_col(m,n,nb2local,a,lda,t,ldt,work(lwt + n*n + 1),iinfo)
-                     
+
            ! (5) copy the factor r_tsqr stored in the square matrix in the
            ! work array work(lwt+1:lwt+n*n) into the upper-triangular
            ! part of a.
@@ -70677,11 +70677,11 @@ module stdlib_linalg_lapack_c
            real(sp),intent(out) :: rwork(*)
            complex(sp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(sp),intent(out) :: alpha(*),beta(*),vsl(ldvsl,*),vsr(ldvsr,*),work(*)
-                     
+
            ! Function Arguments
            procedure(stdlib_selctg_c) :: selctg
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: cursl,ilascl,ilbscl,ilvsl,ilvsr,lastsl,lquery,wantst
            integer(ilp) :: i,icols,ierr,ihi,ijobvl,ijobvr,ileft,ilo,iright,irows,irwrk, &
@@ -70747,7 +70747,7 @@ module stdlib_linalg_lapack_c
               lwkopt = max(lwkopt,n + n*stdlib_ilaenv(1,'CUNMQR',' ',n,1,n,-1))
               if (ilvsl) then
                  lwkopt = max(lwkopt,n + n*stdlib_ilaenv(1,'CUNGQR',' ',n,1,n,-1))
-                           
+
               end if
               work(1) = lwkopt
               if (lwork < lwkmin .and. .not. lquery) info = -18
@@ -70850,16 +70850,16 @@ module stdlib_linalg_lapack_c
            if (wantst) then
               ! undo scaling on eigenvalues before selecting
               if (ilascl) call stdlib_clascl('G',0,0,anrm,anrmto,n,1,alpha,n,ierr)
-                        
+
               if (ilbscl) call stdlib_clascl('G',0,0,bnrm,bnrmto,n,1,beta,n,ierr)
-                        
+
               ! select eigenvalues
               do i = 1,n
                  bwork(i) = selctg(alpha(i),beta(i))
               end do
               call stdlib_ctgsen(0,ilvsl,ilvsr,bwork,n,a,lda,b,ldb,alpha,beta,vsl, &
               ldvsl,vsr,ldvsr,sdim,pvsl,pvsr,dif,work(iwrk),lwork - iwrk + 1,idum,1,ierr)
-                        
+
               if (ierr == 1) info = n + 3
            end if
            ! apply back-permutation to vsl and vsr
@@ -70888,7 +70888,7 @@ module stdlib_linalg_lapack_c
                  lastsl = cursl
               end do
            end if
-30         continue
+           30 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_cgges
@@ -70918,7 +70918,7 @@ module stdlib_linalg_lapack_c
 
      subroutine stdlib_cggesx(jobvsl,jobvsr,sort,selctg,sense,n,a,lda,b,ldb,sdim,alpha, &
       beta,vsl,ldvsl,vsr,ldvsr,rconde,rcondv,work,lwork,rwork,iwork,liwork,bwork,info)
-                
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -70932,11 +70932,11 @@ module stdlib_linalg_lapack_c
            real(sp),intent(out) :: rconde(2),rcondv(2),rwork(*)
            complex(sp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(sp),intent(out) :: alpha(*),beta(*),vsl(ldvsl,*),vsr(ldvsr,*),work(*)
-                     
+
            ! Function Arguments
            procedure(stdlib_selctg_c) :: selctg
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: cursl,ilascl,ilbscl,ilvsl,ilvsr,lastsl,lquery,wantsb,wantse, &
                      wantsn,wantst,wantsv
@@ -71017,7 +71017,7 @@ module stdlib_linalg_lapack_c
                  minwrk = 2*n
                  maxwrk = n*(1 + stdlib_ilaenv(1,'CGEQRF',' ',n,1,n,0))
                  maxwrk = max(maxwrk,n*(1 + stdlib_ilaenv(1,'CUNMQR',' ',n,1,n,-1)))
-                           
+
                  if (ilvsl) then
                     maxwrk = max(maxwrk,n*(1 + stdlib_ilaenv(1,'CUNGQR',' ',n,1,n,-1)) &
                               )
@@ -71140,9 +71140,9 @@ module stdlib_linalg_lapack_c
            if (wantst) then
               ! undo scaling on eigenvalues before selctging
               if (ilascl) call stdlib_clascl('G',0,0,anrmto,anrm,n,1,alpha,n,ierr)
-                        
+
               if (ilbscl) call stdlib_clascl('G',0,0,bnrmto,bnrm,n,1,beta,n,ierr)
-                        
+
               ! select eigenvalues
               do i = 1,n
                  bwork(i) = selctg(alpha(i),beta(i))
@@ -71196,7 +71196,7 @@ module stdlib_linalg_lapack_c
                  lastsl = cursl
               end do
            end if
-40         continue
+           40 continue
            work(1) = maxwrk
            iwork(1) = liwmin
            return
@@ -71232,7 +71232,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(sp),intent(out) :: alpha(*),beta(*),vl(ldvl,*),vr(ldvr,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: ilascl,ilbscl,ilv,ilvl,ilvr,lquery
            character :: chtemp
@@ -71302,7 +71302,7 @@ module stdlib_linalg_lapack_c
               lwkopt = max(lwkopt,n + n*stdlib_ilaenv(1,'CUNMQR',' ',n,1,n,0))
               if (ilvl) then
                  lwkopt = max(lwkopt,n + n*stdlib_ilaenv(1,'CUNGQR',' ',n,1,n,-1))
-                           
+
               end if
               work(1) = lwkopt
               if (lwork < lwkmin .and. .not. lquery) info = -15
@@ -71464,7 +71464,7 @@ module stdlib_linalg_lapack_c
               end if
            end if
            ! undo scaling if necessary
-70   continue
+           70 continue
            if (ilascl) call stdlib_clascl('G',0,0,anrmto,anrm,n,1,alpha,n,ierr)
            if (ilbscl) call stdlib_clascl('G',0,0,bnrmto,bnrm,n,1,beta,n,ierr)
            work(1) = lwkopt
@@ -71510,7 +71510,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(sp),intent(out) :: alpha(*),beta(*),vl(ldvl,*),vr(ldvr,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: ilascl,ilbscl,ilv,ilvl,ilvr,lquery,noscl,wantsb,wantse,wantsn, &
                      wantsv
@@ -71598,12 +71598,12 @@ module stdlib_linalg_lapack_c
                  end if
                  maxwrk = minwrk
                  maxwrk = max(maxwrk,n + n*stdlib_ilaenv(1,'CGEQRF',' ',n,1,n,0))
-                           
+
                  maxwrk = max(maxwrk,n + n*stdlib_ilaenv(1,'CUNMQR',' ',n,1,n,0))
-                           
+
                  if (ilvl) then
                     maxwrk = max(maxwrk,n + n*stdlib_ilaenv(1,'CUNGQR',' ',n,1,n,0))
-                              
+
                  end if
               end if
               work(1) = maxwrk
@@ -71651,7 +71651,7 @@ module stdlib_linalg_lapack_c
            ! permute and/or balance the matrix pair (a,b)
            ! (real workspace: need 6*n if balanc = 's' or 'b', 1 otherwise)
            call stdlib_cggbal(balanc,n,a,lda,b,ldb,ilo,ihi,lscale,rscale,rwork,ierr)
-                     
+
            ! compute abnrm and bbnrm
            abnrm = stdlib_clange('1',n,n,a,lda,rwork(1))
            if (ilascl) then
@@ -71782,7 +71782,7 @@ module stdlib_linalg_lapack_c
            ! (workspace: none needed)
            if (ilvl) then
               call stdlib_cggbak(balanc,'L',n,ilo,ihi,lscale,rscale,n,vl,ldvl,ierr)
-                        
+
               loop_50: do jc = 1,n
                  temp = zero
                  do jr = 1,n
@@ -71797,7 +71797,7 @@ module stdlib_linalg_lapack_c
            end if
            if (ilvr) then
               call stdlib_cggbak(balanc,'R',n,ilo,ihi,lscale,rscale,n,vr,ldvr,ierr)
-                        
+
               loop_80: do jc = 1,n
                  temp = zero
                  do jr = 1,n
@@ -71811,7 +71811,7 @@ module stdlib_linalg_lapack_c
               end do loop_80
            end if
            ! undo scaling if necessary
-90   continue
+           90 continue
            if (ilascl) call stdlib_clascl('G',0,0,anrmto,anrm,n,1,alpha,n,ierr)
            if (ilbscl) call stdlib_clascl('G',0,0,bnrmto,bnrm,n,1,beta,n,ierr)
            work(1) = maxwrk
@@ -71834,7 +71834,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: ab(ldab,*)
            complex(sp),intent(out) :: work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,wantz
            integer(ilp) :: iinfo,imax,inde,indrwk,iscale
@@ -71901,14 +71901,14 @@ module stdlib_linalg_lapack_c
            ! call stdlib_chbtrd to reduce hermitian band matrix to tridiagonal form.
            inde = 1
            call stdlib_chbtrd(jobz,uplo,n,kd,ab,ldab,w,rwork(inde),z,ldz,work,iinfo)
-                     
+
            ! for eigenvalues only, call stdlib_ssterf.  for eigenvectors, call stdlib_csteqr.
            if (.not. wantz) then
               call stdlib_ssterf(n,w,rwork(inde),info)
            else
               indrwk = inde + n
               call stdlib_csteqr(jobz,n,w,rwork(inde),z,ldz,rwork(indrwk),info)
-                        
+
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
            if (iscale == 1) then
@@ -71947,7 +71947,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: ab(ldab,*)
            complex(sp),intent(out) :: work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,lquery,wantz
            integer(ilp) :: iinfo,imax,inde,indwk2,indwrk,iscale,liwmin,llrwk,llwk2, &
@@ -72045,7 +72045,7 @@ module stdlib_linalg_lapack_c
            llwk2 = lwork - indwk2 + 1
            llrwk = lrwork - indwrk + 1
            call stdlib_chbtrd(jobz,uplo,n,kd,ab,ldab,w,rwork(inde),z,ldz,work,iinfo)
-                     
+
            ! for eigenvalues only, call stdlib_ssterf.  for eigenvectors, call stdlib_cstedc.
            if (.not. wantz) then
               call stdlib_ssterf(n,w,rwork(inde),info)
@@ -72092,7 +72092,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: ab(ldab,*)
            complex(sp),intent(out) :: q(ldq,*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,lower,test,valeig,wantz
            character :: order
@@ -72226,7 +72226,7 @@ module stdlib_linalg_lapack_c
                  call stdlib_clacpy('A',n,n,q,ldq,z,ldz)
                  call stdlib_scopy(n - 1,rwork(inde),1,rwork(indee),1)
                  call stdlib_csteqr(jobz,n,w,rwork(indee),z,ldz,rwork(indrwk),info)
-                           
+
                  if (info == 0) then
                     do i = 1,n
                        ifail(i) = 0
@@ -72262,7 +72262,7 @@ module stdlib_linalg_lapack_c
               end do
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
-30   continue
+           30 continue
            if (iscale == 1) then
               if (info == 0) then
                  imax = m
@@ -72370,13 +72370,13 @@ module stdlib_linalg_lapack_c
               vect = 'N'
            end if
            call stdlib_chbtrd(vect,uplo,n,ka,ab,ldab,w,rwork(inde),z,ldz,work,iinfo)
-                     
+
            ! for eigenvalues only, call stdlib_ssterf.  for eigenvectors, call stdlib_csteqr.
            if (.not. wantz) then
               call stdlib_ssterf(n,w,rwork(inde),info)
            else
               call stdlib_csteqr(jobz,n,w,rwork(inde),z,ldz,rwork(indwrk),info)
-                        
+
            end if
            return
      end subroutine stdlib_chbgv
@@ -72408,7 +72408,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: ab(ldab,*),bb(ldbb,*)
            complex(sp),intent(out) :: work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper,wantz
            character :: vect
@@ -72491,7 +72491,7 @@ module stdlib_linalg_lapack_c
               vect = 'N'
            end if
            call stdlib_chbtrd(vect,uplo,n,ka,ab,ldab,w,rwork(inde),z,ldz,work,iinfo)
-                     
+
            ! for eigenvalues only, call stdlib_ssterf.  for eigenvectors, call stdlib_cstedc.
            if (.not. wantz) then
               call stdlib_ssterf(n,w,rwork(inde),info)
@@ -72531,7 +72531,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: ab(ldab,*),bb(ldbb,*)
            complex(sp),intent(out) :: q(ldq,*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,test,upper,valeig,wantz
            character :: order,vect
@@ -72629,7 +72629,7 @@ module stdlib_linalg_lapack_c
               else
                  call stdlib_clacpy('A',n,n,q,ldq,z,ldz)
                  call stdlib_csteqr(jobz,n,w,rwork(indee),z,ldz,rwork(indrwk),info)
-                           
+
                  if (info == 0) then
                     do i = 1,n
                        ifail(i) = 0
@@ -72665,7 +72665,7 @@ module stdlib_linalg_lapack_c
                  call stdlib_cgemv('N',n,n,cone,q,ldq,work,1,czero,z(1,j),1)
               end do
            end if
-30         continue
+           30 continue
            ! if eigenvalues are not in order, then sort them, along with
            ! eigenvectors.
            if (wantz) then
@@ -72721,7 +72721,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,lquery,wantz
            integer(ilp) :: iinfo,imax,inde,indrwk,indtau,indwk2,indwrk,iscale,liopt, &
@@ -72875,7 +72875,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper,wantz
            character :: trans
@@ -72961,7 +72961,7 @@ module stdlib_linalg_lapack_c
                     trans = 'C'
                  end if
                  call stdlib_ctrsm('LEFT',uplo,trans,'NON-UNIT',n,n,cone,b,ldb,a,lda)
-                           
+
               else if (itype == 3) then
                  ! for b*a*x=(lambda)*x;
                  ! backtransform eigenvectors: x = l*y or u**h *y
@@ -72971,7 +72971,7 @@ module stdlib_linalg_lapack_c
                     trans = 'N'
                  end if
                  call stdlib_ctrmm('LEFT',uplo,trans,'NON-UNIT',n,n,cone,b,ldb,a,lda)
-                           
+
               end if
            end if
            work(1) = lopt
@@ -73005,7 +73005,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: ap(*)
            complex(sp),intent(out) :: work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wantz
            integer(ilp) :: iinfo,imax,inde,indrwk,indtau,indwrk,iscale,liwmin,llrwk, &
@@ -73280,7 +73280,7 @@ module stdlib_linalg_lapack_c
            ! Function Arguments
            procedure(stdlib_select_c) :: select
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,scalea,wantst,wantvs
            integer(ilp) :: hswork,i,ibal,icond,ierr,ieval,ihi,ilo,itau,iwrk,maxwrk, &
@@ -73325,7 +73325,7 @@ module stdlib_linalg_lapack_c
                  maxwrk = n + n*stdlib_ilaenv(1,'CGEHRD',' ',n,1,n,0)
                  minwrk = 2*n
                  call stdlib_chseqr('S',jobvs,n,1,n,a,lda,w,vs,ldvs,work,-1,ieval)
-                           
+
                  hswork = real(work(1),KIND=sp)
                  if (.not. wantvs) then
                     maxwrk = max(maxwrk,hswork)
@@ -73458,7 +73458,7 @@ module stdlib_linalg_lapack_c
            ! Function Arguments
            procedure(stdlib_select_c) :: select
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,scalea,wantsb,wantse,wantsn,wantst,wantsv,wantvs
            integer(ilp) :: hswork,i,ibal,icond,ierr,ieval,ihi,ilo,itau,iwrk,lwrk, &
@@ -73513,7 +73513,7 @@ module stdlib_linalg_lapack_c
                  maxwrk = n + n*stdlib_ilaenv(1,'CGEHRD',' ',n,1,n,0)
                  minwrk = 2*n
                  call stdlib_chseqr('S',jobvs,n,1,n,a,lda,w,vs,ldvs,work,-1,ieval)
-                           
+
                  hswork = real(work(1),KIND=sp)
                  if (.not. wantvs) then
                     maxwrk = max(maxwrk,hswork)
@@ -73652,7 +73652,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: vl(ldvl,*),vr(ldvr,*),w(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,scalea,wantvl,wantvr
            character :: side
@@ -73709,7 +73709,7 @@ module stdlib_linalg_lapack_c
                     lwork_trevc = int(work(1),KIND=ilp)
                     maxwrk = max(maxwrk,n + lwork_trevc)
                     call stdlib_chseqr('S','V',n,1,n,a,lda,w,vl,ldvl,work,-1,info)
-                              
+
                  else if (wantvr) then
                     maxwrk = max(maxwrk,n + (n - 1)*stdlib_ilaenv(1,'CUNGHR',' ',n,1,n,- &
                               1))
@@ -73718,10 +73718,10 @@ module stdlib_linalg_lapack_c
                     lwork_trevc = int(work(1),KIND=ilp)
                     maxwrk = max(maxwrk,n + lwork_trevc)
                     call stdlib_chseqr('S','V',n,1,n,a,lda,w,vr,ldvr,work,-1,info)
-                              
+
                  else
                     call stdlib_chseqr('E','N',n,1,n,a,lda,w,vr,ldvr,work,-1,info)
-                              
+
                  end if
                  hswork = int(work(1),KIND=ilp)
                  maxwrk = max(maxwrk,hswork,minwrk)
@@ -73864,7 +73864,7 @@ module stdlib_linalg_lapack_c
               end do
            end if
            ! undo scaling if necessary
-50   continue
+           50 continue
            if (scalea) then
               call stdlib_clascl('G',0,0,cscale,anrm,n - info,1,w(info + 1),max(n - info,1) &
                         ,ierr)
@@ -73917,7 +73917,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: vl(ldvl,*),vr(ldvr,*),w(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,scalea,wantvl,wantvr,wntsnb,wntsne,wntsnn,wntsnv
            character :: job,side
@@ -73981,21 +73981,21 @@ module stdlib_linalg_lapack_c
                     lwork_trevc = int(work(1),KIND=ilp)
                     maxwrk = max(maxwrk,lwork_trevc)
                     call stdlib_chseqr('S','V',n,1,n,a,lda,w,vl,ldvl,work,-1,info)
-                              
+
                  else if (wantvr) then
                     call stdlib_ctrevc3('R','B',select,n,a,lda,vl,ldvl,vr,ldvr,n,nout, &
                               work,-1,rwork,-1,ierr)
                     lwork_trevc = int(work(1),KIND=ilp)
                     maxwrk = max(maxwrk,lwork_trevc)
                     call stdlib_chseqr('S','V',n,1,n,a,lda,w,vr,ldvr,work,-1,info)
-                              
+
                  else
                     if (wntsnn) then
                        call stdlib_chseqr('E','N',n,1,n,a,lda,w,vr,ldvr,work,-1,info)
-                                 
+
                     else
                        call stdlib_chseqr('S','N',n,1,n,a,lda,w,vr,ldvr,work,-1,info)
-                                 
+
                     end if
                  end if
                  hswork = int(work(1),KIND=ilp)
@@ -74163,7 +74163,7 @@ module stdlib_linalg_lapack_c
               end do
            end if
            ! undo scaling if necessary
-50   continue
+           50 continue
            if (scalea) then
               call stdlib_clascl('G',0,0,cscale,anrm,n - info,1,w(info + 1),max(n - info,1) &
                         ,ierr)
@@ -74204,7 +74204,7 @@ module stdlib_linalg_lapack_c
            integer(ilp),intent(out) :: iwork(*)
            character,intent(in) :: joba,jobp,jobr,jobt,jobu,jobv
         ! ===========================================================================
-           
+
            ! Local Scalars
            complex(sp) :: ctemp
            real(sp) :: aapp,aaqq,aatmax,aatmin,big,big1,cond_ok,condr1,condr2,entra, &
@@ -74292,7 +74292,7 @@ module stdlib_linalg_lapack_c
                lrwsvdj = n
                if (lquery) then
                    call stdlib_cgeqp3(m,n,a,lda,iwork,cdummy,cdummy,-1,rdummy,ierr)
-                             
+
                    lwrk_cgeqp3 = real(cdummy(1),KIND=sp)
                    call stdlib_cgeqrf(n,n,a,lda,cdummy,cdummy,-1,ierr)
                    lwrk_cgeqrf = real(cdummy(1),KIND=sp)
@@ -74316,7 +74316,7 @@ module stdlib_linalg_lapack_c
                        lwrk_cgesvj = real(cdummy(1),KIND=sp)
                        if (errest) then
                            optwrk = max(n + lwrk_cgeqp3,n**2 + lwcon,n + lwrk_cgeqrf,lwrk_cgesvj)
-                                     
+
                        else
                            optwrk = max(n + lwrk_cgeqp3,n + lwrk_cgeqrf,lwrk_cgesvj)
                        end if
@@ -74343,7 +74343,7 @@ module stdlib_linalg_lapack_c
                                 lwunmlq)
                   else
                       minwrk = max(n + lwqp3,lwsvdj,n + lwlqf,2*n + lwqrf,n + lwsvdj,n + lwunmlq)
-                                
+
                   end if
                   if (lquery) then
                       call stdlib_cgesvj('L','U','N',n,n,u,ldu,sva,n,a,lda,cdummy,-1, &
@@ -74394,7 +74394,7 @@ module stdlib_linalg_lapack_c
                                 lwrk_cunmqrm)
                       else
                       optwrk = n + max(lwrk_cgeqp3,n + lwrk_cgeqrf,lwrk_cgesvj,lwrk_cunmqrm)
-                                
+
                       end if
                   end if
                   if (l2tran .or. rowpiv) then
@@ -74447,7 +74447,7 @@ module stdlib_linalg_lapack_c
                       lwrk_cunmqr = real(cdummy(1),KIND=sp)
                       if (.not. jracc) then
                           call stdlib_cgeqp3(n,n,a,lda,iwork,cdummy,cdummy,-1,rdummy,ierr)
-                                    
+
                           lwrk_cgeqp3n = real(cdummy(1),KIND=sp)
                           call stdlib_cgesvj('L','U','N',n,n,u,ldu,sva,n,v,ldv,cdummy, &
                                     -1,rdummy,-1,ierr)
@@ -74835,7 +74835,7 @@ module stdlib_linalg_lapack_c
               iwork(p) = 0
            end do
            call stdlib_cgeqp3(m,n,a,lda,iwork,cwork,cwork(n + 1),lwork - n,rwork,ierr)
-                     
+
            ! the upper triangular matrix r1 from the first qrf is inspected for
            ! rank deficiency and possibilities for deflation, or possible
            ! ill-conditioning. depending on the user specified flag l2rank,
@@ -74857,7 +74857,7 @@ module stdlib_linalg_lapack_c
                     go to 3002
                  end if
               end do
-3002          continue
+              3002 continue
            else if (l2rank) then
               ! .. similarly as above, only slightly more gentle (less aggressive).
               ! sudden drop on the diagonal of r1 is used as the criterion for
@@ -74868,7 +74868,7 @@ module stdlib_linalg_lapack_c
                            l2kill .and. (abs(a(p,p)) < temp1))) go to 3402
                  nr = nr + 1
               end do
-3402          continue
+              3402 continue
            else
               ! the goal is high relative accuracy. however, if the matrix
               ! has high scaled condition number the relative accuracy is in
@@ -74883,7 +74883,7 @@ module stdlib_linalg_lapack_c
                            3302
                  nr = nr + 1
               end do
-3302          continue
+              3302 continue
            end if
            almort = .false.
            if (nr == n) then
@@ -74908,10 +74908,10 @@ module stdlib_linalg_lapack_c
                     end do
                     if (lsvec) then
                         call stdlib_cpocon('U',n,v,ldv,one,temp1,cwork(n + 1),rwork,ierr)
-                                  
+
                     else
                         call stdlib_cpocon('U',n,v,ldv,one,temp1,cwork,rwork,ierr)
-                                  
+
                     end if
                  else if (lsvec) then
                     ! U Is Available As Workspace
@@ -74921,7 +74921,7 @@ module stdlib_linalg_lapack_c
                        call stdlib_csscal(p,one/temp1,u(1,p),1)
                     end do
                     call stdlib_cpocon('U',n,u,ldu,one,temp1,cwork(n + 1),rwork,ierr)
-                              
+
                  else
                     call stdlib_clacpy('U',n,n,a,lda,cwork,n)
       ! []            call stdlib_clacpy( 'u', n, n, a, lda, cwork(n+1), n )
@@ -74936,7 +74936,7 @@ module stdlib_linalg_lapack_c
       ! []               call stdlib_cpocon( 'u', n, cwork(n+1), n, one, temp1,
       ! []     $              cwork(n+n*n+1), rwork, ierr )
                     call stdlib_cpocon('U',n,cwork,n,one,temp1,cwork(n*n + 1),rwork,ierr)
-                              
+
                  end if
                  if (temp1 /= zero) then
                     sconda = one/sqrt(temp1)
@@ -75040,7 +75040,7 @@ module stdlib_linalg_lapack_c
                  call stdlib_clacpy('L',nr,nr,a,lda,v,ldv)
                  call stdlib_claset('U',nr - 1,nr - 1,czero,czero,v(1,2),ldv)
                  call stdlib_cgeqrf(nr,nr,v,ldv,cwork(n + 1),cwork(2*n + 1),lwork - 2*n,ierr)
-                           
+
                  do p = 1,nr
                     call stdlib_ccopy(nr - p + 1,v(p,p),ldv,v(p,p),1)
                     call stdlib_clacgv(nr - p + 1,v(p,p),1)
@@ -75061,7 +75061,7 @@ module stdlib_linalg_lapack_c
                ! Permute The Rows Of V
                ! do 8991 p = 1, n
                   ! call stdlib_ccopy( n, v(p,1), ldv, a(iwork(p),1), lda )
-8991 continue
+                  8991 continue
                ! call stdlib_clacpy( 'all', n, n, a, lda, v, ldv )
               call stdlib_clapmr(.false.,n,n,v,ldv,iwork)
                if (transp) then
@@ -75084,7 +75084,7 @@ module stdlib_linalg_lapack_c
               end do
               call stdlib_claset('U',nr - 1,nr - 1,czero,czero,u(1,2),ldu)
               call stdlib_cgeqrf(n,nr,u,ldu,cwork(n + 1),cwork(2*n + 1),lwork - 2*n,ierr)
-                        
+
               do p = 1,nr - 1
                  call stdlib_ccopy(nr - p,u(p,p + 1),ldu,u(p + 1,p),1)
                  call stdlib_clacgv(n - p + 1,u(p,p),1)
@@ -75173,7 +75173,7 @@ module stdlib_linalg_lapack_c
                     ! of a lower triangular matrix.
                     ! r1^* = q2 * r2
                     call stdlib_cgeqrf(n,nr,v,ldv,cwork(n + 1),cwork(2*n + 1),lwork - 2*n,ierr)
-                              
+
                     if (l2pert) then
                        xsc = sqrt(small)/epsln
                        do p = 2,nr
@@ -75185,7 +75185,7 @@ module stdlib_linalg_lapack_c
                        end do
                     end if
                     if (nr /= n) call stdlib_clacpy('A',n,nr,v,ldv,cwork(2*n + 1),n)
-                              
+
                     ! .. save ...
                  ! This Transposed Copy Should Be Better Than Naive
                     do p = 1,nr - 1
@@ -75486,7 +75486,7 @@ module stdlib_linalg_lapack_c
                  call stdlib_claset('U',nr - 1,nr - 1,czero,czero,v(1,2),ldv)
               end if
               call stdlib_cgeqrf(n,nr,v,ldv,cwork(n + 1),cwork(2*n + 1),lwork - 2*n,ierr)
-                        
+
               call stdlib_clacpy('L',n,nr,v,ldv,cwork(2*n + 1),n)
               do p = 1,nr
                  call stdlib_ccopy(nr - p + 1,v(p,p),ldv,u(p,p),1)
@@ -75610,7 +75610,7 @@ module stdlib_linalg_lapack_c
         ! =====================================================================
            ! Local Parameters
            integer(ilp),parameter :: nsweep = 30
-           
+
            ! Local Scalars
            complex(sp) :: aapq,ompq
            real(sp) :: aapp,aapp0,aapq1,aaqq,apoaq,aqoap,big,bigtheta,cs,ctol,epsln, &
@@ -75822,7 +75822,7 @@ module stdlib_linalg_lapack_c
        ! #:) quick return for one-column matrix
            if (n == 1) then
               if (lsvec) call stdlib_clascl('G',0,0,sva(1),skl,m,1,a(1,1),lda,ierr)
-                        
+
               rwork(1) = one/skl
               if (sva(1) >= sfmin) then
                  rwork(2) = one
@@ -75938,12 +75938,12 @@ module stdlib_linalg_lapack_c
                            tol,2,cwork(n + 1),lwork - n,ierr)
                  call stdlib_cgsvj0(jobv,n2,n4,a(1,n4 + 1),lda,cwork(n4 + 1),sva(n4 + 1), &
                  mvl,v(n4*q + 1,n4 + 1),ldv,epsln,sfmin,tol,1,cwork(n + 1),lwork - n,ierr)
-                           
+
                  call stdlib_cgsvj1(jobv,n2,n2,n4,a,lda,cwork,sva,mvl,v,ldv,epsln, &
                            sfmin,tol,1,cwork(n + 1),lwork - n,ierr)
                  call stdlib_cgsvj0(jobv,n2 + n4,n4,a(1,n2 + 1),lda,cwork(n2 + 1),sva(n2 + 1) &
                  ,mvl,v(n2*q + 1,n2 + 1),ldv,epsln,sfmin,tol,1,cwork(n + 1),lwork - n,ierr)
-                           
+
               end if
            end if
            ! .. row-cyclic pivot strategy with de rijk's pivoting ..
@@ -76057,19 +76057,19 @@ module stdlib_linalg_lapack_c
                                                        conjg(ompq)*t)
                                          end if
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq1))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq1))
                                          mxsinj = max(mxsinj,abs(t))
                                       else
                        ! Choose Correct Signum For Theta And Rotate
                                          thsign = -sign(one,aapq1)
                                          t = one/(theta + thsign*sqrt(one + theta*theta))
-                                                   
+
                                          cs = sqrt(one/(one + t*t))
                                          sn = t*cs
                                          mxsinj = max(mxsinj,abs(sn))
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq1))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq1))
                                          call stdlib_crot(m,a(1,p),1,a(1,q),1,cs,conjg(ompq) &
                                                    *sn)
@@ -76087,7 +76087,7 @@ module stdlib_linalg_lapack_c
                                       call stdlib_clascl('G',0,0,aaqq,one,m,1,a(1,q), &
                                                 lda,ierr)
                                       call stdlib_caxpy(m,-aapq,cwork(n + 1),1,a(1,q),1)
-                                                
+
                                       call stdlib_clascl('G',0,0,one,aaqq,m,1,a(1,q), &
                                                 lda,ierr)
                                       sva(q) = aaqq*sqrt(max(zero,one - aapq1*aapq1))
@@ -76135,7 +76135,7 @@ module stdlib_linalg_lapack_c
                              end if
                           end do loop_2002
            ! end q-loop
-2103 continue
+           2103 continue
            ! bailed out of q-loop
                           sva(p) = aapp
                        else
@@ -76222,7 +76222,7 @@ module stdlib_linalg_lapack_c
                                                        conjg(ompq)*t)
                                          end if
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq1))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq1))
                                          mxsinj = max(mxsinj,abs(t))
                                       else
@@ -76230,12 +76230,12 @@ module stdlib_linalg_lapack_c
                                          thsign = -sign(one,aapq1)
                                          if (aaqq > aapp0) thsign = -thsign
                                          t = one/(theta + thsign*sqrt(one + theta*theta))
-                                                   
+
                                          cs = sqrt(one/(one + t*t))
                                          sn = t*cs
                                          mxsinj = max(mxsinj,abs(sn))
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq1))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq1))
                                          call stdlib_crot(m,a(1,p),1,a(1,q),1,cs,conjg(ompq) &
                                                    *sn)
@@ -76249,17 +76249,17 @@ module stdlib_linalg_lapack_c
                     ! .. have to use modified gram-schmidt like transformation
                                     if (aapp > aaqq) then
                                          call stdlib_ccopy(m,a(1,p),1,cwork(n + 1),1)
-                                                   
+
                                          call stdlib_clascl('G',0,0,aapp,one,m,1,cwork(n + 1) &
                                                    ,lda,ierr)
                                          call stdlib_clascl('G',0,0,aaqq,one,m,1,a(1,q), &
                                                     lda,ierr)
                                          call stdlib_caxpy(m,-aapq,cwork(n + 1),1,a(1,q),1)
-                                                   
+
                                          call stdlib_clascl('G',0,0,one,aaqq,m,1,a(1,q), &
                                                     lda,ierr)
                                          sva(q) = aaqq*sqrt(max(zero,one - aapq1*aapq1))
-                                                   
+
                                          mxsinj = max(mxsinj,sfmin)
                                     else
                                         call stdlib_ccopy(m,a(1,q),1,cwork(n + 1),1)
@@ -76272,7 +76272,7 @@ module stdlib_linalg_lapack_c
                                          call stdlib_clascl('G',0,0,one,aapp,m,1,a(1,p), &
                                                     lda,ierr)
                                          sva(p) = aapp*sqrt(max(zero,one - aapq1*aapq1))
-                                                   
+
                                          mxsinj = max(mxsinj,sfmin)
                                     end if
                                    end if
@@ -76324,7 +76324,7 @@ module stdlib_linalg_lapack_c
                              end if
                           end do loop_2200
               ! end of the q-loop
-2203 continue
+              2203 continue
                           sva(p) = aapp
                        else
                           if (aapp == zero) notrot = notrot + min(jgl + kbl - 1,n) - jgl + 1
@@ -76334,7 +76334,7 @@ module stdlib_linalg_lapack_c
            ! end of the p-loop
                  end do loop_2010
            ! end of the jbc-loop
-2011 continue
+           2011 continue
       ! 2011 bailed out of the jbc-loop
                  do p = igl,min(igl + kbl - 1,n)
                     sva(p) = abs(sva(p))
@@ -76363,12 +76363,12 @@ module stdlib_linalg_lapack_c
        ! #:( reaching this point means that the procedure has not converged.
            info = nsweep - 1
            go to 1995
-1994       continue
+           1994 continue
        ! #:) reaching this point means numerical convergence after the i-th
            ! sweep.
            info = 0
        ! #:) info = 0 confirms successful iterations.
-1995 continue
+       1995 continue
            ! sort the singular values and find how many are above
            ! the underflow threshold.
            n2 = 0
@@ -76469,11 +76469,11 @@ module stdlib_linalg_lapack_c
            real(sp),intent(out) :: rwork(*)
            complex(sp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(sp),intent(out) :: alpha(*),beta(*),vsl(ldvsl,*),vsr(ldvsr,*),work(*)
-                     
+
            ! Function Arguments
            procedure(stdlib_selctg_c) :: selctg
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: cursl,ilascl,ilbscl,ilvsl,ilvsr,lastsl,lquery,wantst
            integer(ilp) :: i,icols,ierr,ihi,ijobvl,ijobvr,ileft,ilo,iright,irows,irwrk, &
@@ -76642,16 +76642,16 @@ module stdlib_linalg_lapack_c
            if (wantst) then
               ! undo scaling on eigenvalues before selecting
               if (ilascl) call stdlib_clascl('G',0,0,anrm,anrmto,n,1,alpha,n,ierr)
-                        
+
               if (ilbscl) call stdlib_clascl('G',0,0,bnrm,bnrmto,n,1,beta,n,ierr)
-                        
+
               ! select eigenvalues
               do i = 1,n
                  bwork(i) = selctg(alpha(i),beta(i))
               end do
               call stdlib_ctgsen(0,ilvsl,ilvsr,bwork,n,a,lda,b,ldb,alpha,beta,vsl, &
               ldvsl,vsr,ldvsr,sdim,pvsl,pvsr,dif,work(iwrk),lwork - iwrk + 1,idum,1,ierr)
-                        
+
               if (ierr == 1) info = n + 3
            end if
            ! apply back-permutation to vsl and vsr
@@ -76679,7 +76679,7 @@ module stdlib_linalg_lapack_c
                  lastsl = cursl
               end do
            end if
-30         continue
+           30 continue
            work(1) = cmplx(lwkopt,KIND=sp)
            return
      end subroutine stdlib_cgges3
@@ -76714,7 +76714,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(sp),intent(out) :: alpha(*),beta(*),vl(ldvl,*),vr(ldvr,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: ilascl,ilbscl,ilv,ilvl,ilvr,lquery
            character :: chtemp
@@ -76948,7 +76948,7 @@ module stdlib_linalg_lapack_c
               end if
            end if
            ! undo scaling if necessary
-70   continue
+           70 continue
            if (ilascl) call stdlib_clascl('G',0,0,anrmto,anrm,n,1,alpha,n,ierr)
            if (ilbscl) call stdlib_clascl('G',0,0,bnrmto,bnrm,n,1,beta,n,ierr)
            work(1) = cmplx(lwkopt,KIND=sp)
@@ -76975,7 +76975,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(out) :: work(lwork)
            real(sp),intent(inout) :: sva(n)
         ! =====================================================================
-           
+
            ! Local Scalars
            complex(sp) :: aapq,ompq
            real(sp) :: aapp,aapp0,aapq1,aaqq,apoaq,aqoap,big,bigtheta,cs,mxaapq,mxsinj, &
@@ -77168,19 +77168,19 @@ module stdlib_linalg_lapack_c
                                                        conjg(ompq)*t)
                                          end if
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq1))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq1))
                                          mxsinj = max(mxsinj,abs(t))
                                       else
                        ! Choose Correct Signum For Theta And Rotate
                                          thsign = -sign(one,aapq1)
                                          t = one/(theta + thsign*sqrt(one + theta*theta))
-                                                   
+
                                          cs = sqrt(one/(one + t*t))
                                          sn = t*cs
                                          mxsinj = max(mxsinj,abs(sn))
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq1))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq1))
                                          call stdlib_crot(m,a(1,p),1,a(1,q),1,cs,conjg(ompq) &
                                                    *sn)
@@ -77245,7 +77245,7 @@ module stdlib_linalg_lapack_c
                              end if
                           end do loop_2002
            ! end q-loop
-2103 continue
+           2103 continue
            ! bailed out of q-loop
                           sva(p) = aapp
                        else
@@ -77332,7 +77332,7 @@ module stdlib_linalg_lapack_c
                                                        conjg(ompq)*t)
                                          end if
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq1))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq1))
                                          mxsinj = max(mxsinj,abs(t))
                                       else
@@ -77340,12 +77340,12 @@ module stdlib_linalg_lapack_c
                                          thsign = -sign(one,aapq1)
                                          if (aaqq > aapp0) thsign = -thsign
                                          t = one/(theta + thsign*sqrt(one + theta*theta))
-                                                   
+
                                          cs = sqrt(one/(one + t*t))
                                          sn = t*cs
                                          mxsinj = max(mxsinj,abs(sn))
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq1))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq1))
                                          call stdlib_crot(m,a(1,p),1,a(1,q),1,cs,conjg(ompq) &
                                                    *sn)
@@ -77364,11 +77364,11 @@ module stdlib_linalg_lapack_c
                                          call stdlib_clascl('G',0,0,aaqq,one,m,1,a(1,q), &
                                                     lda,ierr)
                                          call stdlib_caxpy(m,-aapq,work,1,a(1,q),1)
-                                                   
+
                                          call stdlib_clascl('G',0,0,one,aaqq,m,1,a(1,q), &
                                                     lda,ierr)
                                          sva(q) = aaqq*sqrt(max(zero,one - aapq1*aapq1))
-                                                   
+
                                          mxsinj = max(mxsinj,sfmin)
                                     else
                                         call stdlib_ccopy(m,a(1,q),1,work,1)
@@ -77381,7 +77381,7 @@ module stdlib_linalg_lapack_c
                                          call stdlib_clascl('G',0,0,one,aapp,m,1,a(1,p), &
                                                     lda,ierr)
                                          sva(p) = aapp*sqrt(max(zero,one - aapq1*aapq1))
-                                                   
+
                                          mxsinj = max(mxsinj,sfmin)
                                     end if
                                    end if
@@ -77433,7 +77433,7 @@ module stdlib_linalg_lapack_c
                              end if
                           end do loop_2200
               ! end of the q-loop
-2203 continue
+              2203 continue
                           sva(p) = aapp
                        else
                           if (aapp == zero) notrot = notrot + min(jgl + kbl - 1,n) - jgl + 1
@@ -77443,7 +77443,7 @@ module stdlib_linalg_lapack_c
            ! end of the p-loop
                  end do loop_2010
            ! end of the jbc-loop
-2011 continue
+           2011 continue
       ! 2011 bailed out of the jbc-loop
                  do p = igl,min(igl + kbl - 1,n)
                     sva(p) = abs(sva(p))
@@ -77472,12 +77472,12 @@ module stdlib_linalg_lapack_c
        ! #:( reaching this point means that the procedure has not converged.
            info = nsweep - 1
            go to 1995
-1994       continue
+           1994 continue
        ! #:) reaching this point means numerical convergence after the i-th
            ! sweep.
            info = 0
        ! #:) info = 0 confirms successful iterations.
-1995 continue
+       1995 continue
            ! sort the vector sva() of column norms.
            do p = 1,n - 1
               q = stdlib_isamax(n - p + 1,sva(p),1) + p - 1
@@ -77535,7 +77535,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(out) :: work(lwork)
            real(sp),intent(inout) :: sva(n)
         ! =====================================================================
-           
+
            ! Local Scalars
            complex(sp) :: aapq,ompq
            real(sp) :: aapp,aapp0,aapq1,aaqq,apoaq,aqoap,big,bigtheta,cs,mxaapq,mxsinj, &
@@ -77705,7 +77705,7 @@ module stdlib_linalg_lapack_c
                                                        conjg(ompq)*t)
                                          end if
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq1))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq1))
                                          mxsinj = max(mxsinj,abs(t))
                                       else
@@ -77713,12 +77713,12 @@ module stdlib_linalg_lapack_c
                                          thsign = -sign(one,aapq1)
                                          if (aaqq > aapp0) thsign = -thsign
                                          t = one/(theta + thsign*sqrt(one + theta*theta))
-                                                   
+
                                          cs = sqrt(one/(one + t*t))
                                          sn = t*cs
                                          mxsinj = max(mxsinj,abs(sn))
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq1))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq1))
                                          call stdlib_crot(m,a(1,p),1,a(1,q),1,cs,conjg(ompq) &
                                                    *sn)
@@ -77737,11 +77737,11 @@ module stdlib_linalg_lapack_c
                                          call stdlib_clascl('G',0,0,aaqq,one,m,1,a(1,q), &
                                                     lda,ierr)
                                          call stdlib_caxpy(m,-aapq,work,1,a(1,q),1)
-                                                   
+
                                          call stdlib_clascl('G',0,0,one,aaqq,m,1,a(1,q), &
                                                     lda,ierr)
                                          sva(q) = aaqq*sqrt(max(zero,one - aapq1*aapq1))
-                                                   
+
                                          mxsinj = max(mxsinj,sfmin)
                                     else
                                         call stdlib_ccopy(m,a(1,q),1,work,1)
@@ -77754,7 +77754,7 @@ module stdlib_linalg_lapack_c
                                          call stdlib_clascl('G',0,0,one,aapp,m,1,a(1,p), &
                                                     lda,ierr)
                                          sva(p) = aapp*sqrt(max(zero,one - aapq1*aapq1))
-                                                   
+
                                          mxsinj = max(mxsinj,sfmin)
                                     end if
                                    end if
@@ -77806,7 +77806,7 @@ module stdlib_linalg_lapack_c
                              end if
                           end do loop_2200
               ! end of the q-loop
-2203 continue
+              2203 continue
                           sva(p) = aapp
                        else
                           if (aapp == zero) notrot = notrot + min(jgl + kbl - 1,n) - jgl + 1
@@ -77816,7 +77816,7 @@ module stdlib_linalg_lapack_c
            ! end of the p-loop
                  end do loop_2010
            ! end of the jbc-loop
-2011 continue
+           2011 continue
       ! 2011 bailed out of the jbc-loop
                  do p = igl,min(igl + kbl - 1,n)
                     sva(p) = abs(sva(p))
@@ -77845,12 +77845,12 @@ module stdlib_linalg_lapack_c
        ! #:( reaching this point means that the procedure has not converged.
            info = nsweep - 1
            go to 1995
-1994       continue
+           1994 continue
        ! #:) reaching this point means numerical convergence after the i-th
            ! sweep.
            info = 0
        ! #:) info = 0 confirms successful iterations.
-1995 continue
+       1995 continue
            ! sort the vector sva() of column norms.
            do p = 1,n - 1
               q = stdlib_isamax(n - p + 1,sva(p),1) + p - 1
@@ -77880,7 +77880,7 @@ module stdlib_linalg_lapack_c
      !> of A is then used to solve the system of equations A * X = B.
 
      pure subroutine stdlib_chesv_aa(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -77934,7 +77934,7 @@ module stdlib_linalg_lapack_c
            if (info == 0) then
               ! solve the system a*x = b, overwriting b with x.
               call stdlib_chetrs_aa(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-                        
+
            end if
            work(1) = lwkopt
            return
@@ -77960,7 +77960,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper
            integer(ilp) :: j,lwkopt
@@ -78017,7 +78017,7 @@ module stdlib_linalg_lapack_c
               ! jb, where jb is the number of columns factorized by stdlib_clahef;
               ! jb is either nb, or n-j+1 for the last block
               j = 0
-10            continue
+              10 continue
               if (j >= n) go to 20
               ! each step of the main loop
                ! j is the last column of the previous panel
@@ -78049,7 +78049,7 @@ module stdlib_linalg_lapack_c
                     alpha = conjg(a(j,j + 1))
                     a(j,j + 1) = cone
                     call stdlib_ccopy(n - j,a(j - 1,j + 1),lda,work((j + 1 - j1 + 1) + jb*n),1)
-                              
+
                     call stdlib_cscal(n - j,alpha,work((j + 1 - j1 + 1) + jb*n),1)
                     ! k1 identifies if the previous column of the panel has been
                      ! explicitly stored, e.g., k1=0 and k2=1 for the first panel,
@@ -78070,7 +78070,7 @@ module stdlib_linalg_lapack_c
                        do mj = nj - 1,1,-1
                           call stdlib_cgemm('CONJUGATE TRANSPOSE','TRANSPOSE',1,mj,jb + 1,-cone, &
                            a(j1 - k2,j3),lda,work((j3 - j1 + 1) + k1*n),n,cone,a(j3,j3),lda)
-                                     
+
                           j3 = j3 + 1
                        end do
                        ! update off-diagonal block of j2-th block row with stdlib_cgemm
@@ -78096,7 +78096,7 @@ module stdlib_linalg_lapack_c
               ! jb, where jb is the number of columns factorized by stdlib_clahef;
               ! jb is either nb, or n-j+1 for the last block
               j = 0
-11            continue
+              11 continue
               if (j >= n) go to 20
               ! each step of the main loop
                ! j is the last column of the previous panel
@@ -78164,7 +78164,7 @@ module stdlib_linalg_lapack_c
               end if
               go to 11
            end if
-20         continue
+           20 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_chetrf_aa
@@ -78179,7 +78179,7 @@ module stdlib_linalg_lapack_c
      !> by the unitary matrix Q:  A = Q*H*Q**H = (QZ)*T*(QZ)**H.
 
      pure subroutine stdlib_chseqr(job,compz,n,ilo,ihi,h,ldh,w,z,ldz,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -78198,14 +78198,14 @@ module stdlib_linalg_lapack_c
            ! ==== matrices of order ntiny or smaller must be processed by
            ! .    stdlib_clahqr because of insufficient subdiagonal scratch space.
            ! .    (this is a hard limit.) ====
-           
+
            ! ==== nl allocates some local workspace to help small matrices
            ! .    through a rare stdlib_clahqr failure.  nl > ntiny = 15 is
            ! .    required and nl <= nmin = stdlib_ilaenv(ispec=12,...) is recom-
            ! .    mended.  (the default value of nmin is 75.)  using nl = 49
            ! .    allows up to six simultaneous shifts and a 16-by-16
            ! .    deflation window.  ====
-           
+
            ! Local Arrays
            complex(sp) :: hl(nl,nl),workl(nl)
            ! Local Scalars
@@ -78258,7 +78258,7 @@ module stdlib_linalg_lapack_c
               ! ==== copy eigenvalues isolated by stdlib_cgebal ====
               if (ilo > 1) call stdlib_ccopy(ilo - 1,h,ldh + 1,w,1)
               if (ihi < n) call stdlib_ccopy(n - ihi,h(ihi + 1,ihi + 1),ldh + 1,w(ihi + 1),1)
-                        
+
               ! ==== initialize z, if requested ====
               if (initz) call stdlib_claset('A',n,n,czero,cone,z,ldz)
               ! ==== quick return if possible ====
@@ -78268,7 +78268,7 @@ module stdlib_linalg_lapack_c
               end if
               ! ==== stdlib_clahqr/stdlib_claqr0 crossover point ====
               nmin = stdlib_ilaenv(12,'CHSEQR',job(:1)//compz(:1),n,ilo,ihi,lwork)
-                        
+
               nmin = max(ntiny,nmin)
               ! ==== stdlib_claqr0 for big matrices; stdlib_clahqr for small ones ====
               if (n > nmin) then
@@ -78277,7 +78277,7 @@ module stdlib_linalg_lapack_c
               else
                  ! ==== small matrix ====
                  call stdlib_clahqr(wantt,wantz,n,ilo,ihi,h,ldh,w,ilo,ihi,z,ldz,info)
-                           
+
                  if (info > 0) then
                     ! ==== a rare stdlib_clahqr failure!  stdlib_claqr0 sometimes succeeds
                     ! .    when stdlib_clahqr fails. ====
@@ -78298,7 +78298,7 @@ module stdlib_linalg_lapack_c
                        call stdlib_claqr0(wantt,wantz,nl,ilo,kbot,hl,nl,w,ilo,ihi,z, &
                                  ldz,workl,nl,info)
                        if (wantt .or. info /= 0) call stdlib_clacpy('A',n,n,hl,nl,h,ldh)
-                                 
+
                     end if
                  end if
               end if
@@ -78335,7 +78335,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*),h(ldh,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j,k,k1,i1,i2,mj
            complex(sp) :: piv,alpha
@@ -78350,7 +78350,7 @@ module stdlib_linalg_lapack_c
               ! .....................................................
               ! factorize a as u**t*d*u using the upper triangle of a
               ! .....................................................
-10   continue
+              10 continue
               if (j > min(m,nb)) go to 20
               ! k is the column to be factorized
                ! when being called from stdlib_chetrf_aa,
@@ -78406,7 +78406,7 @@ module stdlib_linalg_lapack_c
                     i1 = i1 + j - 1
                     i2 = i2 + j - 1
                     call stdlib_cswap(i2 - i1 - 1,a(j1 + i1 - 1,i1 + 1),lda,a(j1 + i1,i2),1)
-                              
+
                     call stdlib_clacgv(i2 - i1,a(j1 + i1 - 1,i1 + 1),lda)
                     call stdlib_clacgv(i2 - i1 - 1,a(j1 + i1,i2),1)
                     ! swap a(i1, i2+1:n) with a(i2, i2+1:n)
@@ -78442,18 +78442,18 @@ module stdlib_linalg_lapack_c
                        call stdlib_cscal(m - j - 1,alpha,a(k,j + 2),lda)
                     else
                        call stdlib_claset('FULL',1,m - j - 1,czero,czero,a(k,j + 2),lda)
-                                 
+
                     end if
                  end if
               end if
               j = j + 1
               go to 10
-20            continue
+              20 continue
            else
               ! .....................................................
               ! factorize a as l*d*l**t using the lower triangle of a
               ! .....................................................
-30   continue
+              30 continue
               if (j > min(m,nb)) go to 40
               ! k is the column to be factorized
                ! when being called from stdlib_chetrf_aa,
@@ -78509,7 +78509,7 @@ module stdlib_linalg_lapack_c
                     i1 = i1 + j - 1
                     i2 = i2 + j - 1
                     call stdlib_cswap(i2 - i1 - 1,a(i1 + 1,j1 + i1 - 1),1,a(i2,j1 + i1),lda)
-                              
+
                     call stdlib_clacgv(i2 - i1,a(i1 + 1,j1 + i1 - 1),1)
                     call stdlib_clacgv(i2 - i1 - 1,a(i2,j1 + i1),lda)
                     ! swap a(i2+1:n, i1) with a(i2+1:n, i2)
@@ -78545,13 +78545,13 @@ module stdlib_linalg_lapack_c
                        call stdlib_cscal(m - j - 1,alpha,a(j + 2,k),1)
                     else
                        call stdlib_claset('FULL',m - j - 1,1,czero,czero,a(j + 2,k),lda)
-                                 
+
                     end if
                  end if
               end if
               j = j + 1
               go to 30
-40            continue
+              40 continue
            end if
            return
      end subroutine stdlib_clahef_aa
@@ -78586,18 +78586,18 @@ module stdlib_linalg_lapack_c
            ! ==== matrices of order ntiny or smaller must be processed by
            ! .    stdlib_clahqr because of insufficient subdiagonal scratch space.
            ! .    (this is a hard limit.) ====
-           
+
            ! ==== exceptional deflation windows:  try to cure rare
            ! .    slow convergence by varying the size of the
            ! .    deflation window after kexnw iterations. ====
-           
+
            ! ==== exceptional shifts: try to cure rare slow convergence
            ! .    with ad-hoc exceptional shifts every kexsh iterations.
            ! .    ====
-           
+
            ! ==== the constant wilk1 is used to form the exceptional
            ! .    shifts. ====
-           
+
            ! Local Scalars
            complex(sp) :: aa,bb,cc,cdum,dd,det,rtdisc,swap,tr2
            real(sp) :: s
@@ -78702,7 +78702,7 @@ module stdlib_linalg_lapack_c
                     if (h(k,k - 1) == czero) go to 20
                  end do
                  k = ilo
-20               continue
+                 20 continue
                  ktop = k
                  ! ==== select deflation window size:
                  ! .    typical case:
@@ -78798,7 +78798,7 @@ module stdlib_linalg_lapack_c
                           ks = kbot - ns + 1
                           kt = n - ns + 1
                           call stdlib_clacpy('A',ns,ns,h(ks,ks),ldh,h(kt,1),ldh)
-                                    
+
                           if (ns > nmin) then
                              call stdlib_claqr4(.false.,.false.,ns,1,ns,h(kt,1),ldh,w( &
                                        ks),1,1,zdum,1,work,lwork,inf)
@@ -78843,7 +78843,7 @@ module stdlib_linalg_lapack_c
                                 end if
                              end do
                           end do
-60                        continue
+                          60 continue
                        end if
                     end if
                     ! ==== if there are only two shifts, then use
@@ -78895,7 +78895,7 @@ module stdlib_linalg_lapack_c
               ! ==== iteration limit exceeded.  set info to show where
               ! .    the problem occurred and exit. ====
               info = kbot
-80            continue
+              80 continue
            end if
            ! ==== return the optimal value of lwork. ====
            work(1) = cmplx(lwkopt,0,KIND=sp)
@@ -78928,7 +78928,7 @@ module stdlib_linalg_lapack_c
            ! Parameters
            real(sp),parameter :: rzero = 0.0_sp
            real(sp),parameter :: rone = 1.0_sp
-           
+
            ! Local Scalars
            complex(sp) :: beta,cdum,s,tau
            real(sp) :: foo,safmax,safmin,smlnum,ulp
@@ -78951,7 +78951,7 @@ module stdlib_linalg_lapack_c
               lwk1 = int(work(1),KIND=ilp)
               ! ==== workspace query call to stdlib_cunmhr ====
               call stdlib_cunmhr('R','N',jw,jw,1,jw - 1,t,ldt,work,v,ldv,work,-1,info)
-                        
+
               lwk2 = int(work(1),KIND=ilp)
               ! ==== workspace query call to stdlib_claqr4 ====
               call stdlib_claqr4(.true.,.true.,jw,1,jw,t,ldt,sh,1,jw,v,ldv,work,-1, &
@@ -79046,7 +79046,7 @@ module stdlib_linalg_lapack_c
                  end do
                  ilst = i
                  if (ifst /= ilst) call stdlib_ctrexc('V',jw,t,ldt,v,ldv,ifst,ilst,info)
-                           
+
               end do
            end if
            ! ==== restore shift/eigenvalue array from t ====
@@ -79065,11 +79065,11 @@ module stdlib_linalg_lapack_c
                  work(1) = cone
                  call stdlib_claset('L',jw - 2,jw - 2,czero,czero,t(3,1),ldt)
                  call stdlib_clarf('L',ns,jw,work,1,conjg(tau),t,ldt,work(jw + 1))
-                           
+
                  call stdlib_clarf('R',ns,ns,work,1,tau,t,ldt,work(jw + 1))
                  call stdlib_clarf('R',jw,ns,work,1,tau,v,ldv,work(jw + 1))
                  call stdlib_cgehrd(jw,1,ns,t,ldt,work,work(jw + 1),lwork - jw,info)
-                           
+
               end if
               ! ==== copy updated reduced window into place ====
               if (kwtop > 1) h(kwtop,kwtop - 1) = s*conjg(v(1,1))
@@ -79158,18 +79158,18 @@ module stdlib_linalg_lapack_c
            ! ==== matrices of order ntiny or smaller must be processed by
            ! .    stdlib_clahqr because of insufficient subdiagonal scratch space.
            ! .    (this is a hard limit.) ====
-           
+
            ! ==== exceptional deflation windows:  try to cure rare
            ! .    slow convergence by varying the size of the
            ! .    deflation window after kexnw iterations. ====
-           
+
            ! ==== exceptional shifts: try to cure rare slow convergence
            ! .    with ad-hoc exceptional shifts every kexsh iterations.
            ! .    ====
-           
+
            ! ==== the constant wilk1 is used to form the exceptional
            ! .    shifts. ====
-           
+
            ! Local Scalars
            complex(sp) :: aa,bb,cc,cdum,dd,det,rtdisc,swap,tr2
            real(sp) :: s
@@ -79274,7 +79274,7 @@ module stdlib_linalg_lapack_c
                     if (h(k,k - 1) == czero) go to 20
                  end do
                  k = ilo
-20               continue
+                 20 continue
                  ktop = k
                  ! ==== select deflation window size:
                  ! .    typical case:
@@ -79370,7 +79370,7 @@ module stdlib_linalg_lapack_c
                           ks = kbot - ns + 1
                           kt = n - ns + 1
                           call stdlib_clacpy('A',ns,ns,h(ks,ks),ldh,h(kt,1),ldh)
-                                    
+
                           call stdlib_clahqr(.false.,.false.,ns,1,ns,h(kt,1),ldh,w(ks) &
                                     ,1,1,zdum,1,inf)
                           ks = ks + inf
@@ -79410,7 +79410,7 @@ module stdlib_linalg_lapack_c
                                 end if
                              end do
                           end do
-60                        continue
+                          60 continue
                        end if
                     end if
                     ! ==== if there are only two shifts, then use
@@ -79462,7 +79462,7 @@ module stdlib_linalg_lapack_c
               ! ==== iteration limit exceeded.  set info to show where
               ! .    the problem occurred and exit. ====
               info = kbot
-80            continue
+              80 continue
            end if
            ! ==== return the optimal value of lwork. ====
            work(1) = cmplx(lwkopt,0,KIND=sp)
@@ -79518,7 +79518,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*),b(ldb,*),q(ldq,*),z(ldz,*), &
                      alpha(*),beta(*),work(*)
            real(sp),intent(out) :: rwork(*)
-           
+
            ! local scalars
            real(sp) :: smlnum,ulp,safmin,safmax,c1,tempr
            complex(sp) :: eshift,s1,temp
@@ -79722,7 +79722,7 @@ module stdlib_linalg_lapack_c
                        end if
                        if (k2 < istop) then
                           call stdlib_clartg(a(k2,k2 - 1),a(k2 + 1,k2 - 1),c1,s1,temp)
-                                    
+
                           a(k2,k2 - 1) = temp
                           a(k2 + 1,k2 - 1) = czero
                           call stdlib_crot(istopm - k2 + 1,a(k2,k2),lda,a(k2 + 1,k2),lda,c1, &
@@ -79731,7 +79731,7 @@ module stdlib_linalg_lapack_c
                                     s1)
                           if (ilq) then
                              call stdlib_crot(n,q(1,k2),1,q(1,k2 + 1),1,c1,conjg(s1))
-                                       
+
                           end if
                        end if
                     end do
@@ -79834,7 +79834,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: qc(ldqc,*),zc(ldzc,*)
            complex(sp),intent(out) :: work(*)
            real(sp),intent(out) :: rwork(*)
-           
+
            ! local scalars
            integer(ilp) :: jw,kwtop,kwbot,istopm,istartm,k,k2,ctgexc_info,ifst,ilst, &
                      lworkreq,qz_small_info
@@ -79890,7 +79890,7 @@ module stdlib_linalg_lapack_c
            ! store window in case of convergence failure
            call stdlib_clacpy('ALL',jw,jw,a(kwtop,kwtop),lda,work,jw)
            call stdlib_clacpy('ALL',jw,jw,b(kwtop,kwtop),ldb,work(jw**2 + 1),jw)
-                     
+
            ! transform window to real schur form
            call stdlib_claset('FULL',jw,jw,czero,cone,qc,ldqc)
            call stdlib_claset('FULL',jw,jw,czero,cone,zc,ldzc)
@@ -79903,7 +79903,7 @@ module stdlib_linalg_lapack_c
               ns = jw - qz_small_info
               call stdlib_clacpy('ALL',jw,jw,work,jw,a(kwtop,kwtop),lda)
               call stdlib_clacpy('ALL',jw,jw,work(jw**2 + 1),jw,b(kwtop,kwtop),ldb)
-                        
+
               return
            end if
            ! deflation detection loop
@@ -79953,7 +79953,7 @@ module stdlib_linalg_lapack_c
                  k2 = max(kwtop,k - 1)
                  call stdlib_crot(ihi - k2 + 1,a(k,k2),lda,a(k + 1,k2),lda,c1,s1)
                  call stdlib_crot(ihi - (k - 1) + 1,b(k,k - 1),ldb,b(k + 1,k - 1),ldb,c1,s1)
-                           
+
                  call stdlib_crot(jw,qc(1,k - kwtop + 1),1,qc(1,k + 1 - kwtop + 1),1,c1,conjg( &
                            s1))
               end do
@@ -80031,7 +80031,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*),h(ldh,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j,k,k1,i1,i2,mj
            complex(sp) :: piv,alpha
@@ -80046,7 +80046,7 @@ module stdlib_linalg_lapack_c
               ! .....................................................
               ! factorize a as u**t*d*u using the upper triangle of a
               ! .....................................................
-10   continue
+              10 continue
               if (j > min(m,nb)) go to 20
               ! k is the column to be factorized
                ! when being called from stdlib_csytrf_aa,
@@ -80100,7 +80100,7 @@ module stdlib_linalg_lapack_c
                     i1 = i1 + j - 1
                     i2 = i2 + j - 1
                     call stdlib_cswap(i2 - i1 - 1,a(j1 + i1 - 1,i1 + 1),lda,a(j1 + i1,i2),1)
-                              
+
                     ! swap a(i1, i2+1:m) with a(i2, i2+1:m)
                     if (i2 < m) call stdlib_cswap(m - i2,a(j1 + i1 - 1,i2 + 1),lda,a(j1 + i2 - 1,i2 + 1), &
                                lda)
@@ -80134,18 +80134,18 @@ module stdlib_linalg_lapack_c
                        call stdlib_cscal(m - j - 1,alpha,a(k,j + 2),lda)
                     else
                        call stdlib_claset('FULL',1,m - j - 1,czero,czero,a(k,j + 2),lda)
-                                 
+
                     end if
                  end if
               end if
               j = j + 1
               go to 10
-20            continue
+              20 continue
            else
               ! .....................................................
               ! factorize a as l*d*l**t using the lower triangle of a
               ! .....................................................
-30   continue
+              30 continue
               if (j > min(m,nb)) go to 40
               ! k is the column to be factorized
                ! when being called from stdlib_csytrf_aa,
@@ -80199,7 +80199,7 @@ module stdlib_linalg_lapack_c
                     i1 = i1 + j - 1
                     i2 = i2 + j - 1
                     call stdlib_cswap(i2 - i1 - 1,a(i1 + 1,j1 + i1 - 1),1,a(i2,j1 + i1),lda)
-                              
+
                     ! swap a(i2+1:m, i1) with a(i2+1:m, i2)
                     if (i2 < m) call stdlib_cswap(m - i2,a(i2 + 1,j1 + i1 - 1),1,a(i2 + 1,j1 + i2 - 1), &
                               1)
@@ -80233,13 +80233,13 @@ module stdlib_linalg_lapack_c
                        call stdlib_cscal(m - j - 1,alpha,a(j + 2,k),1)
                     else
                        call stdlib_claset('FULL',m - j - 1,1,czero,czero,a(j + 2,k),lda)
-                                 
+
                     end if
                  end if
               end if
               j = j + 1
               go to 30
-40            continue
+              40 continue
            end if
            return
      end subroutine stdlib_clasyf_aa
@@ -80256,7 +80256,7 @@ module stdlib_linalg_lapack_c
      !> form of A is then used to solve the system of equations A * X = B.
 
      pure subroutine stdlib_csysv_aa(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -80310,7 +80310,7 @@ module stdlib_linalg_lapack_c
            if (info == 0) then
               ! solve the system a*x = b, overwriting b with x.
               call stdlib_csytrs_aa(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-                        
+
            end if
            work(1) = lwkopt
            return
@@ -80336,7 +80336,7 @@ module stdlib_linalg_lapack_c
            complex(sp),intent(inout) :: a(lda,*)
            complex(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper
            integer(ilp) :: j,lwkopt
@@ -80392,7 +80392,7 @@ module stdlib_linalg_lapack_c
               ! jb, where jb is the number of columns factorized by stdlib_clasyf;
               ! jb is either nb, or n-j+1 for the last block
               j = 0
-10            continue
+              10 continue
               if (j >= n) go to 20
               ! each step of the main loop
                ! j is the last column of the previous panel
@@ -80424,7 +80424,7 @@ module stdlib_linalg_lapack_c
                     alpha = a(j,j + 1)
                     a(j,j + 1) = cone
                     call stdlib_ccopy(n - j,a(j - 1,j + 1),lda,work((j + 1 - j1 + 1) + jb*n),1)
-                              
+
                     call stdlib_cscal(n - j,alpha,work((j + 1 - j1 + 1) + jb*n),1)
                     ! k1 identifies if the previous column of the panel has been
                      ! explicitly stored, e.g., k1=1 and k2= 0 for the first panel,
@@ -80469,7 +80469,7 @@ module stdlib_linalg_lapack_c
               ! jb, where jb is the number of columns factorized by stdlib_clasyf;
               ! jb is either nb, or n-j+1 for the last block
               j = 0
-11            continue
+              11 continue
               if (j >= n) go to 20
               ! each step of the main loop
                ! j is the last column of the previous panel
@@ -80526,7 +80526,7 @@ module stdlib_linalg_lapack_c
                        ! update off-diagonal block in j2-th block column with stdlib_cgemm
                        call stdlib_cgemm('NO TRANSPOSE','TRANSPOSE',n - j3 + 1,nj,jb + 1,-cone, &
                        work(j3 - j1 + 1 + k1*n),n,a(j2,j1 - k2),lda,cone,a(j3,j2),lda)
-                                 
+
                     end do
                     ! recover t( j+1, j )
                     a(j + 1,j) = alpha
@@ -80536,7 +80536,7 @@ module stdlib_linalg_lapack_c
               end if
               go to 11
            end if
-20         continue
+           20 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_csytrf_aa

--- a/src/stdlib_linalg_lapack_d.f90
+++ b/src/stdlib_linalg_lapack_d.f90
@@ -532,7 +532,7 @@ module stdlib_linalg_lapack_d
            integer(ilp),intent(out) :: ipiv(*)
            real(dp),intent(inout) :: ab(ldab,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,jp,ju,km,kv
            ! Intrinsic Functions
@@ -621,7 +621,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: ab(ldab,*)
            real(dp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lnoti,notran
            integer(ilp) :: i,j,kd,l,lm
@@ -713,7 +713,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: scale(*)
            real(dp),intent(inout) :: v(ldv,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: leftv,rightv
            integer(ilp) :: i,ii,k
@@ -768,7 +768,7 @@ module stdlib_linalg_lapack_d
            ! backward permutation
            ! for  i = ilo-1 step -1 until 1,
                     ! ihi+1 step 1 until n do --
-30   continue
+                    30 continue
            if (stdlib_lsame(job,'P') .or. stdlib_lsame(job,'B')) then
               if (rightv) then
                  loop_40: do ii = 1,n
@@ -800,7 +800,7 @@ module stdlib_linalg_lapack_d
      !> DGGBAL.
 
      pure subroutine stdlib_dggbak(job,side,n,ilo,ihi,lscale,rscale,m,v,ldv,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -867,7 +867,7 @@ module stdlib_linalg_lapack_d
               end if
            end if
            ! backward permutation
-30   continue
+           30 continue
            if (stdlib_lsame(job,'P') .or. stdlib_lsame(job,'B')) then
               ! backward permutation on right eigenvectors
               if (rightv) then
@@ -877,7 +877,7 @@ module stdlib_linalg_lapack_d
                     if (k == i) cycle loop_40
                     call stdlib_dswap(m,v(i,1),ldv,v(k,1),ldv)
                  end do loop_40
-50               continue
+                 50 continue
                  if (ihi == n) go to 70
                  loop_60: do i = ihi + 1,n
                     k = int(rscale(i),KIND=ilp)
@@ -886,7 +886,7 @@ module stdlib_linalg_lapack_d
                  end do loop_60
               end if
               ! backward permutation on left eigenvectors
-70   continue
+              70 continue
               if (leftv) then
                  if (ilo == 1) go to 90
                  loop_80: do i = ilo - 1,1,-1
@@ -894,7 +894,7 @@ module stdlib_linalg_lapack_d
                     if (k == i) cycle loop_80
                     call stdlib_dswap(m,v(i,1),ldv,v(k,1),ldv)
                  end do loop_80
-90               continue
+                 90 continue
                  if (ihi == n) go to 110
                  loop_100: do i = ihi + 1,n
                     k = int(lscale(i),KIND=ilp)
@@ -903,7 +903,7 @@ module stdlib_linalg_lapack_d
                  end do loop_100
               end if
            end if
-110        continue
+           110 continue
            return
      end subroutine stdlib_dggbak
 
@@ -924,7 +924,7 @@ module stdlib_linalg_lapack_d
            ! Array Arguments
            real(dp),intent(inout) :: b(ldb,*),d(*),dl(*),du(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(dp) :: fact,temp
@@ -1062,12 +1062,12 @@ module stdlib_linalg_lapack_d
            ! back solve with the matrix u from the factorization.
            if (nrhs <= 2) then
               j = 1
-70            continue
+              70 continue
               b(n,j) = b(n,j)/d(n)
               if (n > 1) b(n - 1,j) = (b(n - 1,j) - du(n - 1)*b(n,j))/d(n - 1)
               do i = n - 2,1,-1
                  b(i,j) = (b(i,j) - du(i)*b(i + 1,j) - dl(i)*b(i + 2,j))/d(i)
-                           
+
               end do
               if (j < nrhs) then
                  j = j + 1
@@ -1079,7 +1079,7 @@ module stdlib_linalg_lapack_d
                  if (n > 1) b(n - 1,j) = (b(n - 1,j) - du(n - 1)*b(n,j))/d(n - 1)
                  do i = n - 2,1,-1
                     b(i,j) = (b(i,j) - du(i)*b(i + 1,j) - dl(i)*b(i + 2,j))/d(i)
-                              
+
                  end do
               end do
            end if
@@ -1106,7 +1106,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: d(*),dl(*),du(*)
            real(dp),intent(out) :: du2(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(dp) :: fact,temp
@@ -1174,7 +1174,7 @@ module stdlib_linalg_lapack_d
                  go to 50
               end if
            end do
-50         continue
+           50 continue
            return
      end subroutine stdlib_dgttrf
 
@@ -1205,7 +1205,7 @@ module stdlib_linalg_lapack_d
               ! overwriting each right hand side vector with its solution.
               if (nrhs <= 1) then
                  j = 1
-10               continue
+                 10 continue
                  ! solve l*x = b.
                  do i = 1,n - 1
                     ip = ipiv(i)
@@ -1218,7 +1218,7 @@ module stdlib_linalg_lapack_d
                  if (n > 1) b(n - 1,j) = (b(n - 1,j) - du(n - 1)*b(n,j))/d(n - 1)
                  do i = n - 2,1,-1
                     b(i,j) = (b(i,j) - du(i)*b(i + 1,j) - du2(i)*b(i + 2,j))/d(i)
-                              
+
                  end do
                  if (j < nrhs) then
                     j = j + 1
@@ -1241,7 +1241,7 @@ module stdlib_linalg_lapack_d
                     if (n > 1) b(n - 1,j) = (b(n - 1,j) - du(n - 1)*b(n,j))/d(n - 1)
                     do i = n - 2,1,-1
                        b(i,j) = (b(i,j) - du(i)*b(i + 1,j) - du2(i)*b(i + 2,j))/d(i)
-                                 
+
                     end do
                  end do
               end if
@@ -1250,7 +1250,7 @@ module stdlib_linalg_lapack_d
               if (nrhs <= 1) then
                  ! solve u**t*x = b.
                  j = 1
-70               continue
+                 70 continue
                  b(1,j) = b(1,j)/d(1)
                  if (n > 1) b(2,j) = (b(2,j) - du(1)*b(1,j))/d(2)
                  do i = 3,n
@@ -1393,7 +1393,7 @@ module stdlib_linalg_lapack_d
              s = (s + s) - s
              y(i) = ((x(i) - s) + w(i)) + y(i)
              x(i) = s
-10           continue
+             10 continue
            return
      end subroutine stdlib_dla_wwaddw
 
@@ -1444,7 +1444,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            integer(ilp) :: i,jlast
            real(dp) :: altsgn,estold,temp,xs
@@ -1462,7 +1462,7 @@ module stdlib_linalg_lapack_d
            go to(20,40,70,110,140) isave(1)
            ! ................ entry   (isave( 1 ) = 1)
            ! first iteration.  x has been overwritten by a*x.
-20   continue
+           20 continue
            if (n == 1) then
               v(1) = x(1)
               est = abs(v(1))
@@ -1483,11 +1483,11 @@ module stdlib_linalg_lapack_d
            return
            ! ................ entry   (isave( 1 ) = 2)
            ! first iteration.  x has been overwritten by transpose(a)*x.
-40   continue
+           40 continue
            isave(2) = stdlib_idamax(n,x,1)
            isave(3) = 2
            ! main loop - iterations 2,3,...,itmax.
-50   continue
+           50 continue
            do i = 1,n
               x(i) = zero
            end do
@@ -1497,7 +1497,7 @@ module stdlib_linalg_lapack_d
            return
            ! ................ entry   (isave( 1 ) = 3)
            ! x has been overwritten by a*x.
-70   continue
+           70 continue
            call stdlib_dcopy(n,x,1,v,1)
            estold = est
            est = stdlib_dasum(n,v,1)
@@ -1511,7 +1511,7 @@ module stdlib_linalg_lapack_d
            end do
            ! repeated sign vector detected, hence algorithm has converged.
            go to 120
-90         continue
+           90 continue
            ! test for cycling.
            if (est <= estold) go to 120
            do i = 1,n
@@ -1527,7 +1527,7 @@ module stdlib_linalg_lapack_d
            return
            ! ................ entry   (isave( 1 ) = 4)
            ! x has been overwritten by transpose(a)*x.
-110  continue
+           110 continue
            jlast = isave(2)
            isave(2) = stdlib_idamax(n,x,1)
            if ((x(jlast) /= abs(x(isave(2)))) .and. (isave(3) < itmax)) then
@@ -1535,7 +1535,7 @@ module stdlib_linalg_lapack_d
               go to 50
            end if
            ! iteration complete.  final stage.
-120  continue
+           120 continue
            altsgn = one
            do i = 1,n
               x(i) = altsgn*(one + real(i - 1,KIND=dp)/real(n - 1,KIND=dp))
@@ -1546,13 +1546,13 @@ module stdlib_linalg_lapack_d
            return
            ! ................ entry   (isave( 1 ) = 5)
            ! x has been overwritten by a*x.
-140  continue
+           140 continue
            temp = two*(stdlib_dasum(n,x,1)/real(3*n,KIND=dp))
            if (temp > est) then
               call stdlib_dcopy(n,x,1,v,1)
               est = temp
            end if
-150        continue
+           150 continue
            kase = 0
            return
      end subroutine stdlib_dlacn2
@@ -1575,7 +1575,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            integer(ilp) :: i,iter,j,jlast,jump
            real(dp) :: altsgn,estold,temp
@@ -1595,7 +1595,7 @@ module stdlib_linalg_lapack_d
            go to(20,40,70,110,140) jump
            ! ................ entry   (jump = 1)
            ! first iteration.  x has been overwritten by a*x.
-20   continue
+           20 continue
            if (n == 1) then
               v(1) = x(1)
               est = abs(v(1))
@@ -1612,11 +1612,11 @@ module stdlib_linalg_lapack_d
            return
            ! ................ entry   (jump = 2)
            ! first iteration.  x has been overwritten by transpose(a)*x.
-40   continue
+           40 continue
            j = stdlib_idamax(n,x,1)
            iter = 2
            ! main loop - iterations 2,3,...,itmax.
-50   continue
+           50 continue
            do i = 1,n
               x(i) = zero
            end do
@@ -1626,7 +1626,7 @@ module stdlib_linalg_lapack_d
            return
            ! ................ entry   (jump = 3)
            ! x has been overwritten by a*x.
-70   continue
+           70 continue
            call stdlib_dcopy(n,x,1,v,1)
            estold = est
            est = stdlib_dasum(n,v,1)
@@ -1635,7 +1635,7 @@ module stdlib_linalg_lapack_d
            end do
            ! repeated sign vector detected, hence algorithm has converged.
            go to 120
-90         continue
+           90 continue
            ! test for cycling.
            if (est <= estold) go to 120
            do i = 1,n
@@ -1647,7 +1647,7 @@ module stdlib_linalg_lapack_d
            return
            ! ................ entry   (jump = 4)
            ! x has been overwritten by transpose(a)*x.
-110  continue
+           110 continue
            jlast = j
            j = stdlib_idamax(n,x,1)
            if ((x(jlast) /= abs(x(j))) .and. (iter < itmax)) then
@@ -1655,7 +1655,7 @@ module stdlib_linalg_lapack_d
               go to 50
            end if
            ! iteration complete.  final stage.
-120  continue
+           120 continue
            altsgn = one
            do i = 1,n
               x(i) = altsgn*(one + real(i - 1,KIND=dp)/real(n - 1,KIND=dp))
@@ -1666,13 +1666,13 @@ module stdlib_linalg_lapack_d
            return
            ! ................ entry   (jump = 5)
            ! x has been overwritten by a*x.
-140  continue
+           140 continue
            temp = two*(stdlib_dasum(n,x,1)/real(3*n,KIND=dp))
            if (temp > est) then
               call stdlib_dcopy(n,x,1,v,1)
               est = temp
            end if
-150        continue
+           150 continue
            kase = 0
            return
      end subroutine stdlib_dlacon
@@ -1725,7 +1725,7 @@ module stdlib_linalg_lapack_d
            ! Scalar Arguments
            real(dp),intent(in) :: a,b,c,d,r,t
         ! =====================================================================
-           
+
            ! Local Scalars
            real(dp) :: br
            ! Executable Statements
@@ -1756,7 +1756,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: a,b,c
            real(dp),intent(out) :: rt1,rt2
        ! =====================================================================
-           
+
            ! Local Scalars
            real(dp) :: ab,acmn,acmx,adf,df,rt,sm,tb
            ! Intrinsic Functions
@@ -1851,7 +1851,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: d(*),e(*),e2(*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: itmp1,itmp2,j,ji,jit,jp,kf,kfnew,kl,klnew
            real(dp) :: tmp1,tmp2
@@ -2068,7 +2068,7 @@ module stdlib_linalg_lapack_d
               if (kf > kl) go to 140
            end do loop_130
            ! converged
-140  continue
+           140 continue
            info = max(kl + 1 - kf,0)
            mout = kl
            return
@@ -2094,7 +2094,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: d(2),z(2)
            real(dp),intent(out) :: delta(2)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(dp) :: b,c,del,tau,temp,w
            ! Intrinsic Functions
@@ -2162,7 +2162,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: givnum(2,*),q(*)
            real(dp),intent(out) :: z(*),ztemp(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: bsiz1,bsiz2,curr,i,k,mid,psiz1,psiz2,ptr,zptr1
            ! Intrinsic Functions
@@ -2191,7 +2191,7 @@ module stdlib_linalg_lapack_d
            ! roots.
            bsiz1 = int(half + sqrt(real(qptr(curr + 1) - qptr(curr),KIND=dp)),KIND=ilp)
            bsiz2 = int(half + sqrt(real(qptr(curr + 2) - qptr(curr + 1),KIND=dp)),KIND=ilp)
-                     
+
            do k = 1,mid - bsiz1 - 1
               z(k) = zero
            end do
@@ -2231,9 +2231,9 @@ module stdlib_linalg_lapack_d
               ! the sqrt in case the machine underestimates one of these
               ! square roots.
               bsiz1 = int(half + sqrt(real(qptr(curr + 1) - qptr(curr),KIND=dp)),KIND=ilp)
-                        
+
               bsiz2 = int(half + sqrt(real(qptr(curr + 2) - qptr(curr + 1),KIND=dp)),KIND=ilp)
-                        
+
               if (bsiz1 > 0) then
                  call stdlib_dgemv('T',bsiz1,bsiz1,one,q(qptr(curr)),bsiz1,ztemp(1), &
                            1,zero,z(zptr1),1)
@@ -2244,7 +2244,7 @@ module stdlib_linalg_lapack_d
                            psiz1 + 1),1,zero,z(mid),1)
               end if
               call stdlib_dcopy(psiz2 - bsiz2,ztemp(psiz1 + bsiz2 + 1),1,z(mid + bsiz2),1)
-                        
+
               ptr = ptr + 2**(tlvls - k)
            end do loop_70
            return
@@ -2267,7 +2267,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: a,b,c
            real(dp),intent(out) :: cs1,rt1,rt2,sn1
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: sgn1,sgn2
            real(dp) :: ab,acmn,acmx,acs,adf,cs,ct,df,rt,sm,tb,tn
@@ -2366,7 +2366,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: fuzzy1 = one + 1.0e-5_dp
-           
+
            ! Local Scalars
            real(dp) :: a11,a12,a21,a22,abi22,anorm,as11,as12,as22,ascale,b11,b12,b22, &
            binv11,binv22,bmin,bnorm,bscale,bsize,c1,c2,c3,c4,c5,diff,discr,pp,qq,r, &
@@ -2491,7 +2491,7 @@ module stdlib_linalg_lapack_d
            ! scale first eigenvalue
            wabs = abs(wr1) + abs(wi)
            wsize = max(safmin,c1,fuzzy1*(wabs*c2 + c3),min(c4,half*max(wabs,c5)))
-                     
+
            if (wsize /= one) then
               wscale = one/wsize
               if (wsize > one) then
@@ -2561,7 +2561,7 @@ module stdlib_linalg_lapack_d
               end do
            end do
            info = 0
-30         continue
+           30 continue
            return
      end subroutine stdlib_dlag2s
 
@@ -2572,7 +2572,7 @@ module stdlib_linalg_lapack_d
      !> 0., 1., or -1.
 
      pure subroutine stdlib_dlagtm(trans,n,nrhs,alpha,dl,d,du,x,ldx,beta,b,ldb)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -2584,7 +2584,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: b(ldb,*)
            real(dp),intent(in) :: d(*),dl(*),du(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            ! Executable Statements
@@ -2700,7 +2700,7 @@ module stdlib_linalg_lapack_d
            ! Scalar Arguments
            character,intent(in) :: cmach
        ! =====================================================================
-           
+
            ! Local Scalars
            real(dp) :: rnd,eps,sfmin,small,rmach
            ! Intrinsic Functions
@@ -2789,7 +2789,7 @@ module stdlib_linalg_lapack_d
            end if
            i = 1
            ! while ( (n1sv > 0)
-10   continue
+           10 continue
            if (n1sv > 0 .and. n2sv > 0) then
               if (a(ind1) <= a(ind2)) then
                  index(i) = ind1
@@ -2882,7 +2882,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: d(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(dp) :: sfmin
            integer(ilp) :: i,iinfo,n1,n2
@@ -2937,17 +2937,17 @@ module stdlib_linalg_lapack_d
               call stdlib_dlaorhr_col_getrfnp2(n1,n1,a,lda,d,iinfo)
               ! solve for b21
               call stdlib_dtrsm('R','U','N','N',m - n1,n1,one,a,lda,a(n1 + 1,1),lda)
-                        
+
               ! solve for b12
               call stdlib_dtrsm('L','L','N','U',n1,n2,one,a,lda,a(1,n1 + 1),lda)
-                        
+
               ! update b22, i.e. compute the schur complement
               ! b22 := b22 - b21*b12
               call stdlib_dgemm('N','N',m - n1,n2,n1,-one,a(n1 + 1,1),lda,a(1,n1 + 1), &
                         lda,one,a(n1 + 1,n1 + 1),lda)
               ! factor b22, recursive call
               call stdlib_dlaorhr_col_getrfnp2(m - n1,n2,a(n1 + 1,n1 + 1),lda,d(n1 + 1),iinfo)
-                        
+
            end if
            return
      end subroutine stdlib_dlaorhr_col_getrfnp2
@@ -2985,7 +2985,7 @@ module stdlib_linalg_lapack_d
                  j = i
                  k(j) = -k(j)
                  in = k(j)
-20               continue
+                 20 continue
                  if (k(in) > 0) go to 40
                  do jj = 1,n
                     temp = x(j,jj)
@@ -2996,7 +2996,7 @@ module stdlib_linalg_lapack_d
                  j = in
                  in = k(in)
                  go to 20
-40               continue
+                 40 continue
               end do
            else
               ! backward permutation
@@ -3004,7 +3004,7 @@ module stdlib_linalg_lapack_d
                  if (k(i) > 0) go to 80
                  k(i) = -k(i)
                  j = k(i)
-60               continue
+                 60 continue
                  if (j == i) go to 80
                  do jj = 1,n
                     temp = x(i,jj)
@@ -3014,7 +3014,7 @@ module stdlib_linalg_lapack_d
                  k(j) = -k(j)
                  j = k(j)
                  go to 60
-80               continue
+                 80 continue
               end do
            end if
            return
@@ -3053,7 +3053,7 @@ module stdlib_linalg_lapack_d
                  j = i
                  k(j) = -k(j)
                  in = k(j)
-20               continue
+                 20 continue
                  if (k(in) > 0) go to 40
                  do ii = 1,m
                     temp = x(ii,j)
@@ -3064,7 +3064,7 @@ module stdlib_linalg_lapack_d
                  j = in
                  in = k(in)
                  go to 20
-40               continue
+                 40 continue
               end do
            else
               ! backward permutation
@@ -3072,7 +3072,7 @@ module stdlib_linalg_lapack_d
                  if (k(i) > 0) go to 80
                  k(i) = -k(i)
                  j = k(i)
-60               continue
+                 60 continue
                  if (j == i) go to 80
                  do ii = 1,m
                     temp = x(ii,i)
@@ -3082,7 +3082,7 @@ module stdlib_linalg_lapack_d
                  k(j) = -k(j)
                  j = k(j)
                  go to 60
-80               continue
+                 80 continue
               end do
            end if
            return
@@ -3098,7 +3098,7 @@ module stdlib_linalg_lapack_d
            ! Scalar Arguments
            real(dp),intent(in) :: x,y,z
         ! =====================================================================
-           
+
            ! Local Scalars
            real(dp) :: w,xabs,yabs,zabs,hugeval
            ! Intrinsic Functions
@@ -3125,7 +3125,7 @@ module stdlib_linalg_lapack_d
      !> in the vectors R and C.
 
      pure subroutine stdlib_dlaqgb(m,n,kl,ku,ab,ldab,r,c,rowcnd,colcnd,amax,equed)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -3139,7 +3139,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: thresh = 0.1e+0_dp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(dp) :: cj,large,small
@@ -3207,7 +3207,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: thresh = 0.1e+0_dp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(dp) :: cj,large,small
@@ -3278,7 +3278,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: h(ldh,*)
            real(dp),intent(out) :: v(*)
         ! ================================================================
-           
+
            ! Local Scalars
            real(dp) :: h21s,h31s,s
            ! Intrinsic Functions
@@ -3334,7 +3334,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: thresh = 0.1e+0_dp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(dp) :: cj,large,small
@@ -3394,7 +3394,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: thresh = 0.1e+0_dp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,jc
            real(dp) :: cj,large,small
@@ -3456,7 +3456,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: thresh = 0.1e+0_dp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(dp) :: cj,large,small
@@ -3558,7 +3558,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: v(*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: applyleft
            integer(ilp) :: i,lastv,lastc
@@ -3632,7 +3632,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: t(ldt,*),v(ldv,*)
            real(dp),intent(out) :: work(ldwork,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            character :: transt
            integer(ilp) :: i,j
@@ -3947,7 +3947,7 @@ module stdlib_linalg_lapack_d
      !> arrays A, B and T. See Further Details section.
 
      pure subroutine stdlib_dlarfb_gett(ident,m,n,k,t,ldt,a,lda,b,ldb,work,ldwork)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -3959,7 +3959,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: t(ldt,*)
            real(dp),intent(out) :: work(ldwork,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lnotident
            integer(ilp) :: i,j
@@ -4097,7 +4097,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(out) :: t(ldt,*)
            real(dp),intent(in) :: tau(*),v(ldv,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,prevlastv,lastv
            ! Executable Statements
@@ -4223,7 +4223,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: v(*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j
            real(dp) :: sum,t1,t10,t2,t3,t4,t5,t6,t7,t8,t9,v1,v10,v2,v3,v4,v5,v6, &
@@ -4236,14 +4236,14 @@ module stdlib_linalg_lapack_d
               ! code for general m
               call stdlib_dlarf(side,m,n,v,1,tau,c,ldc,work)
               go to 410
-10            continue
+              10 continue
               ! special code for 1 x 1 householder
               t1 = one - tau*v(1)*v(1)
               do j = 1,n
                  c(1,j) = t1*c(1,j)
               end do
               go to 410
-30            continue
+              30 continue
               ! special code for 2 x 2 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4255,7 +4255,7 @@ module stdlib_linalg_lapack_d
                  c(2,j) = c(2,j) - sum*t2
               end do
               go to 410
-50            continue
+              50 continue
               ! special code for 3 x 3 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4270,7 +4270,7 @@ module stdlib_linalg_lapack_d
                  c(3,j) = c(3,j) - sum*t3
               end do
               go to 410
-70            continue
+              70 continue
               ! special code for 4 x 4 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4288,7 +4288,7 @@ module stdlib_linalg_lapack_d
                  c(4,j) = c(4,j) - sum*t4
               end do
               go to 410
-90            continue
+              90 continue
               ! special code for 5 x 5 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4302,7 +4302,7 @@ module stdlib_linalg_lapack_d
               t5 = tau*v5
               do j = 1,n
                  sum = v1*c(1,j) + v2*c(2,j) + v3*c(3,j) + v4*c(4,j) + v5*c(5,j)
-                           
+
                  c(1,j) = c(1,j) - sum*t1
                  c(2,j) = c(2,j) - sum*t2
                  c(3,j) = c(3,j) - sum*t3
@@ -4310,7 +4310,7 @@ module stdlib_linalg_lapack_d
                  c(5,j) = c(5,j) - sum*t5
               end do
               go to 410
-110           continue
+              110 continue
               ! special code for 6 x 6 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4335,7 +4335,7 @@ module stdlib_linalg_lapack_d
                  c(6,j) = c(6,j) - sum*t6
               end do
               go to 410
-130           continue
+              130 continue
               ! special code for 7 x 7 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4363,7 +4363,7 @@ module stdlib_linalg_lapack_d
                  c(7,j) = c(7,j) - sum*t7
               end do
               go to 410
-150           continue
+              150 continue
               ! special code for 8 x 8 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4394,7 +4394,7 @@ module stdlib_linalg_lapack_d
                  c(8,j) = c(8,j) - sum*t8
               end do
               go to 410
-170           continue
+              170 continue
               ! special code for 9 x 9 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4428,7 +4428,7 @@ module stdlib_linalg_lapack_d
                  c(9,j) = c(9,j) - sum*t9
               end do
               go to 410
-190           continue
+              190 continue
               ! special code for 10 x 10 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4471,14 +4471,14 @@ module stdlib_linalg_lapack_d
               ! code for general n
               call stdlib_dlarf(side,m,n,v,1,tau,c,ldc,work)
               go to 410
-210           continue
+              210 continue
               ! special code for 1 x 1 householder
               t1 = one - tau*v(1)*v(1)
               do j = 1,m
                  c(j,1) = t1*c(j,1)
               end do
               go to 410
-230           continue
+              230 continue
               ! special code for 2 x 2 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4490,7 +4490,7 @@ module stdlib_linalg_lapack_d
                  c(j,2) = c(j,2) - sum*t2
               end do
               go to 410
-250           continue
+              250 continue
               ! special code for 3 x 3 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4505,7 +4505,7 @@ module stdlib_linalg_lapack_d
                  c(j,3) = c(j,3) - sum*t3
               end do
               go to 410
-270           continue
+              270 continue
               ! special code for 4 x 4 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4523,7 +4523,7 @@ module stdlib_linalg_lapack_d
                  c(j,4) = c(j,4) - sum*t4
               end do
               go to 410
-290           continue
+              290 continue
               ! special code for 5 x 5 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4537,7 +4537,7 @@ module stdlib_linalg_lapack_d
               t5 = tau*v5
               do j = 1,m
                  sum = v1*c(j,1) + v2*c(j,2) + v3*c(j,3) + v4*c(j,4) + v5*c(j,5)
-                           
+
                  c(j,1) = c(j,1) - sum*t1
                  c(j,2) = c(j,2) - sum*t2
                  c(j,3) = c(j,3) - sum*t3
@@ -4545,7 +4545,7 @@ module stdlib_linalg_lapack_d
                  c(j,5) = c(j,5) - sum*t5
               end do
               go to 410
-310           continue
+              310 continue
               ! special code for 6 x 6 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4570,7 +4570,7 @@ module stdlib_linalg_lapack_d
                  c(j,6) = c(j,6) - sum*t6
               end do
               go to 410
-330           continue
+              330 continue
               ! special code for 7 x 7 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4598,7 +4598,7 @@ module stdlib_linalg_lapack_d
                  c(j,7) = c(j,7) - sum*t7
               end do
               go to 410
-350           continue
+              350 continue
               ! special code for 8 x 8 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4629,7 +4629,7 @@ module stdlib_linalg_lapack_d
                  c(j,8) = c(j,8) - sum*t8
               end do
               go to 410
-370           continue
+              370 continue
               ! special code for 9 x 9 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4663,7 +4663,7 @@ module stdlib_linalg_lapack_d
                  c(j,9) = c(j,9) - sum*t9
               end do
               go to 410
-390           continue
+              390 continue
               ! special code for 10 x 10 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4701,7 +4701,7 @@ module stdlib_linalg_lapack_d
               end do
               go to 410
            end if
-410        continue
+           410 continue
            return
      end subroutine stdlib_dlarfx
 
@@ -4725,7 +4725,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: v(*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(dp) :: alpha
            ! Executable Statements
@@ -4754,7 +4754,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(out) :: c(*)
            real(dp),intent(inout) :: x(*),y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,ic,ix,iy
            real(dp) :: f,g,t,tt
@@ -4809,7 +4809,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: d(*)
            real(dp),intent(inout) :: e(*),e2(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(dp) :: eabs,tmp1
@@ -4856,7 +4856,7 @@ module stdlib_linalg_lapack_d
      !> if JOBT = 'L'.
 
      pure subroutine stdlib_dlarrc(jobt,n,vl,vu,d,e,pivmin,eigcnt,lcnt,rcnt,info)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -4868,7 +4868,7 @@ module stdlib_linalg_lapack_d
            ! Array Arguments
            real(dp),intent(in) :: d(*),e(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            logical(lk) :: matt
@@ -4979,7 +4979,7 @@ module stdlib_linalg_lapack_d
            integer(ilp),parameter :: allrng = 1
            integer(ilp),parameter :: valrng = 2
            integer(ilp),parameter :: indrng = 3
-           
+
            ! Local Scalars
            logical(lk) :: ncnvrg,toofew
            integer(ilp) :: i,ib,ibegin,idiscl,idiscu,ie,iend,iinfo,im,in,ioff,iout, &
@@ -5437,7 +5437,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: w(*),werr(*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            integer(ilp) :: maxitr
            ! Local Scalars
            integer(ilp) :: cnt,i,i1,i2,ii,iter,j,k,next,nint,olnint,p,prev, &
@@ -5488,7 +5488,7 @@ module stdlib_linalg_lapack_d
                  ! make sure that [left,right] contains the desired eigenvalue
                  ! do while( cnt(left)>i-1 )
                  fac = one
-20               continue
+                 20 continue
                  cnt = 0
                  s = left
                  dplus = d(1) - s
@@ -5504,7 +5504,7 @@ module stdlib_linalg_lapack_d
                  end if
                  ! do while( cnt(right)<i )
                  fac = one
-50               continue
+                 50 continue
                  cnt = 0
                  s = right
                  dplus = d(1) - s
@@ -5529,7 +5529,7 @@ module stdlib_linalg_lapack_d
            ! do while( nint>0 ), i.e. there are still unconverged intervals
            ! and while (iter<maxitr)
            iter = 0
-80         continue
+           80 continue
            prev = i1 - 1
            i = i1
            olnint = nint
@@ -5616,7 +5616,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: fudge = two
-           
+
            ! Local Scalars
            integer(ilp) :: i,it,itmax,negcnt
            real(dp) :: atoli,eps,left,mid,right,rtoli,tmp1,tmp2,tnorm
@@ -5638,7 +5638,7 @@ module stdlib_linalg_lapack_d
            left = gl - fudge*tnorm*eps*n - fudge*two*pivmin
            right = gu + fudge*tnorm*eps*n + fudge*two*pivmin
            it = 0
-10         continue
+           10 continue
            ! check if interval converged or maximum number of iterations reached
            tmp1 = abs(right - left)
            tmp2 = max(abs(right),abs(left))
@@ -5665,7 +5665,7 @@ module stdlib_linalg_lapack_d
               left = mid
            end if
            goto 10
-30         continue
+           30 continue
            ! converged or maximum number of iterations reached
            w = half*(left + right)
            werr = half*abs(right - left)
@@ -5689,7 +5689,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: relcond = 0.999_dp
-           
+
            ! Local Scalars
            integer(ilp) :: i
            logical(lk) :: yesrel
@@ -5737,7 +5737,7 @@ module stdlib_linalg_lapack_d
               tmp = tmp2
               offdig = offdig2
            end do
-11         continue
+           11 continue
            if (yesrel) then
               info = 0
               return
@@ -5841,7 +5841,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(out) :: cs,r,sn
            real(dp),intent(in) :: f,g
         ! =====================================================================
-           
+
            ! Local Scalars
            ! logical            first
            integer(ilp) :: count,i
@@ -5875,7 +5875,7 @@ module stdlib_linalg_lapack_d
               scale = max(abs(f1),abs(g1))
               if (scale >= safmx2) then
                  count = 0
-10               continue
+                 10 continue
                  count = count + 1
                  f1 = f1*safmn2
                  g1 = g1*safmn2
@@ -5889,7 +5889,7 @@ module stdlib_linalg_lapack_d
                  end do
               else if (scale <= safmn2) then
                  count = 0
-30               continue
+                 30 continue
                  count = count + 1
                  f1 = f1*safmx2
                  g1 = g1*safmx2
@@ -5932,7 +5932,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(out) :: cs,sn
            real(dp),intent(in) :: sigma,x,y
         ! ===================================================================
-           
+
            ! Local Scalars
            real(dp) :: r,s,thresh,w,z
            thresh = stdlib_dlamch('E')
@@ -6023,7 +6023,7 @@ module stdlib_linalg_lapack_d
            integer(ilp),parameter :: lv = 128
            integer(ilp),parameter :: ipw2 = 4096
            real(dp),parameter :: r = one/ipw2
-           
+
            ! Local Scalars
            integer(ilp) :: i,i1,i2,i3,i4,it1,it2,it3,it4,j
            ! Local Arrays
@@ -6165,7 +6165,7 @@ module stdlib_linalg_lapack_d
            i3 = iseed(3)
            i4 = iseed(4)
            loop_10: do i = 1,min(n,lv)
-20         continue
+           20 continue
               ! multiply the seed by i-th power of the multiplier modulo 2**48
               it4 = i4*mm(i,4)
               it3 = it4/ipw2
@@ -6226,7 +6226,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: v(*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Executable Statements
            if (stdlib_lsame(side,'L')) then
               ! form  h * c
@@ -6276,7 +6276,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: c(ldc,*),t(ldt,*),v(ldv,*)
            real(dp),intent(out) :: work(ldwork,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            character :: transt
            integer(ilp) :: i,info,j
@@ -6374,7 +6374,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: tau(*)
            real(dp),intent(inout) :: v(ldv,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,info,j
            ! Executable Statements
@@ -6425,7 +6425,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: f,g,h
            real(dp),intent(out) :: ssmax,ssmin
         ! ====================================================================
-           
+
            ! Local Scalars
            real(dp) :: as,at,au,c,fa,fhmn,fhmx,ga,ha
            ! Intrinsic Functions
@@ -6442,7 +6442,7 @@ module stdlib_linalg_lapack_d
                  ssmax = ga
               else
                  ssmax = max(fhmx,ga)*sqrt(one + (min(fhmx,ga)/max(fhmx,ga))**2)
-                           
+
               end if
            else
               if (ga < fhmx) then
@@ -6494,7 +6494,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: d(2),z(2)
            real(dp),intent(out) :: delta(2),work(2)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(dp) :: b,c,del,delsq,tau,w
            ! Intrinsic Functions
@@ -6581,7 +6581,7 @@ module stdlib_linalg_lapack_d
            ! Array Arguments
            integer(ilp),intent(out) :: inode(*),ndiml(*),ndimr(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,il,ir,llst,maxn,ncrnt,nlvl
            real(dp) :: temp
@@ -6693,7 +6693,7 @@ module stdlib_linalg_lapack_d
            real(dp),parameter :: qurtr = 0.250_dp
            real(dp),parameter :: third = 0.3330_dp
            real(dp),parameter :: hundrd = 100.0_dp
-           
+
            ! Local Scalars
            integer(ilp) :: i4,nn,np
            real(dp) :: a2,b1,b2,gam,gap1,gap2,s
@@ -6761,7 +6761,7 @@ module stdlib_linalg_lapack_d
                        a2 = a2 + b2
                        if (hundrd*max(b2,b1) < a2 .or. cnst1 < a2) go to 20
                     end do
-20                  continue
+                    20 continue
                     a2 = cnst3*a2
                     ! rayleigh quotient residual bound.
                     if (a2 < cnst1) s = gam*(one - sqrt(a2))/(one + a2)
@@ -6789,7 +6789,7 @@ module stdlib_linalg_lapack_d
                        a2 = a2 + b2
                        if (hundrd*max(b2,b1) < a2 .or. cnst1 < a2) go to 40
                     end do
-40                  continue
+                    40 continue
                     a2 = cnst3*a2
                  end if
                  if (a2 < cnst1) s = gam*(one - sqrt(a2))/(one + a2)
@@ -6822,7 +6822,7 @@ module stdlib_linalg_lapack_d
                     b2 = b2 + b1
                     if (hundrd*max(b1,a2) < b2) go to 60
                  end do
-60               continue
+                 60 continue
                  b2 = sqrt(cnst3*b2)
                  a2 = dmin1/(one + b2**2)
                  gap2 = half*dmin2 - a2
@@ -6854,7 +6854,7 @@ module stdlib_linalg_lapack_d
                     b2 = b2 + b1
                     if (hundrd*b1 < b2) go to 80
                  end do
-80               continue
+                 80 continue
                  b2 = sqrt(cnst3*b2)
                  a2 = dmin2/(one + b2**2)
                  gap2 = z(nn - 7) + z(nn - 9) - sqrt(z(nn - 11))*sqrt(z(nn - 9)) - a2
@@ -6893,7 +6893,7 @@ module stdlib_linalg_lapack_d
            ! Array Arguments
            real(dp),intent(inout) :: z(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j4,j4p2
            real(dp) :: d,emin,temp,dthresh
@@ -7117,7 +7117,7 @@ module stdlib_linalg_lapack_d
            ! Array Arguments
            real(dp),intent(inout) :: z(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j4,j4p2
            real(dp) :: d,emin,safmin,temp
@@ -7277,7 +7277,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(in) :: c(*),s(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,info,j
            real(dp) :: ctemp,stemp,temp
@@ -7491,7 +7491,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: select = 20
-           
+
            ! Local Scalars
            integer(ilp) :: dir,endd,i,j,start,stkpnt
            real(dp) :: d1,d2,d3,dmnmx,tmp
@@ -7520,7 +7520,7 @@ module stdlib_linalg_lapack_d
            stkpnt = 1
            stack(1,1) = 1
            stack(2,1) = n
-10         continue
+           10 continue
            start = stack(1,stkpnt)
            endd = stack(2,stkpnt)
            stkpnt = stkpnt - 1
@@ -7581,11 +7581,11 @@ module stdlib_linalg_lapack_d
                  ! sort into decreasing order
                  i = start - 1
                  j = endd + 1
-60               continue
-70               continue
+                 60 continue
+                 70 continue
                  j = j - 1
                  if (d(j) < dmnmx) go to 70
-80               continue
+                 80 continue
                  i = i + 1
                  if (d(i) > dmnmx) go to 80
                  if (i < j) then
@@ -7613,11 +7613,11 @@ module stdlib_linalg_lapack_d
                  ! sort into increasing order
                  i = start - 1
                  j = endd + 1
-90               continue
-100              continue
+                 90 continue
+                 100 continue
                  j = j - 1
                  if (d(j) > dmnmx) go to 100
-110              continue
+                 110 continue
                  i = i + 1
                  if (d(i) < dmnmx) go to 110
                  if (i < j) then
@@ -7782,7 +7782,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(out) :: csl,csr,snl,snr,ssmax,ssmin
            real(dp),intent(in) :: f,g,h
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: gasmal,swap
            integer(ilp) :: pmax
@@ -7991,7 +7991,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: b(ldb,*),tl(ldtl,*),tr(ldtr,*)
            real(dp),intent(out) :: x(ldx,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: bswap,xswap
            integer(ilp) :: i,ip,ipiv,ipsv,j,jp,jpsv,k
@@ -8021,7 +8021,7 @@ module stdlib_linalg_lapack_d
            k = n1 + n1 + n2 - 2
            go to(10,20,30,50) k
            ! 1 by 1: tl11*x + sgn*x*tr11 = b11
-10   continue
+           10 continue
            tau1 = tl(1,1) + sgn*tr(1,1)
            bet = abs(tau1)
            if (bet <= smlnum) then
@@ -8038,7 +8038,7 @@ module stdlib_linalg_lapack_d
            ! 1 by 2:
            ! tl11*[x11 x12] + isgn*[x11 x12]*op[tr11 tr12]  = [b11 b12]
                                              ! [tr21 tr22]
-20   continue
+                                             20 continue
            smin = max(eps*max(abs(tl(1,1)),abs(tr(1,1)),abs(tr(1,2)),abs(tr( &
                      2,1)),abs(tr(2,2))),smlnum)
            tmp(1) = tl(1,1) + sgn*tr(1,1)
@@ -8056,7 +8056,7 @@ module stdlib_linalg_lapack_d
            ! 2 by 1:
                 ! op[tl11 tl12]*[x11] + isgn* [x11]*tr11  = [b11]
                   ! [tl21 tl22] [x21]         [x21]         [b21]
-30   continue
+                  30 continue
            smin = max(eps*max(abs(tr(1,1)),abs(tl(1,1)),abs(tl(1,2)),abs(tl( &
                      2,1)),abs(tl(2,2))),smlnum)
            tmp(1) = tl(1,1) + sgn*tr(1,1)
@@ -8070,7 +8070,7 @@ module stdlib_linalg_lapack_d
            end if
            btmp(1) = b(1,1)
            btmp(2) = b(2,1)
-40         continue
+           40 continue
            ! solve 2 by 2 system using complete pivoting.
            ! set pivots less than smin to smin.
            ipiv = stdlib_idamax(4,tmp,1)
@@ -8123,9 +8123,9 @@ module stdlib_linalg_lapack_d
              ! [tl21 tl22] [x21 x22]        [x21 x22]   [tr21 tr22]   [b21 b22]
            ! solve equivalent 4 by 4 system using complete pivoting.
            ! set pivots less than smin to smin.
-50   continue
+           50 continue
            smin = max(abs(tr(1,1)),abs(tr(1,2)),abs(tr(2,1)),abs(tr(2,2)))
-                     
+
            smin = max(smin,abs(tl(1,1)),abs(tl(1,2)),abs(tl(2,1)),abs(tl(2, &
                      2)))
            smin = max(eps*smin,smlnum)
@@ -8259,7 +8259,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: sevten = 17.0e+0_dp
-           
+
            ! Local Scalars
            integer(ilp) :: imax,j,jb,jj,jmax,jp,k,kk,kkw,kp,kstep,kw
            real(dp) :: absakk,alpha,colmax,d11,d21,d22,r1,rowmax,t
@@ -8276,7 +8276,7 @@ module stdlib_linalg_lapack_d
               ! k is the main loop index, decreasing from n in steps of 1 or 2
               ! kw is the column of w which corresponds to column k of a
               k = n
-10            continue
+              10 continue
               kw = nb + k - n
               ! exit from loop
               if ((k <= n - nb + 1 .and. nb < n) .or. k < 1) go to 30
@@ -8309,7 +8309,7 @@ module stdlib_linalg_lapack_d
                     ! copy column imax to column kw-1 of w and update it
                     call stdlib_dcopy(imax,a(1,imax),1,w(1,kw - 1),1)
                     call stdlib_dcopy(k - imax,a(imax,imax + 1),lda,w(imax + 1,kw - 1),1)
-                              
+
                     if (k < n) call stdlib_dgemv('NO TRANSPOSE',k,n - k,-one,a(1,k + 1),lda,w( &
                               imax,kw + 1),ldw,one,w(1,kw - 1),1)
                     ! jmax is the column-index of the largest off-diagonal
@@ -8430,7 +8430,7 @@ module stdlib_linalg_lapack_d
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-30            continue
+              30 continue
               ! update the upper triangle of a11 (= a(1:k,1:k)) as
               ! a11 := a11 - u12*d*u12**t = a11 - u12*w**t
               ! computing blocks of nb columns at a time
@@ -8448,7 +8448,7 @@ module stdlib_linalg_lapack_d
               ! put u12 in standard form by partially undoing the interchanges
               ! in columns k+1:n looping backwards from k+1 to n
               j = k + 1
-60            continue
+              60 continue
                  ! undo the interchanges (if any) of rows jj and jp at each
                  ! step j
                  ! (here, j is a diagonal index)
@@ -8473,7 +8473,7 @@ module stdlib_linalg_lapack_d
               ! for use in updating a22
               ! k is the main loop index, increasing from 1 in steps of 1 or 2
               k = 1
-70            continue
+              70 continue
               ! exit from loop
               if ((k >= nb .and. nb < n) .or. k > n) go to 90
               ! copy column k of a to column k of w and update it
@@ -8544,7 +8544,7 @@ module stdlib_linalg_lapack_d
                     a(kp,kp) = a(kk,kk)
                     call stdlib_dcopy(kp - kk - 1,a(kk + 1,kk),1,a(kp,kk + 1),lda)
                     if (kp < n) call stdlib_dcopy(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     ! interchange rows kk and kp in first k-1 columns of a
                     ! (columns k (or k and k+1 for 2-by-2 pivot) of a will be
                     ! later overwritten). interchange rows kk and kp
@@ -8626,7 +8626,7 @@ module stdlib_linalg_lapack_d
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 70
-90            continue
+              90 continue
               ! update the lower triangle of a22 (= a(k:n,k:n)) as
               ! a22 := a22 - l21*d*l21**t = a22 - l21*w**t
               ! computing blocks of nb columns at a time
@@ -8644,7 +8644,7 @@ module stdlib_linalg_lapack_d
               ! put l21 in standard form by partially undoing the interchanges
               ! of rows in columns 1:k-1 looping backwards from k-1 to 1
               j = k - 1
-120           continue
+              120 continue
                  ! undo the interchanges (if any) of rows jj and jp at each
                  ! step j
                  ! (here, j is a diagonal index)
@@ -8659,7 +8659,7 @@ module stdlib_linalg_lapack_d
                  ! of the rows to swap back doesn't include diagonal element)
                  j = j - 1
                  if (jp /= jj .and. j >= 1) call stdlib_dswap(j,a(jp,1),lda,a(jj,1),lda)
-                           
+
               if (j > 1) go to 120
               ! set kb to the number of columns factorized
               kb = k - 1
@@ -8695,7 +8695,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: sevten = 17.0e+0_dp
-           
+
            ! Local Scalars
            logical(lk) :: done
            integer(ilp) :: imax,itemp,j,jb,jj,jmax,k,kk,kw,kkw,kp,kstep,p,ii
@@ -8718,7 +8718,7 @@ module stdlib_linalg_lapack_d
               e(1) = zero
               ! k is the main loop index, decreasing from n in steps of 1 or 2
               k = n
-10            continue
+              10 continue
               ! kw is the column of w which corresponds to column k of a
               kw = nb + k - n
               ! exit from loop
@@ -8759,12 +8759,12 @@ module stdlib_linalg_lapack_d
                  else
                     done = .false.
                     ! loop until pivot found
-12   continue
+                    12 continue
                        ! begin pivot search loop body
                        ! copy column imax to column kw-1 of w and update it
                        call stdlib_dcopy(imax,a(1,imax),1,w(1,kw - 1),1)
                        call stdlib_dcopy(k - imax,a(imax,imax + 1),lda,w(imax + 1,kw - 1),1)
-                                 
+
                        if (k < n) call stdlib_dgemv('NO TRANSPOSE',k,n - k,-one,a(1,k + 1),lda, &
                                  w(imax,kw + 1),ldw,one,w(1,kw - 1),1)
                        ! jmax is the column-index of the largest off-diagonal
@@ -8893,7 +8893,7 @@ module stdlib_linalg_lapack_d
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-30            continue
+              30 continue
               ! update the upper triangle of a11 (= a(1:k,1:k)) as
               ! a11 := a11 - u12*d*u12**t = a11 - u12*w**t
               ! computing blocks of nb columns at a time
@@ -8918,7 +8918,7 @@ module stdlib_linalg_lapack_d
               e(n) = zero
               ! k is the main loop index, increasing from 1 in steps of 1 or 2
               k = 1
-70            continue
+              70 continue
               ! exit from loop
               if ((k >= nb .and. nb < n) .or. k > n) go to 90
               kstep = 1
@@ -8957,7 +8957,7 @@ module stdlib_linalg_lapack_d
                  else
                     done = .false.
                     ! loop until pivot found
-72   continue
+                    72 continue
                        ! begin pivot search loop body
                        ! copy column imax to column k+1 of w and update it
                        call stdlib_dcopy(imax - k,a(imax,k),lda,w(k,k + 1),1)
@@ -9086,7 +9086,7 @@ module stdlib_linalg_lapack_d
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 70
-90            continue
+              90 continue
               ! update the lower triangle of a22 (= a(k:n,k:n)) as
               ! a22 := a22 - l21*d*l21**t = a22 - l21*w**t
               ! computing blocks of nb columns at a time
@@ -9135,7 +9135,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: sevten = 17.0e+0_dp
-           
+
            ! Local Scalars
            logical(lk) :: done
            integer(ilp) :: imax,itemp,j,jb,jj,jmax,jp1,jp2,k,kk,kw,kkw,kp,kstep,p, &
@@ -9156,7 +9156,7 @@ module stdlib_linalg_lapack_d
               ! for use in updating a11
               ! k is the main loop index, decreasing from n in steps of 1 or 2
               k = n
-10            continue
+              10 continue
               ! kw is the column of w which corresponds to column k of a
               kw = nb + k - n
               ! exit from loop
@@ -9195,12 +9195,12 @@ module stdlib_linalg_lapack_d
                  else
                     done = .false.
                     ! loop until pivot found
-12   continue
+                    12 continue
                        ! begin pivot search loop body
                        ! copy column imax to column kw-1 of w and update it
                        call stdlib_dcopy(imax,a(1,imax),1,w(1,kw - 1),1)
                        call stdlib_dcopy(k - imax,a(imax,imax + 1),lda,w(imax + 1,kw - 1),1)
-                                 
+
                        if (k < n) call stdlib_dgemv('NO TRANSPOSE',k,n - k,-one,a(1,k + 1),lda, &
                                  w(imax,kw + 1),ldw,one,w(1,kw - 1),1)
                        ! jmax is the column-index of the largest off-diagonal
@@ -9322,7 +9322,7 @@ module stdlib_linalg_lapack_d
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-30            continue
+              30 continue
               ! update the upper triangle of a11 (= a(1:k,1:k)) as
               ! a11 := a11 - u12*d*u12**t = a11 - u12*w**t
               ! computing blocks of nb columns at a time
@@ -9340,7 +9340,7 @@ module stdlib_linalg_lapack_d
               ! put u12 in standard form by partially undoing the interchanges
               ! in columns k+1:n
               j = k + 1
-60            continue
+              60 continue
                  kstep = 1
                  jp1 = 1
                  jj = j
@@ -9366,7 +9366,7 @@ module stdlib_linalg_lapack_d
               ! for use in updating a22
               ! k is the main loop index, increasing from 1 in steps of 1 or 2
               k = 1
-70            continue
+              70 continue
               ! exit from loop
               if ((k >= nb .and. nb < n) .or. k > n) go to 90
               kstep = 1
@@ -9403,7 +9403,7 @@ module stdlib_linalg_lapack_d
                  else
                     done = .false.
                     ! loop until pivot found
-72   continue
+                    72 continue
                        ! begin pivot search loop body
                        ! copy column imax to column k+1 of w and update it
                        call stdlib_dcopy(imax - k,a(imax,k),lda,w(k,k + 1),1)
@@ -9525,7 +9525,7 @@ module stdlib_linalg_lapack_d
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 70
-90            continue
+              90 continue
               ! update the lower triangle of a22 (= a(k:n,k:n)) as
               ! a22 := a22 - l21*d*l21**t = a22 - l21*w**t
               ! computing blocks of nb columns at a time
@@ -9543,7 +9543,7 @@ module stdlib_linalg_lapack_d
               ! put l21 in standard form by partially undoing the interchanges
               ! in columns 1:k-1
               j = k - 1
-120           continue
+              120 continue
                  kstep = 1
                  jp1 = 1
                  jj = j
@@ -9556,7 +9556,7 @@ module stdlib_linalg_lapack_d
                  end if
                  j = j - 1
                  if (jp2 /= jj .and. j >= 1) call stdlib_dswap(j,a(jp2,1),lda,a(jj,1),lda)
-                           
+
                  jj = j + 1
                  if (jp1 /= jj .and. kstep == 2) call stdlib_dswap(j,a(jp1,1),lda,a(jj,1), &
                            lda)
@@ -9614,7 +9614,7 @@ module stdlib_linalg_lapack_d
                  end do
               end do
            end if
-50         continue
+           50 continue
            return
      end subroutine stdlib_dlat2s
 
@@ -9643,7 +9643,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: ab(ldab,*)
            real(dp),intent(inout) :: cnorm(*),x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            integer(ilp) :: i,imax,j,jfirst,jinc,jlast,jlen,maind
@@ -9768,7 +9768,7 @@ module stdlib_linalg_lapack_d
                     grow = grow*(one/(one + cnorm(j)))
                  end do
               end if
-50            continue
+              50 continue
            else
               ! compute the growth in a**t * x = b.
               if (upper) then
@@ -9815,7 +9815,7 @@ module stdlib_linalg_lapack_d
                     grow = grow/xj
                  end do
               end if
-80            continue
+              80 continue
            end if
            if ((grow*tscal) > smlnum) then
               ! use the level 2 blas solve if the reciprocal of the bound on
@@ -9883,7 +9883,7 @@ module stdlib_linalg_lapack_d
                        scale = zero
                        xmax = zero
                     end if
-100                 continue
+                    100 continue
                     ! scale x if necessary to avoid overflow when adding a
                     ! multiple of column j of a.
                     if (xj > one) then
@@ -9959,7 +9959,7 @@ module stdlib_linalg_lapack_d
                        else
                           jlen = min(kd,n - j)
                           if (jlen > 0) sumj = stdlib_ddot(jlen,ab(2,j),1,x(j + 1),1)
-                                    
+
                        end if
                     else
                        ! otherwise, use in-line code for the dot product.
@@ -10020,7 +10020,7 @@ module stdlib_linalg_lapack_d
                           scale = zero
                           xmax = zero
                        end if
-150                    continue
+                       150 continue
                     else
                        ! compute x(j) := x(j) / a(j,j) - sumj if the dot
                        ! product has already been divided by 1/a(j,j).
@@ -10050,7 +10050,7 @@ module stdlib_linalg_lapack_d
      !> then s is set to 0 and a non-trivial solution to A*x = 0 is returned.
 
      pure subroutine stdlib_dlatps(uplo,trans,diag,normin,n,ap,x,scale,cnorm,info)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -10063,7 +10063,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: ap(*)
            real(dp),intent(inout) :: cnorm(*),x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            integer(ilp) :: i,imax,ip,j,jfirst,jinc,jlast,jlen
@@ -10185,7 +10185,7 @@ module stdlib_linalg_lapack_d
                     grow = grow*(one/(one + cnorm(j)))
                  end do
               end if
-50            continue
+              50 continue
            else
               ! compute the growth in a**t * x = b.
               if (upper) then
@@ -10234,7 +10234,7 @@ module stdlib_linalg_lapack_d
                     grow = grow/xj
                  end do
               end if
-80            continue
+              80 continue
            end if
            if ((grow*tscal) > smlnum) then
               ! use the level 2 blas solve if the reciprocal of the bound on
@@ -10303,7 +10303,7 @@ module stdlib_linalg_lapack_d
                        scale = zero
                        xmax = zero
                     end if
-100                 continue
+                    100 continue
                     ! scale x if necessary to avoid overflow when adding a
                     ! multiple of column j of a.
                     if (xj > one) then
@@ -10333,7 +10333,7 @@ module stdlib_linalg_lapack_d
                           ! compute the update
                              ! x(j+1:n) := x(j+1:n) - x(j) * a(j+1:n,j)
                           call stdlib_daxpy(n - j,-x(j)*tscal,ap(ip + 1),1,x(j + 1),1)
-                                    
+
                           i = j + stdlib_idamax(n - j,x(j + 1),1)
                           xmax = abs(x(i))
                        end if
@@ -10436,7 +10436,7 @@ module stdlib_linalg_lapack_d
                           scale = zero
                           xmax = zero
                        end if
-150                    continue
+                       150 continue
                     else
                        ! compute x(j) := x(j) / a(j,j)  - sumj if the dot
                        ! product has already been divided by 1/a(j,j).
@@ -10468,7 +10468,7 @@ module stdlib_linalg_lapack_d
      !> non-trivial solution to A*x = 0 is returned.
 
      pure subroutine stdlib_dlatrs(uplo,trans,diag,normin,n,a,lda,x,scale,cnorm,info)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -10481,7 +10481,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: a(lda,*)
            real(dp),intent(inout) :: cnorm(*),x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            integer(ilp) :: i,imax,j,jfirst,jinc,jlast
@@ -10597,7 +10597,7 @@ module stdlib_linalg_lapack_d
                     grow = grow*(one/(one + cnorm(j)))
                  end do
               end if
-50            continue
+              50 continue
            else
               ! compute the growth in a**t * x = b.
               if (upper) then
@@ -10642,7 +10642,7 @@ module stdlib_linalg_lapack_d
                     grow = grow/xj
                  end do
               end if
-80            continue
+              80 continue
            end if
            if ((grow*tscal) > smlnum) then
               ! use the level 2 blas solve if the reciprocal of the bound on
@@ -10710,7 +10710,7 @@ module stdlib_linalg_lapack_d
                        scale = zero
                        xmax = zero
                     end if
-100                 continue
+                    100 continue
                     ! scale x if necessary to avoid overflow when adding a
                     ! multiple of column j of a.
                     if (xj > one) then
@@ -10739,7 +10739,7 @@ module stdlib_linalg_lapack_d
                           ! compute the update
                              ! x(j+1:n) := x(j+1:n) - x(j) * a(j+1:n,j)
                           call stdlib_daxpy(n - j,-x(j)*tscal,a(j + 1,j),1,x(j + 1),1)
-                                    
+
                           i = j + stdlib_idamax(n - j,x(j + 1),1)
                           xmax = abs(x(i))
                        end if
@@ -10839,7 +10839,7 @@ module stdlib_linalg_lapack_d
                           scale = zero
                           xmax = zero
                        end if
-150                    continue
+                       150 continue
                     else
                        ! compute x(j) := x(j) / a(j,j)  - sumj if the dot
                        ! product has already been divided by 1/a(j,j).
@@ -10877,7 +10877,7 @@ module stdlib_linalg_lapack_d
            ! Array Arguments
            real(dp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i
@@ -10949,7 +10949,7 @@ module stdlib_linalg_lapack_d
            ! Array Arguments
            real(dp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,ib,nb
@@ -11039,7 +11039,7 @@ module stdlib_linalg_lapack_d
            real(dp),parameter :: alphasq = 0.01_dp
            real(dp),parameter :: realone = 1.0_dp
            real(dp),parameter :: realzero = 0.0_dp
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(dp) :: normsq1,normsq2,scl1,scl2,ssq1,ssq2
@@ -11157,7 +11157,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: tau(*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,ii,j,l
            ! Intrinsic Functions
@@ -11192,7 +11192,7 @@ module stdlib_linalg_lapack_d
               ! apply h(i) to a(1:m-k+i,1:n-k+i) from the left
               a(m - n + ii,ii) = one
               call stdlib_dlarf('LEFT',m - n + ii,ii - 1,a(1,ii),1,tau(i),a,lda,work)
-                        
+
               call stdlib_dscal(m - n + ii - 1,-tau(i),a(1,ii),1)
               a(m - n + ii,ii) = one - tau(i)
               ! set a(m-k+i+1:m,n-k+i) to zero
@@ -11221,7 +11221,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: tau(*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,l
            ! Intrinsic Functions
@@ -11286,7 +11286,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: tau(*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,l
            ! Intrinsic Functions
@@ -11355,7 +11355,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: tau(*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,iinfo,iws,j,ki,kk,l,ldwork,lwkopt,nb,nbmin,nx
@@ -11437,7 +11437,7 @@ module stdlib_linalg_lapack_d
                     ! apply h**t to a(i+ib:m,i:n) from the right
                     call stdlib_dlarfb('RIGHT','TRANSPOSE','FORWARD','ROWWISE',m - i - ib + 1,n - i + &
                     1,ib,a(i,i),lda,work,ldwork,a(i + ib,i),lda,work(ib + 1),ldwork)
-                              
+
                  end if
                  ! apply h**t to columns i:n of current block
                  call stdlib_dorgl2(ib,n - i + 1,ib,a(i,i),lda,tau(i),work,iinfo)
@@ -11471,7 +11471,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: tau(*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,iinfo,iws,j,kk,l,ldwork,lwkopt,nb,nbmin,nx
@@ -11557,7 +11557,7 @@ module stdlib_linalg_lapack_d
                     ! apply h to a(1:m-k+i+ib-1,1:n-k+i-1) from the left
                     call stdlib_dlarfb('LEFT','NO TRANSPOSE','BACKWARD','COLUMNWISE',m - k + i + ib - &
                     1,n - k + i - 1,ib,a(1,n - k + i),lda,work,ldwork,a,lda,work(ib + 1),ldwork)
-                              
+
                  end if
                  ! apply h to rows 1:m-k+i+ib-1 of current block
                  call stdlib_dorg2l(m - k + i + ib - 1,ib,ib,a(1,n - k + i),lda,tau(i),work,iinfo &
@@ -11592,7 +11592,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: tau(*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,iinfo,iws,j,ki,kk,l,ldwork,lwkopt,nb,nbmin,nx
@@ -11708,7 +11708,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: tau(*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,ii,j,l
            ! Intrinsic Functions
@@ -11745,7 +11745,7 @@ module stdlib_linalg_lapack_d
               ! apply h(i) to a(1:m-k+i,1:n-k+i) from the right
               a(ii,n - m + ii) = one
               call stdlib_dlarf('RIGHT',ii - 1,n - m + ii,a(ii,1),lda,tau(i),a,lda,work)
-                        
+
               call stdlib_dscal(n - m + ii - 1,-tau(i),a(ii,1),lda)
               a(ii,n - m + ii) = one - tau(i)
               ! set a(m-k+i,n-k+i+1:n) to zero
@@ -11774,7 +11774,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: tau(*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,ii,iinfo,iws,j,kk,l,ldwork,lwkopt,nb,nbmin,nx
@@ -11864,7 +11864,7 @@ module stdlib_linalg_lapack_d
                  end if
                  ! apply h**t to columns 1:n-k+i+ib-1 of current block
                  call stdlib_dorgr2(ib,n - k + i + ib - 1,ib,a(ii,1),lda,tau(i),work,iinfo)
-                           
+
                  ! set columns n-k+i+ib:n of current block to zero
                  do l = n - k + i + ib,n
                     do j = ii,ii + ib - 1
@@ -11905,7 +11905,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: t(ldt,*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: nblocal,mb2,m_plus_one,itmp,ib_bottom,lworkopt, &
@@ -12021,7 +12021,7 @@ module stdlib_linalg_lapack_d
      end subroutine stdlib_dorgtsqr_row
 
      pure subroutine stdlib_dorm22(side,trans,m,n,n1,n2,q,ldq,c,ldc,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -12034,7 +12034,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: c(ldc,*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            integer(ilp) :: i,ldwork,len,lwkopt,nb,nq,nw
@@ -12093,12 +12093,12 @@ module stdlib_linalg_lapack_d
            ! degenerate cases (n1 = 0 or n2 = 0) are handled using stdlib_dtrmm.
            if (n1 == 0) then
               call stdlib_dtrmm(side,'UPPER',trans,'NON-UNIT',m,n,one,q,ldq,c,ldc)
-                        
+
               work(1) = one
               return
            else if (n2 == 0) then
               call stdlib_dtrmm(side,'LOWER',trans,'NON-UNIT',m,n,one,q,ldq,c,ldc)
-                        
+
               work(1) = one
               return
            end if
@@ -12118,7 +12118,7 @@ module stdlib_linalg_lapack_d
                                1,i),ldc,one,work,ldwork)
                     ! multiply top part of c by q21.
                     call stdlib_dlacpy('ALL',n2,len,c(1,i),ldc,work(n1 + 1),ldwork)
-                              
+
                     call stdlib_dtrmm('LEFT','UPPER','NO TRANSPOSE','NON-UNIT',n2,len,one, &
                               q(n1 + 1,1),ldq,work(n1 + 1),ldwork)
                     ! multiply bottom part of c by q22.
@@ -12140,7 +12140,7 @@ module stdlib_linalg_lapack_d
                                i),ldc,one,work,ldwork)
                     ! multiply top part of c by q12**t.
                     call stdlib_dlacpy('ALL',n1,len,c(1,i),ldc,work(n2 + 1),ldwork)
-                              
+
                     call stdlib_dtrmm('LEFT','LOWER','TRANSPOSE','NON-UNIT',n1,len,one,q( &
                               1,n2 + 1),ldq,work(n2 + 1),ldwork)
                     ! multiply bottom part of c by q22**t.
@@ -12225,7 +12225,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: tau(*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: left,notran
            integer(ilp) :: i,i1,i2,i3,mi,ni,nq
@@ -12319,7 +12319,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: tau(*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: left,notran
            integer(ilp) :: i,i1,i2,i3,ic,jc,mi,ni,nq
@@ -12388,7 +12388,7 @@ module stdlib_linalg_lapack_d
               aii = a(i,i)
               a(i,i) = one
               call stdlib_dlarf(side,mi,ni,a(i,i),1,tau(i),c(ic,jc),ldc,work)
-                        
+
               a(i,i) = aii
            end do
            return
@@ -12418,7 +12418,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: tau(*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: left,notran
            integer(ilp) :: i,i1,i2,i3,ic,jc,mi,ni,nq
@@ -12487,7 +12487,7 @@ module stdlib_linalg_lapack_d
               aii = a(i,i)
               a(i,i) = one
               call stdlib_dlarf(side,mi,ni,a(i,i),lda,tau(i),c(ic,jc),ldc,work)
-                        
+
               a(i,i) = aii
            end do
            return
@@ -12504,7 +12504,7 @@ module stdlib_linalg_lapack_d
      !> if SIDE = 'R'.
 
      pure subroutine stdlib_dormlq(side,trans,m,n,k,a,lda,tau,c,ldc,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -12521,7 +12521,7 @@ module stdlib_linalg_lapack_d
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            character :: transt
@@ -12647,7 +12647,7 @@ module stdlib_linalg_lapack_d
      !> if SIDE = 'R'.
 
      pure subroutine stdlib_dormql(side,trans,m,n,k,a,lda,tau,c,ldc,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -12664,7 +12664,7 @@ module stdlib_linalg_lapack_d
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            integer(ilp) :: i,i1,i2,i3,ib,iinfo,iwt,ldwork,lwkopt,mi,nb,nbmin,ni,nq, &
@@ -12708,7 +12708,7 @@ module stdlib_linalg_lapack_d
                  lwkopt = 1
               else
                  nb = min(nbmax,stdlib_ilaenv(1,'DORMQL',side//trans,m,n,k,-1))
-                           
+
                  lwkopt = nw*nb + tsize
               end if
               work(1) = lwkopt
@@ -12784,7 +12784,7 @@ module stdlib_linalg_lapack_d
      !> if SIDE = 'R'.
 
      pure subroutine stdlib_dormqr(side,trans,m,n,k,a,lda,tau,c,ldc,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -12801,7 +12801,7 @@ module stdlib_linalg_lapack_d
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            integer(ilp) :: i,i1,i2,i3,ib,ic,iinfo,iwt,jc,ldwork,lwkopt,mi,nb,nbmin, &
@@ -12934,7 +12934,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: tau(*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: left,notran
            integer(ilp) :: i,i1,i2,i3,mi,ni,nq
@@ -13016,7 +13016,7 @@ module stdlib_linalg_lapack_d
      !> if SIDE = 'R'.
 
      pure subroutine stdlib_dormr3(side,trans,m,n,k,l,a,lda,tau,c,ldc,work,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -13114,7 +13114,7 @@ module stdlib_linalg_lapack_d
      !> if SIDE = 'R'.
 
      pure subroutine stdlib_dormrq(side,trans,m,n,k,a,lda,tau,c,ldc,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -13131,7 +13131,7 @@ module stdlib_linalg_lapack_d
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            character :: transt
@@ -13176,7 +13176,7 @@ module stdlib_linalg_lapack_d
                  lwkopt = 1
               else
                  nb = min(nbmax,stdlib_ilaenv(1,'DORMRQ',side//trans,m,n,k,-1))
-                           
+
                  lwkopt = nw*nb + tsize
               end if
               work(1) = lwkopt
@@ -13274,7 +13274,7 @@ module stdlib_linalg_lapack_d
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            character :: transt
@@ -13321,7 +13321,7 @@ module stdlib_linalg_lapack_d
                  lwkopt = 1
               else
                  nb = min(nbmax,stdlib_ilaenv(1,'DORMRQ',side//trans,m,n,k,-1))
-                           
+
                  lwkopt = nw*nb + tsize
               end if
               work(1) = lwkopt
@@ -13348,7 +13348,7 @@ module stdlib_linalg_lapack_d
            if (nb < nbmin .or. nb >= k) then
               ! use unblocked code
               call stdlib_dormr3(side,trans,m,n,k,l,a,lda,tau,c,ldc,work,iinfo)
-                        
+
            else
               ! use blocked code
               iwt = 1 + nw*nb
@@ -13421,7 +13421,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: ab(ldab,*)
            real(dp),intent(out) :: s(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,j
@@ -13507,7 +13507,7 @@ module stdlib_linalg_lapack_d
            ! Array Arguments
            real(dp),intent(inout) :: ab(ldab,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,kld,km,m
@@ -13549,7 +13549,7 @@ module stdlib_linalg_lapack_d
                  ! the leading submatrix within the band.
                  call stdlib_dscal(km,one/ajj,ab(kd + 1 - km,j),1)
                  call stdlib_dsyr('UPPER',km,-one,ab(kd + 1 - km,j),1,ab(kd + 1,j - km),kld)
-                           
+
               end do
               ! factorize the updated submatrix a(1:m,1:m) as u**t*u.
               do j = 1,m
@@ -13564,7 +13564,7 @@ module stdlib_linalg_lapack_d
                  if (km > 0) then
                     call stdlib_dscal(km,one/ajj,ab(kd,j + 1),kld)
                     call stdlib_dsyr('UPPER',km,-one,ab(kd,j + 1),kld,ab(kd + 1,j + 1),kld)
-                              
+
                  end if
               end do
            else
@@ -13580,7 +13580,7 @@ module stdlib_linalg_lapack_d
                  ! trailing submatrix within the band.
                  call stdlib_dscal(km,one/ajj,ab(km + 1,j - km),kld)
                  call stdlib_dsyr('LOWER',km,-one,ab(km + 1,j - km),kld,ab(1,j - km),kld)
-                           
+
               end do
               ! factorize the updated submatrix a(1:m,1:m) as u**t*u.
               do j = 1,m
@@ -13599,7 +13599,7 @@ module stdlib_linalg_lapack_d
               end do
            end if
            return
-50         continue
+           50 continue
            info = j
            return
      end subroutine stdlib_dpbstf
@@ -13624,7 +13624,7 @@ module stdlib_linalg_lapack_d
            ! Array Arguments
            real(dp),intent(inout) :: ab(ldab,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,kld,kn
@@ -13665,7 +13665,7 @@ module stdlib_linalg_lapack_d
                  if (kn > 0) then
                     call stdlib_dscal(kn,one/ajj,ab(kd,j + 1),kld)
                     call stdlib_dsyr('UPPER',kn,-one,ab(kd,j + 1),kld,ab(kd + 1,j + 1),kld)
-                              
+
                  end if
               end do
            else
@@ -13686,7 +13686,7 @@ module stdlib_linalg_lapack_d
               end do
            end if
            return
-30         continue
+           30 continue
            info = j
            return
      end subroutine stdlib_dpbtf2
@@ -13780,7 +13780,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: a(lda,*)
            real(dp),intent(out) :: s(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(dp) :: smin
@@ -13859,7 +13859,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: a(lda,*)
            real(dp),intent(out) :: s(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(dp) :: smin,base,tmp
@@ -13931,7 +13931,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: a(lda,*)
            real(dp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            ! Intrinsic Functions
@@ -13999,7 +13999,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: ap(*)
            real(dp),intent(out) :: s(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,jj
@@ -14088,7 +14088,7 @@ module stdlib_linalg_lapack_d
            ! Array Arguments
            real(dp),intent(inout) :: ap(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,jc,jj
@@ -14149,9 +14149,9 @@ module stdlib_linalg_lapack_d
               end do
            end if
            go to 40
-30         continue
+           30 continue
            info = j
-40         continue
+           40 continue
            return
      end subroutine stdlib_dpptrf
 
@@ -14202,14 +14202,14 @@ module stdlib_linalg_lapack_d
                  call stdlib_dtpsv('UPPER','TRANSPOSE','NON-UNIT',n,ap,b(1,i),1)
                  ! solve u*x = b, overwriting b with x.
                  call stdlib_dtpsv('UPPER','NO TRANSPOSE','NON-UNIT',n,ap,b(1,i),1)
-                           
+
               end do
            else
               ! solve a*x = b where a = l * l**t.
               do i = 1,nrhs
                  ! solve l*y = b, overwriting b with x.
                  call stdlib_dtpsv('LOWER','NO TRANSPOSE','NON-UNIT',n,ap,b(1,i),1)
-                           
+
                  ! solve l**t *x = y, overwriting b with x.
                  call stdlib_dtpsv('LOWER','TRANSPOSE','NON-UNIT',n,ap,b(1,i),1)
               end do
@@ -14238,7 +14238,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: d(*),e(*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,ix
            real(dp) :: ainvnm
@@ -14304,7 +14304,7 @@ module stdlib_linalg_lapack_d
            ! Array Arguments
            real(dp),intent(inout) :: d(*),e(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,i4
            real(dp) :: ei
@@ -14369,7 +14369,7 @@ module stdlib_linalg_lapack_d
            end do loop_20
            ! check d(n) for positive definiteness.
            if (d(n) <= zero) info = n
-30         continue
+           30 continue
            return
      end subroutine stdlib_dpttrf
 
@@ -14428,7 +14428,7 @@ module stdlib_linalg_lapack_d
            ! Array Arguments
            real(dp),intent(inout) :: sx(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: done
            real(dp) :: bignum,cden,cden1,cnum,cnum1,mul,smlnum
@@ -14444,7 +14444,7 @@ module stdlib_linalg_lapack_d
            ! initialize the denominator to sa and the numerator to 1.
            cden = sa
            cnum = one
-10         continue
+           10 continue
            cden1 = cden*smlnum
            cnum1 = cnum/bignum
            if (abs(cden1) > abs(cnum) .and. cnum /= zero) then
@@ -14477,7 +14477,7 @@ module stdlib_linalg_lapack_d
      !> bandwidth of A.
 
      pure subroutine stdlib_dsbgst(vect,uplo,n,ka,kb,ab,ldab,bb,ldbb,x,ldx,work,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -14490,7 +14490,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: bb(ldbb,*)
            real(dp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: update,upper,wantx
            integer(ilp) :: i,i0,i1,i2,inca,j,j1,j1t,j2,j2t,k,ka1,kb1,kbt,l,m,nr, &
@@ -14582,7 +14582,7 @@ module stdlib_linalg_lapack_d
            ! to avoid duplicating code, the two loops are merged.
            update = .true.
            i = n + 1
-10         continue
+           10 continue
            if (update) then
               i = i - 1
               kbt = min(kb,i - 1)
@@ -14619,13 +14619,13 @@ module stdlib_linalg_lapack_d
                     end do
                     do j = max(1,i - ka),i - kbt - 1
                        ab(j - k + ka1,k) = ab(j - k + ka1,k) - bb(k - i + kb1,i)*ab(j - i + ka1,i)
-                                 
+
                     end do
                  end do
                  do j = i,i1
                     do k = max(j - ka,i - kbt),i - 1
                        ab(k - j + ka1,j) = ab(k - j + ka1,j) - bb(k - i + kb1,i)*ab(i - j + ka1,j)
-                                 
+
                     end do
                  end do
                  if (wantx) then
@@ -14652,9 +14652,9 @@ module stdlib_linalg_lapack_d
                        ! band and store it in work(i-k)
                        t = -bb(kb1 - k,i)*ra1
                        work(i - k) = work(n + i - k + ka - m)*t - work(i - k + ka - m)*ab(1,i - k + ka)
-                                 
+
                        ab(1,i - k + ka) = work(i - k + ka - m)*t + work(n + i - k + ka - m)*ab(1,i - k + ka)
-                                 
+
                        ra1 = ra
                     end if
                  end if
@@ -14745,7 +14745,7 @@ module stdlib_linalg_lapack_d
                     ! generate rotations in 2nd set to annihilate elements
                     ! which have been created outside the band
                     call stdlib_dlargv(nr,ab(1,j2),inca,work(j2),ka1,work(n + j2),ka1)
-                              
+
                     ! apply rotations in 2nd set from the right
                     do l = 1,ka - 1
                        call stdlib_dlartv(nr,ab(ka1 - l,j2),inca,ab(ka - l,j2 + 1),inca,work( &
@@ -14835,7 +14835,7 @@ module stdlib_linalg_lapack_d
                        t = -bb(k + 1,i - k)*ra1
                        work(i - k) = work(n + i - k + ka - m)*t - work(i - k + ka - m)*ab(ka1,i - k)
                        ab(ka1,i - k) = work(i - k + ka - m)*t + work(n + i - k + ka - m)*ab(ka1,i - k)
-                                 
+
                        ra1 = ra
                     end if
                  end if
@@ -14968,7 +14968,7 @@ module stdlib_linalg_lapack_d
               end if
            end if
            go to 10
-480        continue
+           480 continue
            ! **************************** phase 2 *****************************
            ! the logical structure of this phase is:
            ! update = .true.
@@ -14983,7 +14983,7 @@ module stdlib_linalg_lapack_d
            ! to avoid duplicating code, the two loops are merged.
            update = .true.
            i = 0
-490        continue
+           490 continue
            if (update) then
               i = i + 1
               kbt = min(kb,m - i)
@@ -15025,13 +15025,13 @@ module stdlib_linalg_lapack_d
                     end do
                     do j = i + kbt + 1,min(n,i + ka)
                        ab(k - j + ka1,j) = ab(k - j + ka1,j) - bb(i - k + kb1,k)*ab(i - j + ka1,j)
-                                 
+
                     end do
                  end do
                  do j = i1,i
                     do k = i + 1,min(j + ka,i + kbt)
                        ab(j - k + ka1,k) = ab(j - k + ka1,k) - bb(i - k + kb1,k)*ab(j - i + ka1,i)
-                                 
+
                     end do
                  end do
                  if (wantx) then
@@ -15102,7 +15102,7 @@ module stdlib_linalg_lapack_d
                     ! post-multiply x by product of rotations in 1st set
                     do j = j1,j2,ka1
                        call stdlib_drot(nx,x(1,j),1,x(1,j - 1),1,work(n + j),work(j))
-                                 
+
                     end do
                  end if
               end do loop_610
@@ -15240,9 +15240,9 @@ module stdlib_linalg_lapack_d
                        ! band and store it in work(m-kb+i+k)
                        t = -bb(k + 1,i)*ra1
                        work(m - kb + i + k) = work(n + i + k - ka)*t - work(i + k - ka)*ab(ka1,i + k - ka)
-                                 
+
                        ab(ka1,i + k - ka) = work(i + k - ka)*t + work(n + i + k - ka)*ab(ka1,i + k - ka)
-                                 
+
                        ra1 = ra
                     end if
                  end if
@@ -15287,7 +15287,7 @@ module stdlib_linalg_lapack_d
                     ! post-multiply x by product of rotations in 1st set
                     do j = j1,j2,ka1
                        call stdlib_drot(nx,x(1,j),1,x(1,j - 1),1,work(n + j),work(j))
-                                 
+
                     end do
                  end if
               end do loop_840
@@ -15397,7 +15397,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: ab(ldab,*),q(ldq,*)
            real(dp),intent(out) :: d(*),e(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: initq,upper,wantq
            integer(ilp) :: i,i2,ibl,inca,incx,iqaend,iqb,iqend,j,j1,j1end,j1inc,j2, &
@@ -15733,7 +15733,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: a(lda,*)
            real(dp),intent(inout) :: c(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,normaltransr,nisodd,notrans
            integer(ilp) :: info,nrowa,j,nk,n1,n2
@@ -15803,7 +15803,7 @@ module stdlib_linalg_lapack_d
                     if (notrans) then
                        ! n is odd, transr = 'n', uplo = 'l', and trans = 'n'
                        call stdlib_dsyrk('L','N',n1,k,alpha,a(1,1),lda,beta,c(1),n)
-                                 
+
                        call stdlib_dsyrk('U','N',n2,k,alpha,a(n1 + 1,1),lda,beta,c(n + 1) &
                                  ,n)
                        call stdlib_dgemm('N','T',n2,n1,k,alpha,a(n1 + 1,1),lda,a(1,1), &
@@ -15811,7 +15811,7 @@ module stdlib_linalg_lapack_d
                     else
                        ! n is odd, transr = 'n', uplo = 'l', and trans = 't'
                        call stdlib_dsyrk('L','T',n1,k,alpha,a(1,1),lda,beta,c(1),n)
-                                 
+
                        call stdlib_dsyrk('U','T',n2,k,alpha,a(1,n1 + 1),lda,beta,c(n + 1) &
                                  ,n)
                        call stdlib_dgemm('T','N',n2,n1,k,alpha,a(1,n1 + 1),lda,a(1,1), &
@@ -15988,7 +15988,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: ap(*)
            real(dp),intent(in) :: bp(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,j1,j1j1,jj,k,k1,k1k1,kk
@@ -16060,7 +16060,7 @@ module stdlib_linalg_lapack_d
                     akk = ap(kk)
                     bkk = bp(kk)
                     call stdlib_dtpmv(uplo,'NO TRANSPOSE','NON-UNIT',k - 1,bp,ap(k1),1)
-                              
+
                     ct = half*akk
                     call stdlib_daxpy(k - 1,ct,bp(k1),1,ap(k1),1)
                     call stdlib_dspr2(uplo,k - 1,one,ap(k1),1,bp(k1),1,ap)
@@ -16111,7 +16111,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: sevten = 17.0e+0_dp
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,imax,j,jmax,k,kc,kk,knc,kp,kpc,kstep,kx,npp
@@ -16140,7 +16140,7 @@ module stdlib_linalg_lapack_d
               ! 1 or 2
               k = n
               kc = (n - 1)*n/2 + 1
-10            continue
+              10 continue
               knc = kc
               ! if k < 1, exit from loop
               if (k < 1) go to 110
@@ -16243,9 +16243,9 @@ module stdlib_linalg_lapack_d
                        d12 = t/d12
                        do j = k - 2,1,-1
                           wkm1 = d12*(d11*ap(j + (k - 2)*(k - 1)/2) - ap(j + (k - 1)*k/2))
-                                    
+
                           wk = d12*(d22*ap(j + (k - 1)*k/2) - ap(j + (k - 2)*(k - 1)/2))
-                                    
+
                           do i = j,1,-1
                              ap(i + (j - 1)*j/2) = ap(i + (j - 1)*j/2) - ap(i + (k - 1)*k/2) &
                                        *wk - ap(i + (k - 2)*(k - 1)/2)*wkm1
@@ -16274,7 +16274,7 @@ module stdlib_linalg_lapack_d
               k = 1
               kc = 1
               npp = n*(n + 1)/2
-60            continue
+              60 continue
               knc = kc
               ! if k > n, exit from loop
               if (k > n) go to 110
@@ -16335,7 +16335,7 @@ module stdlib_linalg_lapack_d
                     ! interchange rows and columns kk and kp in the trailing
                     ! submatrix a(k:n,k:n)
                     if (kp < n) call stdlib_dswap(n - kp,ap(knc + kp - kk + 1),1,ap(kpc + 1),1)
-                              
+
                     kx = knc + kp - kk
                     do j = kk + 1,kp - 1
                        kx = kx + n - j + 1
@@ -16383,7 +16383,7 @@ module stdlib_linalg_lapack_d
                        d21 = t/d21
                        do j = k + 2,n
                           wk = d21*(d11*ap(j + (k - 1)*(2*n - k)/2) - ap(j + k*(2*n - k - 1)/2))
-                                    
+
                           wkp1 = d21*(d22*ap(j + k*(2*n - k - 1)/2) - ap(j + (k - 1)*(2*n - k)/2) &
                                      )
                           do i = j,n
@@ -16408,7 +16408,7 @@ module stdlib_linalg_lapack_d
               kc = knc + n - k + 2
               go to 60
            end if
-110        continue
+           110 continue
            return
      end subroutine stdlib_dsptrf
 
@@ -16429,7 +16429,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: ap(*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kc,kcnext,kp,kpc,kstep,kx,npp
@@ -16474,7 +16474,7 @@ module stdlib_linalg_lapack_d
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
               kc = 1
-30            continue
+              30 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               kcnext = kc + k
@@ -16509,9 +16509,9 @@ module stdlib_linalg_lapack_d
                               kcnext),1)
                     call stdlib_dcopy(k - 1,ap(kcnext),1,work,1)
                     call stdlib_dspmv(uplo,k - 1,-one,ap,work,1,zero,ap(kcnext),1)
-                              
+
                     ap(kcnext + k) = ap(kcnext + k) - stdlib_ddot(k - 1,work,1,ap(kcnext),1)
-                              
+
                  end if
                  kstep = 2
                  kcnext = kcnext + k + 1
@@ -16541,7 +16541,7 @@ module stdlib_linalg_lapack_d
               k = k + kstep
               kc = kcnext
               go to 30
-50            continue
+              50 continue
            else
               ! compute inv(a) from the factorization a = l*d*l**t.
               ! k is the main loop index, increasing from 1 to n in steps of
@@ -16549,7 +16549,7 @@ module stdlib_linalg_lapack_d
               npp = n*(n + 1)/2
               k = n
               kc = npp
-60            continue
+              60 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 80
               kcnext = kc - (n - k + 2)
@@ -16588,7 +16588,7 @@ module stdlib_linalg_lapack_d
                     call stdlib_dspmv(uplo,n - k,-one,ap(kc + (n - k + 1)),work,1,zero,ap( &
                               kcnext + 2),1)
                     ap(kcnext) = ap(kcnext) - stdlib_ddot(n - k,work,1,ap(kcnext + 2),1)
-                              
+
                  end if
                  kstep = 2
                  kcnext = kcnext - (n - k + 3)
@@ -16618,7 +16618,7 @@ module stdlib_linalg_lapack_d
               k = k - kstep
               kc = kcnext
               go to 60
-80            continue
+              80 continue
            end if
            return
      end subroutine stdlib_dsptri
@@ -16640,7 +16640,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: ap(*)
            real(dp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kc,kp
@@ -16672,7 +16672,7 @@ module stdlib_linalg_lapack_d
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
               kc = n*(n + 1)/2 + 1
-10            continue
+              10 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 30
               kc = kc - k
@@ -16684,7 +16684,7 @@ module stdlib_linalg_lapack_d
                  ! multiply by inv(u(k)), where u(k) is the transformation
                  ! stored in column k of a.
                  call stdlib_dger(k - 1,nrhs,-one,ap(kc),1,b(k,1),ldb,b(1,1),ldb)
-                           
+
                  ! multiply by the inverse of the diagonal block.
                  call stdlib_dscal(nrhs,one/ap(kc + k - 1),b(k,1),ldb)
                  k = k - 1
@@ -16696,7 +16696,7 @@ module stdlib_linalg_lapack_d
                  ! multiply by inv(u(k)), where u(k) is the transformation
                  ! stored in columns k-1 and k of a.
                  call stdlib_dger(k - 2,nrhs,-one,ap(kc),1,b(k,1),ldb,b(1,1),ldb)
-                           
+
                  call stdlib_dger(k - 2,nrhs,-one,ap(kc - (k - 1)),1,b(k - 1,1),ldb,b(1,1 &
                            ),ldb)
                  ! multiply by the inverse of the diagonal block.
@@ -16714,13 +16714,13 @@ module stdlib_linalg_lapack_d
                  k = k - 2
               end if
               go to 10
-30            continue
+              30 continue
               ! next solve u**t*x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
               kc = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               if (ipiv(k) > 0) then
@@ -16749,7 +16749,7 @@ module stdlib_linalg_lapack_d
                  k = k + 2
               end if
               go to 40
-50            continue
+              50 continue
            else
               ! solve a*x = b, where a = l*d*l**t.
               ! first solve l*d*x = b, overwriting b with x.
@@ -16757,7 +16757,7 @@ module stdlib_linalg_lapack_d
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
               kc = 1
-60            continue
+              60 continue
               ! if k > n, exit from loop.
               if (k > n) go to 80
               if (ipiv(k) > 0) then
@@ -16801,13 +16801,13 @@ module stdlib_linalg_lapack_d
                  k = k + 2
               end if
               go to 60
-80            continue
+              80 continue
               ! next solve l**t*x = b, overwriting b with x.
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
               kc = n*(n + 1)/2 + 1
-90            continue
+              90 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 100
               kc = kc - (n - k + 1)
@@ -16838,7 +16838,7 @@ module stdlib_linalg_lapack_d
                  k = k - 2
               end if
               go to 90
-100           continue
+              100 continue
            end if
            return
      end subroutine stdlib_dsptrs
@@ -16872,7 +16872,7 @@ module stdlib_linalg_lapack_d
            ! Parameters
            real(dp),parameter :: fudge = 2.1_dp
            real(dp),parameter :: relfac = 2.0_dp
-           
+
            ! Local Scalars
            logical(lk) :: ncnvrg,toofew
            integer(ilp) :: ib,ibegin,idiscl,idiscu,ie,iend,iinfo,im,in,ioff,iorder, &
@@ -17252,7 +17252,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: e(*)
         ! =====================================================================
-           
+
            ! External Subroutines
            logical(lk) :: upper,convert
            integer(ilp) :: i,ip,j
@@ -17468,7 +17468,7 @@ module stdlib_linalg_lapack_d
            integer(ilp),intent(inout) :: ipiv(*)
            real(dp),intent(inout) :: a(lda,*),e(*)
         ! =====================================================================
-           
+
            ! External Subroutines
            logical(lk) :: upper,convert
            integer(ilp) :: i,ip
@@ -17532,7 +17532,7 @@ module stdlib_linalg_lapack_d
                        if (i < n) then
                           if (ip /= (i - 1)) then
                              call stdlib_dswap(n - i,a(i - 1,i + 1),lda,a(ip,i + 1),lda)
-                                       
+
                           end if
                        end if
                        ! convert ipiv
@@ -17568,7 +17568,7 @@ module stdlib_linalg_lapack_d
                        if (i < n) then
                           if (ip /= (i - 1)) then
                              call stdlib_dswap(n - i,a(ip,i + 1),lda,a(i - 1,i + 1),lda)
-                                       
+
                           end if
                        end if
                        ! convert ipiv
@@ -17721,7 +17721,7 @@ module stdlib_linalg_lapack_d
            integer(ilp),intent(in) :: ipiv(*)
            real(dp),intent(inout) :: a(lda,*),e(*)
         ! =====================================================================
-           
+
            ! External Subroutines
            logical(lk) :: upper,convert
            integer(ilp) :: i,ip,ip2
@@ -17790,7 +17790,7 @@ module stdlib_linalg_lapack_d
                           end if
                           if (ip2 /= (i - 1)) then
                              call stdlib_dswap(n - i,a(i - 1,i + 1),lda,a(ip2,i + 1),lda)
-                                       
+
                           end if
                        end if
                        i = i - 1
@@ -17823,7 +17823,7 @@ module stdlib_linalg_lapack_d
                        if (i < n) then
                           if (ip2 /= (i - 1)) then
                              call stdlib_dswap(n - i,a(ip2,i + 1),lda,a(i - 1,i + 1),lda)
-                                       
+
                           end if
                           if (ip /= i) then
                              call stdlib_dswap(n - i,a(ip,i + 1),lda,a(i,i + 1),lda)
@@ -17971,7 +17971,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: max_iter = 100
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,iter
            real(dp) :: avg,std,tol,c0,c1,c2,t,u,si,d,base,smin,smax,smlnum,bignum, &
@@ -18107,7 +18107,7 @@ module stdlib_linalg_lapack_d
                  s(i) = si
               end do
            end do
-999        continue
+           999 continue
            smlnum = stdlib_dlamch('SAFEMIN')
            bignum = one/smlnum
            smin = bignum
@@ -18143,7 +18143,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(in) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: k
@@ -18232,11 +18232,11 @@ module stdlib_linalg_lapack_d
                     akk = a(k,k)
                     bkk = b(k,k)
                     call stdlib_dtrmv(uplo,'TRANSPOSE','NON-UNIT',k - 1,b,ldb,a(k,1),lda)
-                              
+
                     ct = half*akk
                     call stdlib_daxpy(k - 1,ct,b(k,1),ldb,a(k,1),lda)
                     call stdlib_dsyr2(uplo,k - 1,one,a(k,1),lda,b(k,1),ldb,a,lda)
-                              
+
                     call stdlib_daxpy(k - 1,ct,b(k,1),ldb,a(k,1),lda)
                     call stdlib_dscal(k - 1,bkk,a(k,1),lda)
                     a(k,k) = akk*bkk**2
@@ -18266,7 +18266,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(in) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: k,kb,nb
@@ -18307,7 +18307,7 @@ module stdlib_linalg_lapack_d
                        kb = min(n - k + 1,nb)
                        ! update the upper triangle of a(k:n,k:n)
                        call stdlib_dsygs2(itype,uplo,kb,a(k,k),lda,b(k,k),ldb,info)
-                                 
+
                        if (k + kb <= n) then
                           call stdlib_dtrsm('LEFT',uplo,'TRANSPOSE','NON-UNIT',kb,n - k - kb + 1, &
                                     one,b(k,k),ldb,a(k,k + kb),lda)
@@ -18327,7 +18327,7 @@ module stdlib_linalg_lapack_d
                        kb = min(n - k + 1,nb)
                        ! update the lower triangle of a(k:n,k:n)
                        call stdlib_dsygs2(itype,uplo,kb,a(k,k),lda,b(k,k),ldb,info)
-                                 
+
                        if (k + kb <= n) then
                           call stdlib_dtrsm('RIGHT',uplo,'TRANSPOSE','NON-UNIT',n - k - kb + 1,kb, &
                                     one,b(k,k),ldb,a(k + kb,k),lda)
@@ -18359,7 +18359,7 @@ module stdlib_linalg_lapack_d
                        call stdlib_dtrmm('RIGHT',uplo,'TRANSPOSE','NON-UNIT',k - 1,kb,one,b( &
                                  k,k),ldb,a(1,k),lda)
                        call stdlib_dsygs2(itype,uplo,kb,a(k,k),lda,b(k,k),ldb,info)
-                                 
+
                     end do
                  else
                     ! compute l**t*a*l
@@ -18377,7 +18377,7 @@ module stdlib_linalg_lapack_d
                        call stdlib_dtrmm('LEFT',uplo,'TRANSPOSE','NON-UNIT',kb,k - 1,one,b( &
                                  k,k),ldb,a(k,1),lda)
                        call stdlib_dsygs2(itype,uplo,kb,a(k,k),lda,b(k,k),ldb,info)
-                                 
+
                     end do
                  end if
               end if
@@ -18478,7 +18478,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: sevten = 17.0e+0_dp
-           
+
            ! Local Scalars
            logical(lk) :: upper,done
            integer(ilp) :: i,imax,j,jmax,itemp,k,kk,kp,kstep,p,ii
@@ -18513,7 +18513,7 @@ module stdlib_linalg_lapack_d
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 34
               kstep = 1
@@ -18547,7 +18547,7 @@ module stdlib_linalg_lapack_d
                  else
                     done = .false.
                     ! loop until pivot found
-12   continue
+                    12 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -18597,7 +18597,7 @@ module stdlib_linalg_lapack_d
                     ! submatrix a(1:k,1:k) if we have a 2-by-2 pivot
                     if (p > 1) call stdlib_dswap(p - 1,a(1,k),1,a(1,p),1)
                     if (p < (k - 1)) call stdlib_dswap(k - p - 1,a(p + 1,k),1,a(p,p + 1),lda)
-                              
+
                     t = a(k,k)
                     a(k,k) = a(p,p)
                     a(p,p) = t
@@ -18700,7 +18700,7 @@ module stdlib_linalg_lapack_d
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-34            continue
+              34 continue
            else
               ! factorize a as l*d*l**t using the lower triangle of a
               ! initialize the unused last entry of the subdiagonal array e.
@@ -18708,7 +18708,7 @@ module stdlib_linalg_lapack_d
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop
               if (k > n) go to 64
               kstep = 1
@@ -18741,7 +18741,7 @@ module stdlib_linalg_lapack_d
                  else
                     done = .false.
                     ! loop until pivot found
-42   continue
+                    42 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -18791,7 +18791,7 @@ module stdlib_linalg_lapack_d
                     ! submatrix a(k:n,k:n) if we have a 2-by-2 pivot
                     if (p < n) call stdlib_dswap(n - p,a(p + 1,k),1,a(p + 1,p),1)
                     if (p > (k + 1)) call stdlib_dswap(p - k - 1,a(k + 1,k),1,a(p,k + 1),lda)
-                              
+
                     t = a(k,k)
                     a(k,k) = a(p,p)
                     a(p,p) = t
@@ -18805,7 +18805,7 @@ module stdlib_linalg_lapack_d
                     ! interchange rows and columns kk and kp in the trailing
                     ! submatrix a(k:n,k:n)
                     if (kp < n) call stdlib_dswap(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     if ((kk < n) .and. (kp > (kk + 1))) call stdlib_dswap(kp - kk - 1,a(kk + 1,kk), &
                               1,a(kp,kk + 1),lda)
                     t = a(kk,kk)
@@ -18834,7 +18834,7 @@ module stdlib_linalg_lapack_d
                              ! = a - w(k)*(1/d(k))*w(k)**t
                           d11 = one/a(k,k)
                           call stdlib_dsyr(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                           ! store l(k) in column k
                           call stdlib_dscal(n - k,d11,a(k + 1,k),1)
                        else
@@ -18848,7 +18848,7 @@ module stdlib_linalg_lapack_d
                              ! = a - w(k)*(1/d(k))*w(k)**t
                              ! = a - (w(k)/d(k))*(d(k))*(w(k)/d(k))**t
                           call stdlib_dsyr(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                        end if
                        ! store the subdiagonal element of d in array e
                        e(k) = zero
@@ -18899,7 +18899,7 @@ module stdlib_linalg_lapack_d
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 40
-64            continue
+              64 continue
            end if
            return
      end subroutine stdlib_dsytf2_rk
@@ -18926,7 +18926,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: sevten = 17.0e+0_dp
-           
+
            ! Local Scalars
            logical(lk) :: upper,done
            integer(ilp) :: i,imax,j,jmax,itemp,k,kk,kp,kstep,p,ii
@@ -18958,7 +18958,7 @@ module stdlib_linalg_lapack_d
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 70
               kstep = 1
@@ -18990,7 +18990,7 @@ module stdlib_linalg_lapack_d
                  else
                     done = .false.
                     ! loop until pivot found
-12   continue
+                    12 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -19040,7 +19040,7 @@ module stdlib_linalg_lapack_d
                     ! submatrix a(1:k,1:k) if we have a 2-by-2 pivot
                     if (p > 1) call stdlib_dswap(p - 1,a(1,k),1,a(1,p),1)
                     if (p < (k - 1)) call stdlib_dswap(k - p - 1,a(p + 1,k),1,a(p,p + 1),lda)
-                              
+
                     t = a(k,k)
                     a(k,k) = a(p,p)
                     a(p,p) = t
@@ -19134,7 +19134,7 @@ module stdlib_linalg_lapack_d
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop
               if (k > n) go to 70
               kstep = 1
@@ -19165,7 +19165,7 @@ module stdlib_linalg_lapack_d
                  else
                     done = .false.
                     ! loop until pivot found
-42   continue
+                    42 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -19215,7 +19215,7 @@ module stdlib_linalg_lapack_d
                     ! submatrix a(k:n,k:n) if we have a 2-by-2 pivot
                     if (p < n) call stdlib_dswap(n - p,a(p + 1,k),1,a(p + 1,p),1)
                     if (p > (k + 1)) call stdlib_dswap(p - k - 1,a(k + 1,k),1,a(p,k + 1),lda)
-                              
+
                     t = a(k,k)
                     a(k,k) = a(p,p)
                     a(p,p) = t
@@ -19226,7 +19226,7 @@ module stdlib_linalg_lapack_d
                     ! interchange rows and columns kk and kp in the trailing
                     ! submatrix a(k:n,k:n)
                     if (kp < n) call stdlib_dswap(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     if ((kk < n) .and. (kp > (kk + 1))) call stdlib_dswap(kp - kk - 1,a(kk + 1,kk), &
                               1,a(kp,kk + 1),lda)
                     t = a(kk,kk)
@@ -19252,7 +19252,7 @@ module stdlib_linalg_lapack_d
                              ! = a - w(k)*(1/d(k))*w(k)**t
                           d11 = one/a(k,k)
                           call stdlib_dsyr(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                           ! store l(k) in column k
                           call stdlib_dscal(n - k,d11,a(k + 1,k),1)
                        else
@@ -19266,7 +19266,7 @@ module stdlib_linalg_lapack_d
                              ! = a - w(k)*(1/d(k))*w(k)**t
                              ! = a - (w(k)/d(k))*(d(k))*(w(k)/d(k))**t
                           call stdlib_dsyr(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                        end if
                     end if
                  else
@@ -19310,7 +19310,7 @@ module stdlib_linalg_lapack_d
               k = k + kstep
               go to 40
            end if
-70         continue
+           70 continue
            return
      end subroutine stdlib_dsytf2_rook
 
@@ -19386,14 +19386,14 @@ module stdlib_linalg_lapack_d
               ! kb, where kb is the number of columns factorized by stdlib_dlasyf_rk;
               ! kb is either nb or nb-1, or k for the last block
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 15
               if (k > nb) then
                  ! factorize columns k-kb+1:k of a and use blocked code to
                  ! update columns 1:k-kb
                  call stdlib_dlasyf_rk(uplo,k,nb,kb,a,lda,e,ipiv,work,ldwork,iinfo)
-                           
+
               else
                  ! use unblocked code to factorize columns 1:k of a
                  call stdlib_dsytf2_rk(uplo,k,a,lda,e,ipiv,iinfo)
@@ -19422,14 +19422,14 @@ module stdlib_linalg_lapack_d
               go to 10
               ! this label is the exit from main loop over k decreasing
               ! from n to 1 in steps of kb
-15   continue
+              15 continue
            else
               ! factorize a as l*d*l**t using the lower triangle of a
               ! k is the main loop index, increasing from 1 to n in steps of
               ! kb, where kb is the number of columns factorized by stdlib_dlasyf_rk;
               ! kb is either nb or nb-1, or n-k+1 for the last block
               k = 1
-20            continue
+              20 continue
               ! if k > n, exit from loop
               if (k > n) go to 35
               if (k <= n - nb) then
@@ -19440,7 +19440,7 @@ module stdlib_linalg_lapack_d
               else
                  ! use unblocked code to factorize columns k:n of a
                  call stdlib_dsytf2_rk(uplo,n - k + 1,a(k,k),lda,e(k),ipiv(k),iinfo)
-                           
+
                  kb = n - k + 1
               end if
               ! set info on the first occurrence of a zero pivot
@@ -19473,7 +19473,7 @@ module stdlib_linalg_lapack_d
               go to 20
               ! this label is the exit from main loop over k increasing
               ! from 1 to n in steps of kb
-35   continue
+              35 continue
            ! end lower
            end if
            work(1) = lwkopt
@@ -19551,14 +19551,14 @@ module stdlib_linalg_lapack_d
               ! kb, where kb is the number of columns factorized by stdlib_dlasyf_rook;
               ! kb is either nb or nb-1, or k for the last block
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 40
               if (k > nb) then
                  ! factorize columns k-kb+1:k of a and use blocked code to
                  ! update columns 1:k-kb
                  call stdlib_dlasyf_rook(uplo,k,nb,kb,a,lda,ipiv,work,ldwork,iinfo)
-                           
+
               else
                  ! use unblocked code to factorize columns 1:k of a
                  call stdlib_dsytf2_rook(uplo,k,a,lda,ipiv,iinfo)
@@ -19576,7 +19576,7 @@ module stdlib_linalg_lapack_d
               ! kb, where kb is the number of columns factorized by stdlib_dlasyf_rook;
               ! kb is either nb or nb-1, or n-k+1 for the last block
               k = 1
-20            continue
+              20 continue
               ! if k > n, exit from loop
               if (k > n) go to 40
               if (k <= n - nb) then
@@ -19603,7 +19603,7 @@ module stdlib_linalg_lapack_d
               k = k + kb
               go to 20
            end if
-40         continue
+           40 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_dsytrf_rook
@@ -19625,7 +19625,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: k,kp,kstep
@@ -19667,7 +19667,7 @@ module stdlib_linalg_lapack_d
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-30            continue
+              30 continue
               ! if k > n, exit from loop.
               if (k > n) go to 40
               if (ipiv(k) > 0) then
@@ -19678,7 +19678,7 @@ module stdlib_linalg_lapack_d
                  if (k > 1) then
                     call stdlib_dcopy(k - 1,a(1,k),1,work,1)
                     call stdlib_dsymv(uplo,k - 1,-one,a,lda,work,1,zero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - stdlib_ddot(k - 1,work,1,a(1,k),1)
                  end if
                  kstep = 1
@@ -19697,15 +19697,15 @@ module stdlib_linalg_lapack_d
                  if (k > 1) then
                     call stdlib_dcopy(k - 1,a(1,k),1,work,1)
                     call stdlib_dsymv(uplo,k - 1,-one,a,lda,work,1,zero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - stdlib_ddot(k - 1,work,1,a(1,k),1)
                     a(k,k + 1) = a(k,k + 1) - stdlib_ddot(k - 1,a(1,k),1,a(1,k + 1),1)
-                              
+
                     call stdlib_dcopy(k - 1,a(1,k + 1),1,work,1)
                     call stdlib_dsymv(uplo,k - 1,-one,a,lda,work,1,zero,a(1,k + 1),1)
-                              
+
                     a(k + 1,k + 1) = a(k + 1,k + 1) - stdlib_ddot(k - 1,work,1,a(1,k + 1),1)
-                              
+
                  end if
                  kstep = 2
               end if
@@ -19726,13 +19726,13 @@ module stdlib_linalg_lapack_d
               end if
               k = k + kstep
               go to 30
-40            continue
+              40 continue
            else
               ! compute inv(a) from the factorization a = l*d*l**t.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-50            continue
+              50 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 60
               if (ipiv(k) > 0) then
@@ -19765,12 +19765,12 @@ module stdlib_linalg_lapack_d
                               k),1)
                     a(k,k) = a(k,k) - stdlib_ddot(n - k,work,1,a(k + 1,k),1)
                     a(k,k - 1) = a(k,k - 1) - stdlib_ddot(n - k,a(k + 1,k),1,a(k + 1,k - 1),1)
-                              
+
                     call stdlib_dcopy(n - k,a(k + 1,k - 1),1,work,1)
                     call stdlib_dsymv(uplo,n - k,-one,a(k + 1,k + 1),lda,work,1,zero,a(k + 1, &
                               k - 1),1)
                     a(k - 1,k - 1) = a(k - 1,k - 1) - stdlib_ddot(n - k,work,1,a(k + 1,k - 1),1)
-                              
+
                  end if
                  kstep = 2
               end if
@@ -19791,7 +19791,7 @@ module stdlib_linalg_lapack_d
               end if
               k = k - kstep
               go to 50
-60            continue
+              60 continue
            end if
            return
      end subroutine stdlib_dsytri
@@ -19813,7 +19813,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: k,kp,kstep
@@ -19855,7 +19855,7 @@ module stdlib_linalg_lapack_d
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-30            continue
+              30 continue
               ! if k > n, exit from loop.
               if (k > n) go to 40
               if (ipiv(k) > 0) then
@@ -19866,7 +19866,7 @@ module stdlib_linalg_lapack_d
                  if (k > 1) then
                     call stdlib_dcopy(k - 1,a(1,k),1,work,1)
                     call stdlib_dsymv(uplo,k - 1,-one,a,lda,work,1,zero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - stdlib_ddot(k - 1,work,1,a(1,k),1)
                  end if
                  kstep = 1
@@ -19885,15 +19885,15 @@ module stdlib_linalg_lapack_d
                  if (k > 1) then
                     call stdlib_dcopy(k - 1,a(1,k),1,work,1)
                     call stdlib_dsymv(uplo,k - 1,-one,a,lda,work,1,zero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - stdlib_ddot(k - 1,work,1,a(1,k),1)
                     a(k,k + 1) = a(k,k + 1) - stdlib_ddot(k - 1,a(1,k),1,a(1,k + 1),1)
-                              
+
                     call stdlib_dcopy(k - 1,a(1,k + 1),1,work,1)
                     call stdlib_dsymv(uplo,k - 1,-one,a,lda,work,1,zero,a(1,k + 1),1)
-                              
+
                     a(k + 1,k + 1) = a(k + 1,k + 1) - stdlib_ddot(k - 1,work,1,a(1,k + 1),1)
-                              
+
                  end if
                  kstep = 2
               end if
@@ -19934,13 +19934,13 @@ module stdlib_linalg_lapack_d
               end if
               k = k + 1
               go to 30
-40            continue
+              40 continue
            else
               ! compute inv(a) from the factorization a = l*d*l**t.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-50            continue
+              50 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 60
               if (ipiv(k) > 0) then
@@ -19973,12 +19973,12 @@ module stdlib_linalg_lapack_d
                               k),1)
                     a(k,k) = a(k,k) - stdlib_ddot(n - k,work,1,a(k + 1,k),1)
                     a(k,k - 1) = a(k,k - 1) - stdlib_ddot(n - k,a(k + 1,k),1,a(k + 1,k - 1),1)
-                              
+
                     call stdlib_dcopy(n - k,a(k + 1,k - 1),1,work,1)
                     call stdlib_dsymv(uplo,n - k,-one,a(k + 1,k + 1),lda,work,1,zero,a(k + 1, &
                               k - 1),1)
                     a(k - 1,k - 1) = a(k - 1,k - 1) - stdlib_ddot(n - k,work,1,a(k + 1,k - 1),1)
-                              
+
                  end if
                  kstep = 2
               end if
@@ -20019,7 +20019,7 @@ module stdlib_linalg_lapack_d
               end if
               k = k - 1
               go to 50
-60            continue
+              60 continue
            end if
            return
      end subroutine stdlib_dsytri_rook
@@ -20041,7 +20041,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: a(lda,*)
            real(dp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kp
@@ -20074,7 +20074,7 @@ module stdlib_linalg_lapack_d
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 30
               if (ipiv(k) > 0) then
@@ -20085,7 +20085,7 @@ module stdlib_linalg_lapack_d
                  ! multiply by inv(u(k)), where u(k) is the transformation
                  ! stored in column k of a.
                  call stdlib_dger(k - 1,nrhs,-one,a(1,k),1,b(k,1),ldb,b(1,1),ldb)
-                           
+
                  ! multiply by the inverse of the diagonal block.
                  call stdlib_dscal(nrhs,one/a(k,k),b(k,1),ldb)
                  k = k - 1
@@ -20097,7 +20097,7 @@ module stdlib_linalg_lapack_d
                  ! multiply by inv(u(k)), where u(k) is the transformation
                  ! stored in columns k-1 and k of a.
                  call stdlib_dger(k - 2,nrhs,-one,a(1,k),1,b(k,1),ldb,b(1,1),ldb)
-                           
+
                  call stdlib_dger(k - 2,nrhs,-one,a(1,k - 1),1,b(k - 1,1),ldb,b(1,1), &
                            ldb)
                  ! multiply by the inverse of the diagonal block.
@@ -20114,12 +20114,12 @@ module stdlib_linalg_lapack_d
                  k = k - 2
               end if
               go to 10
-30            continue
+              30 continue
               ! next solve u**t *x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               if (ipiv(k) > 0) then
@@ -20146,14 +20146,14 @@ module stdlib_linalg_lapack_d
                  k = k + 2
               end if
               go to 40
-50            continue
+              50 continue
            else
               ! solve a*x = b, where a = l*d*l**t.
               ! first solve l*d*x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-60            continue
+              60 continue
               ! if k > n, exit from loop.
               if (k > n) go to 80
               if (ipiv(k) > 0) then
@@ -20195,12 +20195,12 @@ module stdlib_linalg_lapack_d
                  k = k + 2
               end if
               go to 60
-80            continue
+              80 continue
               ! next solve l**t *x = b, overwriting b with x.
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-90            continue
+              90 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 100
               if (ipiv(k) > 0) then
@@ -20229,7 +20229,7 @@ module stdlib_linalg_lapack_d
                  k = k - 2
               end if
               go to 90
-100           continue
+              100 continue
            end if
            return
      end subroutine stdlib_dsytrs
@@ -20251,7 +20251,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*),b(ldb,*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,iinfo,j,k,kp
@@ -20360,7 +20360,7 @@ module stdlib_linalg_lapack_d
                  ! interchange rows k and -ipiv(k+1).
                  kp = -ipiv(k + 1)
                  if (kp == -ipiv(k)) call stdlib_dswap(nrhs,b(k + 1,1),ldb,b(kp,1),ldb)
-                           
+
                  k = k + 2
               end if
              end do
@@ -20435,7 +20435,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: a(lda,*),e(*)
            real(dp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,j,k,kp
@@ -20574,7 +20574,7 @@ module stdlib_linalg_lapack_d
      !> A = L*T*L**T computed by DSYTRF_AA.
 
      pure subroutine stdlib_dsytrs_aa(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -20588,7 +20588,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: b(ldb,*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            logical(lk) :: lquery,upper
            integer(ilp) :: k,kp,lwkopt
            ! Intrinsic Functions
@@ -20705,7 +20705,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: a(lda,*)
            real(dp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kp
@@ -20738,7 +20738,7 @@ module stdlib_linalg_lapack_d
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 30
               if (ipiv(k) > 0) then
@@ -20749,7 +20749,7 @@ module stdlib_linalg_lapack_d
                  ! multiply by inv(u(k)), where u(k) is the transformation
                  ! stored in column k of a.
                  call stdlib_dger(k - 1,nrhs,-one,a(1,k),1,b(k,1),ldb,b(1,1),ldb)
-                           
+
                  ! multiply by the inverse of the diagonal block.
                  call stdlib_dscal(nrhs,one/a(k,k),b(k,1),ldb)
                  k = k - 1
@@ -20782,12 +20782,12 @@ module stdlib_linalg_lapack_d
                  k = k - 2
               end if
               go to 10
-30            continue
+              30 continue
               ! next solve u**t *x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               if (ipiv(k) > 0) then
@@ -20818,14 +20818,14 @@ module stdlib_linalg_lapack_d
                  k = k + 2
               end if
               go to 40
-50            continue
+              50 continue
            else
               ! solve a*x = b, where a = l*d*l**t.
               ! first solve l*d*x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-60            continue
+              60 continue
               ! if k > n, exit from loop.
               if (k > n) go to 80
               if (ipiv(k) > 0) then
@@ -20869,12 +20869,12 @@ module stdlib_linalg_lapack_d
                  k = k + 2
               end if
               go to 60
-80            continue
+              80 continue
               ! next solve l**t *x = b, overwriting b with x.
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-90            continue
+              90 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 100
               if (ipiv(k) > 0) then
@@ -20905,7 +20905,7 @@ module stdlib_linalg_lapack_d
                  k = k - 2
               end if
               go to 90
-100           continue
+              100 continue
            end if
            return
      end subroutine stdlib_dsytrs_rook
@@ -20931,7 +20931,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: ab(ldab,*),b(ldb,*),x(ldx,*)
            real(dp),intent(out) :: berr(*),ferr(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            character :: transt
@@ -21117,14 +21117,14 @@ module stdlib_linalg_lapack_d
                  end if
               end do
               kase = 0
-210           continue
+              210 continue
               call stdlib_dlacn2(n,work(2*n + 1),work(n + 1),iwork,ferr(j),kase,isave)
-                        
+
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(op(a)**t).
                     call stdlib_dtbsv(uplo,transt,diag,n,kd,ab,ldab,work(n + 1),1)
-                              
+
                     do i = 1,n
                        work(n + i) = work(i)*work(n + i)
                     end do
@@ -21153,7 +21153,7 @@ module stdlib_linalg_lapack_d
      !> N-by NRHS matrix.  A check is made to verify that A is nonsingular.
 
      pure subroutine stdlib_dtbtrs(uplo,trans,diag,n,kd,nrhs,ab,ldab,b,ldb,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -21165,7 +21165,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: ab(ldab,*)
            real(dp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,upper
            integer(ilp) :: j
@@ -21230,7 +21230,7 @@ module stdlib_linalg_lapack_d
      !> The matrix X is overwritten on B.
 
      pure subroutine stdlib_dtfsm(transr,side,uplo,trans,diag,m,n,alpha,a,b,ldb)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -21242,7 +21242,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: a(0:*)
            real(dp),intent(inout) :: b(0:ldb - 1,0:*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,lside,misodd,nisodd,normaltransr,notrans
            integer(ilp) :: m1,m2,n1,n2,k,info,i,j
@@ -21317,7 +21317,7 @@ module stdlib_linalg_lapack_d
                           ! trans = 'n'
                           if (m == 1) then
                              call stdlib_dtrsm('L','L','N',diag,m1,n,alpha,a,m,b,ldb)
-                                       
+
                           else
                              call stdlib_dtrsm('L','L','N',diag,m1,n,alpha,a(0),m,b, &
                                        ldb)
@@ -21360,7 +21360,7 @@ module stdlib_linalg_lapack_d
                           call stdlib_dgemm('N','N',m1,n,m2,-one,a(0),m,b(m1,0),ldb, &
                                      alpha,b,ldb)
                           call stdlib_dtrsm('L','L','T',diag,m1,n,one,a(m2),m,b,ldb)
-                                    
+
                        end if
                     end if
                  else
@@ -21442,7 +21442,7 @@ module stdlib_linalg_lapack_d
                           call stdlib_dgemm('T','N',k,n,k,-one,a(k + 1),m + 1,b(k,0), &
                                     ldb,alpha,b,ldb)
                           call stdlib_dtrsm('L','L','T',diag,k,n,one,a(1),m + 1,b,ldb)
-                                    
+
                        end if
                     else
                        ! side  ='l', n is even, transr = 'n', and uplo = 'u'
@@ -21474,7 +21474,7 @@ module stdlib_linalg_lapack_d
                           ! side  ='l', n is even, transr = 't', uplo = 'l',
                           ! and trans = 'n'
                           call stdlib_dtrsm('L','U','T',diag,k,n,alpha,a(k),k,b,ldb)
-                                    
+
                           call stdlib_dgemm('T','N',k,n,k,-one,a(k*(k + 1)),k,b,ldb, &
                                     alpha,b(k,0),ldb)
                           call stdlib_dtrsm('L','L','N',diag,k,n,one,a(0),k,b(k,0), &
@@ -21487,7 +21487,7 @@ module stdlib_linalg_lapack_d
                           call stdlib_dgemm('N','N',k,n,k,-one,a(k*(k + 1)),k,b(k,0), &
                                      ldb,alpha,b,ldb)
                           call stdlib_dtrsm('L','U','N',diag,k,n,one,a(k),k,b,ldb)
-                                    
+
                        end if
                     else
                        ! side  ='l', n is even, transr = 't', and uplo = 'u'
@@ -22224,7 +22224,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: t(ldt,*),v(ldv,*)
            real(dp),intent(out) :: work(ldwork,*)
         ! ==========================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,mp,np,kp
            logical(lk) :: left,forward,column,right,backward,row
@@ -22280,9 +22280,9 @@ module stdlib_linalg_lapack_d
                  end do
               end do
               call stdlib_dtrmm('L','U','T','N',l,n,one,v(mp,1),ldv,work,ldwork)
-                        
+
               call stdlib_dgemm('T','N',l,n,m - l,one,v,ldv,b,ldb,one,work,ldwork)
-                        
+
               call stdlib_dgemm('T','N',k - l,n,m,one,v(1,kp),ldv,b,ldb,zero,work(kp, &
                          1),ldwork)
               do j = 1,n
@@ -22297,11 +22297,11 @@ module stdlib_linalg_lapack_d
                  end do
               end do
               call stdlib_dgemm('N','N',m - l,n,k,-one,v,ldv,work,ldwork,one,b,ldb)
-                        
+
               call stdlib_dgemm('N','N',l,n,k - l,-one,v(mp,kp),ldv,work(kp,1), &
                         ldwork,one,b(mp,1),ldb)
               call stdlib_dtrmm('L','U','N','N',l,n,one,v(mp,1),ldv,work,ldwork)
-                        
+
               do j = 1,n
                  do i = 1,l
                     b(m - l + i,j) = b(m - l + i,j) - work(i,j)
@@ -22325,9 +22325,9 @@ module stdlib_linalg_lapack_d
                  end do
               end do
               call stdlib_dtrmm('R','U','N','N',m,l,one,v(np,1),ldv,work,ldwork)
-                        
+
               call stdlib_dgemm('N','N',m,l,n - l,one,b,ldb,v,ldv,one,work,ldwork)
-                        
+
               call stdlib_dgemm('N','N',m,k - l,n,one,b,ldb,v(1,kp),ldv,zero,work(1, &
                         kp),ldwork)
               do j = 1,k
@@ -22342,11 +22342,11 @@ module stdlib_linalg_lapack_d
                  end do
               end do
               call stdlib_dgemm('N','T',m,n - l,k,-one,work,ldwork,v,ldv,one,b,ldb)
-                        
+
               call stdlib_dgemm('N','T',m,l,k - l,-one,work(1,kp),ldwork,v(np,kp), &
                         ldv,one,b(1,np),ldb)
               call stdlib_dtrmm('R','U','T','N',m,l,one,v(np,1),ldv,work,ldwork)
-                        
+
               do j = 1,l
                  do i = 1,m
                     b(i,n - l + j) = b(i,n - l + j) - work(i,j)
@@ -22375,7 +22375,7 @@ module stdlib_linalg_lapack_d
               call stdlib_dgemm('T','N',l,n,m - l,one,v(mp,kp),ldv,b(mp,1),ldb,one, &
                         work(kp,1),ldwork)
               call stdlib_dgemm('T','N',k - l,n,m,one,v,ldv,b,ldb,zero,work,ldwork)
-                        
+
               do j = 1,n
                  do i = 1,k
                     work(i,j) = work(i,j) + a(i,j)
@@ -22390,7 +22390,7 @@ module stdlib_linalg_lapack_d
               call stdlib_dgemm('N','N',m - l,n,k,-one,v(mp,1),ldv,work,ldwork,one,b( &
                         mp,1),ldb)
               call stdlib_dgemm('N','N',l,n,k - l,-one,v,ldv,work,ldwork,one,b,ldb)
-                        
+
               call stdlib_dtrmm('L','L','N','N',l,n,one,v(1,kp),ldv,work(kp,1), &
                         ldwork)
               do j = 1,n
@@ -22420,7 +22420,7 @@ module stdlib_linalg_lapack_d
               call stdlib_dgemm('N','N',m,l,n - l,one,b(1,np),ldb,v(np,kp),ldv,one, &
                         work(1,kp),ldwork)
               call stdlib_dgemm('N','N',m,k - l,n,one,b,ldb,v,ldv,zero,work,ldwork)
-                        
+
               do j = 1,k
                  do i = 1,m
                     work(i,j) = work(i,j) + a(i,j)
@@ -22435,7 +22435,7 @@ module stdlib_linalg_lapack_d
               call stdlib_dgemm('N','T',m,n - l,k,-one,work,ldwork,v(np,1),ldv,one,b( &
                         1,np),ldb)
               call stdlib_dgemm('N','T',m,l,k - l,-one,work,ldwork,v,ldv,one,b,ldb)
-                        
+
               call stdlib_dtrmm('R','L','T','N',m,l,one,v(1,kp),ldv,work(1,kp), &
                         ldwork)
               do j = 1,l
@@ -22461,9 +22461,9 @@ module stdlib_linalg_lapack_d
                  end do
               end do
               call stdlib_dtrmm('L','L','N','N',l,n,one,v(1,mp),ldv,work,ldb)
-                        
+
               call stdlib_dgemm('N','N',l,n,m - l,one,v,ldv,b,ldb,one,work,ldwork)
-                        
+
               call stdlib_dgemm('N','N',k - l,n,m,one,v(kp,1),ldv,b,ldb,zero,work(kp, &
                          1),ldwork)
               do j = 1,n
@@ -22478,11 +22478,11 @@ module stdlib_linalg_lapack_d
                  end do
               end do
               call stdlib_dgemm('T','N',m - l,n,k,-one,v,ldv,work,ldwork,one,b,ldb)
-                        
+
               call stdlib_dgemm('T','N',l,n,k - l,-one,v(kp,mp),ldv,work(kp,1), &
                         ldwork,one,b(mp,1),ldb)
               call stdlib_dtrmm('L','L','T','N',l,n,one,v(1,mp),ldv,work,ldwork)
-                        
+
               do j = 1,n
                  do i = 1,l
                     b(m - l + i,j) = b(m - l + i,j) - work(i,j)
@@ -22505,9 +22505,9 @@ module stdlib_linalg_lapack_d
                  end do
               end do
               call stdlib_dtrmm('R','L','T','N',m,l,one,v(1,np),ldv,work,ldwork)
-                        
+
               call stdlib_dgemm('N','T',m,l,n - l,one,b,ldb,v,ldv,one,work,ldwork)
-                        
+
               call stdlib_dgemm('N','T',m,k - l,n,one,b,ldb,v(kp,1),ldv,zero,work(1, &
                         kp),ldwork)
               do j = 1,k
@@ -22522,11 +22522,11 @@ module stdlib_linalg_lapack_d
                  end do
               end do
               call stdlib_dgemm('N','N',m,n - l,k,-one,work,ldwork,v,ldv,one,b,ldb)
-                        
+
               call stdlib_dgemm('N','N',m,l,k - l,-one,work(1,kp),ldwork,v(kp,np), &
                         ldv,one,b(1,np),ldb)
               call stdlib_dtrmm('R','L','N','N',m,l,one,v(1,np),ldv,work,ldwork)
-                        
+
               do j = 1,l
                  do i = 1,m
                     b(i,n - l + j) = b(i,n - l + j) - work(i,j)
@@ -22554,7 +22554,7 @@ module stdlib_linalg_lapack_d
               call stdlib_dgemm('N','N',l,n,m - l,one,v(kp,mp),ldv,b(mp,1),ldb,one, &
                         work(kp,1),ldwork)
               call stdlib_dgemm('N','N',k - l,n,m,one,v,ldv,b,ldb,zero,work,ldwork)
-                        
+
               do j = 1,n
                  do i = 1,k
                     work(i,j) = work(i,j) + a(i,j)
@@ -22569,7 +22569,7 @@ module stdlib_linalg_lapack_d
               call stdlib_dgemm('T','N',m - l,n,k,-one,v(1,mp),ldv,work,ldwork,one,b( &
                         mp,1),ldb)
               call stdlib_dgemm('T','N',l,n,k - l,-one,v,ldv,work,ldwork,one,b,ldb)
-                        
+
               call stdlib_dtrmm('L','U','T','N',l,n,one,v(kp,1),ldv,work(kp,1), &
                         ldwork)
               do j = 1,n
@@ -22598,7 +22598,7 @@ module stdlib_linalg_lapack_d
               call stdlib_dgemm('N','T',m,l,n - l,one,b(1,np),ldb,v(kp,np),ldv,one, &
                         work(1,kp),ldwork)
               call stdlib_dgemm('N','T',m,k - l,n,one,b,ldb,v,ldv,zero,work,ldwork)
-                        
+
               do j = 1,k
                  do i = 1,m
                     work(i,j) = work(i,j) + a(i,j)
@@ -22613,7 +22613,7 @@ module stdlib_linalg_lapack_d
               call stdlib_dgemm('N','N',m,n - l,k,-one,work,ldwork,v(1,np),ldv,one,b( &
                         1,np),ldb)
               call stdlib_dgemm('N','N',m,l,k - l,-one,work,ldwork,v,ldv,one,b,ldb)
-                        
+
               call stdlib_dtrmm('R','U','N','N',m,l,one,v(kp,1),ldv,work(1,kp), &
                         ldwork)
               do j = 1,l
@@ -22646,7 +22646,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: ap(*),b(ldb,*),x(ldx,*)
            real(dp),intent(out) :: berr(*),ferr(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            character :: transt
@@ -22840,9 +22840,9 @@ module stdlib_linalg_lapack_d
                  end if
               end do
               kase = 0
-210           continue
+              210 continue
               call stdlib_dlacn2(n,work(2*n + 1),work(n + 1),iwork,ferr(j),kase,isave)
-                        
+
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(op(a)**t).
@@ -22883,7 +22883,7 @@ module stdlib_linalg_lapack_d
            ! Array Arguments
            real(dp),intent(inout) :: ap(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,upper
            integer(ilp) :: j,jc,jclast,jj
@@ -22977,7 +22977,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: ap(*)
            real(dp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,upper
            integer(ilp) :: j,jc
@@ -23349,7 +23349,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: a(lda,*),b(ldb,*),x(ldx,*)
            real(dp),intent(out) :: berr(*),ferr(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            character :: transt
@@ -23533,9 +23533,9 @@ module stdlib_linalg_lapack_d
                  end if
               end do
               kase = 0
-210           continue
+              210 continue
               call stdlib_dlacn2(n,work(2*n + 1),work(n + 1),iwork,ferr(j),kase,isave)
-                        
+
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(op(a)**t).
@@ -23577,7 +23577,7 @@ module stdlib_linalg_lapack_d
            ! Array Arguments
            real(dp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,upper
            integer(ilp) :: j
@@ -23613,7 +23613,7 @@ module stdlib_linalg_lapack_d
                  end if
                  ! compute elements 1:j-1 of j-th column.
                  call stdlib_dtrmv('UPPER','NO TRANSPOSE',diag,j - 1,a,lda,a(1,j),1)
-                           
+
                  call stdlib_dscal(j - 1,ajj,a(1,j),1)
               end do
            else
@@ -23651,7 +23651,7 @@ module stdlib_linalg_lapack_d
            ! Array Arguments
            real(dp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,upper
            integer(ilp) :: j,jb,nb,nn
@@ -23740,7 +23740,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: a(lda,*)
            real(dp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit
            ! Intrinsic Functions
@@ -24098,7 +24098,7 @@ module stdlib_linalg_lapack_d
            stdlib_dzsum1 = stemp
            return
            ! code for increment equal to 1
-20   continue
+           20 continue
            do i = 1,n
               ! next line modified.
               stemp = stemp + abs(cx(i))
@@ -24180,7 +24180,7 @@ module stdlib_linalg_lapack_d
            real(dp),parameter :: hundred = 100.0_dp
            real(dp),parameter :: meighth = -0.125_dp
            real(dp),parameter :: piover2 = 1.57079632679489661923132169163975144210_dp
-           
+
            ! Local Scalars
            logical(lk) :: colmajor,lquery,restart11,restart12,restart21,restart22,wantu1, &
                      wantu2,wantv1t,wantv2t
@@ -24330,9 +24330,9 @@ module stdlib_linalg_lapack_d
               else
                  ! compute shifts for b11 and b21 and use the lesser
                  call stdlib_dlas2(b11d(imax - 1),b11e(imax - 1),b11d(imax),sigma11,dummy)
-                           
+
                  call stdlib_dlas2(b21d(imax - 1),b21e(imax - 1),b21d(imax),sigma21,dummy)
-                           
+
                  if (sigma11 <= sigma21) then
                     mu = sigma11
                     nu = sqrt(one - mu**2)
@@ -24395,7 +24395,7 @@ module stdlib_linalg_lapack_d
               work(iu2sn + imin - 1) = -work(iu2sn + imin - 1)
               temp = work(iu1cs + imin - 1)*b11e(imin) + work(iu1sn + imin - 1)*b11d(imin + 1)
               b11d(imin + 1) = work(iu1cs + imin - 1)*b11d(imin + 1) - work(iu1sn + imin - 1)*b11e(imin)
-                        
+
               b11e(imin) = temp
               if (imax > imin + 1) then
                  b11bulge = work(iu1sn + imin - 1)*b11e(imin + 1)
@@ -24408,7 +24408,7 @@ module stdlib_linalg_lapack_d
               b12d(imin + 1) = work(iu1cs + imin - 1)*b12d(imin + 1)
               temp = work(iu2cs + imin - 1)*b21e(imin) + work(iu2sn + imin - 1)*b21d(imin + 1)
               b21d(imin + 1) = work(iu2cs + imin - 1)*b21d(imin + 1) - work(iu2sn + imin - 1)*b21e(imin)
-                        
+
               b21e(imin) = temp
               if (imax > imin + 1) then
                  b21bulge = work(iu2sn + imin - 1)*b21e(imin + 1)
@@ -24448,16 +24448,16 @@ module stdlib_linalg_lapack_d
                               r)
                  else if (mu <= nu) then
                     call stdlib_dlartgs(b11d(i),b11e(i),mu,work(iv1tcs + i - 1),work(iv1tsn + i - 1))
-                              
+
                  else
                     call stdlib_dlartgs(b21d(i),b21e(i),nu,work(iv1tcs + i - 1),work(iv1tsn + i - 1))
-                              
+
                  end if
                  work(iv1tcs + i - 1) = -work(iv1tcs + i - 1)
                  work(iv1tsn + i - 1) = -work(iv1tsn + i - 1)
                  if (.not. restart12 .and. .not. restart22) then
                     call stdlib_dlartgp(y2,y1,work(iv2tsn + i - 1 - 1),work(iv2tcs + i - 1 - 1),r)
-                              
+
                  else if (.not. restart12 .and. restart22) then
                     call stdlib_dlartgp(b12bulge,b12d(i - 1),work(iv2tsn + i - 1 - 1),work(iv2tcs + i - 1 - &
                               1),r)
@@ -24510,31 +24510,31 @@ module stdlib_linalg_lapack_d
                     call stdlib_dlartgp(x2,x1,work(iu1sn + i - 1),work(iu1cs + i - 1),r)
                  else if (.not. restart11 .and. restart12) then
                     call stdlib_dlartgp(b11bulge,b11d(i),work(iu1sn + i - 1),work(iu1cs + i - 1),r)
-                              
+
                  else if (restart11 .and. .not. restart12) then
                     call stdlib_dlartgp(b12bulge,b12e(i - 1),work(iu1sn + i - 1),work(iu1cs + i - 1),r)
-                              
+
                  else if (mu <= nu) then
                     call stdlib_dlartgs(b11e(i),b11d(i + 1),mu,work(iu1cs + i - 1),work(iu1sn + i - 1))
-                              
+
                  else
                     call stdlib_dlartgs(b12d(i),b12e(i),nu,work(iu1cs + i - 1),work(iu1sn + i - 1))
-                              
+
                  end if
                  if (.not. restart21 .and. .not. restart22) then
                     call stdlib_dlartgp(y2,y1,work(iu2sn + i - 1),work(iu2cs + i - 1),r)
                  else if (.not. restart21 .and. restart22) then
                     call stdlib_dlartgp(b21bulge,b21d(i),work(iu2sn + i - 1),work(iu2cs + i - 1),r)
-                              
+
                  else if (restart21 .and. .not. restart22) then
                     call stdlib_dlartgp(b22bulge,b22e(i - 1),work(iu2sn + i - 1),work(iu2cs + i - 1),r)
-                              
+
                  else if (nu < mu) then
                     call stdlib_dlartgs(b21e(i),b21e(i + 1),nu,work(iu2cs + i - 1),work(iu2sn + i - 1))
-                              
+
                  else
                     call stdlib_dlartgs(b22d(i),b22e(i),mu,work(iu2cs + i - 1),work(iu2sn + i - 1))
-                              
+
                  end if
                  work(iu2cs + i - 1) = -work(iu2cs + i - 1)
                  work(iu2sn + i - 1) = -work(iu2sn + i - 1)
@@ -24573,7 +24573,7 @@ module stdlib_linalg_lapack_d
               restart22 = b22d(imax - 1)**2 + b22bulge**2 <= thresh**2
               if (.not. restart12 .and. .not. restart22) then
                  call stdlib_dlartgp(y2,y1,work(iv2tsn + imax - 1 - 1),work(iv2tcs + imax - 1 - 1),r)
-                           
+
               else if (.not. restart12 .and. restart22) then
                  call stdlib_dlartgp(b12bulge,b12d(imax - 1),work(iv2tsn + imax - 1 - 1),work(iv2tcs + &
                            imax - 1 - 1),r)
@@ -24589,11 +24589,11 @@ module stdlib_linalg_lapack_d
               end if
               temp = work(iv2tcs + imax - 1 - 1)*b12e(imax - 1) + work(iv2tsn + imax - 1 - 1)*b12d(imax)
               b12d(imax) = work(iv2tcs + imax - 1 - 1)*b12d(imax) - work(iv2tsn + imax - 1 - 1)*b12e(imax - 1)
-                        
+
               b12e(imax - 1) = temp
               temp = work(iv2tcs + imax - 1 - 1)*b22e(imax - 1) + work(iv2tsn + imax - 1 - 1)*b22d(imax)
               b22d(imax) = work(iv2tcs + imax - 1 - 1)*b22d(imax) - work(iv2tsn + imax - 1 - 1)*b22e(imax - 1)
-                        
+
               b22e(imax - 1) = temp
               ! update singular vectors
               if (wantu1) then
@@ -24728,9 +24728,9 @@ module stdlib_linalg_lapack_d
                     if (wantu1) call stdlib_dswap(p,u1(1,i),1,u1(1,mini),1)
                     if (wantu2) call stdlib_dswap(m - p,u2(1,i),1,u2(1,mini),1)
                     if (wantv1t) call stdlib_dswap(q,v1t(i,1),ldv1t,v1t(mini,1),ldv1t)
-                              
+
                     if (wantv2t) call stdlib_dswap(m - q,v2t(i,1),ldv2t,v2t(mini,1),ldv2t)
-                              
+
                  else
                     if (wantu1) call stdlib_dswap(p,u1(i,1),ldu1,u1(mini,1),ldu1)
                     if (wantu2) call stdlib_dswap(m - p,u2(i,1),ldu2,u2(mini,1),ldu2)
@@ -24768,7 +24768,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: d(*)
            real(dp),intent(out) :: sep(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: decr,eigen,incr,left,right,sing
            integer(ilp) :: i,k
@@ -24865,7 +24865,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: ab(ldab,*),c(ldc,*)
            real(dp),intent(out) :: d(*),e(*),pt(ldpt,*),q(ldq,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: wantb,wantc,wantpt,wantq
            integer(ilp) :: i,inca,j,j1,j2,kb,kb1,kk,klm,klu1,kun,l,minmn,ml,ml0,mn, &
@@ -25062,7 +25062,7 @@ module stdlib_linalg_lapack_d
                  end if
                  if (wantq) call stdlib_drot(m,q(1,i),1,q(1,i + 1),1,rc,rs)
                  if (wantc) call stdlib_drot(ncc,c(i,1),ldc,c(i + 1,1),ldc,rc,rs)
-                           
+
               end do
               if (m <= n) d(m) = ab(1,m)
            else if (ku > 0) then
@@ -25080,7 +25080,7 @@ module stdlib_linalg_lapack_d
                        e(i - 1) = rc*ab(ku,i)
                     end if
                     if (wantpt) call stdlib_drot(n,pt(i,1),ldpt,pt(m + 1,1),ldpt,rc,rs)
-                              
+
                  end do
               else
                  ! copy off-diagonal elements to e and diagonal elements to d
@@ -25128,7 +25128,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: ab(ldab,*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lnoti,onenrm
            character :: normin
@@ -25179,7 +25179,7 @@ module stdlib_linalg_lapack_d
            kd = kl + ku + 1
            lnoti = kl > 0
            kase = 0
-10         continue
+           10 continue
            call stdlib_dlacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == kase1) then
@@ -25208,7 +25208,7 @@ module stdlib_linalg_lapack_d
                     do j = n - 1,1,-1
                        lm = min(kl,n - j)
                        work(j) = work(j) - stdlib_ddot(lm,ab(kd + 1,j),1,work(j + 1),1)
-                                 
+
                        jp = ipiv(j)
                        if (jp /= j) then
                           t = work(jp)
@@ -25229,7 +25229,7 @@ module stdlib_linalg_lapack_d
            end if
            ! compute the estimate of the reciprocal condition number.
            if (ainvnm /= zero) rcond = (one/ainvnm)/anorm
-40         continue
+           40 continue
            return
      end subroutine stdlib_dgbcon
 
@@ -25244,7 +25244,7 @@ module stdlib_linalg_lapack_d
      !> works well in practice.
 
      pure subroutine stdlib_dgbequ(m,n,kl,ku,ab,ldab,r,c,rowcnd,colcnd,amax,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -25256,7 +25256,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: ab(ldab,*)
            real(dp),intent(out) :: c(*),r(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,kd
            real(dp) :: bignum,rcmax,rcmin,smlnum
@@ -25380,7 +25380,7 @@ module stdlib_linalg_lapack_d
      !> between sqrt(radix) and 1/sqrt(radix).
 
      pure subroutine stdlib_dgbequb(m,n,kl,ku,ab,ldab,r,c,rowcnd,colcnd,amax,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -25392,7 +25392,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: ab(ldab,*)
            real(dp),intent(out) :: c(*),r(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,kd
            real(dp) :: bignum,rcmax,rcmin,smlnum,radix,logrdx
@@ -25530,7 +25530,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: notran
            character :: transt
@@ -25591,7 +25591,7 @@ module stdlib_linalg_lapack_d
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - op(a) * x,
               ! where op(a) = a, a**t, or a**h, depending on trans.
@@ -25643,7 +25643,7 @@ module stdlib_linalg_lapack_d
               if (berr(j) > eps .and. two*berr(j) <= lstres .and. count <= itmax) then
                  ! update solution and try again.
                  call stdlib_dgbtrs(trans,n,kl,ku,1,afb,ldafb,ipiv,work(n + 1),n,info)
-                           
+
                  call stdlib_daxpy(n,one,work(n + 1),1,x(1,j),1)
                  lstres = berr(j)
                  count = count + 1
@@ -25674,9 +25674,9 @@ module stdlib_linalg_lapack_d
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_dlacn2(n,work(2*n + 1),work(n + 1),iwork,ferr(j),kase,isave)
-                        
+
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(op(a)**t).
@@ -25723,7 +25723,7 @@ module stdlib_linalg_lapack_d
            ! Parameters
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldwork = nbmax + 1
-           
+
            ! Local Scalars
            integer(ilp) :: i,i2,i3,ii,ip,j,j2,j3,jb,jj,jm,jp,ju,k2,km,kv,nb, &
                      nw
@@ -25855,7 +25855,7 @@ module stdlib_linalg_lapack_d
                     ! use stdlib_dlaswp to apply the row interchanges to a12, a22, and
                     ! a32.
                     call stdlib_dlaswp(j2,ab(kv + 1 - jb,j + jb),ldab - 1,1,jb,ipiv(j),1)
-                              
+
                     ! adjust the pivot indices.
                     do i = j,j + jb - 1
                        ipiv(i) = ipiv(i) + j - 1
@@ -25907,7 +25907,7 @@ module stdlib_linalg_lapack_d
                           ! update a23
                           call stdlib_dgemm('NO TRANSPOSE','NO TRANSPOSE',i2,j3,jb,-one,ab( &
                           kv + 1 + jb,j),ldab - 1,work13,ldwork,one,ab(1 + jb,j + kv),ldab - 1)
-                                    
+
                        end if
                        if (i3 > 0) then
                           ! update a33
@@ -25976,7 +25976,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: onenrm
            character :: normin
@@ -26021,7 +26021,7 @@ module stdlib_linalg_lapack_d
               kase1 = 2
            end if
            kase = 0
-10         continue
+           10 continue
            call stdlib_dlacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == kase1) then
@@ -26051,7 +26051,7 @@ module stdlib_linalg_lapack_d
            end if
            ! compute the estimate of the reciprocal condition number.
            if (ainvnm /= zero) rcond = (one/ainvnm)/anorm
-20         continue
+           20 continue
            return
      end subroutine stdlib_dgecon
 
@@ -26077,7 +26077,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: a(lda,*)
            real(dp),intent(out) :: c(*),r(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(dp) :: bignum,rcmax,rcmin,smlnum
@@ -26206,7 +26206,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: a(lda,*)
            real(dp),intent(out) :: c(*),r(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(dp) :: bignum,rcmax,rcmin,smlnum,radix,logrdx
@@ -26328,7 +26328,7 @@ module stdlib_linalg_lapack_d
      !> Q is of order M if SIDE = 'L' and of order N  if SIDE = 'R'.
 
      pure subroutine stdlib_dgemlqt(side,trans,m,n,k,mb,v,ldv,t,ldt,c,ldc,work,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -26426,7 +26426,7 @@ module stdlib_linalg_lapack_d
      !> Q is of order M if SIDE = 'L' and of order N  if SIDE = 'R'.
 
      pure subroutine stdlib_dgemqrt(side,trans,m,n,k,nb,v,ldv,t,ldt,c,ldc,work,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -26530,7 +26530,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: a(lda,*)
            real(dp),intent(inout) :: rhs(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(dp) :: bignum,eps,smlnum,temp
@@ -26588,7 +26588,7 @@ module stdlib_linalg_lapack_d
            integer(ilp),intent(out) :: ipiv(*),jpiv(*)
            real(dp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,ip,ipv,j,jp,jpv
            real(dp) :: bignum,eps,smin,smlnum,xmax
@@ -26675,7 +26675,7 @@ module stdlib_linalg_lapack_d
            integer(ilp),intent(out) :: ipiv(*)
            real(dp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(dp) :: sfmin
            integer(ilp) :: i,j,jp
@@ -26759,7 +26759,7 @@ module stdlib_linalg_lapack_d
            integer(ilp),intent(out) :: ipiv(*)
            real(dp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(dp) :: sfmin,temp
            integer(ilp) :: i,iinfo,n1,n2
@@ -26826,7 +26826,7 @@ module stdlib_linalg_lapack_d
               call stdlib_dlaswp(n2,a(1,n1 + 1),lda,1,n1,ipiv,1)
               ! solve a12
               call stdlib_dtrsm('L','L','N','U',n1,n2,one,a,lda,a(1,n1 + 1),lda)
-                        
+
               ! update a22
               call stdlib_dgemm('N','N',m - n1,n2,n1,-one,a(n1 + 1,1),lda,a(1,n1 + 1), &
                         lda,one,a(n1 + 1,n1 + 1),lda)
@@ -26860,7 +26860,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,iws,j,jb,jj,jp,ldwork,lwkopt,nb,nbmin,nn
@@ -26963,7 +26963,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: a(lda,*)
            real(dp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran
            ! Intrinsic Functions
@@ -27025,7 +27025,7 @@ module stdlib_linalg_lapack_d
      !> generalized eigenvalue problem A*x = lambda*B*x.
 
      pure subroutine stdlib_dggbal(job,n,a,lda,b,ldb,ilo,ihi,lscale,rscale,work,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -27039,7 +27039,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: sclfac = 1.0e+1_dp
-           
+
            ! Local Scalars
            integer(ilp) :: i,icab,iflow,ip1,ir,irab,it,j,jc,jp1,k,kount,l,lcab,lm1, &
                      lrab,lsfmax,lsfmin,m,nr,nrp2
@@ -27092,13 +27092,13 @@ module stdlib_linalg_lapack_d
            go to 30
            ! permute the matrices a and b to isolate the eigenvalues.
            ! find row with one nonzero in columns 1 through l
-20   continue
+           20 continue
            l = lm1
            if (l /= 1) go to 30
            rscale(1) = one
            lscale(1) = one
            go to 190
-30         continue
+           30 continue
            lm1 = l - 1
            loop_80: do i = l,1,-1
               do j = 1,lm1
@@ -27107,21 +27107,21 @@ module stdlib_linalg_lapack_d
               end do
               j = l
               go to 70
-50            continue
+              50 continue
               do j = jp1,l
                  if (a(i,j) /= zero .or. b(i,j) /= zero) cycle loop_80
               end do
               j = jp1 - 1
-70            continue
+              70 continue
               m = l
               iflow = 1
               go to 160
            end do loop_80
            go to 100
            ! find column with one nonzero in rows k through n
-90   continue
+           90 continue
            k = k + 1
-100        continue
+           100 continue
            loop_150: do j = k,l
               do i = k,lm1
                  ip1 = i + 1
@@ -27129,32 +27129,32 @@ module stdlib_linalg_lapack_d
               end do
               i = l
               go to 140
-120           continue
+              120 continue
               do i = ip1,l
                  if (a(i,j) /= zero .or. b(i,j) /= zero) cycle loop_150
               end do
               i = ip1 - 1
-140           continue
+              140 continue
               m = k
               iflow = 2
               go to 160
            end do loop_150
            go to 190
            ! permute rows m and i
-160  continue
+           160 continue
            lscale(m) = i
            if (i == m) go to 170
            call stdlib_dswap(n - k + 1,a(i,k),lda,a(m,k),lda)
            call stdlib_dswap(n - k + 1,b(i,k),ldb,b(m,k),ldb)
            ! permute columns m and j
-170  continue
+           170 continue
            rscale(m) = j
            if (j == m) go to 180
            call stdlib_dswap(l,a(1,j),1,a(1,m),1)
            call stdlib_dswap(l,b(1,j),1,b(1,m),1)
-180        continue
+           180 continue
            go to(20,90) iflow
-190        continue
+           190 continue
            ilo = k
            ihi = l
            if (stdlib_lsame(job,'P')) then
@@ -27185,10 +27185,10 @@ module stdlib_linalg_lapack_d
                  ta = a(i,j)
                  if (ta == zero) go to 210
                  ta = log10(abs(ta))/basl
-210              continue
+                 210 continue
                  if (tb == zero) go to 220
                  tb = log10(abs(tb))/basl
-220              continue
+                 220 continue
                  work(i + 4*n) = work(i + 4*n) - ta - tb
                  work(j + 5*n) = work(j + 5*n) - ta - tb
               end do
@@ -27200,7 +27200,7 @@ module stdlib_linalg_lapack_d
            beta = zero
            it = 1
            ! start generalized conjugate gradient iteration
-250  continue
+           250 continue
            gamma = stdlib_ddot(nr,work(ilo + 4*n),1,work(ilo + 4*n),1) + stdlib_ddot(nr, &
                      work(ilo + 5*n),1,work(ilo + 5*n),1)
            ew = zero
@@ -27230,7 +27230,7 @@ module stdlib_linalg_lapack_d
                  if (a(i,j) == zero) go to 280
                  kount = kount + 1
                  sum = sum + work(j)
-280              continue
+                 280 continue
                  if (b(i,j) == zero) cycle loop_290
                  kount = kount + 1
                  sum = sum + work(j)
@@ -27244,7 +27244,7 @@ module stdlib_linalg_lapack_d
                  if (a(i,j) == zero) go to 310
                  kount = kount + 1
                  sum = sum + work(i + n)
-310              continue
+                 310 continue
                  if (b(i,j) == zero) cycle loop_320
                  kount = kount + 1
                  sum = sum + work(i + n)
@@ -27271,7 +27271,7 @@ module stdlib_linalg_lapack_d
            it = it + 1
            if (it <= nrp2) go to 250
            ! end generalized conjugate gradient iteration
-350  continue
+           350 continue
            sfmin = stdlib_dlamch('S')
            sfmax = one/sfmin
            lsfmin = int(log10(sfmin)/basl + one,KIND=ilp)
@@ -27343,7 +27343,7 @@ module stdlib_linalg_lapack_d
            ! Array Arguments
            real(dp),intent(inout) :: a(lda,*),b(ldb,*),q(ldq,*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: ilq,ilz
            integer(ilp) :: icompq,icompz,jcol,jrow
@@ -27421,7 +27421,7 @@ module stdlib_linalg_lapack_d
                  call stdlib_dlartg(temp,a(jrow,jcol),c,s,a(jrow - 1,jcol))
                  a(jrow,jcol) = zero
                  call stdlib_drot(n - jcol,a(jrow - 1,jcol + 1),lda,a(jrow,jcol + 1),lda,c,s)
-                           
+
                  call stdlib_drot(n + 2 - jrow,b(jrow - 1,jrow - 1),ldb,b(jrow,jrow - 1),ldb,c, &
                            s)
                  if (ilq) call stdlib_drot(n,q(1,jrow - 1),1,q(1,jrow),1,c,s)
@@ -27532,7 +27532,7 @@ module stdlib_linalg_lapack_d
      !> in computing that entry have at least one zero multiplicand.
 
      subroutine stdlib_dla_gbamv(trans,m,n,kl,ku,alpha,ab,ldab,x,incx,beta,y,incy)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -27543,7 +27543,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: ab(ldab,*),x(*)
            real(dp),intent(inout) :: y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: symb_zero
            real(dp) :: temp,safe1
@@ -27806,7 +27806,7 @@ module stdlib_linalg_lapack_d
            ! estimate the norm of inv(op(a)).
            ainvnm = zero
            kase = 0
-10         continue
+           10 continue
            call stdlib_dlacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == 2) then
@@ -27886,7 +27886,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: a(lda,*),x(*)
            real(dp),intent(inout) :: y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: symb_zero
            real(dp) :: temp,safe1
@@ -28137,7 +28137,7 @@ module stdlib_linalg_lapack_d
            ! estimate the norm of inv(op(a)).
            ainvnm = zero
            kase = 0
-10         continue
+           10 continue
            call stdlib_dlacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == 2) then
@@ -28147,7 +28147,7 @@ module stdlib_linalg_lapack_d
                  end do
                  if (notrans) then
                     call stdlib_dgetrs('NO TRANSPOSE',n,1,af,ldaf,ipiv,work,n,info)
-                              
+
                  else
                     call stdlib_dgetrs('TRANSPOSE',n,1,af,ldaf,ipiv,work,n,info)
                  end if
@@ -28176,7 +28176,7 @@ module stdlib_linalg_lapack_d
                     call stdlib_dgetrs('TRANSPOSE',n,1,af,ldaf,ipiv,work,n,info)
                  else
                     call stdlib_dgetrs('NO TRANSPOSE',n,1,af,ldaf,ipiv,work,n,info)
-                              
+
                  end if
                  ! multiply by r.
                  do i = 1,n
@@ -28242,7 +28242,7 @@ module stdlib_linalg_lapack_d
      !> infinity-norm condition number.
 
      real(dp) function stdlib_dla_porcond(uplo,n,a,lda,af,ldaf,cmode,c,info,work,iwork)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -28339,7 +28339,7 @@ module stdlib_linalg_lapack_d
            ! estimate the norm of inv(op(a)).
            ainvnm = zero
            kase = 0
-10         continue
+           10 continue
            call stdlib_dlacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == 2) then
@@ -28414,7 +28414,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: a(lda,*),x(*)
            real(dp),intent(inout) :: y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: symb_zero
            real(dp) :: temp,safe1
@@ -28695,7 +28695,7 @@ module stdlib_linalg_lapack_d
            ainvnm = zero
            normin = 'N'
            kase = 0
-10         continue
+           10 continue
            call stdlib_dlacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == 2) then
@@ -28939,7 +28939,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: b,c,d
            real(dp),intent(out) :: p,q
         ! =====================================================================
-           
+
            ! Local Scalars
            real(dp) :: r,t
            ! Executable Statements
@@ -28978,7 +28978,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: maxit = 40
-           
+
            ! Local Arrays
            real(dp) :: dscale(3),zscale(3)
            ! Local Scalars
@@ -29048,7 +29048,7 @@ module stdlib_linalg_lapack_d
            eps = stdlib_dlamch('EPSILON')
            base = stdlib_dlamch('BASE')
            small1 = base**(int(log(stdlib_dlamch('SAFMIN'))/log(base)/three,KIND=ilp))
-                     
+
            sminv1 = one/small1
            small2 = small1*small1
            sminv2 = sminv1*sminv1
@@ -29170,7 +29170,7 @@ module stdlib_linalg_lapack_d
               end if
            end do loop_50
            info = 1
-60         continue
+           60 continue
            ! undo scaling
            if (scale) tau = tau*sclinv
            return
@@ -29195,7 +29195,7 @@ module stdlib_linalg_lapack_d
      !> Z**T denotes the transpose of Z.
 
      pure subroutine stdlib_dlags2(upper,a1,a2,a3,b1,b2,b3,csu,snu,csv,snv,csq,snq)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -29204,7 +29204,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: a1,a2,a3,b1,b2,b3
            real(dp),intent(out) :: csq,csu,csv,snq,snu,snv
         ! =====================================================================
-           
+
            ! Local Scalars
            real(dp) :: a,aua11,aua12,aua21,aua22,avb11,avb12,avb21,avb22,b,c,csl,csr, &
            d,r,s1,s2,snl,snr,ua11,ua11r,ua12,ua21,ua22,ua22r,vb11,vb11r,vb12,vb21, &
@@ -29362,7 +29362,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(*),b(*),c(*)
            real(dp),intent(out) :: d(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: k
            real(dp) :: eps,mult,piv1,piv2,scale1,scale2,temp,tl
@@ -29450,7 +29450,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: a(*),b(*),c(*),d(*)
            real(dp),intent(inout) :: y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: k
            real(dp) :: absak,ak,bignum,eps,pert,sfmin,temp
@@ -29530,7 +29530,7 @@ module stdlib_linalg_lapack_d
                     end if
                     ak = a(k)
                     pert = sign(tol,ak)
-40                  continue
+                    40 continue
                     absak = abs(ak)
                     if (absak < one) then
                        if (absak < sfmin) then
@@ -29591,7 +29591,7 @@ module stdlib_linalg_lapack_d
                     end if
                     ak = a(k)
                     pert = sign(tol,ak)
-70                  continue
+                    70 continue
                     absak = abs(ak)
                     if (absak < one) then
                        if (absak < sfmin) then
@@ -29656,7 +29656,7 @@ module stdlib_linalg_lapack_d
            ! Array Arguments
            real(dp),intent(in) :: w(j),x(j)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(dp) :: absalp,absest,absgam,alpha,b,cosine,eps,norma,s1,s2,sine,t, &
                      test,tmp,zeta1,zeta2
@@ -29802,7 +29802,7 @@ module stdlib_linalg_lapack_d
                  zeta1 = alpha/absest
                  zeta2 = gamma/absest
                  norma = max(one + zeta1*zeta1 + abs(zeta1*zeta2),abs(zeta1*zeta2) + zeta2*zeta2)
-                           
+
                  ! see if root is closer to zero or to one
                  test = one + two*(zeta1 - zeta2)*(zeta1 + zeta2)
                  if (test >= zero) then
@@ -29863,13 +29863,13 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: blklen = 128
-           
+
            ! some architectures propagate infinities and nans very slowly, so
            ! the code computes counts in blklen chunks.  then a nan can
            ! propagate at most blklen columns before being detected.  this is
            ! not a general tuning parameter; it needs only to be just large
            ! enough that the overhead is tiny in common cases.
-           
+
            ! Local Scalars
            integer(ilp) :: bj,j,neg1,neg2,negcnt
            real(dp) :: bsav,dminus,dplus,gamma,p,t,tmp
@@ -29955,7 +29955,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: ab(ldab,*)
            real(dp),intent(out) :: work(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,k,l
            real(dp) :: scale,sum,value,temp
@@ -30030,7 +30030,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: a(lda,*)
            real(dp),intent(out) :: work(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(dp) :: scale,sum,value,temp
@@ -30101,7 +30101,7 @@ module stdlib_linalg_lapack_d
            ! Array Arguments
            real(dp),intent(in) :: d(*),dl(*),du(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(dp) :: anorm,scale,sum,temp
@@ -30115,11 +30115,11 @@ module stdlib_linalg_lapack_d
               anorm = abs(d(n))
               do i = 1,n - 1
                  if (anorm < abs(dl(i)) .or. stdlib_disnan(abs(dl(i)))) anorm = abs(dl(i))
-                           
+
                  if (anorm < abs(d(i)) .or. stdlib_disnan(abs(d(i)))) anorm = abs(d(i))
-                           
+
                  if (anorm < abs(du(i)) .or. stdlib_disnan(abs(du(i)))) anorm = abs(du(i))
-                           
+
               end do
            else if (stdlib_lsame(norm,'O') .or. norm == '1') then
               ! find norm1(a).
@@ -30178,7 +30178,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: a(lda,*)
            real(dp),intent(out) :: work(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(dp) :: scale,sum,value
@@ -30250,7 +30250,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: ab(ldab,*)
            real(dp),intent(out) :: work(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,l
            real(dp) :: absa,scale,sum,value
@@ -30320,7 +30320,7 @@ module stdlib_linalg_lapack_d
                  if (stdlib_lsame(uplo,'U')) then
                     do j = 2,n
                        call stdlib_dlassq(min(j - 1,k),ab(max(k + 2 - j,1),j),1,scale,sum)
-                                 
+
                     end do
                     l = k + 1
                  else
@@ -30355,7 +30355,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: a(0:*)
            real(dp),intent(out) :: work(0:*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,ifm,ilu,noe,n1,k,l,lda
            real(dp) :: scale,s,value,aa,temp
@@ -30472,7 +30472,7 @@ module stdlib_linalg_lapack_d
                           end do
                           work(j) = work(j) + s
                        end do
-10                     continue
+                       10 continue
                        value = work(0)
                        do i = 1,n - 1
                           temp = work(i)
@@ -31059,7 +31059,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: ap(*)
            real(dp),intent(out) :: work(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,k
            real(dp) :: absa,scale,sum,value
@@ -31182,7 +31182,7 @@ module stdlib_linalg_lapack_d
            ! Array Arguments
            real(dp),intent(in) :: d(*),e(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(dp) :: anorm,scale,sum
@@ -31245,7 +31245,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: a(lda,*)
            real(dp),intent(out) :: work(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(dp) :: absa,scale,sum,value
@@ -31341,7 +31341,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: ab(ldab,*)
            real(dp),intent(out) :: work(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: udiag
            integer(ilp) :: i,j,l
@@ -31493,7 +31493,7 @@ module stdlib_linalg_lapack_d
                     sum = one
                     do j = 1,n
                        call stdlib_dlassq(min(j,k + 1),ab(max(k + 2 - j,1),j),1,scale,sum)
-                                 
+
                     end do
                  end if
               else
@@ -31534,7 +31534,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: ap(*)
            real(dp),intent(out) :: work(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: udiag
            integer(ilp) :: i,j,k
@@ -31740,7 +31740,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: a(lda,*)
            real(dp),intent(out) :: work(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: udiag
            integer(ilp) :: i,j
@@ -31956,7 +31956,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: d(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: iinfo,j,jb,nb
            ! Intrinsic Functions
@@ -31988,7 +31988,7 @@ module stdlib_linalg_lapack_d
                  jb = min(min(m,n) - j + 1,nb)
                  ! factor diagonal and subdiagonal blocks.
                  call stdlib_dlaorhr_col_getrfnp2(m - j + 1,jb,a(j,j),lda,d(j),iinfo)
-                           
+
                  if (j + jb <= n) then
                     ! compute block row of u.
                     call stdlib_dtrsm('LEFT','LOWER','NO TRANSPOSE','UNIT',jb,n - j - jb + 1,one, &
@@ -31997,7 +31997,7 @@ module stdlib_linalg_lapack_d
                        ! update trailing submatrix.
                        call stdlib_dgemm('NO TRANSPOSE','NO TRANSPOSE',m - j - jb + 1,n - j - jb + 1,jb,- &
                        one,a(j + jb,j),lda,a(j,j + jb),lda,one,a(j + jb,j + jb),lda)
-                                 
+
                     end if
                  end if
               end do
@@ -32015,7 +32015,7 @@ module stdlib_linalg_lapack_d
            ! Scalar Arguments
            real(dp),intent(in) :: x,y
         ! =====================================================================
-           
+
            ! Local Scalars
            real(dp) :: w,xabs,yabs,z,hugeval
            logical(lk) :: x_is_nan,y_is_nan
@@ -32056,7 +32056,7 @@ module stdlib_linalg_lapack_d
            integer(ilp),intent(in) :: lda,ldb
            real(dp),intent(in) :: a(lda,*),b(ldb,*),sr1,sr2,si,beta1,beta2
            real(dp),intent(out) :: v(*)
-           
+
            ! local scalars
            real(dp) :: w(2),safmin,safmax,scale1,scale2
            safmin = stdlib_dlamch('SAFE MINIMUM')
@@ -32105,7 +32105,7 @@ module stdlib_linalg_lapack_d
            integer(ilp),intent(in) :: k,lda,ldb,ldq,ldz,istartm,istopm,nq,nz,qstart, &
                      zstart,ihi
            real(dp),intent(inout) :: a(lda,*),b(ldb,*),q(ldq,*),z(ldz,*)
-           
+
            ! local variables
            real(dp) :: h(2,3),c1,s1,c2,s2,temp
            if (k + 2 == ihi) then
@@ -32150,7 +32150,7 @@ module stdlib_linalg_lapack_d
               b(ihi,ihi) = temp
               b(ihi,ihi - 1) = zero
               call stdlib_drot(ihi - istartm,b(istartm,ihi),1,b(istartm,ihi - 1),1,c1,s1)
-                        
+
               call stdlib_drot(ihi - istartm + 1,a(istartm,ihi),1,a(istartm,ihi - 1),1,c1, &
                         s1)
               if (ilz) then
@@ -32171,18 +32171,18 @@ module stdlib_linalg_lapack_d
               call stdlib_dlartg(h(1,2),h(1,1),c2,s2,temp)
               ! apply transformations from the right
               call stdlib_drot(k + 3 - istartm + 1,a(istartm,k + 2),1,a(istartm,k + 1),1,c1,s1)
-                        
+
               call stdlib_drot(k + 3 - istartm + 1,a(istartm,k + 1),1,a(istartm,k),1,c2,s2)
-                        
+
               call stdlib_drot(k + 2 - istartm + 1,b(istartm,k + 2),1,b(istartm,k + 1),1,c1,s1)
-                        
+
               call stdlib_drot(k + 2 - istartm + 1,b(istartm,k + 1),1,b(istartm,k),1,c2,s2)
-                        
+
               if (ilz) then
                  call stdlib_drot(nz,z(1,k + 2 - zstart + 1),1,z(1,k + 1 - zstart + 1),1,c1,s1)
-                           
+
                  call stdlib_drot(nz,z(1,k + 1 - zstart + 1),1,z(1,k - zstart + 1),1,c2,s2)
-                           
+
               end if
               b(k + 1,k) = zero
               b(k + 2,k) = zero
@@ -32200,9 +32200,9 @@ module stdlib_linalg_lapack_d
               call stdlib_drot(istopm - k,b(k + 1,k + 1),ldb,b(k + 2,k + 1),ldb,c2,s2)
               if (ilq) then
                  call stdlib_drot(nq,q(1,k + 2 - qstart + 1),1,q(1,k + 3 - qstart + 1),1,c1,s1)
-                           
+
                  call stdlib_drot(nq,q(1,k + 1 - qstart + 1),1,q(1,k + 2 - qstart + 1),1,c2,s2)
-                           
+
               end if
            end if
      end subroutine stdlib_dlaqz2
@@ -32218,7 +32218,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*),b(ldb,*),q(ldq,*),z(ldz,*),qc( &
                      ldqc,*),zc(ldzc,*),work(*),sr(*),si(*),ss(*)
            integer(ilp),intent(out) :: info
-           
+
            ! local scalars
            integer(ilp) :: i,j,ns,istartm,istopm,sheight,swidth,k,np,istartb,istopb, &
                      ishift,nblock,npos
@@ -32312,11 +32312,11 @@ module stdlib_linalg_lapack_d
               call stdlib_dgemm('T','N',sheight,swidth,sheight,one,qc,ldqc,a(ilo,ilo + ns &
                         ),lda,zero,work,sheight)
               call stdlib_dlacpy('ALL',sheight,swidth,work,sheight,a(ilo,ilo + ns),lda)
-                        
+
               call stdlib_dgemm('T','N',sheight,swidth,sheight,one,qc,ldqc,b(ilo,ilo + ns &
                         ),ldb,zero,work,sheight)
               call stdlib_dlacpy('ALL',sheight,swidth,work,sheight,b(ilo,ilo + ns),ldb)
-                        
+
            end if
            if (ilq) then
               call stdlib_dgemm('N','N',n,sheight,sheight,one,q(1,ilo),ldq,qc,ldqc, &
@@ -32331,11 +32331,11 @@ module stdlib_linalg_lapack_d
               call stdlib_dgemm('N','N',sheight,swidth,swidth,one,a(istartm,ilo),lda, &
                         zc,ldzc,zero,work,sheight)
               call stdlib_dlacpy('ALL',sheight,swidth,work,sheight,a(istartm,ilo),lda)
-                        
+
               call stdlib_dgemm('N','N',sheight,swidth,swidth,one,b(istartm,ilo),ldb, &
                         zc,ldzc,zero,work,sheight)
               call stdlib_dlacpy('ALL',sheight,swidth,work,sheight,b(istartm,ilo),ldb)
-                        
+
            end if
            if (ilz) then
               call stdlib_dgemm('N','N',n,swidth,swidth,one,z(1,ilo),ldz,zc,ldzc, &
@@ -32395,11 +32395,11 @@ module stdlib_linalg_lapack_d
                  call stdlib_dgemm('N','N',sheight,swidth,swidth,one,a(istartm,k),lda, &
                            zc,ldzc,zero,work,sheight)
                  call stdlib_dlacpy('ALL',sheight,swidth,work,sheight,a(istartm,k),lda)
-                           
+
                  call stdlib_dgemm('N','N',sheight,swidth,swidth,one,b(istartm,k),ldb, &
                            zc,ldzc,zero,work,sheight)
                  call stdlib_dlacpy('ALL',sheight,swidth,work,sheight,b(istartm,k),ldb)
-                           
+
               end if
               if (ilz) then
                  call stdlib_dgemm('N','N',n,nblock,nblock,one,z(1,k),ldz,zc,ldzc, &
@@ -32498,7 +32498,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(out) :: work(*)
            real(dp),intent(inout) :: z(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: sawnan1,sawnan2
            integer(ilp) :: i,indlpl,indp,inds,indumn,neg1,neg2,r1,r2
@@ -32546,7 +32546,7 @@ module stdlib_linalg_lapack_d
               s = work(inds + i) - lambda
            end do
            sawnan1 = stdlib_disnan(s)
-60         continue
+           60 continue
            if (sawnan1) then
               ! runs a slower version of the above loop if a nan is detected
               neg1 = 0
@@ -32631,7 +32631,7 @@ module stdlib_linalg_lapack_d
                  end if
                  ztz = ztz + z(i)*z(i)
               end do
-220           continue
+              220 continue
            else
               ! run slower loop if nan occurred.
               do i = r - 1,b1,-1
@@ -32647,7 +32647,7 @@ module stdlib_linalg_lapack_d
                  end if
                  ztz = ztz + z(i)*z(i)
               end do
-240           continue
+              240 continue
            end if
            ! compute the fp vector downwards from r in blocks of size blksiz
            if (.not. sawnan1 .and. .not. sawnan2) then
@@ -32660,7 +32660,7 @@ module stdlib_linalg_lapack_d
                  end if
                  ztz = ztz + z(i + 1)*z(i + 1)
               end do
-260           continue
+              260 continue
            else
               ! run slower loop if nan occurred.
               do i = r,bn - 1
@@ -32676,7 +32676,7 @@ module stdlib_linalg_lapack_d
                  end if
                  ztz = ztz + z(i + 1)*z(i + 1)
               end do
-280           continue
+              280 continue
            end if
            ! compute quantities for convergence test
            tmp = one/ztz
@@ -32711,7 +32711,7 @@ module stdlib_linalg_lapack_d
            ! Array Arguments
            real(dp),intent(inout) :: x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j,knt
            real(dp) :: beta,rsafmn,safmin,xnorm
@@ -32734,7 +32734,7 @@ module stdlib_linalg_lapack_d
               if (abs(beta) < safmin) then
                  ! xnorm, beta may be inaccurate; scale x and recompute them
                  rsafmn = one/safmin
-10               continue
+                 10 continue
                  knt = knt + 1
                  call stdlib_dscal(n - 1,rsafmn,x,incx)
                  beta = beta*rsafmn
@@ -32779,7 +32779,7 @@ module stdlib_linalg_lapack_d
            ! Array Arguments
            real(dp),intent(inout) :: x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j,knt
            real(dp) :: beta,bignum,savealpha,smlnum,xnorm
@@ -32815,7 +32815,7 @@ module stdlib_linalg_lapack_d
               if (abs(beta) < smlnum) then
                  ! xnorm, beta may be inaccurate; scale x and recompute them
                  bignum = one/smlnum
-10               continue
+                 10 continue
                  knt = knt + 1
                  call stdlib_dscal(n - 1,bignum,x,incx)
                  beta = beta*bignum
@@ -32879,7 +32879,7 @@ module stdlib_linalg_lapack_d
            ! Parameters
            integer(ilp),parameter :: lv = 128
            real(dp),parameter :: twopi = 6.28318530717958647692528676655900576839e+0_dp
-           
+
            ! Local Scalars
            integer(ilp) :: i,il,il2,iv
            ! Local Arrays
@@ -32913,7 +32913,7 @@ module stdlib_linalg_lapack_d
                     x(iv + i - 1) = sqrt(-two*log(u(2*i - 1)))*cos(twopi*u(2*i))
                  end do
               end if
-40            continue
+              40 continue
            return
      end subroutine stdlib_dlarnv
 
@@ -32941,7 +32941,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: w(*),werr(*),wgap(*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            integer(ilp) :: maxitr
            ! Local Scalars
            integer(ilp) :: i,i1,ii,ip,iter,k,negcnt,next,nint,olnint,prev,r
@@ -32982,7 +32982,7 @@ module stdlib_linalg_lapack_d
               ! compute negcount from dstqds facto l+d+l+^t = l d l^t - left
               ! do while( negcnt(left)>i-1 )
               back = werr(ii)
-20            continue
+              20 continue
               negcnt = stdlib_dlaneg(n,d,lld,left,pivmin,r)
               if (negcnt > i - 1) then
                  left = left - back
@@ -32992,7 +32992,7 @@ module stdlib_linalg_lapack_d
               ! do while( negcnt(right)<i )
               ! compute negcount from dstqds facto l+d+l+^t = l d l^t - right
               back = werr(ii)
-50            continue
+              50 continue
               negcnt = stdlib_dlaneg(n,d,lld,right,pivmin,r)
                if (negcnt < i) then
                   right = right + back
@@ -33024,7 +33024,7 @@ module stdlib_linalg_lapack_d
            ! do while( nint>0 ), i.e. there are still unconverged intervals
            ! and while (iter<maxitr)
            iter = 0
-80         continue
+           80 continue
            prev = i1 - 1
            i = i1
            olnint = nint
@@ -33118,7 +33118,7 @@ module stdlib_linalg_lapack_d
            integer(ilp),parameter :: ktrymax = 1
            integer(ilp),parameter :: sleft = 1
            integer(ilp),parameter :: sright = 2
-           
+
            ! Local Scalars
            logical(lk) :: dorrr1,forcer,nofail,sawnan1,sawnan2,tryrrr1
            integer(ilp) :: i,indx,ktry,shift
@@ -33174,7 +33174,7 @@ module stdlib_linalg_lapack_d
            ! while (ktry <= ktrymax)
            ktry = 0
            growthbound = maxgrowth1*spdiam
-5          continue
+           5 continue
            sawnan1 = .false.
            sawnan2 = .false.
            ! ensure that we do not back off too much of the initial shifts
@@ -33316,7 +33316,7 @@ module stdlib_linalg_lapack_d
               end if
            end if
            end if
-50         continue
+           50 continue
            if (ktry < ktrymax) then
               ! if we are here, both shifts failed also the rrr test.
               ! back off to the outside
@@ -33339,7 +33339,7 @@ module stdlib_linalg_lapack_d
                  return
               end if
            end if
-100        continue
+           100 continue
            if (shift == sleft) then
            elseif (shift == sright) then
               ! store new l and d back into dplus, lplus
@@ -33373,7 +33373,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: maxitr = 10
-           
+
            ! Local Scalars
            logical(lk) :: eskip,needbs,stp2ii,tryrqc,usedbs,usedrq
            integer(ilp) :: done,i,ibegin,idone,iend,ii,iindc1,iindc2,iindr,iindwk,iinfo, &
@@ -33452,7 +33452,7 @@ module stdlib_linalg_lapack_d
               ! find the eigenvectors of the submatrix indexed ibegin
               ! through iend.
               wend = wbegin - 1
-15            continue
+              15 continue
               if (wend < m) then
                  if (iblock(wend + 1) == jblk) then
                     wend = wend + 1
@@ -33520,7 +33520,7 @@ module stdlib_linalg_lapack_d
               ! loop while( idone<im )
               ! generate the representation tree for the current block and
               ! compute the eigenvectors
-40   continue
+              40 continue
               if (idone < im) then
                  ! this is a crude protection against infinitely deep trees
                  if (ndepth > m) then
@@ -33608,7 +33608,7 @@ module stdlib_linalg_lapack_d
                        if (oldfst > 1) then
                           wgap(wbegin + oldfst - 2) = max(wgap(wbegin + oldfst - 2),w(wbegin + oldfst - 1) - &
                           werr(wbegin + oldfst - 1) - w(wbegin + oldfst - 2) - werr(wbegin + oldfst - 2))
-                                    
+
                        end if
                        if (wbegin + oldlst - 1 < wend) then
                           wgap(wbegin + oldlst - 1) = max(wgap(wbegin + oldlst - 1),w(wbegin + oldlst) - &
@@ -33809,7 +33809,7 @@ module stdlib_linalg_lapack_d
                           usedrq = .false.
                           ! bisection is initially turned off unless it is forced
                           needbs = .not. tryrqc
-120                       continue
+                          120 continue
                           ! check if bisection should be used to refine eigenvalue
                           if (needbs) then
                              ! take the bisection as new iterate
@@ -33943,7 +33943,7 @@ module stdlib_linalg_lapack_d
                              end do
                           end if
                           call stdlib_dscal(zto - zfrom + 1,nrminv,z(zfrom,windex),1)
-125                       continue
+                          125 continue
                           ! update w
                           w(windex) = lambda + sigma
                           ! recompute the gaps on the left and right
@@ -33965,7 +33965,7 @@ module stdlib_linalg_lapack_d
                           idone = idone + 1
                        end if
                        ! here ends the code for the current child
-139  continue
+                       139 continue
                        ! proceed to any remaining child nodes
                        newfst = j + 1
                     end do loop_140
@@ -33997,7 +33997,7 @@ module stdlib_linalg_lapack_d
            ! Array Arguments
            real(dp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: done
            integer(ilp) :: i,itype,j,k1,k2,k3,k4
@@ -34058,7 +34058,7 @@ module stdlib_linalg_lapack_d
            bignum = one/smlnum
            cfromc = cfrom
            ctoc = cto
-10         continue
+           10 continue
            cfrom1 = cfromc*smlnum
            if (cfrom1 == cfromc) then
               ! cfromc is an inf.  multiply by a correctly signed zero for
@@ -34176,7 +34176,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: maxit = 400
-           
+
            ! Local Scalars
            logical(lk) :: orgati,swtch,swtch3,geomavg
            integer(ilp) :: ii,iim1,iip1,ip1,iter,j,niter
@@ -34872,7 +34872,7 @@ module stdlib_linalg_lapack_d
               ! return with info = 1, niter = maxit and not converged
               info = 1
            end if
-240        continue
+           240 continue
            return
      end subroutine stdlib_dlasd4
 
@@ -34886,7 +34886,7 @@ module stdlib_linalg_lapack_d
 
      pure subroutine stdlib_dlasd7(icompq,nl,nr,sqre,k,d,z,zw,vf,vfw,vl,vlw,alpha, &
      beta,dsigma,idx,idxp,idxq,perm,givptr,givcol,ldgcol,givnum,ldgnum,c,s,info)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -34900,9 +34900,9 @@ module stdlib_linalg_lapack_d
            integer(ilp),intent(inout) :: idxq(*)
            real(dp),intent(inout) :: d(*),vf(*),vl(*)
            real(dp),intent(out) :: dsigma(*),givnum(ldgnum,*),vfw(*),vlw(*),z(*),zw(*)
-                     
+
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,idxi,idxj,idxjp,j,jp,jprev,k2,m,n,nlp1,nlp2
            real(dp) :: eps,hlftol,tau,tol,z1
@@ -35004,9 +35004,9 @@ module stdlib_linalg_lapack_d
                  go to 70
               end if
            end do
-70         continue
+           70 continue
            j = jprev
-80         continue
+           80 continue
            j = j + 1
            if (j > n) go to 90
            if (abs(z(j)) <= tol) then
@@ -35056,13 +35056,13 @@ module stdlib_linalg_lapack_d
               end if
            end if
            go to 80
-90         continue
+           90 continue
            ! record the last singular value.
            k = k + 1
            zw(k) = z(jprev)
            dsigma(k) = d(jprev)
            idxp(k) = jprev
-100        continue
+           100 continue
            ! sort the singular values into dsigma. the singular values which
            ! were not deflated go into the first k slots of dsigma, except
            ! that dsigma(1) is treated separately.
@@ -35135,7 +35135,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(out) :: d(*),difl(*),difr(lddifr,*),work(*)
            real(dp),intent(inout) :: dsigma(*),vf(*),vl(*),z(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,iwk1,iwk2,iwk2i,iwk3,iwk3i,j
            real(dp) :: diflj,difrj,dj,dsigj,dsigjp,rho,temp
@@ -35200,7 +35200,7 @@ module stdlib_linalg_lapack_d
            ! and the updated z.
            do j = 1,k
               call stdlib_dlasd4(k,j,dsigma,z,work(iwk1),rho,d(j),work(iwk2),info)
-                        
+
               ! if the root finder fails, report the convergence failure.
               if (info /= 0) then
                  return
@@ -35273,7 +35273,7 @@ module stdlib_linalg_lapack_d
            real(dp),parameter :: cbias = 1.50_dp
            real(dp),parameter :: qurtr = 0.250_dp
            real(dp),parameter :: hundrd = 100.0_dp
-           
+
            ! Local Scalars
            integer(ilp) :: ipn4,j4,n0in,nn
            integer(ilp),intent(inout) :: ttype
@@ -35286,7 +35286,7 @@ module stdlib_linalg_lapack_d
            tol = eps*hundrd
            tol2 = tol**2
            ! check for deflation.
-10   continue
+           10 continue
            if (n0 < i0) return
            if (n0 == i0) go to 20
            nn = 4*n0 + pp
@@ -35294,14 +35294,14 @@ module stdlib_linalg_lapack_d
            ! check whether e(n0-1) is negligible, 1 eigenvalue.
            if (z(nn - 5) > tol2*(sigma + z(nn - 3)) .and. z(nn - 2*pp - 4) > tol2*z(nn - 7)) go to &
                      30
-20         continue
+                     20 continue
            z(4*n0 - 3) = z(4*n0 + pp - 3) + sigma
            n0 = n0 - 1
            go to 10
            ! check  whether e(n0-2) is negligible, 2 eigenvalues.
-30   continue
+           30 continue
            if (z(nn - 9) > tol2*sigma .and. z(nn - 2*pp - 8) > tol2*z(nn - 11)) go to 50
-40         continue
+           40 continue
            if (z(nn - 3) > z(nn - 7)) then
               s = z(nn - 3)
               z(nn - 3) = z(nn - 7)
@@ -35323,7 +35323,7 @@ module stdlib_linalg_lapack_d
            z(4*n0 - 3) = z(nn - 3) + sigma
            n0 = n0 - 2
            go to 10
-50         continue
+           50 continue
            if (pp == 2) pp = 0
            ! reverse the qd-array, if warranted.
            if (dmin <= zero .or. n0 < n0in) then
@@ -35358,7 +35358,7 @@ module stdlib_linalg_lapack_d
            call stdlib_dlasq4(i0,n0,z,pp,n0in,dmin,dmin1,dmin2,dn,dn1,dn2,tau,ttype, &
                      g)
            ! call dqds until dmin > 0.
-70   continue
+           70 continue
            call stdlib_dlasq5(i0,n0,z,pp,tau,sigma,dmin,dmin1,dmin2,dn,dn1,dn2,ieee, &
                      eps)
            ndiv = ndiv + (n0 - i0 + 2)
@@ -35402,12 +35402,12 @@ module stdlib_linalg_lapack_d
               go to 80
            end if
            ! risk of underflow.
-80   continue
+           80 continue
            call stdlib_dlasq6(i0,n0,z,pp,dmin,dmin1,dmin2,dn,dn1,dn2)
            ndiv = ndiv + (n0 - i0 + 2)
            iter = iter + 1
            tau = zero
-90         continue
+           90 continue
            if (tau < sigma) then
               desig = desig + tau
               t = sigma + desig
@@ -35442,7 +35442,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: maxdim = 8
-           
+
            ! Local Scalars
            integer(ilp) :: i,info,j,k
            real(dp) :: bm,bp,pmone,sminu,splus,temp
@@ -35550,7 +35550,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: e(*),tau(*),w(ldw,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,iw
            real(dp) :: alpha
@@ -35591,7 +35591,7 @@ module stdlib_linalg_lapack_d
                     end if
                     call stdlib_dscal(i - 1,tau(i - 1),w(1,iw),1)
                     alpha = -half*tau(i - 1)*stdlib_ddot(i - 1,w(1,iw),1,a(1,i),1)
-                              
+
                     call stdlib_daxpy(i - 1,alpha,a(1,i),1,w(1,iw),1)
                  end if
               end do loop_10
@@ -35607,7 +35607,7 @@ module stdlib_linalg_lapack_d
                     ! generate elementary reflector h(i) to annihilate
                     ! a(i+2:n,i)
                     call stdlib_dlarfg(n - i,a(i + 1,i),a(min(i + 2,n),i),1,tau(i))
-                              
+
                     e(i) = a(i + 1,i)
                     a(i + 1,i) = one
                     ! compute w(i+1:n,i)
@@ -35623,7 +35623,7 @@ module stdlib_linalg_lapack_d
                                1,one,w(i + 1,i),1)
                     call stdlib_dscal(n - i,tau(i),w(i + 1,i),1)
                     alpha = -half*tau(i)*stdlib_ddot(n - i,w(i + 1,i),1,a(i + 1,i),1)
-                              
+
                     call stdlib_daxpy(n - i,alpha,a(i + 1,i),1,w(i + 1,i),1)
                  end if
               end do
@@ -35646,7 +35646,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            ! Executable Statements
@@ -35701,11 +35701,11 @@ module stdlib_linalg_lapack_d
            real(dp),intent(out) :: phi(*),theta(*)
            real(dp),intent(out) :: taup1(*),taup2(*),tauq1(*),tauq2(*),work(*)
            real(dp),intent(inout) :: x11(ldx11,*),x12(ldx12,*),x21(ldx21,*),x22(ldx22,*)
-                     
+
         ! ====================================================================
            ! Parameters
            real(dp),parameter :: realone = 1.0_dp
-           
+
            ! Local Scalars
            logical(lk) :: colmajor,lquery
            integer(ilp) :: i,lworkmin,lworkopt
@@ -35775,7 +35775,7 @@ module stdlib_linalg_lapack_d
                  else
                     call stdlib_dscal(p - i + 1,z1*cos(phi(i - 1)),x11(i,i),1)
                     call stdlib_daxpy(p - i + 1,-z1*z3*z4*sin(phi(i - 1)),x12(i,i - 1),1,x11(i,i),1)
-                              
+
                  end if
                  if (i == 1) then
                     call stdlib_dscal(m - p - i + 1,z2,x21(i,i),1)
@@ -35837,7 +35837,7 @@ module stdlib_linalg_lapack_d
                        call stdlib_dlarfgp(m - q - i + 1,x12(i,i),x12(i,i),ldx12,tauq2(i))
                     else
                        call stdlib_dlarfgp(m - q - i + 1,x12(i,i),x12(i,i + 1),ldx12,tauq2(i))
-                                 
+
                     end if
                  end if
                  x12(i,i) = one
@@ -35877,7 +35877,7 @@ module stdlib_linalg_lapack_d
                  call stdlib_dscal(m - p - q - i + 1,z2*z4,x22(q + i,p + i),ldx22)
                  if (i == m - p - q) then
                     call stdlib_dlarfgp(m - p - q - i + 1,x22(q + i,p + i),x22(q + i,p + i),ldx22,tauq2(p + i))
-                              
+
                  else
                     call stdlib_dlarfgp(m - p - q - i + 1,x22(q + i,p + i),x22(q + i,p + i + 1),ldx22,tauq2(p + i) &
                                )
@@ -35934,11 +35934,11 @@ module stdlib_linalg_lapack_d
                  if (i < q) then
                     call stdlib_dscal(q - i,-z1*z3*sin(theta(i)),x11(i + 1,i),1)
                     call stdlib_daxpy(q - i,z2*z3*cos(theta(i)),x21(i + 1,i),1,x11(i + 1,i),1)
-                              
+
                  end if
                  call stdlib_dscal(m - q - i + 1,-z1*z4*sin(theta(i)),x12(i,i),1)
                  call stdlib_daxpy(m - q - i + 1,z2*z4*cos(theta(i)),x22(i,i),1,x12(i,i),1)
-                           
+
                  if (i < q) phi(i) = atan2(stdlib_dnrm2(q - i,x11(i + 1,i),1),stdlib_dnrm2(m - q - &
                            i + 1,x12(i,i),1))
                  if (i < q) then
@@ -35985,10 +35985,10 @@ module stdlib_linalg_lapack_d
                  call stdlib_dscal(m - p - q - i + 1,z2*z4,x22(p + i,q + i),1)
                  if (m - p - q == i) then
                     call stdlib_dlarfgp(m - p - q - i + 1,x22(p + i,q + i),x22(p + i,q + i),1,tauq2(p + i))
-                              
+
                  else
                     call stdlib_dlarfgp(m - p - q - i + 1,x22(p + i,q + i),x22(p + i + 1,q + i),1,tauq2(p + i))
-                              
+
                     call stdlib_dlarf('L',m - p - q - i + 1,m - p - q - i,x22(p + i,q + i),1,tauq2(p + i),x22(p + &
                               i,q + i + 1),ldx22,work)
                  end if
@@ -36023,7 +36023,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(out) :: work(*)
            real(dp),intent(inout) :: x1(*),x2(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: childinfo,i,j
            ! Intrinsic Function
@@ -36126,11 +36126,11 @@ module stdlib_linalg_lapack_d
            integer(ilp),intent(out) :: iwork(*)
            real(dp),intent(out) :: theta(*)
            real(dp),intent(out) :: u1(ldu1,*),u2(ldu2,*),v1t(ldv1t,*),v2t(ldv2t,*),work(*)
-                     
+
            real(dp),intent(inout) :: x11(ldx11,*),x12(ldx12,*),x21(ldx21,*),x22(ldx22,*)
-                     
+
         ! ===================================================================
-           
+
            ! Local Scalars
            character :: transt,signst
            integer(ilp) :: childinfo,i,ib11d,ib11e,ib12d,ib12e,ib21d,ib21e,ib22d,ib22e, &
@@ -36328,7 +36328,7 @@ module stdlib_linalg_lapack_d
               if (wantv2t .and. m - q > 0) then
                  call stdlib_dlacpy('L',m - q,p,x12,ldx12,v2t,ldv2t)
                  call stdlib_dlacpy('L',m - p - q,m - p - q,x22(p + 1,q + 1),ldx22,v2t(p + 1,p + 1),ldv2t)
-                           
+
                  call stdlib_dorgqr(m - q,m - q,m - q,v2t,ldv2t,work(itauq2),work(iorgqr), &
                            lorgqrwork,info)
               end if
@@ -36389,7 +36389,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: tau(*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,iinfo,j,lwkopt,nb,nh
@@ -36483,7 +36483,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: d(*),t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,iinfo,j,jb,jbtemp1,jbtemp2,jnb,nplusone
            ! Intrinsic Functions
@@ -36523,7 +36523,7 @@ module stdlib_linalg_lapack_d
            ! (1-2) solve for v2.
            if (m > n) then
               call stdlib_dtrsm('R','U','N','N',m - n,n,one,a,lda,a(n + 1,1),lda)
-                        
+
            end if
            ! (2) reconstruct the block reflector t stored in t(1:nb, 1:n)
            ! as a sequence of upper-triangular blocks with nb-size column
@@ -36705,7 +36705,7 @@ module stdlib_linalg_lapack_d
      !> condition number is computed as RCOND = 1 / (ANORM * norm(inv(A))).
 
      pure subroutine stdlib_dpbcon(uplo,n,kd,ab,ldab,anorm,rcond,work,iwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -36720,7 +36720,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: ab(ldab,*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            character :: normin
@@ -36761,7 +36761,7 @@ module stdlib_linalg_lapack_d
            ! estimate the 1-norm of the inverse.
            kase = 0
            normin = 'N'
-10         continue
+           10 continue
            call stdlib_dlacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               if (upper) then
@@ -36792,7 +36792,7 @@ module stdlib_linalg_lapack_d
            end if
            ! compute the estimate of the reciprocal condition number.
            if (ainvnm /= zero) rcond = (one/ainvnm)/anorm
-20         continue
+           20 continue
            return
      end subroutine stdlib_dpbcon
 
@@ -36818,7 +36818,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,j,k,kase,l,nz
@@ -36870,12 +36870,12 @@ module stdlib_linalg_lapack_d
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_dcopy(n,b(1,j),1,work(n + 1),1)
               call stdlib_dsbmv(uplo,n,kd,-one,ab,ldab,x(1,j),1,one,work(n + 1),1)
-                        
+
               ! compute componentwise relative backward error from formula
               ! max(i) ( abs(r(i)) / ( abs(a)*abs(x) + abs(b) )(i) )
               ! where abs(z) is the componentwise absolute value of the matrix
@@ -36957,9 +36957,9 @@ module stdlib_linalg_lapack_d
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_dlacn2(n,work(2*n + 1),work(n + 1),iwork,ferr(j),kase,isave)
-                        
+
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(a**t).
@@ -37002,7 +37002,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: a(0:*)
            real(dp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,normaltransr
            ! Intrinsic Functions
@@ -37061,7 +37061,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            character :: normin
@@ -37100,7 +37100,7 @@ module stdlib_linalg_lapack_d
            ! estimate the 1-norm of inv(a).
            kase = 0
            normin = 'N'
-10         continue
+           10 continue
            call stdlib_dlacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               if (upper) then
@@ -37131,7 +37131,7 @@ module stdlib_linalg_lapack_d
            end if
            ! compute the estimate of the reciprocal condition number.
            if (ainvnm /= zero) rcond = (one/ainvnm)/anorm
-20         continue
+           20 continue
            return
      end subroutine stdlib_dpocon
 
@@ -37157,7 +37157,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,j,k,kase,nz
@@ -37207,7 +37207,7 @@ module stdlib_linalg_lapack_d
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_dcopy(n,b(1,j),1,work(n + 1),1)
@@ -37291,9 +37291,9 @@ module stdlib_linalg_lapack_d
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_dlacn2(n,work(2*n + 1),work(n + 1),iwork,ferr(j),kase,isave)
-                        
+
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(a**t).
@@ -37339,7 +37339,7 @@ module stdlib_linalg_lapack_d
            ! Array Arguments
            real(dp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j
@@ -37401,9 +37401,9 @@ module stdlib_linalg_lapack_d
               end do
            end if
            go to 40
-30         continue
+           30 continue
            info = j
-40         continue
+           40 continue
            return
      end subroutine stdlib_dpotf2
 
@@ -37432,7 +37432,7 @@ module stdlib_linalg_lapack_d
            ! Array Arguments
            real(dp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: n1,n2,iinfo
@@ -37568,7 +37568,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: ap(*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            character :: normin
@@ -37605,7 +37605,7 @@ module stdlib_linalg_lapack_d
            ! estimate the 1-norm of the inverse.
            kase = 0
            normin = 'N'
-10         continue
+           10 continue
            call stdlib_dlacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               if (upper) then
@@ -37636,7 +37636,7 @@ module stdlib_linalg_lapack_d
            end if
            ! compute the estimate of the reciprocal condition number.
            if (ainvnm /= zero) rcond = (one/ainvnm)/anorm
-20         continue
+           20 continue
            return
      end subroutine stdlib_dppcon
 
@@ -37662,7 +37662,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,ik,j,k,kase,kk,nz
@@ -37708,7 +37708,7 @@ module stdlib_linalg_lapack_d
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_dcopy(n,b(1,j),1,work(n + 1),1)
@@ -37799,9 +37799,9 @@ module stdlib_linalg_lapack_d
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_dlacn2(n,work(2*n + 1),work(n + 1),iwork,ferr(j),kase,isave)
-                        
+
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(a**t).
@@ -37901,7 +37901,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: afp(*),ap(*),b(ldb,*),s(*)
            real(dp),intent(out) :: berr(*),ferr(*),work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: equil,nofact,rcequ
            integer(ilp) :: i,infequ,j
@@ -38031,7 +38031,7 @@ module stdlib_linalg_lapack_d
            ! Array Arguments
            real(dp),intent(inout) :: ap(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,jc,jj,jjn
@@ -38102,7 +38102,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(out) :: work(2*n)
            integer(ilp),intent(out) :: piv(n)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(dp) :: ajj,dstop,dtemp
            integer(ilp) :: i,itemp,j,pvt
@@ -38180,7 +38180,7 @@ module stdlib_linalg_lapack_d
                     a(pvt,pvt) = a(j,j)
                     call stdlib_dswap(j - 1,a(1,j),1,a(1,pvt),1)
                     if (pvt < n) call stdlib_dswap(n - pvt,a(j,pvt + 1),lda,a(pvt,pvt + 1),lda)
-                              
+
                     call stdlib_dswap(pvt - j - 1,a(j,j + 1),lda,a(j + 1,pvt),1)
                     ! swap dot products and piv
                     dtemp = work(j)
@@ -38225,7 +38225,7 @@ module stdlib_linalg_lapack_d
                     a(pvt,pvt) = a(j,j)
                     call stdlib_dswap(j - 1,a(j,1),lda,a(pvt,1),lda)
                     if (pvt < n) call stdlib_dswap(n - pvt,a(pvt + 1,j),1,a(pvt + 1,pvt),1)
-                              
+
                     call stdlib_dswap(pvt - j - 1,a(j + 1,j),1,a(pvt,j + 1),lda)
                     ! swap dot products and piv
                     dtemp = work(j)
@@ -38248,12 +38248,12 @@ module stdlib_linalg_lapack_d
            ! ran to completion, a has full rank
            rank = n
            go to 170
-160        continue
+           160 continue
            ! rank is number of steps completed.  set info = 1 to signal
            ! that the factorization cannot be used to solve a system.
            rank = j - 1
            info = 1
-170        continue
+           170 continue
            return
      end subroutine stdlib_dpstf2
 
@@ -38281,7 +38281,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(out) :: work(2*n)
            integer(ilp),intent(out) :: piv(n)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(dp) :: ajj,dstop,dtemp
            integer(ilp) :: i,itemp,j,jb,k,nb,pvt
@@ -38459,12 +38459,12 @@ module stdlib_linalg_lapack_d
            ! ran to completion, a has full rank
            rank = n
            go to 200
-190        continue
+           190 continue
            ! rank is the number of steps completed.  set info = 1 to signal
            ! that the factorization cannot be used to solve a system.
            rank = j - 1
            info = 1
-200        continue
+           200 continue
            return
      end subroutine stdlib_dpstrf
 
@@ -38539,7 +38539,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: v(*),tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,j1,j2,lm,ln,vpos,taupos,dpos,ofdpos,ajeter
@@ -38628,7 +38628,7 @@ module stdlib_linalg_lapack_d
                        a(ofdpos + i,st - 1) = zero
                    end do
                    call stdlib_dlarfg(lm,a(ofdpos,st - 1),v(vpos + 1),1,tau(taupos))
-                             
+
                    lm = ed - st + 1
                    call stdlib_dlarfy(uplo,lm,v(vpos),1, (tau(taupos)),a(dpos,st), &
                              lda - 1,work)
@@ -38659,7 +38659,7 @@ module stdlib_linalg_lapack_d
                            a(dpos + nb + i,st) = zero
                        end do
                        call stdlib_dlarfg(lm,a(dpos + nb,st),v(vpos + 1),1,tau(taupos))
-                                 
+
                        call stdlib_dlarfx('LEFT',lm,ln - 1,v(vpos), (tau(taupos)),a(dpos + &
                                  nb - 1,st + 1),lda - 1,work)
                    end if
@@ -38690,7 +38690,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: ap(*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,ip,kase
@@ -38738,7 +38738,7 @@ module stdlib_linalg_lapack_d
            end if
            ! estimate the 1-norm of the inverse.
            kase = 0
-30         continue
+           30 continue
            call stdlib_dlacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               ! multiply by inv(l*d*l**t) or inv(u*d*u**t).
@@ -38773,7 +38773,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,ik,j,k,kase,kk,nz
@@ -38819,7 +38819,7 @@ module stdlib_linalg_lapack_d
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_dcopy(n,b(1,j),1,work(n + 1),1)
@@ -38910,9 +38910,9 @@ module stdlib_linalg_lapack_d
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_dlacn2(n,work(2*n + 1),work(n + 1),iwork,ferr(j),kase,isave)
-                        
+
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(a**t).
@@ -39014,7 +39014,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: ap(*),b(ldb,*)
            real(dp),intent(out) :: berr(*),ferr(*),work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nofact
            real(dp) :: anorm
@@ -39084,7 +39084,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: ap(*)
            real(dp),intent(out) :: d(*),e(*),tau(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,i1,i1i1,ii
@@ -39153,7 +39153,7 @@ module stdlib_linalg_lapack_d
                     ! apply the transformation as a rank-2 update:
                        ! a := a - v * w**t - w * v**t
                     call stdlib_dspr2(uplo,n - i,-one,ap(ii + 1),1,tau(i),1,ap(i1i1))
-                              
+
                     ap(ii + 1) = e(i)
                  end if
                  d(i) = ap(ii)
@@ -39190,7 +39190,7 @@ module stdlib_linalg_lapack_d
            real(dp),parameter :: odm1 = 1.0e-1_dp
            integer(ilp),parameter :: maxits = 5
            integer(ilp),parameter :: extra = 2
-           
+
            ! Local Scalars
            integer(ilp) :: b1,blksiz,bn,gpind,i,iinfo,indrv1,indrv2,indrv3,indrv4, &
                      indrv5,its,j,j1,jblk,jmax,nblk,nrmchk
@@ -39223,7 +39223,7 @@ module stdlib_linalg_lapack_d
                     go to 30
                  end if
               end do
-30            continue
+              30 continue
            end if
            if (info /= 0) then
               call stdlib_xerbla('DSTEIN',-info)
@@ -39270,7 +39270,7 @@ module stdlib_linalg_lapack_d
               ortol = odm3*onenrm
               dtpcrt = sqrt(odm1/blksiz)
               ! loop through eigenvalues of block nblk.
-60   continue
+              60 continue
               jblk = 0
               loop_150: do j = j1,m
                  if (iblock(j) /= nblk) then
@@ -39305,7 +39305,7 @@ module stdlib_linalg_lapack_d
                  call stdlib_dlagtf(blksiz,work(indrv4 + 1),xj,work(indrv2 + 2),work(indrv3 + &
                            1),tol,work(indrv5 + 1),iwork,iinfo)
                  ! update iteration count.
-70   continue
+                 70 continue
                  its = its + 1
                  if (its > maxits) go to 100
                  ! normalize and scale the righthand side vector pb.
@@ -39327,7 +39327,7 @@ module stdlib_linalg_lapack_d
                     end do
                  end if
                  ! check the infinity norm of the iterate.
-90   continue
+                 90 continue
                  jmax = stdlib_idamax(blksiz,work(indrv1 + 1),1)
                  nrm = abs(work(indrv1 + jmax))
                  ! continue for additional iterations after norm reaches
@@ -39338,16 +39338,16 @@ module stdlib_linalg_lapack_d
                  go to 110
                  ! if stopping criterion was not satisfied, update info and
                  ! store eigenvector number in array ifail.
-100  continue
+                 100 continue
                  info = info + 1
                  ifail(info) = j
                  ! accept iterate as jth eigenvector.
-110  continue
+                 110 continue
                  scl = one/stdlib_dnrm2(blksiz,work(indrv1 + 1),1)
                  jmax = stdlib_idamax(blksiz,work(indrv1 + 1),1)
                  if (work(indrv1 + jmax) < zero) scl = -scl
                  call stdlib_dscal(blksiz,scl,work(indrv1 + 1),1)
-120              continue
+                 120 continue
                  do i = 1,n
                     z(i,j) = zero
                  end do
@@ -39382,7 +39382,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: maxit = 30
-           
+
            ! Local Scalars
            integer(ilp) :: i,icompz,ii,iscale,j,jtot,k,l,l1,lend,lendm1,lendp1,lendsv, &
                       lm1,lsv,m,mm,mm1,nm1,nmaxit
@@ -39436,7 +39436,7 @@ module stdlib_linalg_lapack_d
            ! element is smaller.
            l1 = 1
            nm1 = n - 1
-10         continue
+           10 continue
            if (l1 > n) go to 160
            if (l1 > 1) e(l1 - 1) = zero
            if (l1 <= nm1) then
@@ -39450,7 +39450,7 @@ module stdlib_linalg_lapack_d
               end do
            end if
            m = n
-30         continue
+           30 continue
            l = l1
            lsv = l
            lend = m
@@ -39478,7 +39478,7 @@ module stdlib_linalg_lapack_d
            if (lend > l) then
               ! ql iteration
               ! look for small subdiagonal element.
-40   continue
+              40 continue
               if (l /= lend) then
                  lendm1 = lend - 1
                  do m = l,lendm1
@@ -39487,7 +39487,7 @@ module stdlib_linalg_lapack_d
                  end do
               end if
               m = lend
-60            continue
+              60 continue
               if (m < lend) e(m) = zero
               p = d(l)
               if (m == l) go to 80
@@ -39547,7 +39547,7 @@ module stdlib_linalg_lapack_d
               e(l) = g
               go to 40
               ! eigenvalue found.
-80   continue
+              80 continue
               d(l) = p
               l = l + 1
               if (l <= lend) go to 40
@@ -39555,7 +39555,7 @@ module stdlib_linalg_lapack_d
            else
               ! qr iteration
               ! look for small superdiagonal element.
-90   continue
+              90 continue
               if (l /= lend) then
                  lendp1 = lend + 1
                  do m = l,lendp1,-1
@@ -39564,7 +39564,7 @@ module stdlib_linalg_lapack_d
                  end do
               end if
               m = lend
-110           continue
+              110 continue
               if (m > lend) e(m - 1) = zero
               p = d(l)
               if (m == l) go to 130
@@ -39624,24 +39624,24 @@ module stdlib_linalg_lapack_d
               e(lm1) = g
               go to 90
               ! eigenvalue found.
-130  continue
+              130 continue
               d(l) = p
               l = l - 1
               if (l >= lend) go to 90
               go to 140
            end if
            ! undo scaling if necessary
-140  continue
+           140 continue
            if (iscale == 1) then
               call stdlib_dlascl('G',0,0,ssfmax,anorm,lendsv - lsv + 1,1,d(lsv),n,info)
-                        
+
               call stdlib_dlascl('G',0,0,ssfmax,anorm,lendsv - lsv,1,e(lsv),n,info)
-                        
+
            else if (iscale == 2) then
               call stdlib_dlascl('G',0,0,ssfmin,anorm,lendsv - lsv + 1,1,d(lsv),n,info)
-                        
+
               call stdlib_dlascl('G',0,0,ssfmin,anorm,lendsv - lsv,1,e(lsv),n,info)
-                        
+
            end if
            ! check for no convergence to an eigenvalue after a total
            ! of n*maxit iterations.
@@ -39651,7 +39651,7 @@ module stdlib_linalg_lapack_d
            end do
            go to 190
            ! order eigenvalues and eigenvectors.
-160  continue
+           160 continue
            if (icompz == 0) then
               ! use quick sort
               call stdlib_dlasrt('I',n,d,info)
@@ -39674,7 +39674,7 @@ module stdlib_linalg_lapack_d
                  end if
               end do
            end if
-190        continue
+           190 continue
            return
      end subroutine stdlib_dsteqr
 
@@ -39693,7 +39693,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: maxit = 30
-           
+
            ! Local Scalars
            integer(ilp) :: i,iscale,jtot,l,l1,lend,lendsv,lsv,m,nmaxit
            real(dp) :: alpha,anorm,bb,c,eps,eps2,gamma,oldc,oldgam,p,r,rt1,rt2,rte, &
@@ -39726,7 +39726,7 @@ module stdlib_linalg_lapack_d
            ! for each block, according to whether top or bottom diagonal
            ! element is smaller.
            l1 = 1
-10         continue
+           10 continue
            if (l1 > n) go to 170
            if (l1 > 1) e(l1 - 1) = zero
            do m = l1,n - 1
@@ -39737,7 +39737,7 @@ module stdlib_linalg_lapack_d
               end if
            end do
            m = n
-30         continue
+           30 continue
            l = l1
            lsv = l
            lend = m
@@ -39768,14 +39768,14 @@ module stdlib_linalg_lapack_d
            if (lend >= l) then
               ! ql iteration
               ! look for small subdiagonal element.
-50   continue
+              50 continue
               if (l /= lend) then
                  do m = l,lend - 1
                     if (abs(e(m)) <= eps2*abs(d(m)*d(m + 1))) go to 70
                  end do
               end if
               m = lend
-70            continue
+              70 continue
               if (m < lend) e(m) = zero
               p = d(l)
               if (m == l) go to 90
@@ -39824,7 +39824,7 @@ module stdlib_linalg_lapack_d
               d(l) = sigma + gamma
               go to 50
               ! eigenvalue found.
-90   continue
+              90 continue
               d(l) = p
               l = l + 1
               if (l <= lend) go to 50
@@ -39832,12 +39832,12 @@ module stdlib_linalg_lapack_d
            else
               ! qr iteration
               ! look for small superdiagonal element.
-100  continue
+              100 continue
               do m = l,lend + 1,-1
                  if (abs(e(m - 1)) <= eps2*abs(d(m)*d(m - 1))) go to 120
               end do
               m = lend
-120           continue
+              120 continue
               if (m > lend) e(m - 1) = zero
               p = d(l)
               if (m == l) go to 140
@@ -39886,14 +39886,14 @@ module stdlib_linalg_lapack_d
               d(l) = sigma + gamma
               go to 100
               ! eigenvalue found.
-140  continue
+              140 continue
               d(l) = p
               l = l - 1
               if (l >= lend) go to 100
               go to 150
            end if
            ! undo scaling if necessary
-150  continue
+           150 continue
            if (iscale == 1) call stdlib_dlascl('G',0,0,ssfmax,anorm,lendsv - lsv + 1,1,d(lsv), &
                      n,info)
            if (iscale == 2) call stdlib_dlascl('G',0,0,ssfmin,anorm,lendsv - lsv + 1,1,d(lsv), &
@@ -39906,9 +39906,9 @@ module stdlib_linalg_lapack_d
            end do
            go to 180
            ! sort eigenvalues in increasing order.
-170  continue
+           170 continue
            call stdlib_dlasrt('I',n,d,info)
-180        continue
+           180 continue
            return
      end subroutine stdlib_dsterf
 
@@ -39927,7 +39927,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: d(*),e(*)
            real(dp),intent(out) :: work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: wantz
            integer(ilp) :: imax,iscale
@@ -40015,7 +40015,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: d(*),e(*)
            real(dp),intent(out) :: w(*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,test,valeig,wantz
            character :: order
@@ -40150,7 +40150,7 @@ module stdlib_linalg_lapack_d
                         indwrk),iwork(indiwo),ifail,info)
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
-20   continue
+           20 continue
            if (iscale == 1) then
               if (info == 0) then
                  imax = m
@@ -40196,7 +40196,7 @@ module stdlib_linalg_lapack_d
      !> condition number is computed as RCOND = 1 / (ANORM * norm(inv(A))).
 
      pure subroutine stdlib_dsycon(uplo,n,a,lda,ipiv,anorm,rcond,work,iwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -40212,7 +40212,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: a(lda,*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,kase
@@ -40260,7 +40260,7 @@ module stdlib_linalg_lapack_d
            end if
            ! estimate the 1-norm of the inverse.
            kase = 0
-30         continue
+           30 continue
            call stdlib_dlacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               ! multiply by inv(l*d*l**t) or inv(u*d*u**t).
@@ -40279,7 +40279,7 @@ module stdlib_linalg_lapack_d
      !> condition number is computed as RCOND = 1 / (ANORM * norm(inv(A))).
 
      pure subroutine stdlib_dsycon_rook(uplo,n,a,lda,ipiv,anorm,rcond,work,iwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -40295,7 +40295,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: a(lda,*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,kase
@@ -40343,7 +40343,7 @@ module stdlib_linalg_lapack_d
            end if
            ! estimate the 1-norm of the inverse.
            kase = 0
-30         continue
+           30 continue
            call stdlib_dlacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               ! multiply by inv(l*d*l**t) or inv(u*d*u**t).
@@ -40377,7 +40377,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,j,k,kase,nz
@@ -40427,7 +40427,7 @@ module stdlib_linalg_lapack_d
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_dcopy(n,b(1,j),1,work(n + 1),1)
@@ -40511,9 +40511,9 @@ module stdlib_linalg_lapack_d
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_dlacn2(n,work(2*n + 1),work(n + 1),iwork,ferr(j),kase,isave)
-                        
+
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(a**t).
@@ -40556,7 +40556,7 @@ module stdlib_linalg_lapack_d
      !> the system of equations A * X = B by calling BLAS3 routine DSYTRS_3.
 
      pure subroutine stdlib_dsysv_rk(uplo,n,nrhs,a,lda,e,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -40635,7 +40635,7 @@ module stdlib_linalg_lapack_d
      !> of equations A * X = B by calling DSYTRS_ROOK.
 
      pure subroutine stdlib_dsysv_rook(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -40711,7 +40711,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: d(*),e(*),tau(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i
@@ -40747,7 +40747,7 @@ module stdlib_linalg_lapack_d
                     a(i,i + 1) = one
                     ! compute  x := tau * a * v  storing x in tau(1:i)
                     call stdlib_dsymv(uplo,i,taui,a,lda,a(1,i + 1),1,zero,tau,1)
-                              
+
                     ! compute  w := x - 1/2 * tau * (x**t * v) * v
                     alpha = -half*taui*stdlib_ddot(i,tau,1,a(1,i + 1),1)
                     call stdlib_daxpy(i,alpha,a(1,i + 1),1,tau,1)
@@ -40812,7 +40812,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: sevten = 17.0e+0_dp
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,imax,j,jmax,k,kk,kp,kstep
@@ -40842,7 +40842,7 @@ module stdlib_linalg_lapack_d
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 70
               kstep = 1
@@ -40957,7 +40957,7 @@ module stdlib_linalg_lapack_d
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop
               if (k > n) go to 70
               kstep = 1
@@ -41010,7 +41010,7 @@ module stdlib_linalg_lapack_d
                     ! interchange rows and columns kk and kp in the trailing
                     ! submatrix a(k:n,k:n)
                     if (kp < n) call stdlib_dswap(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     call stdlib_dswap(kp - kk - 1,a(kk + 1,kk),1,a(kp,kk + 1),lda)
                     t = a(kk,kk)
                     a(kk,kk) = a(kp,kp)
@@ -41031,7 +41031,7 @@ module stdlib_linalg_lapack_d
                        ! a := a - l(k)*d(k)*l(k)**t = a - w(k)*(1/d(k))*w(k)**t
                        d11 = one/a(k,k)
                        call stdlib_dsyr(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                 
+
                        ! store l(k) in column k
                        call stdlib_dscal(n - k,d11,a(k + 1,k),1)
                     end if
@@ -41070,7 +41070,7 @@ module stdlib_linalg_lapack_d
               k = k + kstep
               go to 40
            end if
-70         continue
+           70 continue
            return
      end subroutine stdlib_dsytf2
 
@@ -41090,7 +41090,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: d(*),e(*),tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper
            integer(ilp) :: i,iinfo,iws,j,kk,ldwork,lwkopt,nb,nbmin,nx
@@ -41194,7 +41194,7 @@ module stdlib_linalg_lapack_d
               end do
               ! use unblocked code to reduce the last or only block
               call stdlib_dsytd2(uplo,n - i + 1,a(i,i),lda,d(i),e(i),tau(i),iinfo)
-                        
+
            end if
            work(1) = lwkopt
            return
@@ -41222,7 +41222,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: rzero = 0.0e+0_dp
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wantq,upper,afters1
            integer(ilp) :: i,m,k,ib,sweepid,myid,shift,stt,st,ed,stind,edind, &
@@ -41528,7 +41528,7 @@ module stdlib_linalg_lapack_d
               ! kb, where kb is the number of columns factorized by stdlib_dlasyf;
               ! kb is either nb or nb-1, or k for the last block
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 40
               if (k > nb) then
@@ -41551,7 +41551,7 @@ module stdlib_linalg_lapack_d
               ! kb, where kb is the number of columns factorized by stdlib_dlasyf;
               ! kb is either nb or nb-1, or n-k+1 for the last block
               k = 1
-20            continue
+              20 continue
               ! if k > n, exit from loop
               if (k > n) go to 40
               if (k <= n - nb) then
@@ -41578,7 +41578,7 @@ module stdlib_linalg_lapack_d
               k = k + kb
               go to 20
            end if
-40         continue
+           40 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_dsytrf
@@ -41591,7 +41591,7 @@ module stdlib_linalg_lapack_d
      !> RCOND = 1 / ( norm(A) * norm(inv(A)) ).
 
      subroutine stdlib_dtbcon(norm,uplo,diag,n,kd,ab,ldab,rcond,work,iwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -41605,7 +41605,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: ab(ldab,*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,onenrm,upper
            character :: normin
@@ -41658,7 +41658,7 @@ module stdlib_linalg_lapack_d
                  kase1 = 2
               end if
               kase = 0
-10            continue
+              10 continue
               call stdlib_dlacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
               if (kase /= 0) then
                  if (kase == kase1) then
@@ -41683,7 +41683,7 @@ module stdlib_linalg_lapack_d
               ! compute the estimate of the reciprocal condition number.
               if (ainvnm /= zero) rcond = (one/anorm)/ainvnm
            end if
-20         continue
+           20 continue
            return
      end subroutine stdlib_dtbcon
 
@@ -41702,7 +41702,7 @@ module stdlib_linalg_lapack_d
            ! Array Arguments
            real(dp),intent(inout) :: a(0:*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,nisodd,normaltransr
            integer(ilp) :: n1,n2,k
@@ -41757,12 +41757,12 @@ module stdlib_linalg_lapack_d
                     call stdlib_dtrtri('L',diag,n1,a(0),n,info)
                     if (info > 0) return
                     call stdlib_dtrmm('R','L','N',diag,n2,n1,-one,a(0),n,a(n1),n)
-                              
+
                     call stdlib_dtrtri('U',diag,n2,a(n),n,info)
                     if (info > 0) info = info + n1
                     if (info > 0) return
                     call stdlib_dtrmm('L','U','T',diag,n2,n1,one,a(n),n,a(n1),n)
-                              
+
                  else
                    ! srpa for upper, normal and n is odd ( a(0:n-1,0:n2-1)
                    ! t1 -> a(n1+1,0), t2 -> a(n1,0), s -> a(0,0)
@@ -41770,12 +41770,12 @@ module stdlib_linalg_lapack_d
                     call stdlib_dtrtri('L',diag,n1,a(n2),n,info)
                     if (info > 0) return
                     call stdlib_dtrmm('L','L','T',diag,n1,n2,-one,a(n2),n,a(0),n)
-                              
+
                     call stdlib_dtrtri('U',diag,n2,a(n1),n,info)
                     if (info > 0) info = info + n1
                     if (info > 0) return
                     call stdlib_dtrmm('R','U','N',diag,n1,n2,one,a(n1),n,a(0),n)
-                              
+
                  end if
               else
                  ! n is odd and transr = 't'
@@ -41821,7 +41821,7 @@ module stdlib_linalg_lapack_d
                     if (info > 0) info = info + k
                     if (info > 0) return
                     call stdlib_dtrmm('L','U','T',diag,k,k,one,a(0),n + 1,a(k + 1),n + 1)
-                              
+
                  else
                     ! srpa for upper, normal, and n is even ( a(0:n,0:k-1) )
                     ! t1 -> a(k+1,0) ,  t2 -> a(k,0),   s -> a(0,0)
@@ -41834,7 +41834,7 @@ module stdlib_linalg_lapack_d
                     if (info > 0) info = info + k
                     if (info > 0) return
                     call stdlib_dtrmm('R','U','N',diag,k,k,one,a(k),n + 1,a(0),n + 1)
-                              
+
                  end if
               else
                  ! n is even and transr = 't'
@@ -41863,7 +41863,7 @@ module stdlib_linalg_lapack_d
                     if (info > 0) info = info + k
                     if (info > 0) return
                     call stdlib_dtrmm('L','L','N',diag,k,k,one,a(k*k),k,a(0),k)
-                              
+
                  end if
               end if
            end if
@@ -41919,7 +41919,7 @@ module stdlib_linalg_lapack_d
         ! sven hammarling, 27/5/02.
            ! Parameters
            integer(ilp),parameter :: ldz = 8
-           
+
            ! Local Scalars
            logical(lk) :: notran
            integer(ilp) :: i,ie,ierr,ii,is,isp1,j,je,jj,js,jsp1,k,mb,nb,p,q, &
@@ -41969,7 +41969,7 @@ module stdlib_linalg_lapack_d
            pq = 0
            p = 0
            i = 1
-10         continue
+           10 continue
            if (i > m) go to 20
            p = p + 1
            iwork(p) = i
@@ -41980,12 +41980,12 @@ module stdlib_linalg_lapack_d
               i = i + 1
            end if
            go to 10
-20         continue
+           20 continue
            iwork(p + 1) = m + 1
            ! determine block structure of b
            q = p + 1
            j = 1
-30         continue
+           30 continue
            if (j > n) go to 40
            q = q + 1
            iwork(q) = j
@@ -41996,7 +41996,7 @@ module stdlib_linalg_lapack_d
               j = j + 1
            end if
            go to 30
-40         continue
+           40 continue
            iwork(q + 1) = n + 1
            pq = p*(q - p - 1)
            if (notran) then
@@ -42040,7 +42040,7 @@ module stdlib_linalg_lapack_d
                           end if
                        else
                           call stdlib_dlatdf(ijob,zdim,z,ldz,rhs,rdsum,rdscal,ipiv,jpiv)
-                                    
+
                        end if
                        ! unpack solution vector(s)
                        c(is,js) = rhs(1)
@@ -42095,7 +42095,7 @@ module stdlib_linalg_lapack_d
                           end if
                        else
                           call stdlib_dlatdf(ijob,zdim,z,ldz,rhs,rdsum,rdscal,ipiv,jpiv)
-                                    
+
                        end if
                        ! unpack solution vector(s)
                        c(is,js) = rhs(1)
@@ -42157,7 +42157,7 @@ module stdlib_linalg_lapack_d
                           end if
                        else
                           call stdlib_dlatdf(ijob,zdim,z,ldz,rhs,rdsum,rdscal,ipiv,jpiv)
-                                    
+
                        end if
                        ! unpack solution vector(s)
                        c(is,js) = rhs(1)
@@ -42232,7 +42232,7 @@ module stdlib_linalg_lapack_d
                           end if
                        else
                           call stdlib_dlatdf(ijob,zdim,z,ldz,rhs,rdsum,rdscal,ipiv,jpiv)
-                                    
+
                        end if
                        ! unpack solution vector(s)
                        k = 1
@@ -42313,10 +42313,10 @@ module stdlib_linalg_lapack_d
                        if (i < p) then
                           alpha = -rhs(1)
                           call stdlib_daxpy(m - ie,alpha,a(is,ie + 1),lda,c(ie + 1,js),1)
-                                    
+
                           alpha = -rhs(2)
                           call stdlib_daxpy(m - ie,alpha,d(is,ie + 1),ldd,c(ie + 1,js),1)
-                                    
+
                        end if
                     else if ((mb == 1) .and. (nb == 2)) then
                        ! build a 4-by-4 system z**t * x = rhs
@@ -42361,13 +42361,13 @@ module stdlib_linalg_lapack_d
                        ! equation.
                        if (j > p + 2) then
                           call stdlib_daxpy(js - 1,rhs(1),b(1,js),1,f(is,1),ldf)
-                                    
+
                           call stdlib_daxpy(js - 1,rhs(2),b(1,jsp1),1,f(is,1),ldf)
-                                    
+
                           call stdlib_daxpy(js - 1,rhs(3),e(1,js),1,f(is,1),ldf)
-                                    
+
                           call stdlib_daxpy(js - 1,rhs(4),e(1,jsp1),1,f(is,1),ldf)
-                                    
+
                        end if
                        if (i < p) then
                           call stdlib_dger(m - ie,nb,-one,a(is,ie + 1),lda,rhs(1),1,c(ie + &
@@ -42556,7 +42556,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
         ! replaced various illegal calls to stdlib_dcopy by calls to stdlib_dlaset.
         ! sven hammarling, 1/5/02.
-           
+
            ! Local Scalars
            logical(lk) :: lquery,notran
            integer(ilp) :: i,ie,ifunc,iround,is,isolve,j,je,js,k,linfo,lwmin,mb,nb, &
@@ -42675,7 +42675,7 @@ module stdlib_linalg_lapack_d
            ! determine block structure of a
            p = 0
            i = 1
-40         continue
+           40 continue
            if (i > m) go to 50
            p = p + 1
            iwork(p) = i
@@ -42683,13 +42683,13 @@ module stdlib_linalg_lapack_d
            if (i >= m) go to 50
            if (a(i,i - 1) /= zero) i = i + 1
            go to 40
-50         continue
+           50 continue
            iwork(p + 1) = m + 1
            if (iwork(p) == iwork(p + 1)) p = p - 1
            ! determine block structure of b
            q = p + 1
            j = 1
-60         continue
+           60 continue
            if (j > n) go to 70
            q = q + 1
            iwork(q) = j
@@ -42697,7 +42697,7 @@ module stdlib_linalg_lapack_d
            if (j >= n) go to 70
            if (b(j,j - 1) /= zero) j = j + 1
            go to 60
-70         continue
+           70 continue
            iwork(q + 1) = n + 1
            if (iwork(q) == iwork(q + 1)) q = q - 1
            if (notran) then
@@ -42859,7 +42859,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: ap(*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,onenrm,upper
            character :: normin
@@ -42908,7 +42908,7 @@ module stdlib_linalg_lapack_d
                  kase1 = 2
               end if
               kase = 0
-10            continue
+              10 continue
               call stdlib_dlacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
               if (kase /= 0) then
                  if (kase == kase1) then
@@ -42933,7 +42933,7 @@ module stdlib_linalg_lapack_d
               ! compute the estimate of the reciprocal condition number.
               if (ainvnm /= zero) rcond = (one/anorm)/ainvnm
            end if
-20         continue
+           20 continue
            return
      end subroutine stdlib_dtpcon
 
@@ -42952,7 +42952,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*),b(ldb,*)
            real(dp),intent(out) :: t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,p,mp,np
            real(dp) :: alpha
@@ -43287,7 +43287,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*),b(ldb,*)
            real(dp),intent(out) :: t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,p,mp,np
            real(dp) :: alpha
@@ -43332,7 +43332,7 @@ module stdlib_linalg_lapack_d
                     a(i,i + j) = a(i,i + j) + alpha*(t(j,n))
                  end do
                  call stdlib_dger(p,n - i,alpha,b(1,i),1,t(1,n),1,b(1,i + 1),ldb)
-                           
+
               end if
            end do
            do i = 2,n
@@ -43354,7 +43354,7 @@ module stdlib_linalg_lapack_d
                         np,i),1)
               ! b1
               call stdlib_dgemv('T',m - l,i - 1,alpha,b,ldb,b(1,i),1,one,t(1,i),1)
-                        
+
               ! t(1:i-1,i) := t(1:i-1,1:i-1) * t(1:i-1,i)
               call stdlib_dtrmv('U','N','N',i - 1,t,ldt,t(1,i),1)
               ! t(i,i) = tau(i)
@@ -43384,7 +43384,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: a(lda,*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,onenrm,upper
            character :: normin
@@ -43435,7 +43435,7 @@ module stdlib_linalg_lapack_d
                  kase1 = 2
               end if
               kase = 0
-10            continue
+              10 continue
               call stdlib_dlacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
               if (kase /= 0) then
                  if (kase == kase1) then
@@ -43460,7 +43460,7 @@ module stdlib_linalg_lapack_d
               ! compute the estimate of the reciprocal condition number.
               if (ainvnm /= zero) rcond = (one/anorm)/ainvnm
            end if
-20         continue
+           20 continue
            return
      end subroutine stdlib_dtrcon
 
@@ -43482,7 +43482,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,iws,ki,kk,ldwork,lwkmin,lwkopt,m1,mu,nb,nbmin, &
@@ -43567,7 +43567,7 @@ module stdlib_linalg_lapack_d
                     ! apply h to a(1:i-1,i:n) from the right
                     call stdlib_dlarzb('RIGHT','NO TRANSPOSE','BACKWARD','ROWWISE',i - 1,n - i + 1, &
                      ib,n - m,a(i,m1),lda,work,ldwork,a(1,i),lda,work(ib + 1),ldwork)
-                               
+
                  end if
               end do
               mu = i + nb - 1
@@ -43627,7 +43627,7 @@ module stdlib_linalg_lapack_d
            if (info == 0) then
               ! solve the system a*x = b, overwriting b with x.
               call stdlib_dgbtrs('NO TRANSPOSE',n,kl,ku,nrhs,ab,ldab,ipiv,b,ldb,info)
-                        
+
            end if
            return
      end subroutine stdlib_dgbsv
@@ -43656,7 +43656,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: ab(ldab,*),afb(ldafb,*),b(ldb,*),c(*),r(*)
            real(dp),intent(out) :: berr(*),ferr(*),work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: colequ,equil,nofact,notran,rowequ
            character :: norm
@@ -43746,11 +43746,11 @@ module stdlib_linalg_lapack_d
            if (equil) then
               ! compute row and column scalings to equilibrate the matrix a.
               call stdlib_dgbequ(n,n,kl,ku,ab,ldab,r,c,rowcnd,colcnd,amax,infequ)
-                        
+
               if (infequ == 0) then
                  ! equilibrate the matrix.
                  call stdlib_dlaqgb(n,n,kl,ku,ab,ldab,r,c,rowcnd,colcnd,amax,equed)
-                           
+
                  rowequ = stdlib_lsame(equed,'R') .or. stdlib_lsame(equed,'B')
                  colequ = stdlib_lsame(equed,'C') .or. stdlib_lsame(equed,'B')
               end if
@@ -43777,7 +43777,7 @@ module stdlib_linalg_lapack_d
                  j1 = max(j - ku,1)
                  j2 = min(j + kl,n)
                  call stdlib_dcopy(j2 - j1 + 1,ab(ku + 1 - j + j1,j),1,afb(kl + ku + 1 - j + j1,j),1)
-                           
+
               end do
               call stdlib_dgbtrf(n,n,kl,ku,afb,ldafb,ipiv,info)
               ! return if info is non-zero.
@@ -43818,7 +43818,7 @@ module stdlib_linalg_lapack_d
            end if
            ! compute the reciprocal of the condition number of a.
            call stdlib_dgbcon(norm,n,kl,ku,afb,ldafb,ipiv,anorm,rcond,work,iwork,info)
-                     
+
            ! compute the solution matrix x.
            call stdlib_dlacpy('FULL',n,nrhs,b,ldb,x,ldx)
            call stdlib_dgbtrs(trans,n,kl,ku,nrhs,afb,ldafb,ipiv,x,ldx,info)
@@ -43879,7 +43879,7 @@ module stdlib_linalg_lapack_d
            ! Parameters
            real(dp),parameter :: sclfac = 2.0e+0_dp
            real(dp),parameter :: factor = 0.95e+0_dp
-           
+
            ! Local Scalars
            logical(lk) :: noconv
            integer(ilp) :: i,ica,iexc,ira,j,k,l,m
@@ -43913,18 +43913,18 @@ module stdlib_linalg_lapack_d
            ! permutation to isolate eigenvalues if possible
            go to 50
            ! row and column exchange.
-20   continue
+           20 continue
            scale(m) = j
            if (j == m) go to 30
            call stdlib_dswap(l,a(1,j),1,a(1,m),1)
            call stdlib_dswap(n - k + 1,a(j,k),lda,a(m,k),lda)
-30         continue
+           30 continue
            go to(40,80) iexc
            ! search for rows isolating an eigenvalue and push them down.
-40   continue
+           40 continue
            if (l == 1) go to 210
            l = l - 1
-50         continue
+           50 continue
            loop_70: do j = l,1,-1
               loop_60: do i = 1,l
                  if (i == j) cycle loop_60
@@ -43936,9 +43936,9 @@ module stdlib_linalg_lapack_d
            end do loop_70
            go to 90
            ! search for columns isolating an eigenvalue and push them left.
-80   continue
+           80 continue
            k = k + 1
-90         continue
+           90 continue
            loop_110: do j = k,l
               loop_100: do i = k,l
                  if (i == j) cycle loop_100
@@ -43948,7 +43948,7 @@ module stdlib_linalg_lapack_d
               iexc = 2
               go to 20
            end do loop_110
-120        continue
+           120 continue
            do i = k,l
               scale(i) = one
            end do
@@ -43959,7 +43959,7 @@ module stdlib_linalg_lapack_d
            sfmax1 = one/sfmin1
            sfmin2 = sfmin1*sclfac
            sfmax2 = one/sfmin2
-140        continue
+           140 continue
            noconv = .false.
            loop_200: do i = k,l
               c = stdlib_dnrm2(l - k + 1,a(k,i),1)
@@ -43973,7 +43973,7 @@ module stdlib_linalg_lapack_d
               g = r/sclfac
               f = one
               s = c + r
-160           continue
+              160 continue
               if (c >= g .or. max(f,c,ca) >= sfmax2 .or. min(r,g,ra) <= sfmin2) go to 170
                  if (stdlib_disnan(c + f + ca + r + g + ra)) then
                  ! exit if nan to avoid infinite loop
@@ -43988,9 +43988,9 @@ module stdlib_linalg_lapack_d
               g = g/sclfac
               ra = ra/sclfac
               go to 160
-170           continue
+              170 continue
               g = c/sclfac
-180           continue
+              180 continue
               if (g < r .or. max(r,ra) >= sfmax2 .or. min(f,c,g,ca) <= sfmin2) go to 190
               f = f/sclfac
               c = c/sclfac
@@ -44000,7 +44000,7 @@ module stdlib_linalg_lapack_d
               ra = ra*sclfac
               go to 180
               ! now balance.
-190  continue
+              190 continue
               if ((c + r) >= factor*s) cycle loop_200
               if (f < one .and. scale(i) < one) then
                  if (f*scale(i) <= sfmin1) cycle loop_200
@@ -44015,7 +44015,7 @@ module stdlib_linalg_lapack_d
               call stdlib_dscal(l,f,a(1,i),1)
            end do loop_200
            if (noconv) go to 140
-210        continue
+           210 continue
            ilo = k
            ihi = l
            return
@@ -44036,7 +44036,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: d(*),e(*),taup(*),tauq(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            ! Intrinsic Functions
@@ -44060,7 +44060,7 @@ module stdlib_linalg_lapack_d
               do i = 1,n
                  ! generate elementary reflector h(i) to annihilate a(i+1:m,i)
                  call stdlib_dlarfg(m - i + 1,a(i,i),a(min(i + 1,m),i),1,tauq(i))
-                           
+
                  d(i) = a(i,i)
                  a(i,i) = one
                  ! apply h(i) to a(i:m,i+1:n) from the left
@@ -44071,7 +44071,7 @@ module stdlib_linalg_lapack_d
                     ! generate elementary reflector g(i) to annihilate
                     ! a(i,i+2:n)
                     call stdlib_dlarfg(n - i,a(i,i + 1),a(i,min(i + 2,n)),lda,taup(i))
-                              
+
                     e(i) = a(i,i + 1)
                     a(i,i + 1) = one
                     ! apply g(i) to a(i+1:m,i+1:n) from the right
@@ -44087,7 +44087,7 @@ module stdlib_linalg_lapack_d
               do i = 1,m
                  ! generate elementary reflector g(i) to annihilate a(i,i+1:n)
                  call stdlib_dlarfg(n - i + 1,a(i,i),a(i,min(i + 1,n)),lda,taup(i))
-                           
+
                  d(i) = a(i,i)
                  a(i,i) = one
                  ! apply g(i) to a(i+1:m,i:n) from the right
@@ -44098,7 +44098,7 @@ module stdlib_linalg_lapack_d
                     ! generate elementary reflector h(i) to annihilate
                     ! a(i+2:m,i)
                     call stdlib_dlarfg(m - i,a(i + 1,i),a(min(i + 2,m),i),1,tauq(i))
-                              
+
                     e(i) = a(i + 1,i)
                     a(i + 1,i) = one
                     ! apply h(i) to a(i+1:m,i+1:n) from the left
@@ -44127,7 +44127,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(dp) :: aii
@@ -44183,7 +44183,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            real(dp) :: aii
@@ -44303,7 +44303,7 @@ module stdlib_linalg_lapack_d
                     ! apply h to a(i+ib:m,i:n) from the right
                     call stdlib_dlarfb('RIGHT','NO TRANSPOSE','FORWARD','ROWWISE',m - i - ib + 1,n - &
                     i + 1,ib,a(i,i),lda,work,ldwork,a(i + ib,i),lda,work(ib + 1),ldwork)
-                              
+
                  end if
               end do
            else
@@ -44311,7 +44311,7 @@ module stdlib_linalg_lapack_d
            end if
            ! use unblocked code to factor the last or only block.
            if (i <= k) call stdlib_dgelq2(m - i + 1,n - i + 1,a(i,i),lda,tau(i),work,iinfo)
-                     
+
            work(1) = iws
            return
      end subroutine stdlib_dgelqf
@@ -44332,7 +44332,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,i1,j,j1,m1,m2,iinfo
            ! Executable Statements
@@ -44374,7 +44374,7 @@ module stdlib_linalg_lapack_d
               call stdlib_dgemm('N','N',m2,n - m1,m1,-one,t(i1,1),ldt,a(1,i1),lda, &
                         one,a(i1,i1),lda)
               call stdlib_dtrmm('R','U','N','U',m2,m1,one,a,lda,t(i1,1),ldt)
-                        
+
               do i = 1,m2
                  do j = 1,m1
                     a(i + m1,j) = a(i + m1,j) - t(i + m1,j)
@@ -44394,7 +44394,7 @@ module stdlib_linalg_lapack_d
               call stdlib_dgemm('N','T',m1,m2,n - m,one,a(1,j1),lda,a(i1,j1),lda, &
                         one,t(1,i1),ldt)
               call stdlib_dtrmm('L','U','N','N',m1,m2,-one,t,ldt,t(1,i1),ldt)
-                        
+
               call stdlib_dtrmm('R','U','N','N',m1,m2,one,t(i1,i1),ldt,t(1,i1), &
                         ldt)
               ! y = (y1,y2); l = [ l1            0  ];  t = [t1 t3]
@@ -44417,7 +44417,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            real(dp) :: aii
@@ -44446,7 +44446,7 @@ module stdlib_linalg_lapack_d
               aii = a(m - k + i,n - k + i)
               a(m - k + i,n - k + i) = one
               call stdlib_dlarf('LEFT',m - k + i,n - k + i - 1,a(1,n - k + i),1,tau(i),a,lda,work)
-                        
+
               a(m - k + i,n - k + i) = aii
            end do
            return
@@ -44534,7 +44534,7 @@ module stdlib_linalg_lapack_d
                  ! compute the ql factorization of the current block
                  ! a(1:m-k+i+ib-1,n-k+i:n-k+i+ib-1)
                  call stdlib_dgeql2(m - k + i + ib - 1,ib,a(1,n - k + i),lda,tau(i),work,iinfo)
-                           
+
                  if (n - k + i > 1) then
                     ! form the triangular factor of the block reflector
                     ! h = h(i+ib-1) . . . h(i+1) h(i)
@@ -44543,7 +44543,7 @@ module stdlib_linalg_lapack_d
                     ! apply h**t to a(1:m-k+i+ib-1,1:n-k+i-1) from the left
                     call stdlib_dlarfb('LEFT','TRANSPOSE','BACKWARD','COLUMNWISE',m - k + i + ib - 1, &
                     n - k + i - 1,ib,a(1,n - k + i),lda,work,ldwork,a,lda,work(ib + 1),ldwork)
-                              
+
                  end if
               end do
               mu = m - k + i + nb - 1
@@ -44577,7 +44577,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            real(dp) :: aii
@@ -44633,7 +44633,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            real(dp) :: aii
@@ -44766,7 +44766,7 @@ module stdlib_linalg_lapack_d
            end if
            ! use unblocked code to factor the last or only block.
            if (i <= k) call stdlib_dgeqr2(m - i + 1,n - i + 1,a(i,i),lda,tau(i),work,iinfo)
-                     
+
            work(1) = iws
            return
      end subroutine stdlib_dgeqrf
@@ -44865,7 +44865,7 @@ module stdlib_linalg_lapack_d
            end if
            ! use unblocked code to factor the last or only block.
            if (i <= k) call stdlib_dgeqr2p(m - i + 1,n - i + 1,a(i,i),lda,tau(i),work,iinfo)
-                     
+
            work(1) = iws
            return
      end subroutine stdlib_dgeqrfp
@@ -44884,7 +44884,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            real(dp) :: aii,alpha
@@ -44954,7 +44954,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,i1,j,j1,n1,n2,iinfo
            ! Executable Statements
@@ -45014,7 +45014,7 @@ module stdlib_linalg_lapack_d
               call stdlib_dgemm('T','N',n1,n2,m - n,one,a(i1,1),lda,a(i1,j1),lda, &
                         one,t(1,j1),ldt)
               call stdlib_dtrmm('L','U','N','N',n1,n2,-one,t,ldt,t(1,j1),ldt)
-                        
+
               call stdlib_dtrmm('R','U','N','N',n1,n2,one,t(j1,j1),ldt,t(1,j1), &
                         ldt)
               ! y = (y1,y2); r = [ r1  a(1:n1,j1:n) ];  t = [t1 t3]
@@ -45045,7 +45045,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: notran
            character :: transt
@@ -45102,13 +45102,13 @@ module stdlib_linalg_lapack_d
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - op(a) * x,
               ! where op(a) = a, a**t, or a**h, depending on trans.
               call stdlib_dcopy(n,b(1,j),1,work(n + 1),1)
               call stdlib_dgemv(trans,n,n,-one,a,lda,x(1,j),1,one,work(n + 1),1)
-                        
+
               ! compute componentwise relative backward error from formula
               ! max(i) ( abs(r(i)) / ( abs(op(a))*abs(x) + abs(b) )(i) )
               ! where abs(z) is the componentwise absolute value of the matrix
@@ -45182,14 +45182,14 @@ module stdlib_linalg_lapack_d
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_dlacn2(n,work(2*n + 1),work(n + 1),iwork,ferr(j),kase,isave)
-                        
+
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(op(a)**t).
                     call stdlib_dgetrs(transt,n,1,af,ldaf,ipiv,work(n + 1),n,info)
-                              
+
                     do i = 1,n
                        work(n + i) = work(i)*work(n + i)
                     end do
@@ -45226,7 +45226,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            real(dp) :: aii
@@ -45343,7 +45343,7 @@ module stdlib_linalg_lapack_d
                  ! compute the rq factorization of the current block
                  ! a(m-k+i:m-k+i+ib-1,1:n-k+i+ib-1)
                  call stdlib_dgerq2(ib,n - k + i + ib - 1,a(m - k + i,1),lda,tau(i),work,iinfo)
-                           
+
                  if (m - k + i > 1) then
                     ! form the triangular factor of the block reflector
                     ! h = h(i+ib-1) . . . h(i+1) h(i)
@@ -45352,7 +45352,7 @@ module stdlib_linalg_lapack_d
                     ! apply h to a(1:m-k+i-1,1:n-k+i+ib-1) from the right
                     call stdlib_dlarfb('RIGHT','NO TRANSPOSE','BACKWARD','ROWWISE',m - k + i - 1,n - &
                     k + i + ib - 1,ib,a(m - k + i,1),lda,work,ldwork,a,lda,work(ib + 1),ldwork)
-                              
+
                  end if
               end do
               mu = m - k + i + nb - 1
@@ -45387,7 +45387,7 @@ module stdlib_linalg_lapack_d
            integer(ilp),intent(out) :: ipiv(*)
            real(dp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,iinfo,j,jb,nb
            ! Intrinsic Functions
@@ -45437,7 +45437,7 @@ module stdlib_linalg_lapack_d
                        ! update trailing submatrix.
                        call stdlib_dgemm('NO TRANSPOSE','NO TRANSPOSE',m - j - jb + 1,n - j - jb + 1,jb,- &
                        one,a(j + jb,j),lda,a(j,j + jb),lda,one,a(j + jb,j + jb),lda)
-                                 
+
                     end if
                  end if
               end do
@@ -45484,7 +45484,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*),b(ldb,*),q(ldq,*),z(ldz,*)
            real(dp),intent(out) :: work(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: blk22,initq,initz,lquery,wantq,wantz
            character :: compq2,compz2
@@ -45651,7 +45651,7 @@ module stdlib_linalg_lapack_d
                           call stdlib_dlartg(temp,b(jj + 1,jj),c,s,b(jj + 1,jj + 1))
                           b(jj + 1,jj) = zero
                           call stdlib_drot(jj - top,b(top + 1,jj + 1),1,b(top + 1,jj),1,c,s)
-                                    
+
                           a(jj + 1,j) = c
                           b(jj + 1,j) = -s
                        end if
@@ -45711,7 +45711,7 @@ module stdlib_linalg_lapack_d
                                  len*nblst + 1),nblst,work(pw + len),1)
                        call stdlib_dgemv('TRANSPOSE',len,nblst - len,one,work((len + 1)*nblst - &
                        len + 1),nblst,a(jrow + nblst - len,j + 1),1,one,work(pw + len),1)
-                                 
+
                        ppw = pw
                        do i = jrow,jrow + nblst - 1
                           a(i,j + 1) = work(ppw)
@@ -45763,7 +45763,7 @@ module stdlib_linalg_lapack_d
                  call stdlib_dgemm('TRANSPOSE','NO TRANSPOSE',nblst,cola,nblst,one,work, &
                            nblst,a(j,jcol + nnb),lda,zero,work(pw),nblst)
                  call stdlib_dlacpy('ALL',nblst,cola,work(pw),nblst,a(j,jcol + nnb),lda)
-                           
+
                  ppwo = nblst*nblst + 1
                  j0 = j - nnb
                  do j = j0,jcol + 1,-nnb
@@ -45798,7 +45798,7 @@ module stdlib_linalg_lapack_d
                     call stdlib_dgemm('NO TRANSPOSE','NO TRANSPOSE',nh,nblst,nblst,one,q( &
                               topq,j),ldq,work,nblst,zero,work(pw),nh)
                     call stdlib_dlacpy('ALL',nh,nblst,work(pw),nh,q(topq,j),ldq)
-                              
+
                     ppwo = nblst*nblst + 1
                     j0 = j - nnb
                     do j = j0,jcol + 1,-nnb
@@ -45815,7 +45815,7 @@ module stdlib_linalg_lapack_d
                           call stdlib_dgemm('NO TRANSPOSE','NO TRANSPOSE',nh,2*nnb,2*nnb,one, &
                                      q(topq,j),ldq,work(ppwo),2*nnb,zero,work(pw),nh)
                           call stdlib_dlacpy('ALL',nh,2*nnb,work(pw),nh,q(topq,j),ldq)
-                                    
+
                        end if
                        ppwo = ppwo + 4*nnb*nnb
                     end do
@@ -45828,7 +45828,7 @@ module stdlib_linalg_lapack_d
                     pw = nblst*nblst + 1
                     do i = 1,n2nb
                        call stdlib_dlaset('ALL',2*nnb,2*nnb,zero,one,work(pw),2*nnb)
-                                 
+
                        pw = pw + 4*nnb*nnb
                     end do
                     ! accumulate givens rotations into workspace array.
@@ -45882,7 +45882,7 @@ module stdlib_linalg_lapack_d
                     call stdlib_dgemm('NO TRANSPOSE','NO TRANSPOSE',top,nblst,nblst,one,a( &
                               1,j),lda,work,nblst,zero,work(pw),top)
                     call stdlib_dlacpy('ALL',top,nblst,work(pw),top,a(1,j),lda)
-                              
+
                     ppwo = nblst*nblst + 1
                     j0 = j - nnb
                     do j = j0,jcol + 1,-nnb
@@ -45895,7 +45895,7 @@ module stdlib_linalg_lapack_d
                           call stdlib_dgemm('NO TRANSPOSE','NO TRANSPOSE',top,2*nnb,2*nnb, &
                                     one,a(1,j),lda,work(ppwo),2*nnb,zero,work(pw),top)
                           call stdlib_dlacpy('ALL',top,2*nnb,work(pw),top,a(1,j),lda)
-                                    
+
                        end if
                        ppwo = ppwo + 4*nnb*nnb
                     end do
@@ -45903,7 +45903,7 @@ module stdlib_linalg_lapack_d
                     call stdlib_dgemm('NO TRANSPOSE','NO TRANSPOSE',top,nblst,nblst,one,b( &
                               1,j),ldb,work,nblst,zero,work(pw),top)
                     call stdlib_dlacpy('ALL',top,nblst,work(pw),top,b(1,j),ldb)
-                              
+
                     ppwo = nblst*nblst + 1
                     j0 = j - nnb
                     do j = j0,jcol + 1,-nnb
@@ -45916,7 +45916,7 @@ module stdlib_linalg_lapack_d
                           call stdlib_dgemm('NO TRANSPOSE','NO TRANSPOSE',top,2*nnb,2*nnb, &
                                     one,b(1,j),ldb,work(ppwo),2*nnb,zero,work(pw),top)
                           call stdlib_dlacpy('ALL',top,2*nnb,work(pw),top,b(1,j),ldb)
-                                    
+
                        end if
                        ppwo = ppwo + 4*nnb*nnb
                     end do
@@ -45934,7 +45934,7 @@ module stdlib_linalg_lapack_d
                     call stdlib_dgemm('NO TRANSPOSE','NO TRANSPOSE',nh,nblst,nblst,one,z( &
                               topq,j),ldz,work,nblst,zero,work(pw),nh)
                     call stdlib_dlacpy('ALL',nh,nblst,work(pw),nh,z(topq,j),ldz)
-                              
+
                     ppwo = nblst*nblst + 1
                     j0 = j - nnb
                     do j = j0,jcol + 1,-nnb
@@ -45951,7 +45951,7 @@ module stdlib_linalg_lapack_d
                           call stdlib_dgemm('NO TRANSPOSE','NO TRANSPOSE',nh,2*nnb,2*nnb,one, &
                                      z(topq,j),ldz,work(ppwo),2*nnb,zero,work(pw),nh)
                           call stdlib_dlacpy('ALL',nh,2*nnb,work(pw),nh,z(topq,j),ldz)
-                                    
+
                        end if
                        ppwo = ppwo + 4*nnb*nnb
                     end do
@@ -45992,7 +45992,7 @@ module stdlib_linalg_lapack_d
      !> transpose of the matrix Z.
 
      pure subroutine stdlib_dggqrf(n,m,p,a,lda,taua,b,ldb,taub,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -46070,7 +46070,7 @@ module stdlib_linalg_lapack_d
      !> transpose of the matrix Z.
 
      pure subroutine stdlib_dggrqf(m,p,n,a,lda,taua,b,ldb,taub,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -46147,7 +46147,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*),sva(n),d(n),v(ldv,*)
            real(dp),intent(out) :: work(lwork)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(dp) :: aapp,aapp0,aapq,aaqq,apoaq,aqoap,big,bigtheta,cs,mxaapq,mxsinj, &
                      rootbig,rooteps,rootsfmin,roottol,small,sn,t,temp1,theta,thsign
@@ -46324,23 +46324,23 @@ module stdlib_linalg_lapack_d
                                          fastr(3) = t*d(p)/d(q)
                                          fastr(4) = -t*d(q)/d(p)
                                          call stdlib_drotm(m,a(1,p),1,a(1,q),1,fastr)
-                                                   
+
                                          if (rsvec) call stdlib_drotm(mvl,v(1,p),1,v(1,q), &
                                                     1,fastr)
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq))
                                          mxsinj = max(mxsinj,abs(t))
                                       else
                        ! Choose Correct Signum For Theta And Rotate
                                          thsign = -sign(one,aapq)
                                          t = one/(theta + thsign*sqrt(one + theta*theta))
-                                                   
+
                                          cs = sqrt(one/(one + t*t))
                                          sn = t*cs
                                          mxsinj = max(mxsinj,abs(sn))
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq))
                                          apoaq = d(p)/d(q)
                                          aqoap = d(q)/d(p)
@@ -46468,7 +46468,7 @@ module stdlib_linalg_lapack_d
                              end if
                           end do loop_2002
            ! end q-loop
-2103 continue
+           2103 continue
            ! bailed out of q-loop
                           sva(p) = aapp
                        else
@@ -46548,11 +46548,11 @@ module stdlib_linalg_lapack_d
                                          fastr(3) = t*d(p)/d(q)
                                          fastr(4) = -t*d(q)/d(p)
                                          call stdlib_drotm(m,a(1,p),1,a(1,q),1,fastr)
-                                                   
+
                                          if (rsvec) call stdlib_drotm(mvl,v(1,p),1,v(1,q), &
                                                     1,fastr)
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq))
                                          mxsinj = max(mxsinj,abs(t))
                                       else
@@ -46560,12 +46560,12 @@ module stdlib_linalg_lapack_d
                                          thsign = -sign(one,aapq)
                                          if (aaqq > aapp0) thsign = -thsign
                                          t = one/(theta + thsign*sqrt(one + theta*theta))
-                                                   
+
                                          cs = sqrt(one/(one + t*t))
                                          sn = t*cs
                                          mxsinj = max(mxsinj,abs(sn))
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq))
                                          apoaq = d(p)/d(q)
                                          aqoap = d(q)/d(p)
@@ -46647,7 +46647,7 @@ module stdlib_linalg_lapack_d
                                                     lda,ierr)
                                          temp1 = -aapq*d(p)/d(q)
                                          call stdlib_daxpy(m,temp1,work,1,a(1,q),1)
-                                                   
+
                                          call stdlib_dlascl('G',0,0,one,aaqq,m,1,a(1,q), &
                                                     lda,ierr)
                                          sva(q) = aaqq*sqrt(max(zero,one - aapq*aapq))
@@ -46660,7 +46660,7 @@ module stdlib_linalg_lapack_d
                                                     lda,ierr)
                                          temp1 = -aapq*d(q)/d(p)
                                          call stdlib_daxpy(m,temp1,work,1,a(1,p),1)
-                                                   
+
                                          call stdlib_dlascl('G',0,0,one,aapp,m,1,a(1,p), &
                                                     lda,ierr)
                                          sva(p) = aapp*sqrt(max(zero,one - aapq*aapq))
@@ -46714,7 +46714,7 @@ module stdlib_linalg_lapack_d
                              end if
                           end do loop_2200
               ! end of the q-loop
-2203 continue
+              2203 continue
                           sva(p) = aapp
                        else
                           if (aapp == zero) notrot = notrot + min(jgl + kbl - 1,n) - jgl + 1
@@ -46724,7 +46724,7 @@ module stdlib_linalg_lapack_d
            ! end of the p-loop
                  end do loop_2010
            ! end of the jbc-loop
-2011 continue
+           2011 continue
       ! 2011 bailed out of the jbc-loop
                  do p = igl,min(igl + kbl - 1,n)
                     sva(p) = abs(sva(p))
@@ -46753,12 +46753,12 @@ module stdlib_linalg_lapack_d
            ! number of iterations.
            info = nsweep - 1
            go to 1995
-1994       continue
+           1994 continue
        ! #:) reaching this point means that during the i-th sweep all pivots were
            ! below the given tolerance, causing early exit.
            info = 0
        ! #:) info = 0 confirms successful iterations.
-1995 continue
+       1995 continue
            ! sort the vector d.
            do p = 1,n - 1
               q = stdlib_idamax(n - p + 1,sva(p),1) + p - 1
@@ -46815,7 +46815,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*),d(n),sva(n),v(ldv,*)
            real(dp),intent(out) :: work(lwork)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(dp) :: aapp,aapp0,aapq,aaqq,apoaq,aqoap,big,bigtheta,cs,large,mxaapq, &
            mxsinj,rootbig,rooteps,rootsfmin,roottol,small,sn,t,temp1,theta, &
@@ -46975,11 +46975,11 @@ module stdlib_linalg_lapack_d
                                          fastr(3) = t*d(p)/d(q)
                                          fastr(4) = -t*d(q)/d(p)
                                          call stdlib_drotm(m,a(1,p),1,a(1,q),1,fastr)
-                                                   
+
                                          if (rsvec) call stdlib_drotm(mvl,v(1,p),1,v(1,q), &
                                                     1,fastr)
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq))
                                          mxsinj = max(mxsinj,abs(t))
                                       else
@@ -46987,12 +46987,12 @@ module stdlib_linalg_lapack_d
                                          thsign = -sign(one,aapq)
                                          if (aaqq > aapp0) thsign = -thsign
                                          t = one/(theta + thsign*sqrt(one + theta*theta))
-                                                   
+
                                          cs = sqrt(one/(one + t*t))
                                          sn = t*cs
                                          mxsinj = max(mxsinj,abs(sn))
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq))
                                          apoaq = d(p)/d(q)
                                          aqoap = d(q)/d(p)
@@ -47074,7 +47074,7 @@ module stdlib_linalg_lapack_d
                                                     lda,ierr)
                                          temp1 = -aapq*d(p)/d(q)
                                          call stdlib_daxpy(m,temp1,work,1,a(1,q),1)
-                                                   
+
                                          call stdlib_dlascl('G',0,0,one,aaqq,m,1,a(1,q), &
                                                     lda,ierr)
                                          sva(q) = aaqq*sqrt(max(zero,one - aapq*aapq))
@@ -47087,7 +47087,7 @@ module stdlib_linalg_lapack_d
                                                     lda,ierr)
                                          temp1 = -aapq*d(q)/d(p)
                                          call stdlib_daxpy(m,temp1,work,1,a(1,p),1)
-                                                   
+
                                          call stdlib_dlascl('G',0,0,one,aapp,m,1,a(1,p), &
                                                     lda,ierr)
                                          sva(p) = aapp*sqrt(max(zero,one - aapq*aapq))
@@ -47143,7 +47143,7 @@ module stdlib_linalg_lapack_d
                              end if
                           end do loop_2200
               ! end of the q-loop
-2203 continue
+              2203 continue
                           sva(p) = aapp
                        else
                           if (aapp == zero) notrot = notrot + min(jgl + kbl - 1,n) - jgl + 1
@@ -47154,7 +47154,7 @@ module stdlib_linalg_lapack_d
            ! end of the p-loop
                  end do loop_2010
            ! end of the jbc-loop
-2011 continue
+           2011 continue
       ! 2011 bailed out of the jbc-loop
                  do p = igl,min(igl + kbl - 1,n)
                     sva(p) = abs(sva(p))
@@ -47184,12 +47184,12 @@ module stdlib_linalg_lapack_d
            ! number of sweeps.
            info = nsweep - 1
            go to 1995
-1994       continue
+           1994 continue
        ! #:) reaching this point means that during the i-th sweep all pivots were
            ! below the given threshold, causing early exit.
            info = 0
        ! #:) info = 0 confirms successful iterations.
-1995 continue
+       1995 continue
            ! sort the vector d
            do p = 1,n - 1
               q = stdlib_idamax(n - p + 1,sva(p),1) + p - 1
@@ -47230,7 +47230,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: d(*),dl(*),du(*),du2(*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: onenrm
            integer(ilp) :: i,kase,kase1
@@ -47271,17 +47271,17 @@ module stdlib_linalg_lapack_d
               kase1 = 2
            end if
            kase = 0
-20         continue
+           20 continue
            call stdlib_dlacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == kase1) then
                  ! multiply by inv(u)*inv(l).
                  call stdlib_dgttrs('NO TRANSPOSE',n,1,dl,d,du,du2,ipiv,work,n,info)
-                           
+
               else
                  ! multiply by inv(l**t)*inv(u**t).
                  call stdlib_dgttrs('TRANSPOSE',n,1,dl,d,du,du2,ipiv,work,n,info)
-                           
+
               end if
               go to 20
            end if
@@ -47307,13 +47307,13 @@ module stdlib_linalg_lapack_d
            integer(ilp),intent(in) :: ipiv(*)
            integer(ilp),intent(out) :: iwork(*)
            real(dp),intent(in) :: b(ldb,*),d(*),df(*),dl(*),dlf(*),du(*),du2(*),duf(*)
-                     
+
            real(dp),intent(out) :: berr(*),ferr(*),work(*)
            real(dp),intent(inout) :: x(ldx,*)
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: notran
            character :: transn,transt
@@ -47368,7 +47368,7 @@ module stdlib_linalg_lapack_d
            loop_110: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - op(a) * x,
               ! where op(a) = a, a**t, or a**h, depending on trans.
@@ -47427,7 +47427,7 @@ module stdlib_linalg_lapack_d
               if (berr(j) > eps .and. two*berr(j) <= lstres .and. count <= itmax) then
                  ! update solution and try again.
                  call stdlib_dgttrs(trans,n,1,dlf,df,duf,du2,ipiv,work(n + 1),n,info)
-                           
+
                  call stdlib_daxpy(n,one,work(n + 1),1,x(1,j),1)
                  lstres = berr(j)
                  count = count + 1
@@ -47458,9 +47458,9 @@ module stdlib_linalg_lapack_d
                  end if
               end do
               kase = 0
-70            continue
+              70 continue
               call stdlib_dlacn2(n,work(2*n + 1),work(n + 1),iwork,ferr(j),kase,isave)
-                        
+
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(op(a)**t).
@@ -47513,7 +47513,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(out) :: berr(*),ferr(*),work(*),x(ldx,*)
            real(dp),intent(inout) :: df(*),dlf(*),du2(*),duf(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nofact,notran
            character :: norm
@@ -47565,7 +47565,7 @@ module stdlib_linalg_lapack_d
            anorm = stdlib_dlangt(norm,n,dl,d,du)
            ! compute the reciprocal of the condition number of a.
            call stdlib_dgtcon(norm,n,dlf,df,duf,du2,ipiv,anorm,rcond,work,iwork,info)
-                     
+
            ! compute the solution vectors x.
            call stdlib_dlacpy('FULL',n,nrhs,b,ldb,x,ldx)
            call stdlib_dgttrs(trans,n,nrhs,dlf,df,duf,du2,ipiv,x,ldx,info)
@@ -47638,7 +47638,7 @@ module stdlib_linalg_lapack_d
            ! Parameters
            real(dp),parameter :: safety = 1.0e+2_dp
           ! $                     safety = one )
-           
+
            ! Local Scalars
            logical(lk) :: ilazr2,ilazro,ilpivt,ilq,ilschr,ilz,lquery
            integer(ilp) :: icompq,icompz,ifirst,ifrstm,iiter,ilast,ilastm,in,ischur, &
@@ -47853,7 +47853,7 @@ module stdlib_linalg_lapack_d
                           call stdlib_drot(ilastm - jch,t(jch,jch + 1),ldt,t(jch + 1,jch + 1), &
                                     ldt,c,s)
                           if (ilq) call stdlib_drot(n,q(1,jch),1,q(1,jch + 1),1,c,s)
-                                    
+
                           if (ilazr2) h(jch,jch - 1) = h(jch,jch - 1)*c
                           ilazr2 = .false.
                           if (abs(t(jch + 1,jch + 1)) >= btol) then
@@ -47873,24 +47873,24 @@ module stdlib_linalg_lapack_d
                        do jch = j,ilast - 1
                           temp = t(jch,jch + 1)
                           call stdlib_dlartg(temp,t(jch + 1,jch + 1),c,s,t(jch,jch + 1))
-                                    
+
                           t(jch + 1,jch + 1) = zero
                           if (jch < ilastm - 1) call stdlib_drot(ilastm - jch - 1,t(jch,jch + 2),ldt, &
                                     t(jch + 1,jch + 2),ldt,c,s)
                           call stdlib_drot(ilastm - jch + 2,h(jch,jch - 1),ldh,h(jch + 1,jch - 1), &
                                     ldh,c,s)
                           if (ilq) call stdlib_drot(n,q(1,jch),1,q(1,jch + 1),1,c,s)
-                                    
+
                           temp = h(jch + 1,jch)
                           call stdlib_dlartg(temp,h(jch + 1,jch - 1),c,s,h(jch + 1,jch))
-                                    
+
                           h(jch + 1,jch - 1) = zero
                           call stdlib_drot(jch + 1 - ifrstm,h(ifrstm,jch),1,h(ifrstm,jch - 1), &
                                     1,c,s)
                           call stdlib_drot(jch - ifrstm,t(ifrstm,jch),1,t(ifrstm,jch - 1),1, &
                                      c,s)
                           if (ilz) call stdlib_drot(n,z(1,jch),1,z(1,jch - 1),1,c,s)
-                                    
+
                        end do
                        go to 70
                     end if
@@ -47906,7 +47906,7 @@ module stdlib_linalg_lapack_d
               go to 420
               ! t(ilast,ilast)=0 -- clear h(ilast,ilast-1) to split off a
               ! 1x1 block.
-70   continue
+              70 continue
               temp = h(ilast,ilast)
               call stdlib_dlartg(temp,h(ilast,ilast - 1),c,s,h(ilast,ilast))
               h(ilast,ilast - 1) = zero
@@ -47917,7 +47917,7 @@ module stdlib_linalg_lapack_d
               if (ilz) call stdlib_drot(n,z(1,ilast),1,z(1,ilast - 1),1,c,s)
               ! h(ilast,ilast-1)=0 -- standardize b, set alphar, alphai,
                                     ! and beta
-80   continue
+                                    80 continue
               if (t(ilast,ilast) < zero) then
                  if (ilschr) then
                     do j = ifrstm,ilast
@@ -47951,7 +47951,7 @@ module stdlib_linalg_lapack_d
               ! qz step
               ! this iteration only involves rows/columns ifirst:ilast. we
               ! assume ifirst < ilast, and that the diagonal of b is non-zero.
-110  continue
+              110 continue
               iiter = iiter + 1
               if (.not. ilschr) then
                  ifrstm = ifirst
@@ -48013,7 +48013,7 @@ module stdlib_linalg_lapack_d
                  if (abs((ascale*h(j + 1,j))*temp) <= (ascale*atol)*temp2) go to 130
               end do
               istart = ifirst
-130           continue
+              130 continue
               ! do an implicit single-shift qz sweep.
               ! initial q
               temp = s1*h(istart,istart) - wr*t(istart,istart)
@@ -48068,7 +48068,7 @@ module stdlib_linalg_lapack_d
                     ! but only if the block is at least 3x3.
                     ! this code may break if this point is reached with
                     ! a 2x2 block with real eigenvalues.
-200  continue
+                    200 continue
               if (ifirst + 1 == ilast) then
                  ! special case -- 2x2 block with complex eigenvectors
                  ! step 1: standardize, that is, rotate so that
@@ -48092,9 +48092,9 @@ module stdlib_linalg_lapack_d
                  if (ifrstm < ilast - 1) call stdlib_drot(ifirst - ifrstm,t(ifrstm,ilast - 1),1,t( &
                            ifrstm,ilast),1,cr,sr)
                  if (ilq) call stdlib_drot(n,q(1,ilast - 1),1,q(1,ilast),1,cl,sl)
-                           
+
                  if (ilz) call stdlib_drot(n,z(1,ilast - 1),1,z(1,ilast),1,cr,sr)
-                           
+
                  t(ilast - 1,ilast - 1) = b11
                  t(ilast - 1,ilast) = zero
                  t(ilast,ilast - 1) = zero
@@ -48233,11 +48233,11 @@ module stdlib_linalg_lapack_d
                  ad11l = (ascale*h(ifirst,ifirst))/(bscale*t(ifirst,ifirst))
                  ad21l = (ascale*h(ifirst + 1,ifirst))/(bscale*t(ifirst,ifirst))
                  ad12l = (ascale*h(ifirst,ifirst + 1))/(bscale*t(ifirst + 1,ifirst + 1))
-                           
+
                  ad22l = (ascale*h(ifirst + 1,ifirst + 1))/(bscale*t(ifirst + 1,ifirst + 1))
-                           
+
                  ad32l = (ascale*h(ifirst + 2,ifirst + 1))/(bscale*t(ifirst + 1,ifirst + 1))
-                           
+
                  u12l = t(ifirst,ifirst + 1)/t(ifirst + 1,ifirst + 1)
                  v(1) = (ad11 - ad11l)*(ad22 - ad11l) - ad12*ad21 + ad21*u12*ad11l + (ad12l - &
                            ad11l*u12l)*ad21l
@@ -48273,7 +48273,7 @@ module stdlib_linalg_lapack_d
                     if (ilq) then
                        do jr = 1,n
                           temp = tau*(q(jr,j) + v(2)*q(jr,j + 1) + v(3)*q(jr,j + 2))
-                                    
+
                           q(jr,j) = q(jr,j) - temp
                           q(jr,j + 1) = q(jr,j + 1) - temp*v(2)
                           q(jr,j + 2) = q(jr,j + 2) - temp*v(3)
@@ -48332,7 +48332,7 @@ module stdlib_linalg_lapack_d
                     ! solve
                     u2 = (scale*u2)/w22
                     u1 = (scale*u1 - w12*u2)/w11
-250                 continue
+                    250 continue
                     if (ilpivt) then
                        temp = u2
                        u2 = u1
@@ -48361,7 +48361,7 @@ module stdlib_linalg_lapack_d
                     if (ilz) then
                        do jr = 1,n
                           temp = tau*(z(jr,j) + v(2)*z(jr,j + 1) + v(3)*z(jr,j + 2))
-                                    
+
                           z(jr,j) = z(jr,j) - temp
                           z(jr,j + 1) = z(jr,j + 1) - temp*v(2)
                           z(jr,j + 2) = z(jr,j + 2) - temp*v(3)
@@ -48416,13 +48416,13 @@ module stdlib_linalg_lapack_d
               end if
               go to 350
               ! end of iteration loop
-350  continue
+              350 continue
            end do loop_360
            ! drop-through = non-convergence
            info = ilast
            go to 420
            ! successful completion of all qz steps
-380  continue
+           380 continue
            ! set eigenvalues 1:ilo-1
            do j = 1,ilo - 1
               if (t(j,j) < zero) then
@@ -48448,7 +48448,7 @@ module stdlib_linalg_lapack_d
            ! normal termination
            info = 0
            ! exit (other than argument error) -- return optimal workspace size
-420  continue
+           420 continue
            work(1) = real(n,KIND=dp)
            return
      end subroutine stdlib_dhgeqz
@@ -48471,7 +48471,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: d(*),e(*),taup(*),tauq(*),x(ldx,*),y(ldy,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            ! Intrinsic Functions
@@ -48489,7 +48489,7 @@ module stdlib_linalg_lapack_d
                             one,a(i,i),1)
                  ! generate reflection q(i) to annihilate a(i+1:m,i)
                  call stdlib_dlarfg(m - i + 1,a(i,i),a(min(i + 1,m),i),1,tauq(i))
-                           
+
                  d(i) = a(i,i)
                  if (i < n) then
                     a(i,i) = one
@@ -48512,7 +48512,7 @@ module stdlib_linalg_lapack_d
                               ldx,one,a(i,i + 1),lda)
                     ! generate reflection p(i) to annihilate a(i,i+2:n)
                     call stdlib_dlarfg(n - i,a(i,i + 1),a(i,min(i + 2,n)),lda,taup(i))
-                              
+
                     e(i) = a(i,i + 1)
                     a(i,i + 1) = one
                     ! compute x(i+1:m,i)
@@ -48539,7 +48539,7 @@ module stdlib_linalg_lapack_d
                            one,a(i,i),lda)
                  ! generate reflection p(i) to annihilate a(i,i+1:n)
                  call stdlib_dlarfg(n - i + 1,a(i,i),a(i,min(i + 1,n)),lda,taup(i))
-                           
+
                  d(i) = a(i,i)
                  if (i < m) then
                     a(i,i) = one
@@ -48562,7 +48562,7 @@ module stdlib_linalg_lapack_d
                               1,one,a(i + 1,i),1)
                     ! generate reflection q(i) to annihilate a(i+2:m,i)
                     call stdlib_dlarfg(m - i,a(i + 1,i),a(min(i + 2,m),i),1,tauq(i))
-                              
+
                     e(i) = a(i + 1,i)
                     a(i + 1,i) = one
                     ! compute y(i+1:n,i)
@@ -48601,7 +48601,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: bs = 2.0_dp
-           
+
            ! Local Scalars
            real(dp) :: aa,bb,cc,dd,ab,cd,s,ov,un,be,eps
            ! Intrinsic Functions
@@ -48675,7 +48675,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: maxit = 30
-           
+
            ! Local Scalars
            logical(lk) :: orgati,swtch,swtch3
            integer(ilp) :: ii,iim1,iip1,ip1,iter,j,niter
@@ -48772,7 +48772,7 @@ module stdlib_linalg_lapack_d
               phi = z(n)*temp
               dphi = temp*temp
               erretm = eight*(-phi - psi) + erretm - phi + rhoinv + abs(tau)*(dpsi + dphi)
-                        
+
               w = rhoinv + phi + psi
               ! test for convergence
               if (abs(w) <= eps*erretm) then
@@ -48833,7 +48833,7 @@ module stdlib_linalg_lapack_d
               phi = z(n)*temp
               dphi = temp*temp
               erretm = eight*(-phi - psi) + erretm - phi + rhoinv + abs(tau)*(dpsi + dphi)
-                        
+
               w = rhoinv + phi + psi
               ! main loop to update the values of the array   delta
               iter = niter + 1
@@ -48891,7 +48891,7 @@ module stdlib_linalg_lapack_d
                  phi = z(n)*temp
                  dphi = temp*temp
                  erretm = eight*(-phi - psi) + erretm - phi + rhoinv + abs(tau)*(dpsi + dphi)
-                           
+
                  w = rhoinv + phi + psi
               end do loop_90
               ! return with info = 1, niter = maxit and not converged
@@ -49152,7 +49152,7 @@ module stdlib_linalg_lapack_d
                           if (.not. swtch) then
                              if (orgati) then
                                 a = z(i)*z(i) + delta(ip1)*delta(ip1)*(dpsi + dphi)
-                                          
+
                              else
                                 a = z(ip1)*z(ip1) + delta(i)*delta(i)*(dpsi + dphi)
                              end if
@@ -49249,7 +49249,7 @@ module stdlib_linalg_lapack_d
                  dlam = d(ip1) + tau
               end if
            end if
-250        continue
+           250 continue
            return
      end subroutine stdlib_dlaed4
 
@@ -49277,7 +49277,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: mone = -1.0_dp
-           
+
            ! Local Scalars
            integer(ilp) :: i,imax,j,jlam,jmax,jp,k2,n1,n1p1,n2
            real(dp) :: c,eps,s,t,tau,tol
@@ -49379,7 +49379,7 @@ module stdlib_linalg_lapack_d
                  go to 80
               end if
            end do
-80         continue
+           80 continue
            j = j + 1
            if (j > n) go to 100
            if (rho*abs(z(j)) <= tol) then
@@ -49415,7 +49415,7 @@ module stdlib_linalg_lapack_d
                  d(jlam) = t
                  k2 = k2 - 1
                  i = 1
-90               continue
+                 90 continue
                  if (k2 + i <= n) then
                     if (d(jlam) < d(indxp(k2 + i))) then
                        indxp(k2 + i - 1) = indxp(k2 + i)
@@ -49438,13 +49438,13 @@ module stdlib_linalg_lapack_d
               end if
            end if
            go to 80
-100        continue
+           100 continue
            ! record the last eigenvalue.
            k = k + 1
            w(k) = z(jlam)
            dlamda(k) = d(jlam)
            indxp(k) = jlam
-110        continue
+           110 continue
            ! sort the eigenvalues and corresponding eigenvectors into dlamda
            ! and q2 respectively.  the eigenvalues/vectors which were not
            ! deflated go into the first k slots of dlamda and q2 respectively,
@@ -49482,7 +49482,7 @@ module stdlib_linalg_lapack_d
      !> eigenvectors for use in calculating the next level of Z vectors.
 
      pure subroutine stdlib_dlaed9(k,kstart,kstop,n,d,q,ldq,rho,dlamda,w,s,lds,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -49578,7 +49578,7 @@ module stdlib_linalg_lapack_d
                  s(i,j) = q(i,j)/temp
               end do
            end do
-120        continue
+           120 continue
            return
      end subroutine stdlib_dlaed9
 
@@ -49603,7 +49603,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: tenth = 1.0e-1_dp
-           
+
            ! Local Scalars
            character :: normin,trans
            integer(ilp) :: i,i1,i2,i3,ierr,its,j
@@ -49714,7 +49714,7 @@ module stdlib_linalg_lapack_d
               end do
               ! failure to find eigenvector in n iterations.
               info = 1
-120           continue
+              120 continue
               ! normalize eigenvector.
               i = stdlib_idamax(n,vr,1)
               call stdlib_dscal(n,one/abs(vr(i)),vr,1)
@@ -49729,7 +49729,7 @@ module stdlib_linalg_lapack_d
               else
                  ! scale supplied initial vector.
                  norm = stdlib_dlapy2(stdlib_dnrm2(n,vr,1),stdlib_dnrm2(n,vi,1))
-                           
+
                  rec = (eps3*rootn)/max(norm,nrmsml)
                  call stdlib_dscal(n,rec,vr,1)
                  call stdlib_dscal(n,rec,vi,1)
@@ -49886,7 +49886,7 @@ module stdlib_linalg_lapack_d
                        end if
                        ! divide by diagonal element of b.
                        call stdlib_dladiv(xr,xi,b(i,i),b(i + 1,i),vr(i),vi(i))
-                                 
+
                        vmax = max(abs(vr(i)) + abs(vi(i)),vmax)
                        vcrit = bignum/vmax
                     else
@@ -49916,7 +49916,7 @@ module stdlib_linalg_lapack_d
               end do loop_270
               ! failure to find eigenvector in n iterations
               info = 1
-280           continue
+              280 continue
               ! normalize eigenvector.
               vnorm = zero
               do i = 1,n
@@ -49947,7 +49947,7 @@ module stdlib_linalg_lapack_d
      !> where b11 >= b22 > 0.
 
      pure subroutine stdlib_dlagv2(a,lda,b,ldb,alphar,alphai,beta,csl,snl,csr,snr)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -49958,7 +49958,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*),b(ldb,*)
            real(dp),intent(out) :: alphai(2),alphar(2),beta(2)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(dp) :: anorm,ascale,bnorm,bscale,h1,h2,h3,qq,r,rr,safmin,scale1, &
                      scale2,t,ulp,wi,wr1,wr2
@@ -50036,9 +50036,9 @@ module stdlib_linalg_lapack_d
                  call stdlib_drot(2,b(1,1),1,b(1,2),1,csr,snr)
                  ! compute inf norms of a and b
                  h1 = max(abs(a(1,1)) + abs(a(1,2)),abs(a(2,1)) + abs(a(2,2)))
-                           
+
                  h2 = max(abs(b(1,1)) + abs(b(1,2)),abs(b(2,1)) + abs(b(2,2)))
-                           
+
                  if ((scale1*h1) >= abs(wr1)*h2) then
                     ! find left rotation matrix q to zero out b(2,1)
                     call stdlib_dlartg(b(1,1),b(2,1),csl,snl,r)
@@ -50054,7 +50054,7 @@ module stdlib_linalg_lapack_d
                  ! a pair of complex conjugate eigenvalues
                  ! first compute the svd of the matrix b
                  call stdlib_dlasv2(b(1,1),b(1,2),b(2,2),r,t,snr,csr,snl,csl)
-                           
+
                  ! form (a,b) := q(a,b)z**t where q is left rotation matrix and
                  ! z is right rotation matrix computed from stdlib_dlasv2
                  call stdlib_drot(2,a(1,1),lda,a(2,1),lda,csl,snl)
@@ -50109,7 +50109,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: t(ldt,nb),tau(nb),y(ldy,nb)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(dp) :: ei
@@ -50138,7 +50138,7 @@ module stdlib_linalg_lapack_d
                            1,one,t(1,nb),1)
                  ! w := t**t * w
                  call stdlib_dtrmv('UPPER','TRANSPOSE','NON-UNIT',i - 1,t,ldt,t(1,nb),1)
-                           
+
                  ! b2 := b2 - v2*w
                  call stdlib_dgemv('NO TRANSPOSE',n - k - i + 1,i - 1,-one,a(k + i,1),lda,t(1,nb) &
                            ,1,one,a(k + i,i),1)
@@ -50151,7 +50151,7 @@ module stdlib_linalg_lapack_d
               ! generate the elementary reflector h(i) to annihilate
               ! a(k+i+1:n,i)
               call stdlib_dlarfg(n - k - i + 1,a(k + i,i),a(min(k + i + 1,n),i),1,tau(i))
-                        
+
               ei = a(k + i,i)
               a(k + i,i) = one
               ! compute  y(k+1:n,i)
@@ -50165,7 +50165,7 @@ module stdlib_linalg_lapack_d
               ! compute t(1:i,i)
               call stdlib_dscal(i - 1,-tau(i),t(1,i),1)
               call stdlib_dtrmv('UPPER','NO TRANSPOSE','NON-UNIT',i - 1,t,ldt,t(1,i),1)
-                        
+
               t(i,i) = tau(i)
            end do loop_10
            a(k + nb,nb) = ei
@@ -50221,7 +50221,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: a(lda,*),b(ldb,*)
            real(dp),intent(out) :: x(ldx,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: icmax,j
            real(dp) :: bbnd,bi1,bi2,bignum,bnorm,br1,br2,ci21,ci22,cmax,cnorm,cr21, &
@@ -50542,7 +50542,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: difl(*),difr(ldgnum,*),givnum(ldgnum,*),poles(ldgnum,*),z( &
                      *)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,m,n,nlp1
            real(dp) :: diflj,difrj,dj,dsigj,dsigjp,temp
@@ -50633,9 +50633,9 @@ module stdlib_linalg_lapack_d
                     work(1) = negone
                     temp = stdlib_dnrm2(k,work,1)
                     call stdlib_dgemv('T',k,nrhs,one,bx,ldbx,work,1,zero,b(j,1),ldb)
-                              
+
                     call stdlib_dlascl('G',0,0,temp,one,1,nrhs,b(j,1),ldb,info)
-                              
+
                  end do loop_50
               end if
               ! move the deflated rows of bx to b also.
@@ -50654,7 +50654,7 @@ module stdlib_linalg_lapack_d
                        work(j) = zero
                     else
                        work(j) = -z(j)/difl(j)/(dsigj + poles(j,1))/difr(j,2)
-                                 
+
                     end if
                     do i = 1,j - 1
                        if (z(j) == zero) then
@@ -50673,7 +50673,7 @@ module stdlib_linalg_lapack_d
                        end if
                     end do
                     call stdlib_dgemv('T',k,nrhs,one,b,ldb,work,1,zero,bx(j,1),ldbx)
-                              
+
                  end do
               end if
               ! step (2r): if sqre = 1, apply back the rotation that is
@@ -50775,7 +50775,7 @@ module stdlib_linalg_lapack_d
            end if
            if ((nb <= k) .or. (nb >= max(m,n,k))) then
              call stdlib_dgemlqt(side,trans,m,n,k,mb,a,lda,t,ldt,c,ldc,work,info)
-                       
+
              return
            end if
            if (left .and. tran) then
@@ -50937,7 +50937,7 @@ module stdlib_linalg_lapack_d
            end if
            if ((mb <= k) .or. (mb >= max(m,n,k))) then
              call stdlib_dgemqrt(side,trans,m,n,k,nb,a,lda,t,ldt,c,ldc,work,info)
-                       
+
              return
             end if
            if (left .and. notran) then
@@ -51040,7 +51040,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: multpl = 4.0e+0_dp
-           
+
            ! Local Scalars
            real(dp) :: aa,bb,bcmax,bcmis,cc,cs1,dd,eps,p,sab,sac,scale,sigma,sn1, &
                      tau,temp,z,safmin,safmn2,safmx2
@@ -51093,7 +51093,7 @@ module stdlib_linalg_lapack_d
                  ! make diagonal elements equal.
                  count = 0
                  sigma = b + c
-10               continue
+                 10 continue
                  count = count + 1
                  scale = max(abs(temp),abs(sigma))
                  if (scale >= safmx2) then
@@ -51183,7 +51183,7 @@ module stdlib_linalg_lapack_d
            ! Array Arguments
            real(dp),intent(inout) :: x(*),y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(dp) :: a11,a12,a22,c,ssmax,tau
            ! Executable Statements
@@ -51221,7 +51221,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*),vn1(*),vn2(*)
            real(dp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,itemp,j,mn,offpi,pvt
            real(dp) :: aii,temp,temp2,tol3z
@@ -51246,7 +51246,7 @@ module stdlib_linalg_lapack_d
               ! generate elementary reflector h(i).
               if (offpi < m) then
                  call stdlib_dlarfg(m - offpi + 1,a(offpi,i),a(offpi + 1,i),1,tau(i))
-                           
+
               else
                  call stdlib_dlarfg(1,a(m,i),a(m,i),1,tau(i))
               end if
@@ -51305,7 +51305,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*),auxv(*),f(ldf,*),vn1(*),vn2(*)
            real(dp),intent(out) :: tau(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: itemp,j,k,lastrk,lsticc,pvt,rk
            real(dp) :: akk,temp,temp2,tol3z
@@ -51317,7 +51317,7 @@ module stdlib_linalg_lapack_d
            k = 0
            tol3z = sqrt(stdlib_dlamch('EPSILON'))
            ! beginning of while loop.
-10   continue
+           10 continue
            if ((k < nb) .and. (lsticc == 0)) then
               k = k + 1
               rk = offset + k
@@ -51403,7 +51403,7 @@ module stdlib_linalg_lapack_d
                         lda,f(kb + 1,1),ldf,one,a(rk + 1,kb + 1),lda)
            end if
            ! recomputation of difficult columns.
-40   continue
+           40 continue
            if (lsticc > 0) then
               itemp = nint(vn2(lsticc),KIND=ilp)
               vn1(lsticc) = stdlib_dnrm2(m - rk,a(rk + 1,lsticc),1)
@@ -51433,7 +51433,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: h(ldh,*),si(*),sr(*),z(ldz,*)
            real(dp),intent(out) :: u(ldu,*),v(ldv,*),wh(ldwh,*),wv(ldwv,*)
         ! ================================================================
-           
+
            ! Local Scalars
            real(dp) :: alpha,beta,h11,h12,h21,h22,refsum,safmax,safmin,scl,smlnum,swap, &
                       tst1,tst2,ulp
@@ -51582,9 +51582,9 @@ module stdlib_linalg_lapack_d
                              h12 = max(abs(h(k + 1,k)),abs(h(k,k + 1)))
                              h21 = min(abs(h(k + 1,k)),abs(h(k,k + 1)))
                              h11 = max(abs(h(k + 1,k + 1)),abs(h(k,k) - h(k + 1,k + 1)))
-                                       
+
                              h22 = min(abs(h(k + 1,k + 1)),abs(h(k,k) - h(k + 1,k + 1)))
-                                       
+
                              scl = h11 + h12
                              tst2 = h22*(h11/scl)
                              if (tst2 == zero .or. h21*(h12/scl) <= max(smlnum,ulp*tst2)) &
@@ -51800,7 +51800,7 @@ module stdlib_linalg_lapack_d
                     call stdlib_dgemm('C','N',nu,jlen,nu,one,u(k1,k1),ldu,h(incol + k1, &
                               jcol),ldh,zero,wh,ldwh)
                     call stdlib_dlacpy('ALL',nu,jlen,wh,ldwh,h(incol + k1,jcol),ldh)
-                              
+
                  end do
                  ! ==== vertical multiply ====
                  do jrow = jtop,max(ktop,incol) - 1,nv
@@ -51808,7 +51808,7 @@ module stdlib_linalg_lapack_d
                     call stdlib_dgemm('N','N',jlen,nu,nu,one,h(jrow,incol + k1),ldh,u( &
                               k1,k1),ldu,zero,wv,ldwv)
                     call stdlib_dlacpy('ALL',jlen,nu,wv,ldwv,h(jrow,incol + k1),ldh)
-                              
+
                  end do
                  ! ==== z multiply (also vertical) ====
                  if (wantz) then
@@ -51817,7 +51817,7 @@ module stdlib_linalg_lapack_d
                        call stdlib_dgemm('N','N',jlen,nu,nu,one,z(jrow,incol + k1),ldz,u( &
                                   k1,k1),ldu,zero,wv,ldwv)
                        call stdlib_dlacpy('ALL',jlen,nu,wv,ldwv,z(jrow,incol + k1),ldz)
-                                 
+
                     end do
                  end if
               end if
@@ -51858,7 +51858,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(out) :: work(*)
            real(dp),intent(inout) :: x(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran
            integer(ilp) :: i,ierr,j,j1,j2,jnext,k,n1,n2
@@ -51880,7 +51880,7 @@ module stdlib_linalg_lapack_d
            bignum = one/smlnum
            xnorm = stdlib_dlange('M',n,n,t,ldt,d)
            if (.not. lreal) xnorm = max(xnorm,abs(w),stdlib_dlange('M',n,1,b,n,d))
-                     
+
            smin = max(smlnum,eps*xnorm)
            ! compute 1-norm of each column of strictly upper triangular
            ! part of t to control overflow in triangular solver.
@@ -52197,7 +52197,7 @@ module stdlib_linalg_lapack_d
                        end if
                        x(j1) = x(j1) - stdlib_ddot(j1 - 1,t(1,j1),1,x,1)
                        x(n + j1) = x(n + j1) - stdlib_ddot(j1 - 1,t(1,j1),1,x(n + 1),1)
-                                 
+
                        if (j1 > 1) then
                           x(j1) = x(j1) - b(j1)*x(n + 1)
                           x(n + j1) = x(n + j1) + b(j1)*x(1)
@@ -52231,7 +52231,7 @@ module stdlib_linalg_lapack_d
                        ! scale if necessary to avoid overflow in forming the
                        ! right-hand side element by inner product.
                        xj = max(abs(x(j1)) + abs(x(n + j1)),abs(x(j2)) + abs(x(n + j2)))
-                                 
+
                        if (xmax > one) then
                           rec = one/xmax
                           if (max(work(j1),work(j2)) > (bignum - xj)/xmax) then
@@ -52243,9 +52243,9 @@ module stdlib_linalg_lapack_d
                        d(1,1) = x(j1) - stdlib_ddot(j1 - 1,t(1,j1),1,x,1)
                        d(2,1) = x(j2) - stdlib_ddot(j1 - 1,t(1,j2),1,x,1)
                        d(1,2) = x(n + j1) - stdlib_ddot(j1 - 1,t(1,j1),1,x(n + 1),1)
-                                 
+
                        d(2,2) = x(n + j2) - stdlib_ddot(j1 - 1,t(1,j2),1,x(n + 1),1)
-                                 
+
                        d(1,1) = d(1,1) - b(j1)*x(n + 1)
                        d(2,1) = d(2,1) - b(j2)*x(n + 1)
                        d(1,2) = d(1,2) + b(j1)*x(1)
@@ -52296,7 +52296,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: dsigma(*),vt2(ldvt2,*),z(*)
            real(dp),intent(in) :: u2(ldu2,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: ctemp,i,j,jc,ktemp,m,n,nlp1,nlp2,nrp1
            real(dp) :: rho,temp
@@ -52374,7 +52374,7 @@ module stdlib_linalg_lapack_d
            ! find the new singular values.
            do j = 1,k
               call stdlib_dlasd4(k,j,dsigma,z,u(1,j),rho,d(j),vt(1,j),info)
-                        
+
               ! if the zero finder fails, report the convergence failure.
               if (info /= 0) then
                  return
@@ -52435,7 +52435,7 @@ module stdlib_linalg_lapack_d
            call stdlib_dgemm('N','N',nr,k,ctemp,one,u2(nlp2,ktemp),ldu2,q(ktemp,1), &
                      ldq,zero,u(nlp2,1),ldu)
            ! generate the right singular vectors.
-100  continue
+           100 continue
            do i = 1,k
               temp = stdlib_dnrm2(k,vt(1,i),1)
               q(i,1) = vt(1,i)/temp
@@ -52447,7 +52447,7 @@ module stdlib_linalg_lapack_d
            ! update the right singular vector matrix.
            if (k == 2) then
               call stdlib_dgemm('N','N',k,m,k,one,q,ldq,vt2,ldvt2,zero,vt,ldvt)
-                        
+
               return
            end if
            ktemp = 1 + ctot(1)
@@ -52510,7 +52510,7 @@ module stdlib_linalg_lapack_d
 
      pure subroutine stdlib_dlasd6(icompq,nl,nr,sqre,d,vf,vl,alpha,beta,idxq,perm, &
      givptr,givcol,ldgcol,givnum,ldgnum,poles,difl,difr,z,k,c,s,work,iwork,info)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -52526,7 +52526,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(out) :: difl(*),difr(*),givnum(ldgnum,*),poles(ldgnum,*),work(*), &
                      z(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,idx,idxc,idxp,isigma,ivfw,ivlw,iw,m,n,n1,n2
            real(dp) :: orgnrm
@@ -52618,7 +52618,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: ap(*),tau(*)
            real(dp),intent(out) :: q(ldq,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,iinfo,ij,j
@@ -52711,7 +52711,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: tau(*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: forwrd,left,notran,upper
            integer(ilp) :: i,i1,i2,i3,ic,ii,jc,mi,ni,nq
@@ -52822,7 +52822,7 @@ module stdlib_linalg_lapack_d
                  end if
                  ! apply h(i)
                  call stdlib_dlarf(side,mi,ni,ap(ii),1,tau(i),c(ic,jc),ldc,work)
-                           
+
                  ap(ii) = aii
                  if (forwrd) then
                     ii = ii + nq - i + 1
@@ -52863,7 +52863,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(out) :: taup1(*),taup2(*),tauq1(*),work(*)
            real(dp),intent(inout) :: x11(ldx11,*),x21(ldx21,*)
         ! ====================================================================
-           
+
            ! Local Scalars
            real(dp) :: c,s
            integer(ilp) :: childinfo,i,ilarf,iorbdb5,llarf,lorbdb5,lworkmin, &
@@ -52966,7 +52966,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(out) :: taup1(*),taup2(*),tauq1(*),work(*)
            real(dp),intent(inout) :: x11(ldx11,*),x21(ldx21,*)
         ! ====================================================================
-           
+
            ! Local Scalars
            real(dp) :: c,s
            integer(ilp) :: childinfo,i,ilarf,iorbdb5,llarf,lorbdb5,lworkmin, &
@@ -53079,7 +53079,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(out) :: taup1(*),taup2(*),tauq1(*),work(*)
            real(dp),intent(inout) :: x11(ldx11,*),x21(ldx21,*)
         ! ====================================================================
-           
+
            ! Local Scalars
            real(dp) :: c,s
            integer(ilp) :: childinfo,i,ilarf,iorbdb5,llarf,lorbdb5,lworkmin, &
@@ -53191,7 +53191,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(out) :: phantom(*),taup1(*),taup2(*),tauq1(*),work(*)
            real(dp),intent(inout) :: x11(ldx11,*),x21(ldx21,*)
         ! ====================================================================
-           
+
            ! Local Scalars
            real(dp) :: c,s
            integer(ilp) :: childinfo,i,ilarf,iorbdb5,j,llarf,lorbdb5,lworkmin, &
@@ -53251,7 +53251,7 @@ module stdlib_linalg_lapack_d
                  phantom(1) = one
                  phantom(p + 1) = one
                  call stdlib_dlarf('L',p,q,phantom(1),1,taup1(1),x11,ldx11,work(ilarf))
-                           
+
                  call stdlib_dlarf('L',m - p,q,phantom(p + 1),1,taup2(1),x21,ldx21,work(ilarf) &
                             )
               else
@@ -53296,7 +53296,7 @@ module stdlib_linalg_lapack_d
            ! reduce the bottom-right portion of x21 to [ 0 i ]
            do i = p + 1,q
               call stdlib_dlarfgp(q - i + 1,x21(m - q + i - p,i),x21(m - q + i - p,i + 1),ldx21,tauq1(i))
-                        
+
               x21(m - q + i - p,i) = one
               call stdlib_dlarf('R',q - i,q - i + 1,x21(m - q + i - p,i),ldx21,tauq1(i),x21(m - q + i - p + 1,i) &
                         ,ldx21,work(ilarf))
@@ -53335,7 +53335,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: x11(ldx11,*),x21(ldx21,*)
            integer(ilp),intent(out) :: iwork(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: childinfo,i,ib11d,ib11e,ib12d,ib12e,ib21d,ib21e,ib22d,ib22e, &
            ibbcsd,iorbdb,iorglq,iorgqr,iphi,itaup1,itaup2,itauq1,j,lbbcsd,lorbdb, &
@@ -53420,13 +53420,13 @@ module stdlib_linalg_lapack_d
                  end if
                  if (wantu2 .and. m - p > 0) then
                     call stdlib_dorgqr(m - p,m - p,q,u2,ldu2,dum1,work(1),-1,childinfo)
-                              
+
                     lorgqrmin = max(lorgqrmin,m - p)
                     lorgqropt = max(lorgqropt,int(work(1),KIND=ilp))
                  end if
                  if (wantv1t .and. q > 0) then
                     call stdlib_dorglq(q - 1,q - 1,q - 1,v1t,ldv1t,dum1,work(1),-1,childinfo)
-                              
+
                     lorglqmin = max(lorglqmin,q - 1)
                     lorglqopt = max(lorglqopt,int(work(1),KIND=ilp))
                  end if
@@ -53446,7 +53446,7 @@ module stdlib_linalg_lapack_d
                  end if
                  if (wantu2 .and. m - p > 0) then
                     call stdlib_dorgqr(m - p,m - p,q,u2,ldu2,dum1,work(1),-1,childinfo)
-                              
+
                     lorgqrmin = max(lorgqrmin,m - p)
                     lorgqropt = max(lorgqropt,int(work(1),KIND=ilp))
                  end if
@@ -53494,7 +53494,7 @@ module stdlib_linalg_lapack_d
                  end if
                  if (wantu2 .and. m - p > 0) then
                     call stdlib_dorgqr(m - p,m - p,m - q,u2,ldu2,dum1,work(1),-1,childinfo)
-                              
+
                     lorgqrmin = max(lorgqrmin,m - p)
                     lorgqropt = max(lorgqropt,int(work(1),KIND=ilp))
                  end if
@@ -53663,7 +53663,7 @@ module stdlib_linalg_lapack_d
               ! simultaneously bidiagonalize x11 and x21
               call stdlib_dorbdb4(m,p,q,x11,ldx11,x21,ldx21,theta,work(iphi),work(itaup1) &
               ,work(itaup2),work(itauq1),work(iorbdb),work(iorbdb + m),lorbdb - m,childinfo)
-                        
+
               ! accumulate householder reflectors
               if (wantu2 .and. m - p > 0) then
                  call stdlib_dcopy(m - p,work(iorbdb + p),1,u2,1)
@@ -53690,7 +53690,7 @@ module stdlib_linalg_lapack_d
                  call stdlib_dlacpy('U',p - (m - q),q - (m - q),x11(m - q + 1,m - q + 1),ldx11,v1t(m - q + 1,m - q + &
                            1),ldv1t)
                  call stdlib_dlacpy('U',-p + q,q - p,x21(m - q + 1,p + 1),ldx21,v1t(p + 1,p + 1),ldv1t)
-                           
+
                  call stdlib_dorglq(q,q,q,v1t,ldv1t,work(itauq1),work(iorglq),lorglq, &
                            childinfo)
               end if
@@ -53738,7 +53738,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: tau(*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper
            integer(ilp) :: i,iinfo,j,lwkopt,nb
@@ -53813,7 +53813,7 @@ module stdlib_linalg_lapack_d
               if (n > 1) then
                  ! generate q(2:n,2:n)
                  call stdlib_dorgqr(n - 1,n - 1,n - 1,a(2,2),lda,tau,work,lwork,iinfo)
-                           
+
               end if
            end if
            work(1) = lwkopt
@@ -53838,7 +53838,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: t(ldt,*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: iinfo,ldc,lworkopt,lc,lw,nblocal,j
@@ -54055,7 +54055,7 @@ module stdlib_linalg_lapack_d
            ! Parameters
            integer(ilp),parameter :: nbmax = 32
            integer(ilp),parameter :: ldwork = nbmax + 1
-           
+
            ! Local Scalars
            integer(ilp) :: i,i2,i3,ib,ii,j,jj,nb
            ! Local Arrays
@@ -54228,7 +54228,7 @@ module stdlib_linalg_lapack_d
               end if
            end if
            return
-150        continue
+           150 continue
            return
      end subroutine stdlib_dpbtrf
 
@@ -54247,7 +54247,7 @@ module stdlib_linalg_lapack_d
            ! Array Arguments
            real(dp),intent(inout) :: a(0:*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,nisodd,normaltransr
            integer(ilp) :: n1,n2,k
@@ -54303,7 +54303,7 @@ module stdlib_linalg_lapack_d
                     call stdlib_dlauum('L',n1,a(0),n,info)
                     call stdlib_dsyrk('L','T',n1,n2,one,a(n1),n,one,a(0),n)
                     call stdlib_dtrmm('L','U','N','N',n2,n1,one,a(n),n,a(n1),n)
-                              
+
                     call stdlib_dlauum('U',n2,a(n),n,info)
                  else
                     ! srpa for upper, normal and n is odd ( a(0:n-1,0:n2-1)
@@ -54312,7 +54312,7 @@ module stdlib_linalg_lapack_d
                     call stdlib_dlauum('L',n1,a(n2),n,info)
                     call stdlib_dsyrk('L','N',n1,n2,one,a(0),n,one,a(n2),n)
                     call stdlib_dtrmm('R','U','T','N',n1,n2,one,a(n1),n,a(0),n)
-                              
+
                     call stdlib_dlauum('U',n2,a(n1),n,info)
                  end if
               else
@@ -54322,7 +54322,7 @@ module stdlib_linalg_lapack_d
                     ! t1 -> a(0), t2 -> a(1), s -> a(0+n1*n1)
                     call stdlib_dlauum('U',n1,a(0),n1,info)
                     call stdlib_dsyrk('U','N',n1,n2,one,a(n1*n1),n1,one,a(0),n1)
-                              
+
                     call stdlib_dtrmm('R','L','N','N',n1,n2,one,a(1),n1,a(n1*n1),n1 &
                               )
                     call stdlib_dlauum('L',n2,a(1),n1,info)
@@ -54331,7 +54331,7 @@ module stdlib_linalg_lapack_d
                     ! t1 -> a(0+n2*n2), t2 -> a(0+n1*n2), s -> a(0)
                     call stdlib_dlauum('U',n1,a(n2*n2),n2,info)
                     call stdlib_dsyrk('U','T',n1,n2,one,a(0),n2,one,a(n2*n2),n2)
-                              
+
                     call stdlib_dtrmm('L','L','T','N',n2,n1,one,a(n1*n2),n2,a(0),n2 &
                               )
                     call stdlib_dlauum('L',n2,a(n1*n2),n2,info)
@@ -54347,9 +54347,9 @@ module stdlib_linalg_lapack_d
                     ! t1 -> a(1), t2 -> a(0), s -> a(k+1)
                     call stdlib_dlauum('L',k,a(1),n + 1,info)
                     call stdlib_dsyrk('L','T',k,k,one,a(k + 1),n + 1,one,a(1),n + 1)
-                              
+
                     call stdlib_dtrmm('L','U','N','N',k,k,one,a(0),n + 1,a(k + 1),n + 1)
-                              
+
                     call stdlib_dlauum('U',k,a(0),n + 1,info)
                  else
                     ! srpa for upper, normal, and n is even ( a(0:n,0:k-1) )
@@ -54357,9 +54357,9 @@ module stdlib_linalg_lapack_d
                     ! t1 -> a(k+1), t2 -> a(k), s -> a(0)
                     call stdlib_dlauum('L',k,a(k + 1),n + 1,info)
                     call stdlib_dsyrk('L','N',k,k,one,a(0),n + 1,one,a(k + 1),n + 1)
-                              
+
                     call stdlib_dtrmm('R','U','T','N',k,k,one,a(k),n + 1,a(0),n + 1)
-                              
+
                     call stdlib_dlauum('U',k,a(k),n + 1,info)
                  end if
               else
@@ -54370,7 +54370,7 @@ module stdlib_linalg_lapack_d
                     ! t1 -> a(0+k), t2 -> a(0+0), s -> a(0+k*(k+1)); lda=k
                     call stdlib_dlauum('U',k,a(k),k,info)
                     call stdlib_dsyrk('U','N',k,k,one,a(k*(k + 1)),k,one,a(k),k)
-                              
+
                     call stdlib_dtrmm('R','L','N','N',k,k,one,a(0),k,a(k*(k + 1)),k &
                               )
                     call stdlib_dlauum('L',k,a(0),k,info)
@@ -54380,9 +54380,9 @@ module stdlib_linalg_lapack_d
                     ! t1 -> a(0+k*(k+1)), t2 -> a(0+k*k), s -> a(0+0)); lda=k
                     call stdlib_dlauum('U',k,a(k*(k + 1)),k,info)
                     call stdlib_dsyrk('U','T',k,k,one,a(0),k,one,a(k*(k + 1)),k)
-                              
+
                     call stdlib_dtrmm('L','L','T','N',k,k,one,a(k*k),k,a(0),k)
-                              
+
                     call stdlib_dlauum('L',k,a(k*k),k,info)
                  end if
               end if
@@ -54409,7 +54409,7 @@ module stdlib_linalg_lapack_d
            ! Array Arguments
            real(dp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,jb,nb
@@ -54478,9 +54478,9 @@ module stdlib_linalg_lapack_d
               end if
            end if
            go to 40
-30         continue
+           30 continue
            info = info + j - 1
-40         continue
+           40 continue
            return
      end subroutine stdlib_dpotrf
 
@@ -54490,7 +54490,7 @@ module stdlib_linalg_lapack_d
      !> estimates for the solution.
 
      pure subroutine stdlib_dptrfs(n,nrhs,d,e,df,ef,b,ldb,x,ldx,ferr,berr,work,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -54504,7 +54504,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            integer(ilp) :: count,i,ix,j,nz
            real(dp) :: bi,cx,dx,eps,ex,lstres,s,safe1,safe2,safmin
@@ -54544,7 +54544,7 @@ module stdlib_linalg_lapack_d
            loop_90: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x.  also compute
               ! abs(a)*abs(x) + abs(b) for use in the backward error bound.
@@ -54715,7 +54715,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(out) :: berr(*),ferr(*),work(*),x(ldx,*)
            real(dp),intent(inout) :: df(*),ef(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nofact
            real(dp) :: anorm
@@ -54761,7 +54761,7 @@ module stdlib_linalg_lapack_d
            ! use iterative refinement to improve the computed solutions and
            ! compute error bounds and backward error estimates for them.
            call stdlib_dptrfs(n,nrhs,d,e,df,ef,b,ldb,x,ldx,ferr,berr,work,info)
-                     
+
            ! set info = n+1 if the matrix is singular to working precision.
            if (rcond < stdlib_dlamch('EPSILON')) info = n + 1
            return
@@ -54782,7 +54782,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: ab(ldab,*)
            real(dp),intent(out) :: w(*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,wantz
            integer(ilp) :: iinfo,imax,inde,indwrk,iscale
@@ -54889,7 +54889,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: ab(ldab,*)
            real(dp),intent(out) :: q(ldq,*),w(*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,lower,test,valeig,wantz
            character :: order
@@ -55020,7 +55020,7 @@ module stdlib_linalg_lapack_d
                  call stdlib_dlacpy('A',n,n,q,ldq,z,ldz)
                  call stdlib_dcopy(n - 1,work(inde),1,work(indee),1)
                  call stdlib_dsteqr(jobz,n,w,work(indee),z,ldz,work(indwrk),info)
-                           
+
                  if (info == 0) then
                     do i = 1,n
                        ifail(i) = 0
@@ -55056,7 +55056,7 @@ module stdlib_linalg_lapack_d
               end do
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
-30   continue
+           30 continue
            if (iscale == 1) then
               if (info == 0) then
                  imax = m
@@ -55195,7 +55195,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: ab(ldab,*),bb(ldbb,*)
            real(dp),intent(out) :: q(ldq,*),w(*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,test,upper,valeig,wantz
            character :: order,vect
@@ -55261,7 +55261,7 @@ module stdlib_linalg_lapack_d
            end if
            ! transform problem to standard eigenvalue problem.
            call stdlib_dsbgst(jobz,uplo,n,ka,kb,ab,ldab,bb,ldbb,q,ldq,work,iinfo)
-                     
+
            ! reduce symmetric band matrix to tridiagonal form.
            indd = 1
            inde = indd + n
@@ -55291,7 +55291,7 @@ module stdlib_linalg_lapack_d
               else
                  call stdlib_dlacpy('A',n,n,q,ldq,z,ldz)
                  call stdlib_dsteqr(jobz,n,w,work(indee),z,ldz,work(indwrk),info)
-                           
+
                  if (info == 0) then
                     do i = 1,n
                        ifail(i) = 0
@@ -55316,7 +55316,7 @@ module stdlib_linalg_lapack_d
            indiwo = indisp + n
            call stdlib_dstebz(range,order,n,vl,vu,il,iu,abstol,work(indd),work(inde), &
             m,nsplit,w,iwork(indibl),iwork(indisp),work(indwrk),iwork(indiwo),info)
-                      
+
            if (wantz) then
               call stdlib_dstein(n,work(indd),work(inde),m,w,iwork(indibl),iwork( &
                         indisp),z,ldz,work(indwrk),iwork(indiwo),ifail,info)
@@ -55327,7 +55327,7 @@ module stdlib_linalg_lapack_d
                  call stdlib_dgemv('N',n,n,one,q,ldq,work,1,zero,z(1,j),1)
               end do
            end if
-30         continue
+           30 continue
            ! if eigenvalues are not in order, then sort them, along with
            ! eigenvectors.
            if (wantz) then
@@ -55387,7 +55387,7 @@ module stdlib_linalg_lapack_d
      !> respectively.
 
      subroutine stdlib_dsgesv(n,nrhs,a,lda,ipiv,b,ldb,x,ldx,work,swork,iter,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -55405,7 +55405,7 @@ module stdlib_linalg_lapack_d
            logical(lk),parameter :: doitref = .true.
            integer(ilp),parameter :: itermax = 30
            real(dp),parameter :: bwdmax = 1.0e+00_dp
-           
+
            ! Local Scalars
            integer(ilp) :: i,iiter,ptsa,ptsx
            real(dp) :: anrm,cte,eps,rnrm,xnrm
@@ -55485,7 +55485,7 @@ module stdlib_linalg_lapack_d
            ! stopping criterion. we are good to exit.
            iter = 0
            return
-10         continue
+           10 continue
            loop_30: do iiter = 1,itermax
               ! convert r (in work) from double precision to single precision
               ! and store the result in sx.
@@ -55518,14 +55518,14 @@ module stdlib_linalg_lapack_d
               ! stopping criterion, we are good to exit.
               iter = iiter
               return
-20            continue
+              20 continue
            end do loop_30
            ! if we are at this place of the code, this is because we have
            ! performed iter=itermax iterations and never satisfied the
            ! stopping criterion, set up the iter flag accordingly and follow up
            ! on double precision routine.
            iter = -itermax - 1
-40         continue
+           40 continue
            ! single-precision iterative refinement failed to converge to a
            ! satisfactory solution, so we resort to double precision.
            call stdlib_dgetrf(n,n,a,lda,ipiv,info)
@@ -55550,7 +55550,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: ap(*)
            real(dp),intent(out) :: w(*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: wantz
            integer(ilp) :: iinfo,imax,inde,indtau,indwrk,iscale
@@ -55613,7 +55613,7 @@ module stdlib_linalg_lapack_d
            else
               indwrk = indtau + n
               call stdlib_dopgtr(uplo,n,ap,work(indtau),z,ldz,work(indwrk),iinfo)
-                        
+
               call stdlib_dsteqr(jobz,n,w,work(inde),z,ldz,work(indtau),info)
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
@@ -55648,7 +55648,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: ap(*)
            real(dp),intent(out) :: w(*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,test,valeig,wantz
            character :: order
@@ -55747,7 +55747,7 @@ module stdlib_linalg_lapack_d
            indd = inde + n
            indwrk = indd + n
            call stdlib_dsptrd(uplo,n,ap,work(indd),work(inde),work(indtau),iinfo)
-                     
+
            ! if all eigenvalues are desired and abstol is less than or equal
            ! to zero, then call stdlib_dsterf or stdlib_dopgtr and stdlib_ssteqr.  if this fails
            ! for some eigenvalue, then try stdlib_dstebz.
@@ -55765,10 +55765,10 @@ module stdlib_linalg_lapack_d
                  call stdlib_dsterf(n,w,work(indee),info)
               else
                  call stdlib_dopgtr(uplo,n,ap,work(indtau),z,ldz,work(indwrk),iinfo)
-                           
+
                  call stdlib_dcopy(n - 1,work(inde),1,work(indee),1)
                  call stdlib_dsteqr(jobz,n,w,work(indee),z,ldz,work(indwrk),info)
-                           
+
                  if (info == 0) then
                     do i = 1,n
                        ifail(i) = 0
@@ -55802,7 +55802,7 @@ module stdlib_linalg_lapack_d
                          iinfo)
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
-20   continue
+           20 continue
            if (iscale == 1) then
               if (info == 0) then
                  imax = m
@@ -56067,7 +56067,7 @@ module stdlib_linalg_lapack_d
      !> respectively.
 
      subroutine stdlib_dsposv(uplo,n,nrhs,a,lda,b,ldb,x,ldx,work,swork,iter,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -56085,7 +56085,7 @@ module stdlib_linalg_lapack_d
            logical(lk),parameter :: doitref = .true.
            integer(ilp),parameter :: itermax = 30
            real(dp),parameter :: bwdmax = 1.0e+00_dp
-           
+
            ! Local Scalars
            integer(ilp) :: i,iiter,ptsa,ptsx
            real(dp) :: anrm,cte,eps,rnrm,xnrm
@@ -56165,7 +56165,7 @@ module stdlib_linalg_lapack_d
            ! stopping criterion. we are good to exit.
            iter = 0
            return
-10         continue
+           10 continue
            loop_30: do iiter = 1,itermax
               ! convert r (in work) from double precision to single precision
               ! and store the result in sx.
@@ -56196,14 +56196,14 @@ module stdlib_linalg_lapack_d
               ! stopping criterion, we are good to exit.
               iter = iiter
               return
-20            continue
+              20 continue
            end do loop_30
            ! if we are at this place of the code, this is because we have
            ! performed iter=itermax iterations and never satisfied the
            ! stopping criterion, set up the iter flag accordingly and follow
            ! up on double precision routine.
            iter = -itermax - 1
-40         continue
+           40 continue
            ! single-precision iterative refinement failed to converge to a
            ! satisfactory solution, so we resort to double precision.
            call stdlib_dpotrf(uplo,n,a,lda,info)
@@ -56228,7 +56228,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: w(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,lquery,wantz
            integer(ilp) :: iinfo,imax,inde,indtau,indwrk,iscale,llwork,lwkopt,nb
@@ -56303,7 +56303,7 @@ module stdlib_linalg_lapack_d
               call stdlib_dsterf(n,w,work(inde),info)
            else
               call stdlib_dorgtr(uplo,n,a,lda,work(indtau),work(indwrk),llwork,iinfo)
-                        
+
               call stdlib_dsteqr(jobz,n,w,work(inde),a,lda,work(indtau),info)
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
@@ -56340,7 +56340,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: w(*),work(*),z(ldz,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,lower,lquery,test,valeig,wantz
            character :: order
@@ -56490,7 +56490,7 @@ module stdlib_linalg_lapack_d
                            iinfo)
                  call stdlib_dcopy(n - 1,work(inde),1,work(indee),1)
                  call stdlib_dsteqr(jobz,n,w,work(indee),z,ldz,work(indwrk),info)
-                           
+
                  if (info == 0) then
                     do i = 1,n
                        ifail(i) = 0
@@ -56526,7 +56526,7 @@ module stdlib_linalg_lapack_d
                         indwkn),llwrkn,iinfo)
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
-40   continue
+           40 continue
            if (iscale == 1) then
               if (info == 0) then
                  imax = m
@@ -56585,7 +56585,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*),b(ldb,*)
            real(dp),intent(out) :: w(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper,wantz
            character :: trans
@@ -56650,7 +56650,7 @@ module stdlib_linalg_lapack_d
                     trans = 'T'
                  end if
                  call stdlib_dtrsm('LEFT',uplo,trans,'NON-UNIT',n,neig,one,b,ldb,a,lda)
-                           
+
               else if (itype == 3) then
                  ! for b*a*x=(lambda)*x;
                  ! backtransform eigenvectors: x = l*y or u**t*y
@@ -56660,7 +56660,7 @@ module stdlib_linalg_lapack_d
                     trans = 'N'
                  end if
                  call stdlib_dtrmm('LEFT',uplo,trans,'NON-UNIT',n,neig,one,b,ldb,a,lda)
-                           
+
               end if
            end if
            work(1) = lwkopt
@@ -56689,7 +56689,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*),b(ldb,*)
            real(dp),intent(out) :: w(*),work(*),z(ldz,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,lquery,upper,valeig,wantz
            character :: trans
@@ -56777,7 +56777,7 @@ module stdlib_linalg_lapack_d
                     trans = 'T'
                  end if
                  call stdlib_dtrsm('LEFT',uplo,trans,'NON-UNIT',n,m,one,b,ldb,z,ldz)
-                           
+
               else if (itype == 3) then
                  ! for b*a*x=(lambda)*x;
                  ! backtransform eigenvectors: x = l*y or u**t*y
@@ -56787,7 +56787,7 @@ module stdlib_linalg_lapack_d
                     trans = 'N'
                  end if
                  call stdlib_dtrmm('LEFT',uplo,trans,'NON-UNIT',n,m,one,b,ldb,z,ldz)
-                           
+
               end if
            end if
            ! set work(1) to optimal workspace size.
@@ -56897,7 +56897,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: af(ldaf,*)
            real(dp),intent(out) :: berr(*),ferr(*),work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,nofact
            integer(ilp) :: lwkopt,nb
@@ -56975,7 +56975,7 @@ module stdlib_linalg_lapack_d
      !> Q**T * A * Q = AB.
 
      pure subroutine stdlib_dsytrd_sy2sb(uplo,n,kd,a,lda,ab,ldab,tau,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -56989,7 +56989,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: rone = 1.0e+0_dp
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper
            integer(ilp) :: i,j,iinfo,lwmin,pn,pk,lk,ldt,ldw,lds2,lds1,ls2,ls1,lw,lt, &
@@ -57132,7 +57132,7 @@ module stdlib_linalg_lapack_d
                    ! do 45 j = i, i+pk-1
                       ! lk = min( kd, n-j ) + 1
                       ! call stdlib_dcopy( lk, ab( 1, j ), 1, a( j, j ), 1 )
-45   continue
+                      45 continue
                   ! ==================================================================
                end do loop_40
               ! copy the lower band to ab which is the band storage matrix
@@ -57181,7 +57181,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: safety = 1.0e+2_dp
-           
+
            ! Local Scalars
            logical(lk) :: compl,compr,il2by2,ilabad,ilall,ilback,ilbbad,ilcomp,ilcplx, &
                      lsa,lsb
@@ -57399,7 +57399,7 @@ module stdlib_linalg_lapack_d
                     lsb = abs(salfar) >= safmin .and. abs(bcoefr) < small
                     if (lsa) scale = (small/abs(sbeta))*min(anorm,big)
                     if (lsb) scale = max(scale, (small/abs(salfar))*min(bnorm,big))
-                              
+
                     if (lsa .or. lsb) then
                        scale = min(scale,one/(safmin*max(one,abs(acoef),abs(bcoefr))) &
                                  )
@@ -57438,7 +57438,7 @@ module stdlib_linalg_lapack_d
                               ulp)/bcoefa)
                     if (safmin*acoefa > ascale) scale = ascale/(safmin*acoefa)
                     if (safmin*bcoefa > bscale) scale = min(scale,bscale/(safmin*bcoefa))
-                              
+
                     if (scale /= one) then
                        acoef = scale*acoef
                        acoefa = abs(acoef)
@@ -57489,7 +57489,7 @@ module stdlib_linalg_lapack_d
                     ! check whether scaling is necessary for dot products
                     xscale = one/max(one,xmax)
                     temp = max(work(j),work(n + j),acoefa*work(j) + bcoefa*work(n + j))
-                              
+
                     if (il2by2) temp = max(temp,work(j + 1),work(n + j + 1),acoefa*work(j + 1) + &
                               bcoefa*work(n + j + 1))
                     if (temp > bignum*xscale) then
@@ -57537,7 +57537,7 @@ module stdlib_linalg_lapack_d
                     ! with scaling and perturbation of the denominator
                     call stdlib_dlaln2(.true.,na,nw,dmin,acoef,s(j,j),lds,bdiag(1), &
                     bdiag(2),sum,2,bcoefr,bcoefi,work(2*n + j),n,scale,temp,iinfo)
-                              
+
                     if (scale < one) then
                        do jw = 0,nw - 1
                           do jr = je,j - 1
@@ -57653,7 +57653,7 @@ module stdlib_linalg_lapack_d
                     lsb = abs(salfar) >= safmin .and. abs(bcoefr) < small
                     if (lsa) scale = (small/abs(sbeta))*min(anorm,big)
                     if (lsb) scale = max(scale, (small/abs(salfar))*min(bnorm,big))
-                              
+
                     if (lsa .or. lsb) then
                        scale = min(scale,one/(safmin*max(one,abs(acoef),abs(bcoefr))) &
                                  )
@@ -57696,7 +57696,7 @@ module stdlib_linalg_lapack_d
                               ulp)/bcoefa)
                     if (safmin*acoefa > ascale) scale = ascale/(safmin*acoefa)
                     if (safmin*bcoefa > bscale) scale = min(scale,bscale/(safmin*bcoefa))
-                              
+
                     if (scale /= one) then
                        acoef = scale*acoef
                        acoefa = abs(acoef)
@@ -57763,7 +57763,7 @@ module stdlib_linalg_lapack_d
                     ! compute x(j) (and x(j+1), if 2-by-2 block)
                     call stdlib_dlaln2(.false.,na,nw,dmin,acoef,s(j,j),lds,bdiag(1), &
                     bdiag(2),work(2*n + j),n,bcoefr,bcoefi,sum,2,scale,temp,iinfo)
-                              
+
                     if (scale < one) then
                        do jw = 0,nw - 1
                           do jr = 1,je
@@ -57783,7 +57783,7 @@ module stdlib_linalg_lapack_d
                        xscale = one/max(one,xmax)
                        temp = acoefa*work(j) + bcoefa*work(n + j)
                        if (il2by2) temp = max(temp,acoefa*work(j + 1) + bcoefa*work(n + j + 1))
-                                 
+
                        temp = max(temp,acoefa,bcoefa)
                        if (temp > bignum*xscale) then
                           do jw = 0,nw - 1
@@ -57905,7 +57905,7 @@ module stdlib_linalg_lapack_d
            real(dp),parameter :: twenty = 2.0e+01_dp
            integer(ilp),parameter :: ldst = 4
            logical(lk),parameter :: wands = .true.
-           
+
            ! Local Scalars
            logical(lk) :: strong,weak
            integer(ilp) :: i,idum,linfo,m
@@ -57977,9 +57977,9 @@ module stdlib_linalg_lapack_d
                  call stdlib_dlartg(t(1,1),t(2,1),li(1,1),li(2,1),ddum)
               end if
               call stdlib_drot(2,s(1,1),ldst,s(2,1),ldst,li(1,1),li(2,1))
-                        
+
               call stdlib_drot(2,t(1,1),ldst,t(2,1),ldst,li(1,1),li(2,1))
-                        
+
               li(2,2) = li(1,1)
               li(1,2) = -li(2,1)
               ! weak stability test: |s21| <= o(eps f-norm((a)))
@@ -57993,7 +57993,7 @@ module stdlib_linalg_lapack_d
                      ! f-norm((b-ql**h*t*qr)) <= o(eps*f-norm((b)))
                  call stdlib_dlacpy('FULL',m,m,a(j1,j1),lda,work(m*m + 1),m)
                  call stdlib_dgemm('N','N',m,m,m,one,li,ldst,s,ldst,zero,work,m)
-                           
+
                  call stdlib_dgemm('N','T',m,m,m,-one,work,m,ir,ldst,one,work(m*m + 1), &
                             m)
                  dscale = zero
@@ -58002,7 +58002,7 @@ module stdlib_linalg_lapack_d
                  sa = dscale*sqrt(dsum)
                  call stdlib_dlacpy('FULL',m,m,b(j1,j1),ldb,work(m*m + 1),m)
                  call stdlib_dgemm('N','N',m,m,m,one,li,ldst,t,ldst,zero,work,m)
-                           
+
                  call stdlib_dgemm('N','T',m,m,m,-one,work,m,ir,ldst,one,work(m*m + 1), &
                             m)
                  dscale = zero
@@ -58015,9 +58015,9 @@ module stdlib_linalg_lapack_d
               ! update (a(j1:j1+m-1, m+j1:n), b(j1:j1+m-1, m+j1:n)) and
                      ! (a(1:j1-1, j1:j1+m), b(1:j1-1, j1:j1+m)).
               call stdlib_drot(j1 + 1,a(1,j1),1,a(1,j1 + 1),1,ir(1,1),ir(2,1))
-                        
+
               call stdlib_drot(j1 + 1,b(1,j1),1,b(1,j1 + 1),1,ir(1,1),ir(2,1))
-                        
+
               call stdlib_drot(n - j1 + 1,a(j1,j1),lda,a(j1 + 1,j1),lda,li(1,1),li(2,1 &
                         ))
               call stdlib_drot(n - j1 + 1,b(j1,j1),ldb,b(j1 + 1,j1),ldb,li(1,1),li(2,1 &
@@ -58041,7 +58041,7 @@ module stdlib_linalg_lapack_d
               ! for r and l. solutions in li and ir.
               call stdlib_dlacpy('FULL',n1,n2,t(1,n1 + 1),ldst,li,ldst)
               call stdlib_dlacpy('FULL',n1,n2,s(1,n1 + 1),ldst,ir(n2 + 1,n1 + 1),ldst)
-                        
+
               call stdlib_dtgsy2('N',0,n1,n2,s,ldst,s(n1 + 1,n1 + 1),ldst,ir(n2 + 1,n1 + 1), &
                ldst,t,ldst,t(n1 + 1,n1 + 1),ldst,li,ldst,scale,dsum,dscale,iwork,idum, &
                          linfo)
@@ -58099,9 +58099,9 @@ module stdlib_linalg_lapack_d
               call stdlib_dgeqr2(m,m,tcpy,ldst,taul,work,linfo)
               if (linfo /= 0) go to 70
               call stdlib_dorm2r('L','T',m,m,m,tcpy,ldst,taul,scpy,ldst,work,info)
-                        
+
               call stdlib_dorm2r('R','N',m,m,m,tcpy,ldst,taul,licop,ldst,work,info)
-                        
+
               if (linfo /= 0) go to 70
               ! compute f-norm(s21) in bqra21. (t21 is 0.)
               dscale = zero
@@ -58130,7 +58130,7 @@ module stdlib_linalg_lapack_d
                      ! f-norm((b-ql**h*t*qr)) <= o(eps*f-norm((b)))
                  call stdlib_dlacpy('FULL',m,m,a(j1,j1),lda,work(m*m + 1),m)
                  call stdlib_dgemm('N','N',m,m,m,one,li,ldst,s,ldst,zero,work,m)
-                           
+
                  call stdlib_dgemm('N','N',m,m,m,-one,work,m,ir,ldst,one,work(m*m + 1), &
                             m)
                  dscale = zero
@@ -58139,7 +58139,7 @@ module stdlib_linalg_lapack_d
                  sa = dscale*sqrt(dsum)
                  call stdlib_dlacpy('FULL',m,m,b(j1,j1),ldb,work(m*m + 1),m)
                  call stdlib_dgemm('N','N',m,m,m,one,li,ldst,t,ldst,zero,work,m)
-                           
+
                  call stdlib_dgemm('N','N',m,m,m,-one,work,m,ir,ldst,one,work(m*m + 1), &
                             m)
                  dscale = zero
@@ -58174,7 +58174,7 @@ module stdlib_linalg_lapack_d
               if (n1 > 1) then
                  call stdlib_dlagv2(a(j1 + n2,j1 + n2),lda,b(j1 + n2,j1 + n2),ldb,taur,taul, &
                  work(m*m + 1),work(n2*m + n2 + 1),work(n2*m + n2 + 2),t(n2 + 1,n2 + 1),t(m,m - 1))
-                           
+
                  work(m*m) = work(n2*m + n2 + 1)
                  work(m*m - 1) = -work(n2*m + n2 + 2)
                  t(m,m) = t(n2 + 1,n2 + 1)
@@ -58232,7 +58232,7 @@ module stdlib_linalg_lapack_d
               return
            end if
            ! exit with info = 1 if swap was rejected.
-70   continue
+           70 continue
            info = 1
            return
      end subroutine stdlib_dtgex2
@@ -58264,7 +58264,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*),b(ldb,*),q(ldq,*),z(ldz,*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: here,lwmin,nbf,nbl,nbnext
@@ -58332,7 +58332,7 @@ module stdlib_linalg_lapack_d
               if (nbf == 2 .and. nbl == 1) ilst = ilst - 1
               if (nbf == 1 .and. nbl == 2) ilst = ilst + 1
               here = ifst
-10            continue
+              10 continue
               ! swap with next one below.
               if (nbf == 1 .or. nbf == 2) then
                  ! current block either 1-by-1 or 2-by-2.
@@ -58407,7 +58407,7 @@ module stdlib_linalg_lapack_d
               if (here < ilst) go to 10
            else
               here = ifst
-20            continue
+              20 continue
               ! swap with next one below.
               if (nbf == 1 .or. nbf == 2) then
                  ! current block either 1-by-1 or 2-by-2.
@@ -58525,7 +58525,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: idifjb = 3
-           
+
            ! Local Scalars
            logical(lk) :: lquery,pair,swap,wantd,wantd1,wantd2,wantp
            integer(ilp) :: i,ierr,ijb,k,kase,kk,ks,liwmin,lwmin,mn2,n1,n2
@@ -58726,9 +58726,9 @@ module stdlib_linalg_lapack_d
                  ijb = 0
                  mn2 = 2*n1*n2
                  ! 1-norm-based estimate of difu.
-40   continue
+                 40 continue
                  call stdlib_dlacn2(mn2,work(mn2 + 1),work,iwork,dif(1),kase,isave)
-                           
+
                  if (kase /= 0) then
                     if (kase == 1) then
                        ! solve generalized sylvester equation.
@@ -58745,9 +58745,9 @@ module stdlib_linalg_lapack_d
                  end if
                  dif(1) = dscale/dif(1)
                  ! 1-norm-based estimate of difl.
-50   continue
+                 50 continue
                  call stdlib_dlacn2(mn2,work(mn2 + 1),work,iwork,dif(2),kase,isave)
-                           
+
                  if (kase /= 0) then
                     if (kase == 1) then
                        ! solve generalized sylvester equation.
@@ -58765,7 +58765,7 @@ module stdlib_linalg_lapack_d
                  dif(2) = dscale/dif(2)
               end if
            end if
-60         continue
+           60 continue
            ! compute generalized eigenvalues of reordered pair (a, b) and
            ! normalize the generalized schur form.
            pair = .false.
@@ -58890,7 +58890,7 @@ module stdlib_linalg_lapack_d
            ! Parameters
            integer(ilp),parameter :: maxit = 40
            real(dp),parameter :: hugenum = huge(zero)
-           
+
            ! Local Scalars
            logical(lk) :: initq,initu,initv,upper,wantq,wantu,wantv
            integer(ilp) :: i,j,kcycle
@@ -58968,7 +58968,7 @@ module stdlib_linalg_lapack_d
                     ! update (n-l+i)-th and (n-l+j)-th columns of matrices
                     ! a and b: a*q and b*q
                     call stdlib_drot(min(k + l,m),a(1,n - l + j),1,a(1,n - l + i),1,csq,snq)
-                              
+
                     call stdlib_drot(l,b(1,n - l + j),1,b(1,n - l + i),1,csq,snq)
                     if (upper) then
                        if (k + i <= m) a(k + i,n - l + j) = zero
@@ -58982,7 +58982,7 @@ module stdlib_linalg_lapack_d
                               csu,snu)
                     if (wantv) call stdlib_drot(p,v(1,j),1,v(1,i),1,csv,snv)
                     if (wantq) call stdlib_drot(n,q(1,n - l + j),1,q(1,n - l + i),1,csq,snq)
-                              
+
                  end do loop_10
               end do loop_20
               if (.not. upper) then
@@ -59004,7 +59004,7 @@ module stdlib_linalg_lapack_d
            ! the algorithm has not converged after maxit cycles.
            info = 1
            go to 100
-50         continue
+           50 continue
            ! if error <= min(tola,tolb), then the algorithm has converged.
            ! compute the generalized singular value pairs (alpha, beta), and
            ! set the triangular matrix r to array a.
@@ -59046,7 +59046,7 @@ module stdlib_linalg_lapack_d
                  beta(i) = zero
               end do
            end if
-100        continue
+           100 continue
            ncycle = kcycle
            return
      end subroutine stdlib_dtgsja
@@ -59077,7 +59077,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: difdri = 3
-           
+
            ! Local Scalars
            logical(lk) :: lquery,pair,somcon,wantbh,wantdf,wants
            integer(ilp) :: i,ierr,ifst,ilst,iz,k,ks,lwmin,n1,n2
@@ -59189,21 +59189,21 @@ module stdlib_linalg_lapack_d
                     lnrm = stdlib_dlapy2(stdlib_dnrm2(n,vl(1,ks),1),stdlib_dnrm2(n,vl( &
                               1,ks + 1),1))
                     call stdlib_dgemv('N',n,n,one,a,lda,vr(1,ks),1,zero,work,1)
-                              
+
                     tmprr = stdlib_ddot(n,work,1,vl(1,ks),1)
                     tmpri = stdlib_ddot(n,work,1,vl(1,ks + 1),1)
                     call stdlib_dgemv('N',n,n,one,a,lda,vr(1,ks + 1),1,zero,work,1)
-                              
+
                     tmpii = stdlib_ddot(n,work,1,vl(1,ks + 1),1)
                     tmpir = stdlib_ddot(n,work,1,vl(1,ks),1)
                     uhav = tmprr + tmpii
                     uhavi = tmpir - tmpri
                     call stdlib_dgemv('N',n,n,one,b,ldb,vr(1,ks),1,zero,work,1)
-                              
+
                     tmprr = stdlib_ddot(n,work,1,vl(1,ks),1)
                     tmpri = stdlib_ddot(n,work,1,vl(1,ks + 1),1)
                     call stdlib_dgemv('N',n,n,one,b,ldb,vr(1,ks + 1),1,zero,work,1)
-                              
+
                     tmpii = stdlib_ddot(n,work,1,vl(1,ks + 1),1)
                     tmpir = stdlib_ddot(n,work,1,vl(1,ks),1)
                     uhbv = tmprr + tmpii
@@ -59218,10 +59218,10 @@ module stdlib_linalg_lapack_d
                     rnrm = stdlib_dnrm2(n,vr(1,ks),1)
                     lnrm = stdlib_dnrm2(n,vl(1,ks),1)
                     call stdlib_dgemv('N',n,n,one,a,lda,vr(1,ks),1,zero,work,1)
-                              
+
                     uhav = stdlib_ddot(n,work,1,vl(1,ks),1)
                     call stdlib_dgemv('N',n,n,one,b,ldb,vr(1,ks),1,zero,work,1)
-                              
+
                     uhbv = stdlib_ddot(n,work,1,vl(1,ks),1)
                     cond = stdlib_dlapy2(uhav,uhbv)
                     if (cond == zero) then
@@ -59350,7 +59350,7 @@ module stdlib_linalg_lapack_d
                  lb = nb - n + l - i + 1
               end if
               call stdlib_dtplqt2(ib,nb,lb,a(i,i),lda,b(i,1),ldb,t(1,i),ldt,iinfo)
-                        
+
            ! update by applying h**t to b(i+ib:m,:) from the right
               if (i + ib <= m) then
                  call stdlib_dtprfb('R','N','F','R',m - i - ib + 1,nb,ib,lb,b(i,1),ldb,t( &
@@ -59412,7 +59412,7 @@ module stdlib_linalg_lapack_d
                  lb = mb - m + l - i + 1
               end if
               call stdlib_dtpqrt2(mb,ib,lb,a(i,i),lda,b(1,i),ldb,t(1,i),ldt,iinfo)
-                        
+
            ! update by applying h**t to b(:,i+ib:n) from the left
               if (i + ib <= n) then
                  call stdlib_dtprfb('L','T','F','C',mb,n - i - ib + 1,ib,lb,b(1,i),ldb,t( &
@@ -59453,7 +59453,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: vl(ldvl,*),vr(ldvr,*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: allv,bothv,leftv,over,pair,rightv,somev
            integer(ilp) :: i,ierr,ii,ip,is,j,j1,j2,jnxt,k,ki,n2
@@ -59554,7 +59554,7 @@ module stdlib_linalg_lapack_d
                  if (ki == 1) go to 40
                  if (t(ki,ki - 1) == zero) go to 40
                  ip = -1
-40               continue
+                 40 continue
                  if (somev) then
                     if (ip == 0) then
                        if (.not. select(ki)) go to 130
@@ -59605,7 +59605,7 @@ module stdlib_linalg_lapack_d
                           work(j + n) = x(1,1)
                           ! update right-hand side
                           call stdlib_daxpy(j - 1,-x(1,1),t(1,j),1,work(1 + n),1)
-                                    
+
                        else
                           ! 2-by-2 diagonal block
                           call stdlib_dlaln2(.false.,2,1,smin,one,t(j - 1,j - 1),ldt,one, &
@@ -59626,9 +59626,9 @@ module stdlib_linalg_lapack_d
                           work(j + n) = x(2,1)
                           ! update right-hand side
                           call stdlib_daxpy(j - 2,-x(1,1),t(1,j - 1),1,work(1 + n),1)
-                                    
+
                           call stdlib_daxpy(j - 2,-x(2,1),t(1,j),1,work(1 + n),1)
-                                    
+
                        end if
                     end do loop_60
                     ! copy the vector x or q*x to vr and normalize.
@@ -59702,9 +59702,9 @@ module stdlib_linalg_lapack_d
                           work(j + n2) = x(1,2)
                           ! update the right-hand side
                           call stdlib_daxpy(j - 1,-x(1,1),t(1,j),1,work(1 + n),1)
-                                    
+
                           call stdlib_daxpy(j - 1,-x(1,2),t(1,j),1,work(1 + n2),1)
-                                    
+
                        else
                           ! 2-by-2 diagonal block
                           call stdlib_dlaln2(.false.,2,2,smin,one,t(j - 1,j - 1),ldt,one, &
@@ -59733,13 +59733,13 @@ module stdlib_linalg_lapack_d
                           work(j + n2) = x(2,2)
                           ! update the right-hand side
                           call stdlib_daxpy(j - 2,-x(1,1),t(1,j - 1),1,work(1 + n),1)
-                                    
+
                           call stdlib_daxpy(j - 2,-x(2,1),t(1,j),1,work(1 + n),1)
-                                    
+
                           call stdlib_daxpy(j - 2,-x(1,2),t(1,j - 1),1,work(1 + n2),1)
-                                    
+
                           call stdlib_daxpy(j - 2,-x(2,2),t(1,j),1,work(1 + n2),1)
-                                    
+
                        end if
                     end do loop_90
                     ! copy the vector x or q*x to vr and normalize.
@@ -59778,7 +59778,7 @@ module stdlib_linalg_lapack_d
                  end if
                  is = is - 1
                  if (ip /= 0) is = is - 1
-130              continue
+                 130 continue
                  if (ip == 1) ip = 0
                  if (ip == -1) ip = 1
               end do loop_140
@@ -59792,7 +59792,7 @@ module stdlib_linalg_lapack_d
                  if (ki == n) go to 150
                  if (t(ki + 1,ki) == zero) go to 150
                  ip = 1
-150              continue
+                 150 continue
                  if (somev) then
                     if (.not. select(ki)) go to 250
                  end if
@@ -59841,7 +59841,7 @@ module stdlib_linalg_lapack_d
                                     work(j + n),n,wr,zero,x,2,scale,xnorm,ierr)
                           ! scale if necessary
                           if (scale /= one) call stdlib_dscal(n - ki + 1,scale,work(ki + n),1)
-                                    
+
                           work(j + n) = x(1,1)
                           vmax = max(abs(work(j + n)),vmax)
                           vcrit = bignum/vmax
@@ -59867,7 +59867,7 @@ module stdlib_linalg_lapack_d
                                     work(j + n),n,wr,zero,x,2,scale,xnorm,ierr)
                           ! scale if necessary
                           if (scale /= one) call stdlib_dscal(n - ki + 1,scale,work(ki + n),1)
-                                    
+
                           work(j + n) = x(1,1)
                           work(j + 1 + n) = x(2,1)
                           vmax = max(abs(work(j + n)),abs(work(j + 1 + n)),vmax)
@@ -60027,7 +60027,7 @@ module stdlib_linalg_lapack_d
                  end if
                  is = is + 1
                  if (ip /= 0) is = is + 1
-250              continue
+                 250 continue
                  if (ip == -1) ip = 0
                  if (ip == 1) ip = -1
               end do loop_260
@@ -60070,7 +60070,7 @@ module stdlib_linalg_lapack_d
            ! Parameters
            integer(ilp),parameter :: nbmin = 8
            integer(ilp),parameter :: nbmax = 128
-           
+
            ! Local Scalars
            logical(lk) :: allv,bothv,leftv,lquery,over,pair,rightv,somev
            integer(ilp) :: i,ierr,ii,ip,is,j,j1,j2,jnxt,k,ki,iv,maxwrk,nb, &
@@ -60259,11 +60259,11 @@ module stdlib_linalg_lapack_d
                           end if
                           ! scale if necessary
                           if (scale /= one) call stdlib_dscal(ki,scale,work(1 + iv*n),1)
-                                    
+
                           work(j + iv*n) = x(1,1)
                           ! update right-hand side
                           call stdlib_daxpy(j - 1,-x(1,1),t(1,j),1,work(1 + iv*n),1)
-                                    
+
                        else
                           ! 2-by-2 diagonal block
                           call stdlib_dlaln2(.false.,2,1,smin,one,t(j - 1,j - 1),ldt,one, &
@@ -60280,14 +60280,14 @@ module stdlib_linalg_lapack_d
                           end if
                           ! scale if necessary
                           if (scale /= one) call stdlib_dscal(ki,scale,work(1 + iv*n),1)
-                                    
+
                           work(j - 1 + iv*n) = x(1,1)
                           work(j + iv*n) = x(2,1)
                           ! update right-hand side
                           call stdlib_daxpy(j - 2,-x(1,1),t(1,j - 1),1,work(1 + iv*n),1)
-                                    
+
                           call stdlib_daxpy(j - 2,-x(2,1),t(1,j),1,work(1 + iv*n),1)
-                                    
+
                        end if
                     end do loop_60
                     ! copy the vector x or q*x to vr and normalize.
@@ -60375,9 +60375,9 @@ module stdlib_linalg_lapack_d
                           work(j + (iv)*n) = x(1,2)
                           ! update the right-hand side
                           call stdlib_daxpy(j - 1,-x(1,1),t(1,j),1,work(1 + (iv - 1)*n),1)
-                                    
+
                           call stdlib_daxpy(j - 1,-x(1,2),t(1,j),1,work(1 + (iv)*n),1)
-                                    
+
                        else
                           ! 2-by-2 diagonal block
                           call stdlib_dlaln2(.false.,2,2,smin,one,t(j - 1,j - 1),ldt,one, &
@@ -60412,7 +60412,7 @@ module stdlib_linalg_lapack_d
                           call stdlib_daxpy(j - 2,-x(1,2),t(1,j - 1),1,work(1 + (iv)*n), &
                                     1)
                           call stdlib_daxpy(j - 2,-x(2,2),t(1,j),1,work(1 + (iv)*n),1)
-                                    
+
                        end if
                     end do loop_90
                     ! copy the vector x or q*x to vr and normalize.
@@ -60587,7 +60587,7 @@ module stdlib_linalg_lapack_d
                                     work(j + iv*n),n,wr,zero,x,2,scale,xnorm,ierr)
                           ! scale if necessary
                           if (scale /= one) call stdlib_dscal(n - ki + 1,scale,work(ki + iv*n),1)
-                                    
+
                           work(j + iv*n) = x(1,1)
                           vmax = max(abs(work(j + iv*n)),vmax)
                           vcrit = bignum/vmax
@@ -60613,11 +60613,11 @@ module stdlib_linalg_lapack_d
                                     work(j + iv*n),n,wr,zero,x,2,scale,xnorm,ierr)
                           ! scale if necessary
                           if (scale /= one) call stdlib_dscal(n - ki + 1,scale,work(ki + iv*n),1)
-                                    
+
                           work(j + iv*n) = x(1,1)
                           work(j + 1 + iv*n) = x(2,1)
                           vmax = max(abs(work(j + iv*n)),abs(work(j + 1 + iv*n)),vmax)
-                                    
+
                           vcrit = bignum/vmax
                        end if
                     end do loop_170
@@ -60713,7 +60713,7 @@ module stdlib_linalg_lapack_d
                           work(j + (iv)*n) = x(1,1)
                           work(j + (iv + 1)*n) = x(1,2)
                           vmax = max(abs(work(j + (iv)*n)),abs(work(j + (iv + 1)*n)),vmax)
-                                    
+
                           vcrit = bignum/vmax
                        else
                           ! 2-by-2 diagonal block
@@ -60759,9 +60759,9 @@ module stdlib_linalg_lapack_d
                        ! ------------------------------
                        ! no back-transform: copy x to vl and normalize.
                        call stdlib_dcopy(n - ki + 1,work(ki + (iv)*n),1,vl(ki,is),1)
-                                 
+
                        call stdlib_dcopy(n - ki + 1,work(ki + (iv + 1)*n),1,vl(ki,is + 1),1)
-                                 
+
                        emax = zero
                        do k = ki,n
                           emax = max(emax,abs(vl(k,is)) + abs(vl(k,is + 1)))
@@ -60869,7 +60869,7 @@ module stdlib_linalg_lapack_d
      !> off-diagonal elements of opposite sign.
 
      subroutine stdlib_dtrsyl(trana,tranb,isgn,m,n,a,lda,b,ldb,c,ldc,scale,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -60882,7 +60882,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: a(lda,*),b(ldb,*)
            real(dp),intent(inout) :: c(ldc,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notrna,notrnb
            integer(ilp) :: ierr,j,k,k1,k2,knext,l,l1,l2,lnext
@@ -61532,7 +61532,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: d(*),e(*),taup(*),tauq(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,iinfo,j,ldwrkx,ldwrky,lwkopt,minmn,nb,nbmin,nx,ws
@@ -61640,7 +61640,7 @@ module stdlib_linalg_lapack_d
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,iinfo,iwt,j,ldwork,lwkopt,nb,nbmin,nh,nx
@@ -61832,7 +61832,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*),b(ldb,*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,tpsd
            integer(ilp) :: brow,i,iascl,ibscl,j,mn,nb,scllen,wsize
@@ -62013,7 +62013,7 @@ module stdlib_linalg_lapack_d
            else if (ibscl == 2) then
               call stdlib_dlascl('G',0,0,bignum,bnrm,scllen,nrhs,b,ldb,info)
            end if
-50         continue
+           50 continue
            work(1) = real(wsize,KIND=dp)
            return
      end subroutine stdlib_dgels
@@ -62231,7 +62231,7 @@ module stdlib_linalg_lapack_d
            integer(ilp),parameter :: inb = 1
            integer(ilp),parameter :: inbmin = 2
            integer(ilp),parameter :: ixover = 3
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: fjb,iws,j,jb,lwkopt,minmn,minws,na,nb,nbmin,nfxd,nx,sm, &
@@ -62327,7 +62327,7 @@ module stdlib_linalg_lapack_d
                        ! determine the minimum value of nb.
                        nb = (lwork - 2*sn)/(sn + 1)
                        nbmin = max(2,stdlib_ilaenv(inbmin,'DGEQRF',' ',sm,sn,-1,-1))
-                                 
+
                     end if
                  end if
               end if
@@ -62342,7 +62342,7 @@ module stdlib_linalg_lapack_d
                  j = nfxd + 1
                  ! compute factorization: while loop.
                  topbmn = minmn - nx
-30               continue
+                 30 continue
                  if (j <= topbmn) then
                     jb = min(nb,topbmn - j + 1)
                     ! factorize jb columns among columns j:n.
@@ -62379,7 +62379,7 @@ module stdlib_linalg_lapack_d
            ! Local Scalars
            logical(lk),parameter :: use_recursive_qr = .true.
            integer(ilp) :: i,ib,iinfo,k
-           
+
            ! Executable Statements
            ! test the input arguments
            info = 0
@@ -62494,7 +62494,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Local Parameters
            integer(ilp),parameter :: nsweep = 30
-           
+
            ! Local Scalars
            real(dp) :: aapp,aapp0,aapq,aaqq,apoaq,aqoap,big,bigtheta,cs,ctol,epsln, &
            large,mxaapq,mxsinj,rootbig,rooteps,rootsfmin,roottol,skl,sfmin,small,sn,t, &
@@ -62700,7 +62700,7 @@ module stdlib_linalg_lapack_d
        ! #:) quick return for one-column matrix
            if (n == 1) then
               if (lsvec) call stdlib_dlascl('G',0,0,sva(1),skl,m,1,a(1,1),lda,ierr)
-                        
+
               work(1) = one/skl
               if (sva(1) >= sfmin) then
                  work(2) = one
@@ -62820,12 +62820,12 @@ module stdlib_linalg_lapack_d
                            tol,2,work(n + 1),lwork - n,ierr)
                  call stdlib_dgsvj0(jobv,n2,n4,a(1,n4 + 1),lda,work(n4 + 1),sva(n4 + 1), &
                  mvl,v(n4*q + 1,n4 + 1),ldv,epsln,sfmin,tol,1,work(n + 1),lwork - n,ierr)
-                           
+
                  call stdlib_dgsvj1(jobv,n2,n2,n4,a,lda,work,sva,mvl,v,ldv,epsln, &
                            sfmin,tol,1,work(n + 1),lwork - n,ierr)
                  call stdlib_dgsvj0(jobv,n2 + n4,n4,a(1,n2 + 1),lda,work(n2 + 1),sva(n2 + 1), &
                   mvl,v(n2*q + 1,n2 + 1),ldv,epsln,sfmin,tol,1,work(n + 1),lwork - n,ierr)
-                            
+
               end if
            end if
            ! .. row-cyclic pivot strategy with de rijk's pivoting ..
@@ -62931,23 +62931,23 @@ module stdlib_linalg_lapack_d
                                          fastr(3) = t*work(p)/work(q)
                                          fastr(4) = -t*work(q)/work(p)
                                          call stdlib_drotm(m,a(1,p),1,a(1,q),1,fastr)
-                                                   
+
                                          if (rsvec) call stdlib_drotm(mvl,v(1,p),1,v(1,q), &
                                                     1,fastr)
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq))
                                          mxsinj = max(mxsinj,abs(t))
                                       else
                        ! Choose Correct Signum For Theta And Rotate
                                          thsign = -sign(one,aapq)
                                          t = one/(theta + thsign*sqrt(one + theta*theta))
-                                                   
+
                                          cs = sqrt(one/(one + t*t))
                                          sn = t*cs
                                          mxsinj = max(mxsinj,abs(sn))
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq))
                                          apoaq = work(p)/work(q)
                                          aqoap = work(q)/work(p)
@@ -63029,7 +63029,7 @@ module stdlib_linalg_lapack_d
                                                 lda,ierr)
                                       temp1 = -aapq*work(p)/work(q)
                                       call stdlib_daxpy(m,temp1,work(n + 1),1,a(1,q),1)
-                                                
+
                                       call stdlib_dlascl('G',0,0,one,aaqq,m,1,a(1,q), &
                                                 lda,ierr)
                                       sva(q) = aaqq*sqrt(max(zero,one - aapq*aapq))
@@ -63041,7 +63041,7 @@ module stdlib_linalg_lapack_d
                                    if ((sva(q)/aaqq)**2 <= rooteps) then
                                       if ((aaqq < rootbig) .and. (aaqq > rootsfmin)) then
                                          sva(q) = stdlib_dnrm2(m,a(1,q),1)*work(q)
-                                                   
+
                                       else
                                          t = zero
                                          aaqq = one
@@ -63078,7 +63078,7 @@ module stdlib_linalg_lapack_d
                              end if
                           end do loop_2002
            ! end q-loop
-2103 continue
+           2103 continue
            ! bailed out of q-loop
                           sva(p) = aapp
                        else
@@ -63157,11 +63157,11 @@ module stdlib_linalg_lapack_d
                                          fastr(3) = t*work(p)/work(q)
                                          fastr(4) = -t*work(q)/work(p)
                                          call stdlib_drotm(m,a(1,p),1,a(1,q),1,fastr)
-                                                   
+
                                          if (rsvec) call stdlib_drotm(mvl,v(1,p),1,v(1,q), &
                                                     1,fastr)
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq))
                                          mxsinj = max(mxsinj,abs(t))
                                       else
@@ -63169,12 +63169,12 @@ module stdlib_linalg_lapack_d
                                          thsign = -sign(one,aapq)
                                          if (aaqq > aapp0) thsign = -thsign
                                          t = one/(theta + thsign*sqrt(one + theta*theta))
-                                                   
+
                                          cs = sqrt(one/(one + t*t))
                                          sn = t*cs
                                          mxsinj = max(mxsinj,abs(sn))
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq))
                                          apoaq = work(p)/work(q)
                                          aqoap = work(q)/work(p)
@@ -63250,7 +63250,7 @@ module stdlib_linalg_lapack_d
                                    else
                                       if (aapp > aaqq) then
                                          call stdlib_dcopy(m,a(1,p),1,work(n + 1),1)
-                                                   
+
                                          call stdlib_dlascl('G',0,0,aapp,one,m,1,work(n + 1 &
                                                    ),lda,ierr)
                                          call stdlib_dlascl('G',0,0,aaqq,one,m,1,a(1,q), &
@@ -63264,7 +63264,7 @@ module stdlib_linalg_lapack_d
                                          mxsinj = max(mxsinj,sfmin)
                                       else
                                          call stdlib_dcopy(m,a(1,q),1,work(n + 1),1)
-                                                   
+
                                          call stdlib_dlascl('G',0,0,aaqq,one,m,1,work(n + 1 &
                                                    ),lda,ierr)
                                          call stdlib_dlascl('G',0,0,aapp,one,m,1,a(1,p), &
@@ -63284,7 +63284,7 @@ module stdlib_linalg_lapack_d
                                    if ((sva(q)/aaqq)**2 <= rooteps) then
                                       if ((aaqq < rootbig) .and. (aaqq > rootsfmin)) then
                                          sva(q) = stdlib_dnrm2(m,a(1,q),1)*work(q)
-                                                   
+
                                       else
                                          t = zero
                                          aaqq = one
@@ -63327,7 +63327,7 @@ module stdlib_linalg_lapack_d
                              end if
                           end do loop_2200
               ! end of the q-loop
-2203 continue
+              2203 continue
                           sva(p) = aapp
                        else
                           if (aapp == zero) notrot = notrot + min(jgl + kbl - 1,n) - jgl + 1
@@ -63337,7 +63337,7 @@ module stdlib_linalg_lapack_d
            ! end of the p-loop
                  end do loop_2010
            ! end of the jbc-loop
-2011 continue
+           2011 continue
       ! 2011 bailed out of the jbc-loop
                  do p = igl,min(igl + kbl - 1,n)
                     sva(p) = abs(sva(p))
@@ -63366,12 +63366,12 @@ module stdlib_linalg_lapack_d
        ! #:( reaching this point means that the procedure has not converged.
            info = nsweep - 1
            go to 1995
-1994       continue
+           1994 continue
        ! #:) reaching this point means numerical convergence after the i-th
            ! sweep.
            info = 0
        ! #:) info = 0 confirms successful iterations.
-1995 continue
+       1995 continue
            ! sort the singular values and find how many are above
            ! the underflow threshold.
            n2 = 0
@@ -63469,7 +63469,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*),af(ldaf,*),b(ldb,*),c(*),r(*)
            real(dp),intent(out) :: berr(*),ferr(*),work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: colequ,equil,nofact,notran,rowequ
            character :: norm
@@ -63693,7 +63693,7 @@ module stdlib_linalg_lapack_d
            ! Function Arguments
            procedure(stdlib_selctg_d) :: selctg
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: cursl,ilascl,ilbscl,ilvsl,ilvsr,lastsl,lquery,lst2sl, &
                      wantst
@@ -63873,7 +63873,7 @@ module stdlib_linalg_lapack_d
                  call stdlib_dlascl('G',0,0,anrmto,anrm,n,1,alphai,n,ierr)
               end if
               if (ilbscl) call stdlib_dlascl('G',0,0,bnrmto,bnrm,n,1,beta,n,ierr)
-                        
+
               ! select eigenvalues
               do i = 1,n
                  bwork(i) = selctg(alphar(i),alphai(i),beta(i))
@@ -63963,7 +63963,7 @@ module stdlib_linalg_lapack_d
                  lastsl = cursl
               end do
            end if
-50         continue
+           50 continue
            work(1) = maxwrk
            return
      end subroutine stdlib_dgges
@@ -64016,7 +64016,7 @@ module stdlib_linalg_lapack_d
            ! Function Arguments
            procedure(stdlib_selctg_d) :: selctg
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: cursl,ilascl,ilbscl,ilvsl,ilvsr,lastsl,lquery,lst2sl,wantsb, &
                      wantse,wantsn,wantst,wantsv
@@ -64226,7 +64226,7 @@ module stdlib_linalg_lapack_d
                  call stdlib_dlascl('G',0,0,anrmto,anrm,n,1,alphai,n,ierr)
               end if
               if (ilbscl) call stdlib_dlascl('G',0,0,bnrmto,bnrm,n,1,beta,n,ierr)
-                        
+
               ! select eigenvalues
               do i = 1,n
                  bwork(i) = selctg(alphar(i),alphai(i),beta(i))
@@ -64332,7 +64332,7 @@ module stdlib_linalg_lapack_d
                  lastsl = cursl
               end do
            end if
-60         continue
+           60 continue
            work(1) = maxwrk
            iwork(1) = liwmin
            return
@@ -64366,9 +64366,9 @@ module stdlib_linalg_lapack_d
            ! Array Arguments
            real(dp),intent(inout) :: a(lda,*),b(ldb,*)
            real(dp),intent(out) :: alphai(*),alphar(*),beta(*),vl(ldvl,*),vr(ldvr,*),work(*)
-                     
+
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: ilascl,ilbscl,ilv,ilvl,ilvr,lquery
            character :: chtemp
@@ -64431,10 +64431,10 @@ module stdlib_linalg_lapack_d
               minwrk = max(1,8*n)
               maxwrk = max(1,n*(7 + stdlib_ilaenv(1,'DGEQRF',' ',n,1,n,0)))
               maxwrk = max(maxwrk,n*(7 + stdlib_ilaenv(1,'DORMQR',' ',n,1,n,0)))
-                        
+
               if (ilvl) then
                  maxwrk = max(maxwrk,n*(7 + stdlib_ilaenv(1,'DORGQR',' ',n,1,n,-1)))
-                           
+
               end if
               work(1) = maxwrk
               if (lwork < minwrk .and. .not. lquery) info = -16
@@ -64624,7 +64624,7 @@ module stdlib_linalg_lapack_d
               ! end of eigenvector calculation
            end if
            ! undo scaling if necessary
-110  continue
+           110 continue
            if (ilascl) then
               call stdlib_dlascl('G',0,0,anrmto,anrm,n,1,alphar,n,ierr)
               call stdlib_dlascl('G',0,0,anrmto,anrm,n,1,alphai,n,ierr)
@@ -64675,7 +64675,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(out) :: alphai(*),alphar(*),beta(*),lscale(*),rconde(*),rcondv(*) &
                      ,rscale(*),vl(ldvl,*),vr(ldvr,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: ilascl,ilbscl,ilv,ilvl,ilvr,lquery,noscl,pair,wantsb,wantse, &
                      wantsn,wantsv
@@ -64763,12 +64763,12 @@ module stdlib_linalg_lapack_d
                  end if
                  maxwrk = minwrk
                  maxwrk = max(maxwrk,n + n*stdlib_ilaenv(1,'DGEQRF',' ',n,1,n,0))
-                           
+
                  maxwrk = max(maxwrk,n + n*stdlib_ilaenv(1,'DORMQR',' ',n,1,n,0))
-                           
+
                  if (ilvl) then
                     maxwrk = max(maxwrk,n + n*stdlib_ilaenv(1,'DORGQR',' ',n,1,n,0))
-                              
+
                  end if
               end if
               work(1) = maxwrk
@@ -64816,7 +64816,7 @@ module stdlib_linalg_lapack_d
            ! permute and/or balance the matrix pair (a,b)
            ! (workspace: need 6*n if balanc = 's' or 'b', 1 otherwise)
            call stdlib_dggbal(balanc,n,a,lda,b,ldb,ilo,ihi,lscale,rscale,work,ierr)
-                     
+
            ! compute abnrm and bbnrm
            abnrm = stdlib_dlange('1',n,n,a,lda,work(1))
            if (ilascl) then
@@ -64962,7 +64962,7 @@ module stdlib_linalg_lapack_d
            ! (workspace: none needed)
            if (ilvl) then
               call stdlib_dggbak(balanc,'L',n,ilo,ihi,lscale,rscale,n,vl,ldvl,ierr)
-                        
+
               loop_70: do jc = 1,n
                  if (alphai(jc) < zero) cycle loop_70
                  temp = zero
@@ -64991,7 +64991,7 @@ module stdlib_linalg_lapack_d
            end if
            if (ilvr) then
               call stdlib_dggbak(balanc,'R',n,ilo,ihi,lscale,rscale,n,vr,ldvr,ierr)
-                        
+
               loop_120: do jc = 1,n
                  if (alphai(jc) < zero) cycle loop_120
                  temp = zero
@@ -65019,7 +65019,7 @@ module stdlib_linalg_lapack_d
               end do loop_120
            end if
            ! undo scaling if necessary
-130  continue
+           130 continue
            if (ilascl) then
               call stdlib_dlascl('G',0,0,anrmto,anrm,n,1,alphar,n,ierr)
               call stdlib_dlascl('G',0,0,anrmto,anrm,n,1,alphai,n,ierr)
@@ -65061,7 +65061,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*),b(ldb,*),d(*)
            real(dp),intent(out) :: work(*),x(*),y(*)
         ! ===================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,lopt,lwkmin,lwkopt,nb,nb1,nb2,nb3,nb4,np
@@ -65152,7 +65152,7 @@ module stdlib_linalg_lapack_d
            ! solve triangular system: r11*x = d1
            if (m > 0) then
               call stdlib_dtrtrs('UPPER','NO TRANSPOSE','NON UNIT',m,1,a,lda,d,m,info)
-                        
+
               if (info > 0) then
                  info = 2
                  return
@@ -65191,7 +65191,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*),b(ldb,*),c(*),d(*)
            real(dp),intent(out) :: work(*),x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: lopt,lwkmin,lwkopt,mn,nb,nb1,nb2,nb3,nb4,nr
@@ -65322,7 +65322,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: vl(ldvl,*),vr(ldvr,*),wr(*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: bothv,fromqr,leftv,noinit,pair,rightv
            integer(ilp) :: i,iinfo,k,kl,kln,kr,ksi,ksr,ldwork
@@ -65409,13 +65409,13 @@ module stdlib_linalg_lapack_d
                     do i = k,kl + 1,-1
                        if (h(i,i - 1) == zero) go to 30
                     end do
-30                  continue
+                    30 continue
                     kl = i
                     if (k > kr) then
                        do i = k,n - 1
                           if (h(i + 1,i) == zero) go to 50
                        end do
-50                     continue
+                       50 continue
                        kr = i
                     end if
                  end if
@@ -65438,7 +65438,7 @@ module stdlib_linalg_lapack_d
                  ! h(kl:kr,kl:kr). close roots are modified by eps3.
                  wkr = wr(k)
                  wki = wi(k)
-60               continue
+                 60 continue
                  do i = k - 1,kl,-1
                     if (select(i) .and. abs(wr(i) - wkr) + abs(wi(i) - wki) < eps3) &
                               then
@@ -65616,7 +65616,7 @@ module stdlib_linalg_lapack_d
      !> without guard digits, but we know of none.
 
      pure subroutine stdlib_dlaed3(k,n,n1,d,q,ldq,rho,dlamda,q2,indx,ctot,w,s,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -65630,7 +65630,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: dlamda(*),w(*)
            real(dp),intent(in) :: q2(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,ii,iq2,j,n12,n2,n23
            real(dp) :: temp
@@ -65715,7 +65715,7 @@ module stdlib_linalg_lapack_d
               end do
            end do
            ! compute the updated eigenvectors.
-110  continue
+           110 continue
            n2 = n - n1
            n12 = ctot(1) + ctot(2)
            n23 = ctot(2) + ctot(3)
@@ -65733,7 +65733,7 @@ module stdlib_linalg_lapack_d
            else
               call stdlib_dlaset('A',n1,k,zero,zero,q(1,1),ldq)
            end if
-120        continue
+           120 continue
            return
      end subroutine stdlib_dlaed3
 
@@ -65775,12 +65775,12 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: rho
            ! Array Arguments
            integer(ilp),intent(inout) :: givcol(2,*),givptr(*),perm(*),prmptr(*),qptr(*)
-                     
+
            integer(ilp),intent(out) :: indxq(*),iwork(*)
            real(dp),intent(inout) :: d(*),givnum(2,*),q(ldq,*),qstore(*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: coltyp,curr,i,idlmda,indx,indxc,indxp,iq2,is,iw,iz,k,ldq2, &
                      n1,n2,ptr
@@ -65867,7 +65867,7 @@ module stdlib_linalg_lapack_d
                  indxq(i) = i
               end do
            end if
-30         continue
+           30 continue
            return
      end subroutine stdlib_dlaed7
 
@@ -65894,7 +65894,7 @@ module stdlib_linalg_lapack_d
            ! Parameters
            integer(ilp),parameter :: ldd = 4
            integer(ilp),parameter :: ldx = 2
-           
+
            ! Local Scalars
            integer(ilp) :: ierr,j2,j3,j4,k,nd
            real(dp) :: cs,dnorm,eps,scale,smlnum,sn,t11,t22,t33,tau,tau1,tau2,temp, &
@@ -65919,7 +65919,7 @@ module stdlib_linalg_lapack_d
               call stdlib_dlartg(t(j1,j2),t22 - t11,cs,sn,temp)
               ! apply transformation to the matrix t.
               if (j3 <= n) call stdlib_drot(n - j1 - 1,t(j1,j3),ldt,t(j2,j3),ldt,cs,sn)
-                        
+
               call stdlib_drot(j1 - 1,t(1,j1),1,t(1,j2),1,cs,sn)
               t(j1,j1) = t22
               t(j2,j2) = t11
@@ -65945,7 +65945,7 @@ module stdlib_linalg_lapack_d
               ! swap the adjacent diagonal blocks.
               k = n1 + n1 + n2 - 3
               go to(10,20,30) k
-10            continue
+              10 continue
               ! n1 = 1, n2 = 2: generate elementary reflector h so that:
               ! ( scale, x11, x12 ) h = ( 0, 0, * )
               u(1) = scale
@@ -65971,7 +65971,7 @@ module stdlib_linalg_lapack_d
                  call stdlib_dlarfx('R',n,3,u,tau,q(1,j1),ldq,work)
               end if
               go to 40
-20            continue
+              20 continue
               ! n1 = 2, n2 = 1: generate elementary reflector h so that:
               ! h (  -x11 ) = ( * )
                 ! (  -x21 ) = ( 0 )
@@ -65999,7 +65999,7 @@ module stdlib_linalg_lapack_d
                  call stdlib_dlarfx('R',n,3,u,tau,q(1,j1),ldq,work)
               end if
               go to 40
-30            continue
+              30 continue
               ! n1 = 2, n2 = 2: generate elementary reflectors h(1) and h(2) so
               ! that:
               ! h(2) h(1) (  -x11  -x12 ) = (  *  * )
@@ -66039,7 +66039,7 @@ module stdlib_linalg_lapack_d
                  call stdlib_dlarfx('R',n,3,u1,tau1,q(1,j1),ldq,work)
                  call stdlib_dlarfx('R',n,3,u2,tau2,q(1,j2),ldq,work)
               end if
-40            continue
+              40 continue
               if (n2 == 2) then
                  ! standardize new 2-by-2 block t11
                  call stdlib_dlanv2(t(j1,j1),t(j1,j2),t(j2,j1),t(j2,j2),wr1,wi1, &
@@ -66062,7 +66062,7 @@ module stdlib_linalg_lapack_d
            end if
            return
            ! exit with info = 1 if swap was rejected.
-50   continue
+           50 continue
            info = 1
            return
      end subroutine stdlib_dlaexc
@@ -66089,7 +66089,7 @@ module stdlib_linalg_lapack_d
            real(dp),parameter :: dat1 = 3.0_dp/4.0_dp
            real(dp),parameter :: dat2 = -0.4375_dp
            integer(ilp),parameter :: kexsh = 10
-           
+
            ! Local Scalars
            real(dp) :: aa,ab,ba,bb,cs,det,h11,h12,h21,h21s,h22,rt1i,rt1r,rt2i,rt2r, &
                      rtdisc,s,safmax,safmin,smlnum,sn,sum,t1,t2,t3,tr,tst,ulp,v2,v3
@@ -66138,7 +66138,7 @@ module stdlib_linalg_lapack_d
            ! eigenvalues i+1 to ihi have already converged. either l = ilo or
            ! h(l,l-1) is negligible so that the matrix splits.
            i = ihi
-20         continue
+           20 continue
            l = ilo
            if (i < ilo) go to 160
            ! perform qr iterations on rows and columns ilo to i until a
@@ -66166,7 +66166,7 @@ module stdlib_linalg_lapack_d
                     if (ba*(ab/s) <= max(smlnum,ulp*(bb*(aa/s)))) go to 40
                  end if
               end do
-40            continue
+              40 continue
               l = k
               if (l > ilo) then
                  ! h(l,l-1) is negligible
@@ -66260,7 +66260,7 @@ module stdlib_linalg_lapack_d
                  if (abs(h(m,m - 1))*(abs(v(2)) + abs(v(3))) <= ulp*abs(v(1))*(abs( &
                            h(m - 1,m - 1)) + abs(h(m,m)) + abs(h(m + 1,m + 1)))) go to 60
               end do
-60            continue
+              60 continue
               ! double-shift qr step
               loop_130: do k = m,i - 1
                  ! the first iteration of this loop determines a reflection g
@@ -66343,7 +66343,7 @@ module stdlib_linalg_lapack_d
            ! failure to converge in remaining number of iterations
            info = i
            return
-150        continue
+           150 continue
            if (l == i) then
               ! h(i,i-1) is negligible: one eigenvalue has converged.
               wr(i) = h(i,i)
@@ -66357,7 +66357,7 @@ module stdlib_linalg_lapack_d
               if (wantt) then
                  ! apply the transformation to the rest of h.
                  if (i2 > i) call stdlib_drot(i2 - i,h(i - 1,i + 1),ldh,h(i,i + 1),ldh,cs,sn)
-                           
+
                  call stdlib_drot(i - i1 - 1,h(i1,i - 1),1,h(i1,i),1,cs,sn)
               end if
               if (wantz) then
@@ -66370,7 +66370,7 @@ module stdlib_linalg_lapack_d
            ! return to start of the main loop with new value of i.
            i = l - 1
            go to 20
-160        continue
+           160 continue
            return
      end subroutine stdlib_dlahqr
 
@@ -66397,7 +66397,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: d(*),u(ldu,*),vt(ldvt,*)
            real(dp),intent(out) :: dsigma(*),u2(ldu2,*),vt2(ldvt2,*),z(*)
         ! =====================================================================
-           
+
            ! Local Arrays
            integer(ilp) :: ctot(4),psm(4)
            ! Local Scalars
@@ -66503,9 +66503,9 @@ module stdlib_linalg_lapack_d
                  go to 90
               end if
            end do
-90         continue
+           90 continue
            j = jprev
-100        continue
+           100 continue
            j = j + 1
            if (j > n) go to 110
            if (abs(z(j)) <= tol) then
@@ -66554,13 +66554,13 @@ module stdlib_linalg_lapack_d
               end if
            end if
            go to 100
-110        continue
+           110 continue
            ! record the last singular value.
            k = k + 1
            u2(k,1) = z(jprev)
            dsigma(k) = d(jprev)
            idxp(k) = jprev
-120        continue
+           120 continue
            ! count up the total number of the various types of columns, then
            ! form a permutation which positions the four column types into
            ! four groups of uniform structure (although one or more of these
@@ -66858,7 +66858,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: tau(*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wantq
            integer(ilp) :: i,iinfo,j,lwkopt,mn
@@ -66942,7 +66942,7 @@ module stdlib_linalg_lapack_d
                  if (m > 1) then
                     ! form q(2:m,2:m)
                     call stdlib_dorgqr(m - 1,m - 1,m - 1,a(2,2),lda,tau,work,lwork,iinfo)
-                              
+
                  end if
               end if
            else
@@ -66969,7 +66969,7 @@ module stdlib_linalg_lapack_d
                  if (n > 1) then
                     ! form p**t(2:n,2:n)
                     call stdlib_dorglq(n - 1,n - 1,n - 1,a(2,2),lda,tau,work,lwork,iinfo)
-                              
+
                  end if
               end if
            end if
@@ -67213,7 +67213,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: ab(ldab,*),afb(ldafb,*),b(ldb,*),s(*)
            real(dp),intent(out) :: berr(*),ferr(*),work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: equil,nofact,rcequ,upper
            integer(ilp) :: i,infequ,j,j1,j2
@@ -67302,7 +67302,7 @@ module stdlib_linalg_lapack_d
                  do j = 1,n
                     j1 = max(j - kd,1)
                     call stdlib_dcopy(j - j1 + 1,ab(kd + 1 - j + j1,j),1,afb(kd + 1 - j + j1,j),1)
-                              
+
                  end do
               else
                  do j = 1,n
@@ -67364,7 +67364,7 @@ module stdlib_linalg_lapack_d
            ! Array Arguments
            real(dp),intent(inout) :: a(0:*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,nisodd,normaltransr
            integer(ilp) :: n1,n2,k
@@ -67416,7 +67416,7 @@ module stdlib_linalg_lapack_d
                     call stdlib_dpotrf('L',n1,a(0),n,info)
                     if (info > 0) return
                     call stdlib_dtrsm('R','L','T','N',n2,n1,one,a(0),n,a(n1),n)
-                              
+
                     call stdlib_dsyrk('U','N',n2,n1,-one,a(n1),n,one,a(n),n)
                     call stdlib_dpotrf('U',n2,a(n),n,info)
                     if (info > 0) info = info + n1
@@ -67427,7 +67427,7 @@ module stdlib_linalg_lapack_d
                     call stdlib_dpotrf('L',n1,a(n2),n,info)
                     if (info > 0) return
                     call stdlib_dtrsm('L','L','N','N',n1,n2,one,a(n2),n,a(0),n)
-                              
+
                     call stdlib_dsyrk('U','T',n2,n1,-one,a(0),n,one,a(n1),n)
                     call stdlib_dpotrf('U',n2,a(n1),n,info)
                     if (info > 0) info = info + n1
@@ -67443,7 +67443,7 @@ module stdlib_linalg_lapack_d
                     call stdlib_dtrsm('L','U','T','N',n1,n2,one,a(0),n1,a(n1*n1),n1 &
                               )
                     call stdlib_dsyrk('L','T',n2,n1,-one,a(n1*n1),n1,one,a(1),n1)
-                              
+
                     call stdlib_dpotrf('L',n2,a(1),n1,info)
                     if (info > 0) info = info + n1
                  else
@@ -67455,7 +67455,7 @@ module stdlib_linalg_lapack_d
                     call stdlib_dtrsm('R','U','N','N',n2,n1,one,a(n2*n2),n2,a(0),n2 &
                               )
                     call stdlib_dsyrk('L','N',n2,n1,-one,a(0),n2,one,a(n1*n2),n2)
-                              
+
                     call stdlib_dpotrf('L',n2,a(n1*n2),n2,info)
                     if (info > 0) info = info + n1
                  end if
@@ -67471,9 +67471,9 @@ module stdlib_linalg_lapack_d
                     call stdlib_dpotrf('L',k,a(1),n + 1,info)
                     if (info > 0) return
                     call stdlib_dtrsm('R','L','T','N',k,k,one,a(1),n + 1,a(k + 1),n + 1)
-                              
+
                     call stdlib_dsyrk('U','N',k,k,-one,a(k + 1),n + 1,one,a(0),n + 1)
-                              
+
                     call stdlib_dpotrf('U',k,a(0),n + 1,info)
                     if (info > 0) info = info + k
                  else
@@ -67483,9 +67483,9 @@ module stdlib_linalg_lapack_d
                     call stdlib_dpotrf('L',k,a(k + 1),n + 1,info)
                     if (info > 0) return
                     call stdlib_dtrsm('L','L','N','N',k,k,one,a(k + 1),n + 1,a(0),n + 1)
-                              
+
                     call stdlib_dsyrk('U','T',k,k,-one,a(0),n + 1,one,a(k),n + 1)
-                              
+
                     call stdlib_dpotrf('U',k,a(k),n + 1,info)
                     if (info > 0) info = info + k
                  end if
@@ -67500,7 +67500,7 @@ module stdlib_linalg_lapack_d
                     call stdlib_dtrsm('L','U','T','N',k,k,one,a(k),n1,a(k*(k + 1)), &
                               k)
                     call stdlib_dsyrk('L','T',k,k,-one,a(k*(k + 1)),k,one,a(0),k)
-                              
+
                     call stdlib_dpotrf('L',k,a(0),k,info)
                     if (info > 0) info = info + k
                  else
@@ -67595,7 +67595,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*),af(ldaf,*),b(ldb,*),s(*)
            real(dp),intent(out) :: berr(*),ferr(*),work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: equil,nofact,rcequ
            integer(ilp) :: i,infequ,j
@@ -67738,7 +67738,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: q(ldq,*),t(ldt,*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: wantq
            integer(ilp) :: here,nbf,nbl,nbnext
@@ -67791,7 +67791,7 @@ module stdlib_linalg_lapack_d
               if (nbf == 2 .and. nbl == 1) ilst = ilst - 1
               if (nbf == 1 .and. nbl == 2) ilst = ilst + 1
               here = ifst
-10            continue
+              10 continue
               ! swap block with next one below
               if (nbf == 1 .or. nbf == 2) then
                  ! current block either 1 by 1 or 2 by 2
@@ -67800,7 +67800,7 @@ module stdlib_linalg_lapack_d
                     if (t(here + nbf + 1,here + nbf) /= zero) nbnext = 2
                  end if
                  call stdlib_dlaexc(wantq,n,t,ldt,q,ldq,here,nbf,nbnext,work,info)
-                           
+
                  if (info /= 0) then
                     ilst = here
                     return
@@ -67818,7 +67818,7 @@ module stdlib_linalg_lapack_d
                     if (t(here + 3,here + 2) /= zero) nbnext = 2
                  end if
                  call stdlib_dlaexc(wantq,n,t,ldt,q,ldq,here + 1,1,nbnext,work,info)
-                           
+
                  if (info /= 0) then
                     ilst = here
                     return
@@ -67826,7 +67826,7 @@ module stdlib_linalg_lapack_d
                  if (nbnext == 1) then
                     ! swap two 1 by 1 blocks, no problems possible
                     call stdlib_dlaexc(wantq,n,t,ldt,q,ldq,here,1,nbnext,work,info)
-                              
+
                     here = here + 1
                  else
                     ! recompute nbnext in case 2 by 2 split
@@ -67834,7 +67834,7 @@ module stdlib_linalg_lapack_d
                     if (nbnext == 2) then
                        ! 2 by 2 block did not split
                        call stdlib_dlaexc(wantq,n,t,ldt,q,ldq,here,1,nbnext,work,info)
-                                 
+
                        if (info /= 0) then
                           ilst = here
                           return
@@ -67843,9 +67843,9 @@ module stdlib_linalg_lapack_d
                     else
                        ! 2 by 2 block did split
                        call stdlib_dlaexc(wantq,n,t,ldt,q,ldq,here,1,1,work,info)
-                                 
+
                        call stdlib_dlaexc(wantq,n,t,ldt,q,ldq,here + 1,1,1,work,info)
-                                 
+
                        here = here + 2
                     end if
                  end if
@@ -67853,7 +67853,7 @@ module stdlib_linalg_lapack_d
               if (here < ilst) go to 10
            else
               here = ifst
-20            continue
+              20 continue
               ! swap block with next one above
               if (nbf == 1 .or. nbf == 2) then
                  ! current block either 1 by 1 or 2 by 2
@@ -67880,7 +67880,7 @@ module stdlib_linalg_lapack_d
                     if (t(here - 1,here - 2) /= zero) nbnext = 2
                  end if
                  call stdlib_dlaexc(wantq,n,t,ldt,q,ldq,here - nbnext,nbnext,1,work,info)
-                           
+
                  if (info /= 0) then
                     ilst = here
                     return
@@ -67888,7 +67888,7 @@ module stdlib_linalg_lapack_d
                  if (nbnext == 1) then
                     ! swap two 1 by 1 blocks, no problems possible
                     call stdlib_dlaexc(wantq,n,t,ldt,q,ldq,here,nbnext,1,work,info)
-                              
+
                     here = here - 1
                  else
                     ! recompute nbnext in case 2 by 2 split
@@ -67896,7 +67896,7 @@ module stdlib_linalg_lapack_d
                     if (nbnext == 2) then
                        ! 2 by 2 block did not split
                        call stdlib_dlaexc(wantq,n,t,ldt,q,ldq,here - 1,2,1,work,info)
-                                 
+
                        if (info /= 0) then
                           ilst = here
                           return
@@ -67905,9 +67905,9 @@ module stdlib_linalg_lapack_d
                     else
                        ! 2 by 2 block did split
                        call stdlib_dlaexc(wantq,n,t,ldt,q,ldq,here,1,1,work,info)
-                                 
+
                        call stdlib_dlaexc(wantq,n,t,ldt,q,ldq,here - 1,1,1,work,info)
-                                 
+
                        here = here - 2
                     end if
                  end if
@@ -67946,7 +67946,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: q(ldq,*),t(ldt,*)
            real(dp),intent(out) :: wi(*),work(*),wr(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,pair,swap,wantbh,wantq,wants,wantsp
            integer(ilp) :: ierr,k,kase,kk,ks,liwmin,lwmin,n1,n2,nn
@@ -68049,7 +68049,7 @@ module stdlib_linalg_lapack_d
                     ierr = 0
                     kk = k
                     if (k /= ks) call stdlib_dtrexc(compq,n,t,ldt,q,ldq,kk,ks,work,ierr)
-                              
+
                     if (ierr == 1 .or. ierr == 2) then
                        ! blocks too close to swap: exit.
                        info = 1
@@ -68080,7 +68080,7 @@ module stdlib_linalg_lapack_d
               ! estimate sep(t11,t22).
               est = zero
               kase = 0
-30            continue
+              30 continue
               call stdlib_dlacn2(nn,work(nn + 1),work,iwork,est,kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -68096,7 +68096,7 @@ module stdlib_linalg_lapack_d
               end if
               sep = scale/est
            end if
-40         continue
+           40 continue
            ! store the output eigenvalues in wr and wi.
            do k = 1,n
               wr(k) = t(k,k)
@@ -68137,7 +68137,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(out) :: s(*),sep(*),work(ldwork,*)
            real(dp),intent(in) :: t(ldt,*),vl(ldvl,*),vr(ldvr,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: pair,somcon,wantbh,wants,wantsp
            integer(ilp) :: i,ierr,ifst,ilst,j,k,kase,ks,n2,nn
@@ -68320,7 +68320,7 @@ module stdlib_linalg_lapack_d
                     ! estimate norm(inv(c**t))
                     est = zero
                     kase = 0
-50                  continue
+                    50 continue
                     call stdlib_dlacn2(nn,work(1,n + 2),work(1,n + 4),iwork,est,kase, &
                               isave)
                     if (kase /= 0) then
@@ -68385,7 +68385,7 @@ module stdlib_linalg_lapack_d
            integer(ilp),intent(out) :: iwork(*)
            character,intent(in) :: joba,jobp,jobr,jobt,jobu,jobv
         ! ===========================================================================
-           
+
            ! Local Scalars
            real(dp) :: aapp,aaqq,aatmax,aatmin,big,big1,cond_ok,condr1,condr2,entra, &
                      entrat,epsln,maxprj,scalem,sconda,sfmin,small,temp1,uscal1,uscal2,xsc
@@ -68774,7 +68774,7 @@ module stdlib_linalg_lapack_d
                     go to 3002
                  end if
               end do
-3002          continue
+              3002 continue
            else if (l2rank) then
               ! .. similarly as above, only slightly more gentle (less aggressive).
               ! sudden drop on the diagonal of r1 is used as the criterion for
@@ -68785,7 +68785,7 @@ module stdlib_linalg_lapack_d
                            l2kill .and. (abs(a(p,p)) < temp1))) go to 3402
                  nr = nr + 1
               end do
-3402          continue
+              3402 continue
            else
               ! the goal is high relative accuracy. however, if the matrix
               ! has high scaled condition number the relative accuracy is in
@@ -68800,7 +68800,7 @@ module stdlib_linalg_lapack_d
                            3302
                  nr = nr + 1
               end do
-3302          continue
+              3302 continue
            end if
            almort = .false.
            if (nr == n) then
@@ -68924,7 +68924,7 @@ module stdlib_linalg_lapack_d
                  end do
                  call stdlib_dlaset('UPPER',nr - 1,nr - 1,zero,zero,v(1,2),ldv)
                  call stdlib_dgesvj('L','U','N',n,nr,v,ldv,sva,nr,a,lda,work,lwork,info)
-                           
+
                  scalem = work(1)
                  numrank = nint(work(2),KIND=ilp)
               else
@@ -68935,7 +68935,7 @@ module stdlib_linalg_lapack_d
                  call stdlib_dlacpy('LOWER',nr,nr,a,lda,v,ldv)
                  call stdlib_dlaset('UPPER',nr - 1,nr - 1,zero,zero,v(1,2),ldv)
                  call stdlib_dgeqrf(nr,nr,v,ldv,work(n + 1),work(2*n + 1),lwork - 2*n,ierr)
-                           
+
                  do p = 1,nr
                     call stdlib_dcopy(nr - p + 1,v(p,p),ldv,v(p,p),1)
                  end do
@@ -69053,7 +69053,7 @@ module stdlib_linalg_lapack_d
                     ! of a lower triangular matrix.
                     ! r1^t = q2 * r2
                     call stdlib_dgeqrf(n,nr,v,ldv,work(n + 1),work(2*n + 1),lwork - 2*n,ierr)
-                              
+
                     if (l2pert) then
                        xsc = sqrt(small)/epsln
                        do p = 2,nr
@@ -69607,7 +69607,7 @@ module stdlib_linalg_lapack_d
      !> more simple.
 
      subroutine stdlib_dgelsy(m,n,nrhs,a,lda,b,ldb,jpvt,rcond,rank,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -69623,7 +69623,7 @@ module stdlib_linalg_lapack_d
            ! Parameters
            integer(ilp),parameter :: imax = 1
            integer(ilp),parameter :: imin = 2
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,iascl,ibscl,ismax,ismin,j,lwkmin,lwkopt,mn,nb,nb1,nb2, &
@@ -69715,7 +69715,7 @@ module stdlib_linalg_lapack_d
            ! compute qr factorization with column pivoting of a:
               ! a * p = q * r
            call stdlib_dgeqp3(m,n,a,lda,jpvt,work(1),work(mn + 1),lwork - mn,info)
-                     
+
            wsize = mn + work(mn + 1)
            ! workspace: mn+2*n+nb*(n+1).
            ! details of householder rotations stored in work(1:mn).
@@ -69731,7 +69731,7 @@ module stdlib_linalg_lapack_d
            else
               rank = 1
            end if
-10         continue
+           10 continue
            if (rank < mn) then
               i = rank + 1
               call stdlib_dlaic1(imin,rank,work(ismin),smin,a(1,i),a(i,i),sminpr, &
@@ -69800,7 +69800,7 @@ module stdlib_linalg_lapack_d
            else if (ibscl == 2) then
               call stdlib_dlascl('G',0,0,bignum,bnrm,n,nrhs,b,ldb,info)
            end if
-70         continue
+           70 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_dgelsy
@@ -69951,7 +69951,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*),b(ldb,*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,tran
            integer(ilp) :: i,iascl,ibscl,j,maxmn,brow,scllen,tszo,tszm,lwo,lwm,lw1, &
@@ -70151,7 +70151,7 @@ module stdlib_linalg_lapack_d
            else if (ibscl == 2) then
              call stdlib_dlascl('G',0,0,bignum,bnrm,scllen,nrhs,b,ldb,info)
            end if
-50         continue
+           50 continue
            work(1) = real(tszo + lwo,KIND=dp)
            return
      end subroutine stdlib_dgetsls
@@ -70170,7 +70170,7 @@ module stdlib_linalg_lapack_d
      !> of DGEQRT for more details on the format.
 
      pure subroutine stdlib_dgetsqrhrt(m,n,mb1,nb1,nb2,a,lda,t,ldt,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -70181,7 +70181,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: t(ldt,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,iinfo,j,lw1,lw2,lwt,ldwt,lworkopt,nb1local,nb2local, &
@@ -70250,7 +70250,7 @@ module stdlib_linalg_lapack_d
            nb2local = min(nb2,n)
            ! (1) perform tsqr-factorization of the m-by-n matrix a.
            call stdlib_dlatsqr(m,n,mb1,nb1local,a,lda,work,ldwt,work(lwt + 1),lw1,iinfo)
-                     
+
            ! (2) copy the factor r_tsqr stored in the upper-triangular part
                ! of a into the square matrix in the work array
                ! work(lwt+1:lwt+n*n) column-by-column.
@@ -70264,7 +70264,7 @@ module stdlib_linalg_lapack_d
            ! (4) perform the reconstruction of householder vectors from
            ! the matrix q (stored in a) in place.
            call stdlib_dorhr_col(m,n,nb2local,a,lda,t,ldt,work(lwt + n*n + 1),iinfo)
-                     
+
            ! (5) copy the factor r_tsqr stored in the square matrix in the
            ! work array work(lwt+1:lwt+n*n) into the upper-triangular
            ! part of a.
@@ -70313,7 +70313,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: mone = -1.0_dp
-           
+
            ! Local Arrays
            integer(ilp) :: ctot(4),psm(4)
            ! Local Scalars
@@ -70407,7 +70407,7 @@ module stdlib_linalg_lapack_d
                  go to 80
               end if
            end do
-80         continue
+           80 continue
            j = j + 1
            nj = indx(j)
            if (j > n) go to 100
@@ -70438,7 +70438,7 @@ module stdlib_linalg_lapack_d
                  d(pj) = t
                  k2 = k2 - 1
                  i = 1
-90               continue
+                 90 continue
                  if (k2 + i <= n) then
                     if (d(pj) < d(indxp(k2 + i))) then
                        indxp(k2 + i - 1) = indxp(k2 + i)
@@ -70461,7 +70461,7 @@ module stdlib_linalg_lapack_d
               end if
            end if
            go to 80
-100        continue
+           100 continue
            ! record the last eigenvalue.
            k = k + 1
            dlamda(k) = d(pj)
@@ -70542,7 +70542,7 @@ module stdlib_linalg_lapack_d
            do j = 1,4
               coltyp(j) = ctot(j)
            end do
-190        continue
+           190 continue
            return
      end subroutine stdlib_dlaed2
 
@@ -70572,7 +70572,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: h(ldh,*),z(ldz,*)
            real(dp),intent(out) :: si(*),sr(*),t(ldt,*),v(ldv,*),work(*),wv(ldwv,*)
         ! ================================================================
-           
+
            ! Local Scalars
            real(dp) :: aa,bb,beta,cc,cs,dd,evi,evk,foo,s,safmax,safmin,smlnum,sn, &
                      tau,ulp
@@ -70592,7 +70592,7 @@ module stdlib_linalg_lapack_d
               lwk1 = int(work(1),KIND=ilp)
               ! ==== workspace query call to stdlib_dormhr ====
               call stdlib_dormhr('R','N',jw,jw,1,jw - 1,t,ldt,work,v,ldv,work,-1,info)
-                        
+
               lwk2 = int(work(1),KIND=ilp)
               ! ==== optimal workspace ====
               lwkopt = jw + max(lwk1,lwk2)
@@ -70657,7 +70657,7 @@ module stdlib_linalg_lapack_d
            ! ==== deflation detection loop ====
            ns = jw
            ilst = infqr + 1
-20         continue
+           20 continue
            if (ilst <= ns) then
               if (ns == 1) then
                  bulge = .false.
@@ -70708,7 +70708,7 @@ module stdlib_linalg_lapack_d
               ! .    exchange failures. ====
               sorted = .false.
               i = ns + 1
-30            continue
+              30 continue
               if (sorted) go to 50
               sorted = .true.
               kend = i - 1
@@ -70720,13 +70720,13 @@ module stdlib_linalg_lapack_d
               else
                  k = i + 2
               end if
-40            continue
+              40 continue
               if (k <= kend) then
                  if (k == i + 1) then
                     evi = abs(t(i,i))
                  else
                     evi = abs(t(i,i)) + sqrt(abs(t(i + 1,i)))*sqrt(abs(t(i,i + 1)))
-                              
+
                  end if
                  if (k == kend) then
                     evk = abs(t(k,k))
@@ -70734,7 +70734,7 @@ module stdlib_linalg_lapack_d
                     evk = abs(t(k,k))
                  else
                     evk = abs(t(k,k)) + sqrt(abs(t(k + 1,k)))*sqrt(abs(t(k,k + 1)))
-                              
+
                  end if
                  if (evi >= evk) then
                     i = k
@@ -70759,11 +70759,11 @@ module stdlib_linalg_lapack_d
                  go to 40
               end if
               go to 30
-50            continue
+              50 continue
            end if
            ! ==== restore shift/eigenvalue array from t ====
            i = jw
-60         continue
+           60 continue
            if (i >= infqr + 1) then
               if (i == infqr + 1) then
                  sr(kwtop + i - 1) = t(i,i)
@@ -70796,7 +70796,7 @@ module stdlib_linalg_lapack_d
                  call stdlib_dlarf('R',ns,ns,work,1,tau,t,ldt,work(jw + 1))
                  call stdlib_dlarf('R',jw,ns,work,1,tau,v,ldv,work(jw + 1))
                  call stdlib_dgehrd(jw,1,ns,t,ldt,work,work(jw + 1),lwork - jw,info)
-                           
+
               end if
               ! ==== copy updated reduced window into place ====
               if (kwtop > 1) h(kwtop,kwtop - 1) = s*v(1,1)
@@ -70894,7 +70894,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: d(*),u(ldu,*),vt(ldvt,*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: coltyp,i,idx,idxc,idxp,iq,isigma,iu2,ivt2,iz,k,ldq,ldu2, &
                      ldvt2,m,n,n1,n2
@@ -71063,7 +71063,7 @@ module stdlib_linalg_lapack_d
                  indxq(i) = i
               end do
            end if
-20         continue
+           20 continue
            return
      end subroutine stdlib_dlaed1
 
@@ -71083,7 +71083,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: d(*),e(*),q(ldq,*)
            real(dp),intent(out) :: qstore(ldqs,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: curlvl,curprb,curr,i,igivcl,igivnm,igivpt,indxq,iperm,iprmpt, &
            iq,iqptr,iwrem,j,k,lgn,matsiz,msd2,smlsiz,smm1,spm1,spm2,submat,subpbs, &
@@ -71117,7 +71117,7 @@ module stdlib_linalg_lapack_d
            iwork(1) = n
            subpbs = 1
            tlvls = 0
-10         continue
+           10 continue
            if (iwork(subpbs) > smlsiz) then
               do j = subpbs,1,-1
                  iwork(2*j) = (iwork(j) + 1)/2
@@ -71184,7 +71184,7 @@ module stdlib_linalg_lapack_d
                  if (icompq == 1) then
                     call stdlib_dgemm('N','N',qsiz,matsiz,matsiz,one,q(1,submat),ldq, &
                     work(iq - 1 + iwork(iqptr + curr)),matsiz,zero,qstore(1,submat),ldqs)
-                              
+
                  end if
                  iwork(iqptr + curr + 1) = iwork(iqptr + curr) + matsiz**2
                  curr = curr + 1
@@ -71199,7 +71199,7 @@ module stdlib_linalg_lapack_d
            ! into eigensystem for the corresponding larger matrix.
            ! while ( subpbs > 1 )
            curlvl = 1
-80         continue
+           80 continue
            if (subpbs > 1) then
               spm2 = subpbs - 2
               loop_90: do i = 0,spm2,2
@@ -71224,13 +71224,13 @@ module stdlib_linalg_lapack_d
                  if (icompq == 2) then
                     call stdlib_dlaed1(matsiz,d(submat),q(submat,submat),ldq,iwork( &
                     indxq + submat),e(submat + msd2 - 1),msd2,work,iwork(subpbs + 1),info)
-                              
+
                  else
                     call stdlib_dlaed7(icompq,matsiz,qsiz,tlvls,curlvl,curprb,d(submat), &
                     qstore(1,submat),ldqs,iwork(indxq + submat),e(submat + msd2 - 1),msd2, &
                     work(iq),iwork(iqptr),iwork(iprmpt),iwork(iperm),iwork(igivpt), &
                     iwork(igivcl),work(igivnm),work(iwrem),iwork(subpbs + 1),info)
-                              
+
                  end if
                  if (info /= 0) go to 130
                  iwork(i/2 + 1) = iwork(i + 2)
@@ -71265,9 +71265,9 @@ module stdlib_linalg_lapack_d
               call stdlib_dcopy(n,work,1,d,1)
            end if
            go to 140
-130        continue
+           130 continue
            info = submat*(n + 1) + submat + matsiz - 1
-140        continue
+           140 continue
            return
      end subroutine stdlib_dlaed0
 
@@ -71284,7 +71284,7 @@ module stdlib_linalg_lapack_d
      !> without guard digits, but we know of none.  See DLAED3 for details.
 
      pure subroutine stdlib_dstedc(compz,n,d,e,z,ldz,work,lwork,iwork,liwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -71297,7 +71297,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: d(*),e(*),z(ldz,*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: finish,i,icompz,ii,j,k,lgn,liwmin,lwmin,m,smlsiz,start, &
@@ -71400,7 +71400,7 @@ module stdlib_linalg_lapack_d
               eps = stdlib_dlamch('EPSILON')
               start = 1
               ! while ( start <= n )
-10   continue
+              10 continue
               if (start <= n) then
                  ! let finish be the position of the next subdiagonal entry
                  ! such that e( finish ) <= tiny or finish = n if no such
@@ -71408,7 +71408,7 @@ module stdlib_linalg_lapack_d
                  ! between start and finish constitutes an independent
                  ! sub-problem.
                  finish = start
-20               continue
+                 20 continue
                  if (finish < n) then
                     tiny = eps*sqrt(abs(d(finish)))*sqrt(abs(d(finish + 1)))
                     if (abs(e(finish)) > tiny) then
@@ -71427,7 +71427,7 @@ module stdlib_linalg_lapack_d
                     orgnrm = stdlib_dlanst('M',m,d(start),e(start))
                     call stdlib_dlascl('G',0,0,orgnrm,one,m,1,d(start),m,info)
                     call stdlib_dlascl('G',0,0,orgnrm,one,m - 1,1,e(start),m - 1,info)
-                              
+
                     if (icompz == 1) then
                        strtrw = 1
                     else
@@ -71450,7 +71450,7 @@ module stdlib_linalg_lapack_d
                        call stdlib_dsteqr('I',m,d(start),e(start),work,m,work(m*m + 1), &
                                  info)
                        call stdlib_dlacpy('A',n,m,z(1,start),ldz,work(storez),n)
-                                 
+
                        call stdlib_dgemm('N','N',n,m,m,one,work(storez),n,work,m,zero, &
                                  z(1,start),ldz)
                     else if (icompz == 2) then
@@ -71491,7 +71491,7 @@ module stdlib_linalg_lapack_d
                 end do
               end if
            end if
-50         continue
+           50 continue
            work(1) = lwmin
            iwork(1) = liwmin
            return
@@ -71508,7 +71508,7 @@ module stdlib_linalg_lapack_d
      !> without guard digits, but we know of none.
 
      pure subroutine stdlib_dstevd(jobz,n,d,e,z,ldz,work,lwork,iwork,liwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -71521,7 +71521,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: d(*),e(*)
            real(dp),intent(out) :: work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wantz
            integer(ilp) :: iscale,liwmin,lwmin
@@ -71627,7 +71627,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: w(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,lquery,wantz
            integer(ilp) :: iinfo,inde,indtau,indwk2,indwrk,iscale,liopt,liwmin,llwork, &
@@ -71665,7 +71665,7 @@ module stdlib_linalg_lapack_d
                     lwmin = 2*n + 1
                  end if
                  lopt = max(lwmin,2*n + stdlib_ilaenv(1,'DSYTRD',uplo,n,-1,-1,-1))
-                           
+
                  liopt = liwmin
               end if
               work(1) = lopt
@@ -71762,7 +71762,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*),b(ldb,*)
            real(dp),intent(out) :: w(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper,wantz
            character :: trans
@@ -71839,7 +71839,7 @@ module stdlib_linalg_lapack_d
                     trans = 'T'
                  end if
                  call stdlib_dtrsm('LEFT',uplo,trans,'NON-UNIT',n,n,one,b,ldb,a,lda)
-                           
+
               else if (itype == 3) then
                  ! for b*a*x=(lambda)*x;
                  ! backtransform eigenvectors: x = l*y or u**t*y
@@ -71849,7 +71849,7 @@ module stdlib_linalg_lapack_d
                     trans = 'N'
                  end if
                  call stdlib_dtrmm('LEFT',uplo,trans,'NON-UNIT',n,n,one,b,ldb,a,lda)
-                           
+
               end if
            end if
            work(1) = lopt
@@ -71881,7 +71881,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: ab(ldab,*)
            real(dp),intent(out) :: w(*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,lquery,wantz
            integer(ilp) :: iinfo,inde,indwk2,indwrk,iscale,liwmin,llwrk2,lwmin
@@ -72015,7 +72015,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: ab(ldab,*),bb(ldbb,*)
            real(dp),intent(out) :: w(*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper,wantz
            character :: vect
@@ -72082,7 +72082,7 @@ module stdlib_linalg_lapack_d
            indwk2 = indwrk + n*n
            llwrk2 = lwork - indwk2 + 1
            call stdlib_dsbgst(jobz,uplo,n,ka,kb,ab,ldab,bb,ldbb,z,ldz,work,iinfo)
-                     
+
            ! reduce to tridiagonal form.
            if (wantz) then
               vect = 'U'
@@ -72117,7 +72117,7 @@ module stdlib_linalg_lapack_d
      !> without guard digits, but we know of none.
 
      subroutine stdlib_dspevd(jobz,uplo,n,ap,w,z,ldz,work,lwork,iwork,liwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -72130,7 +72130,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: ap(*)
            real(dp),intent(out) :: w(*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wantz
            integer(ilp) :: iinfo,inde,indtau,indwrk,iscale,liwmin,llwork,lwmin
@@ -72319,7 +72319,7 @@ module stdlib_linalg_lapack_d
            ! transform problem to standard eigenvalue problem and solve.
            call stdlib_dspgst(itype,uplo,n,ap,bp,info)
            call stdlib_dspevd(jobz,uplo,n,ap,w,z,ldz,work,lwork,iwork,liwork,info)
-                     
+
            lwmin = max(real(lwmin,KIND=dp),real(work(1),KIND=dp))
            liwmin = max(real(liwmin,KIND=dp),real(iwork(1),KIND=dp))
            if (wantz) then
@@ -72389,7 +72389,7 @@ module stdlib_linalg_lapack_d
         ! changed dimension statement in comment describing e from (n) to
         ! (n-1).  sven, 17 feb 05.
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: difl,difr,givcol,givnum,givptr,i,ic,icompq,ierr,ii,is,iu, &
            iuplo,ivt,j,k,kk,mlvl,nm1,nsize,perm,poles,qstart,smlsiz,smlszp,sqre, &
@@ -72573,7 +72573,7 @@ module stdlib_linalg_lapack_d
            end do loop_30
            ! unscale
            call stdlib_dlascl('G',0,0,one,orgnrm,n,1,d,n,ierr)
-40         continue
+           40 continue
            ! use selection sort to minimize swaps of singular vectors
            do ii = 2,n
               i = ii - 1
@@ -72656,7 +72656,7 @@ module stdlib_linalg_lapack_d
            real(dp),parameter :: hndrd = 100.0_dp
            real(dp),parameter :: meigth = -0.125_dp
            integer(ilp),parameter :: maxitr = 6
-           
+
            ! Local Scalars
            logical(lk) :: lower,rotate
            integer(ilp) :: i,idir,isub,iter,iterdivn,j,ll,lll,m,maxitdivn,nm1,nm12, &
@@ -72722,9 +72722,9 @@ module stdlib_linalg_lapack_d
               end do
               ! update singular vectors if desired
               if (nru > 0) call stdlib_dlasr('R','V','F',nru,n,work(1),work(n),u,ldu)
-                        
+
               if (ncc > 0) call stdlib_dlasr('L','V','F',n,ncc,work(1),work(n),c,ldc)
-                        
+
            end if
            ! compute singular values to relative accuracy tol
            ! (by setting tol to be negative, algorithm will compute
@@ -72750,7 +72750,7 @@ module stdlib_linalg_lapack_d
                  sminoa = min(sminoa,mu)
                  if (sminoa == zero) go to 50
               end do
-50            continue
+              50 continue
               sminoa = sminoa/sqrt(real(n,KIND=dp))
               thresh = max(tol*sminoa,maxitr*(n*(n*unfl)))
            else
@@ -72768,7 +72768,7 @@ module stdlib_linalg_lapack_d
            ! m points to last element of unconverged part of matrix
            m = n
            ! begin main iteration loop
-60   continue
+           60 continue
            ! check for convergence or exceeding iteration count
            if (m <= 1) go to 160
            if (iter >= n) then
@@ -72791,7 +72791,7 @@ module stdlib_linalg_lapack_d
            end do
            ll = 0
            go to 90
-80         continue
+           80 continue
            e(ll) = zero
            ! matrix splits since e(ll) = 0
            if (ll == m - 1) then
@@ -72799,7 +72799,7 @@ module stdlib_linalg_lapack_d
               m = m - 1
               go to 60
            end if
-90         continue
+           90 continue
            ll = ll + 1
            ! e(ll) through e(m-1) are nonzero, e(ll-1) is zero
            if (ll == m - 1) then
@@ -72814,7 +72814,7 @@ module stdlib_linalg_lapack_d
                         )
               if (nru > 0) call stdlib_drot(nru,u(1,m - 1),1,u(1,m),1,cosl,sinl)
               if (ncc > 0) call stdlib_drot(ncc,c(m - 1,1),ldc,c(m,1),ldc,cosl,sinl)
-                        
+
               m = m - 2
               go to 60
            end if
@@ -73030,7 +73030,7 @@ module stdlib_linalg_lapack_d
            ! qr iteration finished, go back and check convergence
            go to 60
            ! all singular values converged, so make them positive
-160  continue
+           160 continue
            do i = 1,n
               if (d(i) < zero) then
                  d(i) = -d(i)
@@ -73055,20 +73055,20 @@ module stdlib_linalg_lapack_d
                  d(isub) = d(n + 1 - i)
                  d(n + 1 - i) = smin
                  if (ncvt > 0) call stdlib_dswap(ncvt,vt(isub,1),ldvt,vt(n + 1 - i,1),ldvt)
-                           
+
                  if (nru > 0) call stdlib_dswap(nru,u(1,isub),1,u(1,n + 1 - i),1)
                  if (ncc > 0) call stdlib_dswap(ncc,c(isub,1),ldc,c(n + 1 - i,1),ldc)
-                           
+
               end if
            end do
            go to 220
            ! maximum number of iterations exceeded, failure to converge
-200  continue
+           200 continue
            info = 0
            do i = 1,n - 1
               if (e(i) /= zero) info = info + 1
            end do
-220        continue
+           220 continue
            return
      end subroutine stdlib_dbdsqr
 
@@ -73102,7 +73102,7 @@ module stdlib_linalg_lapack_d
            ! Function Arguments
            procedure(stdlib_select_d) :: select
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: cursl,lastsl,lquery,lst2sl,scalea,wantst,wantvs
            integer(ilp) :: hswork,i,i1,i2,ibal,icond,ierr,ieval,ihi,ilo,inxt,ip,itau, &
@@ -73356,7 +73356,7 @@ module stdlib_linalg_lapack_d
            ! Function Arguments
            procedure(stdlib_select_d) :: select
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: cursl,lastsl,lquery,lst2sl,scalea,wantsb,wantse,wantsn,wantst, &
                      wantsv,wantvs
@@ -73636,7 +73636,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: vl(ldvl,*),vr(ldvr,*),wi(*),work(*),wr(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,scalea,wantvl,wantvr
            character :: side
@@ -73856,7 +73856,7 @@ module stdlib_linalg_lapack_d
               end do
            end if
            ! undo scaling if necessary
-50   continue
+           50 continue
            if (scalea) then
               call stdlib_dlascl('G',0,0,cscale,anrm,n - info,1,wr(info + 1),max(n - info,1 &
                         ),ierr)
@@ -73913,7 +73913,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(out) :: rconde(*),rcondv(*),scale(*),vl(ldvl,*),vr(ldvr,*),wi(*), &
                       work(*),wr(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,scalea,wantvl,wantvr,wntsnb,wntsne,wntsnn,wntsnv
            character :: job,side
@@ -74001,12 +74001,12 @@ module stdlib_linalg_lapack_d
                  else
                     minwrk = 3*n
                     if ((.not. wntsnn) .and. (.not. wntsne)) minwrk = max(minwrk,n*n + 6*n)
-                              
+
                     maxwrk = max(maxwrk,hswork)
                     maxwrk = max(maxwrk,n + (n - 1)*stdlib_ilaenv(1,'DORGHR',' ',n,1,n,- &
                               1))
                     if ((.not. wntsnn) .and. (.not. wntsne)) maxwrk = max(maxwrk,n*n + 6*n)
-                              
+
                     maxwrk = max(maxwrk,3*n)
                  end if
                  maxwrk = max(maxwrk,minwrk)
@@ -74165,7 +74165,7 @@ module stdlib_linalg_lapack_d
               end do
            end if
            ! undo scaling if necessary
-50   continue
+           50 continue
            if (scalea) then
               call stdlib_dlascl('G',0,0,cscale,anrm,n - info,1,wr(info + 1),max(n - info,1 &
                         ),ierr)
@@ -74223,7 +74223,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*),b(ldb,*)
            real(dp),intent(out) :: s(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: iascl,ibscl,ie,il,itau,itaup,itauq,ldwork,liwork,maxmn, &
@@ -74269,9 +74269,9 @@ module stdlib_linalg_lapack_d
                  ! path 1a - overdetermined, with many more rows than columns.
                  mm = n
                  maxwrk = max(maxwrk,n + n*stdlib_ilaenv(1,'DGEQRF',' ',m,n,-1,-1))
-                           
+
                  maxwrk = max(maxwrk,n + nrhs*stdlib_ilaenv(1,'DORMQR','LT',m,nrhs,n,-1))
-                           
+
               end if
               if (m >= n) then
                  ! path 1 - overdetermined or exactly determined.
@@ -74430,7 +74430,7 @@ module stdlib_linalg_lapack_d
               ! compute a=l*q.
               ! (workspace: need 2*m, prefer m+m*nb)
               call stdlib_dgelqf(m,n,a,lda,work(itau),work(nwork),lwork - nwork + 1,info)
-                        
+
               il = nwork
               ! copy l to work(il), zeroing out above its diagonal.
               call stdlib_dlacpy('L',m,m,a,lda,work(il),ldwork)
@@ -74500,7 +74500,7 @@ module stdlib_linalg_lapack_d
            else if (ibscl == 2) then
               call stdlib_dlascl('G',0,0,bignum,bnrm,n,nrhs,b,ldb,info)
            end if
-10         continue
+           10 continue
            work(1) = maxwrk
            iwork(1) = liwork
            return
@@ -74520,7 +74520,7 @@ module stdlib_linalg_lapack_d
      !> value.
 
      subroutine stdlib_dgelss(m,n,nrhs,a,lda,b,ldb,s,rcond,rank,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -74532,7 +74532,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*),b(ldb,*)
            real(dp),intent(out) :: s(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: bdspac,bl,chunk,i,iascl,ibscl,ie,il,itau,itaup,itauq,iwork, &
@@ -74780,7 +74780,7 @@ module stdlib_linalg_lapack_d
               ! (workspace: need n, prefer n*nrhs)
               if (lwork >= ldb*nrhs .and. nrhs > 1) then
                  call stdlib_dgemm('T','N',n,nrhs,n,one,a,lda,b,ldb,zero,work,ldb)
-                           
+
                  call stdlib_dlacpy('G',n,nrhs,work,ldb,b,ldb)
               else if (nrhs > 1) then
                  chunk = lwork/n
@@ -74805,7 +74805,7 @@ module stdlib_linalg_lapack_d
               ! compute a=l*q
               ! (workspace: need 2*m, prefer m+m*nb)
               call stdlib_dgelqf(m,n,a,lda,work(itau),work(iwork),lwork - iwork + 1,info)
-                        
+
               il = iwork
               ! copy l to work(il), zeroing out above it
               call stdlib_dlacpy('L',m,m,a,lda,work(il),ldwork)
@@ -74915,7 +74915,7 @@ module stdlib_linalg_lapack_d
               ! (workspace: need n, prefer n*nrhs)
               if (lwork >= ldb*nrhs .and. nrhs > 1) then
                  call stdlib_dgemm('T','N',n,nrhs,m,one,a,lda,b,ldb,zero,work,ldb)
-                           
+
                  call stdlib_dlacpy('F',n,nrhs,work,ldb,b,ldb)
               else if (nrhs > 1) then
                  chunk = lwork/n
@@ -74943,7 +74943,7 @@ module stdlib_linalg_lapack_d
            else if (ibscl == 2) then
               call stdlib_dlascl('G',0,0,bignum,bnrm,n,nrhs,b,ldb,info)
            end if
-70         continue
+           70 continue
            work(1) = maxwrk
            return
      end subroutine stdlib_dgelss
@@ -74969,7 +74969,7 @@ module stdlib_linalg_lapack_d
      !> without guard digits, but we know of none.
 
      subroutine stdlib_dgesdd(jobz,m,n,a,lda,s,u,ldu,vt,ldvt,work,lwork,iwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -74982,7 +74982,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: s(*),u(ldu,*),vt(ldvt,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wntqa,wntqas,wntqn,wntqo,wntqs
            integer(ilp) :: bdspac,blk,chunk,i,ie,ierr,il,ir,iscl,itau,itaup,itauq,iu, &
@@ -75150,7 +75150,7 @@ module stdlib_linalg_lapack_d
                            ierr)
                  lwork_dgebrd_mn = int(dum(1),KIND=ilp)
                  call stdlib_dgebrd(m,m,a,m,s,dum(1),dum(1),dum(1),dum(1),-1,ierr)
-                           
+
                  lwork_dgebrd_mm = int(dum(1),KIND=ilp)
                  call stdlib_dgelqf(m,n,a,m,dum(1),dum(1),-1,ierr)
                  lwork_dgelqf_mn = int(dum(1),KIND=ilp)
@@ -75365,7 +75365,7 @@ module stdlib_linalg_lapack_d
                        call stdlib_dgemm('N','N',chunk,n,n,one,a(i,1),lda,work(iu), &
                                  n,zero,work(ir),ldwrkr)
                        call stdlib_dlacpy('F',chunk,n,work(ir),ldwrkr,a(i,1),lda)
-                                 
+
                     end do
                  else if (wntqs) then
                     ! path 3 (m >> n, jobz='s')
@@ -75546,7 +75546,7 @@ module stdlib_linalg_lapack_d
                           call stdlib_dgemm('N','N',chunk,n,n,one,a(i,1),lda,work(iu) &
                                     ,ldwrku,zero,work(ir),ldwrkr)
                           call stdlib_dlacpy('F',chunk,n,work(ir),ldwrkr,a(i,1),lda)
-                                    
+
                        end do
                     end if
                  else if (wntqs) then
@@ -75684,7 +75684,7 @@ module stdlib_linalg_lapack_d
                        call stdlib_dgemm('N','N',m,blk,m,one,work(ivt),m,a(1,i),lda, &
                                   zero,work(il),ldwrkl)
                        call stdlib_dlacpy('F',m,blk,work(il),ldwrkl,a(1,i),lda)
-                                 
+
                     end do
                  else if (wntqs) then
                     ! path 3t (n >> m, jobz='s')
@@ -75932,7 +75932,7 @@ module stdlib_linalg_lapack_d
      !> Note that the routine returns V**T, not V.
 
      subroutine stdlib_dgesvd(jobu,jobvt,m,n,a,lda,s,u,ldu,vt,ldvt,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -75944,7 +75944,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: s(*),u(ldu,*),vt(ldvt,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wntua,wntuas,wntun,wntuo,wntus,wntva,wntvas,wntvn,wntvo, &
                       wntvs
@@ -76013,7 +76013,7 @@ module stdlib_linalg_lapack_d
                  lwork_dorgqr_m = int(dum(1),KIND=ilp)
                  ! compute space needed for stdlib_dgebrd
                  call stdlib_dgebrd(n,n,a,lda,s,dum(1),dum(1),dum(1),dum(1),-1,ierr)
-                           
+
                  lwork_dgebrd = int(dum(1),KIND=ilp)
                  ! compute space needed for stdlib_dorgbr p
                  call stdlib_dorgbr('P',n,n,n,a,lda,dum(1),dum(1),-1,ierr)
@@ -76113,7 +76113,7 @@ module stdlib_linalg_lapack_d
                  else
                     ! path 10 (m at least n, but not much larger)
                     call stdlib_dgebrd(m,n,a,lda,s,dum(1),dum(1),dum(1),dum(1),-1,ierr)
-                              
+
                     lwork_dgebrd = int(dum(1),KIND=ilp)
                     maxwrk = 3*n + lwork_dgebrd
                     if (wntus .or. wntuo) then
@@ -76146,7 +76146,7 @@ module stdlib_linalg_lapack_d
                  lwork_dorglq_m = int(dum(1),KIND=ilp)
                  ! compute space needed for stdlib_dgebrd
                  call stdlib_dgebrd(m,m,a,lda,s,dum(1),dum(1),dum(1),dum(1),-1,ierr)
-                           
+
                  lwork_dgebrd = int(dum(1),KIND=ilp)
                   ! compute space needed for stdlib_dorgbr p
                  call stdlib_dorgbr('P',m,m,m,a,n,dum(1),dum(1),-1,ierr)
@@ -76246,7 +76246,7 @@ module stdlib_linalg_lapack_d
                  else
                     ! path 10t(n greater than m, but not much larger)
                     call stdlib_dgebrd(m,n,a,lda,s,dum(1),dum(1),dum(1),dum(1),-1,ierr)
-                              
+
                     lwork_dgebrd = int(dum(1),KIND=ilp)
                     maxwrk = 3*m + lwork_dgebrd
                     if (wntvs .or. wntvo) then
@@ -76368,7 +76368,7 @@ module stdlib_linalg_lapack_d
                        ! copy r to work(ir) and zero out below it
                        call stdlib_dlacpy('U',n,n,a,lda,work(ir),ldwrkr)
                        call stdlib_dlaset('L',n - 1,n - 1,zero,zero,work(ir + 1),ldwrkr)
-                                 
+
                        ! generate q in a
                        ! (workspace: need n*n + 2*n, prefer n*n + n + n*nb)
                        call stdlib_dorgqr(m,n,n,a,lda,work(itau),work(iwork),lwork - &
@@ -76400,7 +76400,7 @@ module stdlib_linalg_lapack_d
                           call stdlib_dgemm('N','N',chunk,n,n,one,a(i,1),lda,work(ir) &
                                     ,ldwrkr,zero,work(iu),ldwrku)
                           call stdlib_dlacpy('F',chunk,n,work(iu),ldwrku,a(i,1),lda)
-                                    
+
                        end do
                     else
                        ! insufficient workspace for a fast algorithm
@@ -76452,7 +76452,7 @@ module stdlib_linalg_lapack_d
                        ! copy r to vt, zeroing out below it
                        call stdlib_dlacpy('U',n,n,a,lda,vt,ldvt)
                        if (n > 1) call stdlib_dlaset('L',n - 1,n - 1,zero,zero,vt(2,1),ldvt)
-                                 
+
                        ! generate q in a
                        ! (workspace: need n*n + 2*n, prefer n*n + n + n*nb)
                        call stdlib_dorgqr(m,n,n,a,lda,work(itau),work(iwork),lwork - &
@@ -76490,7 +76490,7 @@ module stdlib_linalg_lapack_d
                           call stdlib_dgemm('N','N',chunk,n,n,one,a(i,1),lda,work(ir) &
                                     ,ldwrkr,zero,work(iu),ldwrku)
                           call stdlib_dlacpy('F',chunk,n,work(iu),ldwrku,a(i,1),lda)
-                                    
+
                        end do
                     else
                        ! insufficient workspace for a fast algorithm
@@ -76503,7 +76503,7 @@ module stdlib_linalg_lapack_d
                        ! copy r to vt, zeroing out below it
                        call stdlib_dlacpy('U',n,n,a,lda,vt,ldvt)
                        if (n > 1) call stdlib_dlaset('L',n - 1,n - 1,zero,zero,vt(2,1),ldvt)
-                                 
+
                        ! generate q in a
                        ! (workspace: need 2*n, prefer n + n*nb)
                        call stdlib_dorgqr(m,n,n,a,lda,work(itau),work(iwork),lwork - &
@@ -76556,7 +76556,7 @@ module stdlib_linalg_lapack_d
                           ! copy r to work(ir), zeroing out below it
                           call stdlib_dlacpy('U',n,n,a,lda,work(ir),ldwrkr)
                           call stdlib_dlaset('L',n - 1,n - 1,zero,zero,work(ir + 1),ldwrkr)
-                                    
+
                           ! generate q in a
                           ! (workspace: need n*n + 2*n, prefer n*n + n + n*nb)
                           call stdlib_dorgqr(m,n,n,a,lda,work(itau),work(iwork),lwork - &
@@ -76604,7 +76604,7 @@ module stdlib_linalg_lapack_d
                           ! zero out below r in a
                           if (n > 1) then
                              call stdlib_dlaset('L',n - 1,n - 1,zero,zero,a(2,1),lda)
-                                       
+
                           end if
                           ! bidiagonalize r in a
                           ! (workspace: need 4*n, prefer 3*n + 2*n*nb)
@@ -76653,7 +76653,7 @@ module stdlib_linalg_lapack_d
                           ! copy r to work(iu), zeroing out below it
                           call stdlib_dlacpy('U',n,n,a,lda,work(iu),ldwrku)
                           call stdlib_dlaset('L',n - 1,n - 1,zero,zero,work(iu + 1),ldwrku)
-                                    
+
                           ! generate q in a
                           ! (workspace: need 2*n*n + 2*n, prefer 2*n*n + n + n*nb)
                           call stdlib_dorgqr(m,n,n,a,lda,work(itau),work(iwork),lwork - &
@@ -76669,7 +76669,7 @@ module stdlib_linalg_lapack_d
                           call stdlib_dgebrd(n,n,work(iu),ldwrku,s,work(ie),work(itauq &
                                     ),work(itaup),work(iwork),lwork - iwork + 1,ierr)
                           call stdlib_dlacpy('U',n,n,work(iu),ldwrku,work(ir),ldwrkr)
-                                    
+
                           ! generate left bidiagonalizing vectors in work(iu)
                           ! (workspace: need 2*n*n + 4*n, prefer 2*n*n + 3*n + n*nb)
                           call stdlib_dorgbr('Q',n,n,n,work(iu),ldwrku,work(itauq), &
@@ -76714,7 +76714,7 @@ module stdlib_linalg_lapack_d
                           ! zero out below r in a
                           if (n > 1) then
                              call stdlib_dlaset('L',n - 1,n - 1,zero,zero,a(2,1),lda)
-                                       
+
                           end if
                           ! bidiagonalize r in a
                           ! (workspace: need 4*n, prefer 3*n + 2*n*nb)
@@ -76760,7 +76760,7 @@ module stdlib_linalg_lapack_d
                           ! copy r to work(iu), zeroing out below it
                           call stdlib_dlacpy('U',n,n,a,lda,work(iu),ldwrku)
                           call stdlib_dlaset('L',n - 1,n - 1,zero,zero,work(iu + 1),ldwrku)
-                                    
+
                           ! generate q in a
                           ! (workspace: need n*n + 2*n, prefer n*n + n + n*nb)
                           call stdlib_dorgqr(m,n,n,a,lda,work(itau),work(iwork),lwork - &
@@ -76863,7 +76863,7 @@ module stdlib_linalg_lapack_d
                           ! copy r to work(ir), zeroing out below it
                           call stdlib_dlacpy('U',n,n,a,lda,work(ir),ldwrkr)
                           call stdlib_dlaset('L',n - 1,n - 1,zero,zero,work(ir + 1),ldwrkr)
-                                    
+
                           ! generate q in u
                           ! (workspace: need n*n + n + m, prefer n*n + n + m*nb)
                           call stdlib_dorgqr(m,m,n,u,ldu,work(itau),work(iwork),lwork - &
@@ -76913,7 +76913,7 @@ module stdlib_linalg_lapack_d
                           ! zero out below r in a
                           if (n > 1) then
                              call stdlib_dlaset('L',n - 1,n - 1,zero,zero,a(2,1),lda)
-                                       
+
                           end if
                           ! bidiagonalize r in a
                           ! (workspace: need 4*n, prefer 3*n + 2*n*nb)
@@ -76968,7 +76968,7 @@ module stdlib_linalg_lapack_d
                           ! copy r to work(iu), zeroing out below it
                           call stdlib_dlacpy('U',n,n,a,lda,work(iu),ldwrku)
                           call stdlib_dlaset('L',n - 1,n - 1,zero,zero,work(iu + 1),ldwrku)
-                                    
+
                           ie = itau
                           itauq = ie + n
                           itaup = itauq + n
@@ -76980,7 +76980,7 @@ module stdlib_linalg_lapack_d
                           call stdlib_dgebrd(n,n,work(iu),ldwrku,s,work(ie),work(itauq &
                                     ),work(itaup),work(iwork),lwork - iwork + 1,ierr)
                           call stdlib_dlacpy('U',n,n,work(iu),ldwrku,work(ir),ldwrkr)
-                                    
+
                           ! generate left bidiagonalizing vectors in work(iu)
                           ! (workspace: need 2*n*n + 4*n, prefer 2*n*n + 3*n + n*nb)
                           call stdlib_dorgbr('Q',n,n,n,work(iu),ldwrku,work(itauq), &
@@ -77026,7 +77026,7 @@ module stdlib_linalg_lapack_d
                           ! zero out below r in a
                           if (n > 1) then
                              call stdlib_dlaset('L',n - 1,n - 1,zero,zero,a(2,1),lda)
-                                       
+
                           end if
                           ! bidiagonalize r in a
                           ! (workspace: need 4*n, prefer 3*n + 2*n*nb)
@@ -77078,7 +77078,7 @@ module stdlib_linalg_lapack_d
                           ! copy r to work(iu), zeroing out below it
                           call stdlib_dlacpy('U',n,n,a,lda,work(iu),ldwrku)
                           call stdlib_dlaset('L',n - 1,n - 1,zero,zero,work(iu + 1),ldwrku)
-                                    
+
                           ie = itau
                           itauq = ie + n
                           itaup = itauq + n
@@ -77299,7 +77299,7 @@ module stdlib_linalg_lapack_d
                        ! copy l to work(ir) and zero out above it
                        call stdlib_dlacpy('L',m,m,a,lda,work(ir),ldwrkr)
                        call stdlib_dlaset('U',m - 1,m - 1,zero,zero,work(ir + ldwrkr),ldwrkr)
-                                 
+
                        ! generate q in a
                        ! (workspace: need m*m + 2*m, prefer m*m + m + m*nb)
                        call stdlib_dorglq(m,n,m,a,lda,work(itau),work(iwork),lwork - &
@@ -77331,7 +77331,7 @@ module stdlib_linalg_lapack_d
                           call stdlib_dgemm('N','N',m,blk,m,one,work(ir),ldwrkr,a(1,i &
                                     ),lda,zero,work(iu),ldwrku)
                           call stdlib_dlacpy('F',m,blk,work(iu),ldwrku,a(1,i),lda)
-                                    
+
                        end do
                     else
                        ! insufficient workspace for a fast algorithm
@@ -77423,7 +77423,7 @@ module stdlib_linalg_lapack_d
                           call stdlib_dgemm('N','N',m,blk,m,one,work(ir),ldwrkr,a(1,i &
                                     ),lda,zero,work(iu),ldwrku)
                           call stdlib_dlacpy('F',m,blk,work(iu),ldwrku,a(1,i),lda)
-                                    
+
                        end do
                     else
                        ! insufficient workspace for a fast algorithm
@@ -77600,7 +77600,7 @@ module stdlib_linalg_lapack_d
                           call stdlib_dgebrd(m,m,work(iu),ldwrku,s,work(ie),work(itauq &
                                     ),work(itaup),work(iwork),lwork - iwork + 1,ierr)
                           call stdlib_dlacpy('L',m,m,work(iu),ldwrku,work(ir),ldwrkr)
-                                    
+
                           ! generate right bidiagonalizing vectors in work(iu)
                           ! (workspace: need 2*m*m + 4*m-1,
                                       ! prefer 2*m*m+3*m+(m-1)*nb)
@@ -77905,7 +77905,7 @@ module stdlib_linalg_lapack_d
                           call stdlib_dgebrd(m,m,work(iu),ldwrku,s,work(ie),work(itauq &
                                     ),work(itaup),work(iwork),lwork - iwork + 1,ierr)
                           call stdlib_dlacpy('L',m,m,work(iu),ldwrku,work(ir),ldwrkr)
-                                    
+
                           ! generate right bidiagonalizing vectors in work(iu)
                           ! (workspace: need 2*m*m + 4*m-1,
                                       ! prefer 2*m*m+3*m+(m-1)*nb)
@@ -78201,7 +78201,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(out) :: s(*),rwork(*)
            integer(ilp),intent(out) :: iwork(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: ierr,iwoff,nr,n1,optratio,p,q
            integer(ilp) :: lwcon,lwqp3,lwrk_dgelqf,lwrk_dgesvd,lwrk_dgesvd2,lwrk_dgeqp3, &
@@ -78532,7 +78532,7 @@ module stdlib_linalg_lapack_d
                      ! .. to prevent overflow in the qr factorization, scale the
                      ! matrix by 1/sqrt(m) if too large entry detected
                      call stdlib_dlascl('G',0,0,sqrt(real(m,KIND=dp)),one,m,n,a,lda,ierr)
-                               
+
                      ascaled = .true.
                  end if
                  call stdlib_dlaswp(n,a,lda,1,m - 1,iwork(n + 1),1)
@@ -78552,7 +78552,7 @@ module stdlib_linalg_lapack_d
                    ! .. to prevent overflow in the qr factorization, scale the
                    ! matrix by 1/sqrt(m) if too large entry detected
                    call stdlib_dlascl('G',0,0,sqrt(real(m,KIND=dp)),one,m,n,a,lda,ierr)
-                             
+
                    ascaled = .true.
                end if
            end if
@@ -78582,7 +78582,7 @@ module stdlib_linalg_lapack_d
                  if (abs(a(p,p)) < (rtmp*abs(a(1,1)))) go to 3002
                     nr = nr + 1
               end do
-3002          continue
+              3002 continue
            elseif (acclm) then
               ! .. similarly as above, only slightly more gentle (less aggressive).
               ! sudden drop on the diagonal of r is used as the criterion for being
@@ -78596,7 +78596,7 @@ module stdlib_linalg_lapack_d
                            to 3402
                  nr = nr + 1
               end do
-3402          continue
+              3402 continue
            else
               ! Rrqr Not Authorized To Determine Numerical Rank Except In The
               ! obvious case of zero pivots.
@@ -78607,7 +78607,7 @@ module stdlib_linalg_lapack_d
                  if (abs(a(p,p)) == zero) go to 3502
                  nr = nr + 1
               end do
-3502          continue
+              3502 continue
               if (conda) then
                  ! estimate the scaled condition number of a. use the fact that it is
                  ! the same as the scaled condition number of r.
@@ -78695,7 +78695,7 @@ module stdlib_linalg_lapack_d
                   ! .. copy r into [u] and overwrite [u] with the left singular vectors
                   call stdlib_dlacpy('U',nr,n,a,lda,u,ldu)
                   if (nr > 1) call stdlib_dlaset('L',nr - 1,nr - 1,zero,zero,u(2,1),ldu)
-                            
+
                   ! .. the right singular vectors not computed, the nr left singular
                   ! vectors overwrite [u](1:nr,1:nr)
                      call stdlib_dgesvd('O','N',nr,n,u,ldu,s,u,ldu,v,ldv,work(n + 1), &
@@ -78775,7 +78775,7 @@ module stdlib_linalg_lapack_d
                   ! Copy R Into V And Overwrite V With The Right Singular Vectors
                   call stdlib_dlacpy('U',nr,n,a,lda,v,ldv)
                   if (nr > 1) call stdlib_dlaset('L',nr - 1,nr - 1,zero,zero,v(2,1),ldv)
-                            
+
                   ! .. the right singular vectors overwrite v, the nr left singular
                   ! vectors stored in u(1:nr,1:nr)
                   if (wntvr .or. (nr == n)) then
@@ -78863,7 +78863,7 @@ module stdlib_linalg_lapack_d
                            end do
                         end do
                         if (nr > 1) call stdlib_dlaset('U',nr - 1,nr - 1,zero,zero,v(1,2),ldv)
-                                  
+
                         call stdlib_dlaset('A',n,n - nr,zero,zero,v(1,nr + 1),ldv)
                         call stdlib_dgesvd('O','A',n,n,v,ldv,s,v,ldv,u,ldu,work(n + 1), &
                                   lwork - n,info)
@@ -78900,7 +78900,7 @@ module stdlib_linalg_lapack_d
                            end do
                         end do
                         if (nr > 1) call stdlib_dlaset('U',nr - 1,nr - 1,zero,zero,u(1,nr + 2),ldu)
-                                  
+
                         call stdlib_dgeqrf(n,nr,u(1,nr + 1),ldu,work(n + 1),work(n + nr + 1),lwork - &
                                   n - nr,ierr)
                         do p = 1,nr
@@ -78934,7 +78934,7 @@ module stdlib_linalg_lapack_d
                       ! .. copy r into [v] and overwrite v with the right singular vectors
                       call stdlib_dlacpy('U',nr,n,a,lda,v,ldv)
                      if (nr > 1) call stdlib_dlaset('L',nr - 1,nr - 1,zero,zero,v(2,1),ldv)
-                               
+
                      ! .. the right singular vectors of r overwrite [v], the nr left
                      ! singular vectors of r stored in [u](1:nr,1:nr)
                      call stdlib_dgesvd('S','O',nr,n,v,ldv,s,u,ldu,v,ldv,work(n + 1), &
@@ -78963,7 +78963,7 @@ module stdlib_linalg_lapack_d
                     if (optratio*nr > n) then
                        call stdlib_dlacpy('U',nr,n,a,lda,v,ldv)
                        if (nr > 1) call stdlib_dlaset('L',nr - 1,nr - 1,zero,zero,v(2,1),ldv)
-                                 
+
                     ! .. the right singular vectors of r overwrite [v], the nr left
                        ! singular vectors of r stored in [u](1:nr,1:nr)
                        call stdlib_dlaset('A',n - nr,n,zero,zero,v(nr + 1,1),ldv)
@@ -78985,7 +78985,7 @@ module stdlib_linalg_lapack_d
                     else
                        call stdlib_dlacpy('U',nr,n,a,lda,u(nr + 1,1),ldu)
                        if (nr > 1) call stdlib_dlaset('L',nr - 1,nr - 1,zero,zero,u(nr + 2,1),ldu)
-                                 
+
                        call stdlib_dgelqf(nr,n,u(nr + 1,1),ldu,work(n + 1),work(n + nr + 1),lwork - n - &
                                  nr,ierr)
                        call stdlib_dlacpy('L',nr,nr,u(nr + 1,1),ldu,v,ldv)
@@ -79026,7 +79026,7 @@ module stdlib_linalg_lapack_d
                if (s(q) > zero) go to 4002
                nr = nr - 1
            end do
-4002       continue
+           4002 continue
            ! .. if numerical rank deficiency is detected, the truncated
            ! singular values are set to zero.
            if (nr < n) call stdlib_dlaset('G',n - nr,1,zero,zero,s(nr + 1),n)
@@ -79087,7 +79087,7 @@ module stdlib_linalg_lapack_d
            ! Function Arguments
            procedure(stdlib_selctg_d) :: selctg
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: cursl,ilascl,ilbscl,ilvsl,ilvsr,lastsl,lquery,lst2sl, &
                      wantst
@@ -79164,7 +79164,7 @@ module stdlib_linalg_lapack_d
               if (wantst) then
                  call stdlib_dtgsen(0,ilvsl,ilvsr,bwork,n,a,lda,b,ldb,alphar,alphai, &
                  beta,vsl,ldvsl,vsr,ldvsr,sdim,pvsl,pvsr,dif,work,-1,idum,1,ierr)
-                           
+
                  lwkopt = max(lwkopt,2*n + int(work(1),KIND=ilp))
               end if
               work(1) = lwkopt
@@ -79263,7 +79263,7 @@ module stdlib_linalg_lapack_d
                  call stdlib_dlascl('G',0,0,anrmto,anrm,n,1,alphai,n,ierr)
               end if
               if (ilbscl) call stdlib_dlascl('G',0,0,bnrmto,bnrm,n,1,beta,n,ierr)
-                        
+
               ! select eigenvalues
               do i = 1,n
                  bwork(i) = selctg(alphar(i),alphai(i),beta(i))
@@ -79352,7 +79352,7 @@ module stdlib_linalg_lapack_d
                  lastsl = cursl
               end do
            end if
-50         continue
+           50 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_dgges3
@@ -79385,9 +79385,9 @@ module stdlib_linalg_lapack_d
            ! Array Arguments
            real(dp),intent(inout) :: a(lda,*),b(ldb,*)
            real(dp),intent(out) :: alphai(*),alphar(*),beta(*),vl(ldvl,*),vr(ldvr,*),work(*)
-                     
+
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: ilascl,ilbscl,ilv,ilvl,ilvr,lquery
            character :: chtemp
@@ -79645,7 +79645,7 @@ module stdlib_linalg_lapack_d
               ! end of eigenvector calculation
            end if
            ! undo scaling if necessary
-110  continue
+           110 continue
            if (ilascl) then
               call stdlib_dlascl('G',0,0,anrmto,anrm,n,1,alphar,n,ierr)
               call stdlib_dlascl('G',0,0,anrmto,anrm,n,1,alphai,n,ierr)
@@ -79667,7 +79667,7 @@ module stdlib_linalg_lapack_d
      !> by the orthogonal matrix Q:  A = Q*H*Q**T = (QZ)*T*(QZ)**T.
 
      subroutine stdlib_dhseqr(job,compz,n,ilo,ihi,h,ldh,wr,wi,z,ldz,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -79685,14 +79685,14 @@ module stdlib_linalg_lapack_d
            ! ==== matrices of order ntiny or smaller must be processed by
            ! .    stdlib_dlahqr because of insufficient subdiagonal scratch space.
            ! .    (this is a hard limit.) ====
-           
+
            ! ==== nl allocates some local workspace to help small matrices
            ! .    through a rare stdlib_dlahqr failure.  nl > ntiny = 15 is
            ! .    required and nl <= nmin = stdlib_ilaenv(ispec=12,...) is recom-
            ! .    mended.  (the default value of nmin is 75.)  using nl = 49
            ! .    allows up to six simultaneous shifts and a 16-by-16
            ! .    deflation window.  ====
-           
+
            ! Local Arrays
            real(dp) :: hl(nl,nl),workl(nl)
            ! Local Scalars
@@ -79760,7 +79760,7 @@ module stdlib_linalg_lapack_d
               end if
               ! ==== stdlib_dlahqr/stdlib_dlaqr0 crossover point ====
               nmin = stdlib_ilaenv(12,'DHSEQR',job(:1)//compz(:1),n,ilo,ihi,lwork)
-                        
+
               nmin = max(ntiny,nmin)
               ! ==== stdlib_dlaqr0 for big matrices; stdlib_dlahqr for small ones ====
               if (n > nmin) then
@@ -79790,7 +79790,7 @@ module stdlib_linalg_lapack_d
                        call stdlib_dlaqr0(wantt,wantz,nl,ilo,kbot,hl,nl,wr,wi,ilo,ihi, &
                                  z,ldz,workl,nl,info)
                        if (wantt .or. info /= 0) call stdlib_dlacpy('A',n,n,hl,nl,h,ldh)
-                                 
+
                     end if
                  end if
               end if
@@ -79829,7 +79829,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(in) :: c(*),difl(ldu,*),difr(ldu,*),givnum(ldu,*),poles(ldu,*),s( &
                      *),u(ldu,*),vt(ldu,*),z(ldu,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,i1,ic,im1,inode,j,lf,ll,lvl,lvl2,nd,ndb1,ndiml,ndimr, &
                      nl,nlf,nlp1,nlvl,nr,nrf,nrp1,sqre
@@ -79927,7 +79927,7 @@ module stdlib_linalg_lapack_d
            end do
            go to 90
            ! icompq = 1: applying back the right singular vector factors.
-50   continue
+           50 continue
            ! first now go through the right singular vector matrices of all
            ! the tree nodes top-down.
            j = 0
@@ -79983,7 +79983,7 @@ module stdlib_linalg_lapack_d
               call stdlib_dgemm('T','N',nrp1,nrhs,nrp1,one,vt(nrf,1),ldu,b(nrf,1), &
                         ldb,zero,bx(nrf,1),ldbx)
            end do
-90         continue
+           90 continue
            return
      end subroutine stdlib_dlalsa
 
@@ -80017,7 +80017,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: b(ldb,*),d(*),e(*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: bx,bxst,c,difl,difr,givcol,givnum,givptr,i,icmpq1,icmpq2, &
            iwk,j,k,nlvl,nm1,nsize,nsub,nwork,perm,poles,s,sizei,smlszp,sqre,st,st1, &
@@ -80109,7 +80109,7 @@ module stdlib_linalg_lapack_d
                     call stdlib_dlaset('A',1,nrhs,zero,zero,b(i,1),ldb)
                  else
                     call stdlib_dlascl('G',0,0,d(i),one,1,nrhs,b(i,1),ldb,info)
-                              
+
                     rank = rank + 1
                  end if
               end do
@@ -80192,7 +80192,7 @@ module stdlib_linalg_lapack_d
                        return
                     end if
                     call stdlib_dlacpy('A',nsize,nrhs,b(st,1),ldb,work(bx + st1),n)
-                              
+
                  else
                     ! a large problem. solve it using divide and conquer.
                     call stdlib_dlasda(icmpq1,smlsiz,nsize,sqre,d(st),e(st),work(u + st1 &
@@ -80226,7 +80226,7 @@ module stdlib_linalg_lapack_d
               else
                  rank = rank + 1
                  call stdlib_dlascl('G',0,0,d(i),one,1,nrhs,work(bx + i - 1),n,info)
-                           
+
               end if
               d(i) = abs(d(i))
            end do
@@ -80291,18 +80291,18 @@ module stdlib_linalg_lapack_d
            ! ==== matrices of order ntiny or smaller must be processed by
            ! .    stdlib_dlahqr because of insufficient subdiagonal scratch space.
            ! .    (this is a hard limit.) ====
-           
+
            ! ==== exceptional deflation windows:  try to cure rare
            ! .    slow convergence by varying the size of the
            ! .    deflation window after kexnw iterations. ====
-           
+
            ! ==== exceptional shifts: try to cure rare slow convergence
            ! .    with ad-hoc exceptional shifts every kexsh iterations.
            ! .    ====
-           
+
            ! ==== the constants wilk1 and wilk2 are used to form the
            ! .    exceptional shifts. ====
-           
+
            ! Local Scalars
            real(dp) :: aa,bb,cc,cs,dd,sn,ss,swap
            integer(ilp) :: i,inf,it,itmax,k,kacc22,kbot,kdu,ks,kt,ktop,ku,kv,kwh, &
@@ -80402,7 +80402,7 @@ module stdlib_linalg_lapack_d
                     if (h(k,k - 1) == zero) go to 20
                  end do
                  k = ilo
-20               continue
+                 20 continue
                  ktop = k
                  ! ==== select deflation window size:
                  ! .    typical case:
@@ -80509,7 +80509,7 @@ module stdlib_linalg_lapack_d
                           ks = kbot - ns + 1
                           kt = n - ns + 1
                           call stdlib_dlacpy('A',ns,ns,h(ks,ks),ldh,h(kt,1),ldh)
-                                    
+
                           if (ns > nmin) then
                              call stdlib_dlaqr4(.false.,.false.,ns,1,ns,h(kt,1),ldh,wr( &
                                        ks),wi(ks),1,1,zdum,1,work,lwork,inf)
@@ -80552,7 +80552,7 @@ module stdlib_linalg_lapack_d
                                 end if
                              end do
                           end do
-60                        continue
+                          60 continue
                        end if
                        ! ==== shuffle shifts into pairs of real shifts
                        ! .    and pairs of complex conjugate shifts
@@ -80623,7 +80623,7 @@ module stdlib_linalg_lapack_d
               ! ==== iteration limit exceeded.  set info to show where
               ! .    the problem occurred and exit. ====
               info = kbot
-90            continue
+              90 continue
            end if
            ! ==== return the optimal value of lwork. ====
            work(1) = real(lwkopt,KIND=dp)
@@ -80653,7 +80653,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: h(ldh,*),z(ldz,*)
            real(dp),intent(out) :: si(*),sr(*),t(ldt,*),v(ldv,*),work(*),wv(ldwv,*)
         ! ================================================================
-           
+
            ! Local Scalars
            real(dp) :: aa,bb,beta,cc,cs,dd,evi,evk,foo,s,safmax,safmin,smlnum,sn, &
                      tau,ulp
@@ -80673,7 +80673,7 @@ module stdlib_linalg_lapack_d
               lwk1 = int(work(1),KIND=ilp)
               ! ==== workspace query call to stdlib_dormhr ====
               call stdlib_dormhr('R','N',jw,jw,1,jw - 1,t,ldt,work,v,ldv,work,-1,info)
-                        
+
               lwk2 = int(work(1),KIND=ilp)
               ! ==== workspace query call to stdlib_dlaqr4 ====
               call stdlib_dlaqr4(.true.,.true.,jw,1,jw,t,ldt,sr,si,1,jw,v,ldv,work,- &
@@ -80748,7 +80748,7 @@ module stdlib_linalg_lapack_d
            ! ==== deflation detection loop ====
            ns = jw
            ilst = infqr + 1
-20         continue
+           20 continue
            if (ilst <= ns) then
               if (ns == 1) then
                  bulge = .false.
@@ -80799,7 +80799,7 @@ module stdlib_linalg_lapack_d
               ! .    exchange failures. ====
               sorted = .false.
               i = ns + 1
-30            continue
+              30 continue
               if (sorted) go to 50
               sorted = .true.
               kend = i - 1
@@ -80811,13 +80811,13 @@ module stdlib_linalg_lapack_d
               else
                  k = i + 2
               end if
-40            continue
+              40 continue
               if (k <= kend) then
                  if (k == i + 1) then
                     evi = abs(t(i,i))
                  else
                     evi = abs(t(i,i)) + sqrt(abs(t(i + 1,i)))*sqrt(abs(t(i,i + 1)))
-                              
+
                  end if
                  if (k == kend) then
                     evk = abs(t(k,k))
@@ -80825,7 +80825,7 @@ module stdlib_linalg_lapack_d
                     evk = abs(t(k,k))
                  else
                     evk = abs(t(k,k)) + sqrt(abs(t(k + 1,k)))*sqrt(abs(t(k,k + 1)))
-                              
+
                  end if
                  if (evi >= evk) then
                     i = k
@@ -80850,11 +80850,11 @@ module stdlib_linalg_lapack_d
                  go to 40
               end if
               go to 30
-50            continue
+              50 continue
            end if
            ! ==== restore shift/eigenvalue array from t ====
            i = jw
-60         continue
+           60 continue
            if (i >= infqr + 1) then
               if (i == infqr + 1) then
                  sr(kwtop + i - 1) = t(i,i)
@@ -80887,7 +80887,7 @@ module stdlib_linalg_lapack_d
                  call stdlib_dlarf('R',ns,ns,work,1,tau,t,ldt,work(jw + 1))
                  call stdlib_dlarf('R',jw,ns,work,1,tau,v,ldv,work(jw + 1))
                  call stdlib_dgehrd(jw,1,ns,t,ldt,work,work(jw + 1),lwork - jw,info)
-                           
+
               end if
               ! ==== copy updated reduced window into place ====
               if (kwtop > 1) h(kwtop,kwtop - 1) = s*v(1,1)
@@ -80977,18 +80977,18 @@ module stdlib_linalg_lapack_d
            ! ==== matrices of order ntiny or smaller must be processed by
            ! .    stdlib_dlahqr because of insufficient subdiagonal scratch space.
            ! .    (this is a hard limit.) ====
-           
+
            ! ==== exceptional deflation windows:  try to cure rare
            ! .    slow convergence by varying the size of the
            ! .    deflation window after kexnw iterations. ====
-           
+
            ! ==== exceptional shifts: try to cure rare slow convergence
            ! .    with ad-hoc exceptional shifts every kexsh iterations.
            ! .    ====
-           
+
            ! ==== the constants wilk1 and wilk2 are used to form the
            ! .    exceptional shifts. ====
-           
+
            ! Local Scalars
            real(dp) :: aa,bb,cc,cs,dd,sn,ss,swap
            integer(ilp) :: i,inf,it,itmax,k,kacc22,kbot,kdu,ks,kt,ktop,ku,kv,kwh, &
@@ -81088,7 +81088,7 @@ module stdlib_linalg_lapack_d
                     if (h(k,k - 1) == zero) go to 20
                  end do
                  k = ilo
-20               continue
+                 20 continue
                  ktop = k
                  ! ==== select deflation window size:
                  ! .    typical case:
@@ -81195,7 +81195,7 @@ module stdlib_linalg_lapack_d
                           ks = kbot - ns + 1
                           kt = n - ns + 1
                           call stdlib_dlacpy('A',ns,ns,h(ks,ks),ldh,h(kt,1),ldh)
-                                    
+
                           call stdlib_dlahqr(.false.,.false.,ns,1,ns,h(kt,1),ldh,wr(ks &
                                     ),wi(ks),1,1,zdum,1,inf)
                           ks = ks + inf
@@ -81233,7 +81233,7 @@ module stdlib_linalg_lapack_d
                                 end if
                              end do
                           end do
-60                        continue
+                          60 continue
                        end if
                        ! ==== shuffle shifts into pairs of real shifts
                        ! .    and pairs of complex conjugate shifts
@@ -81304,7 +81304,7 @@ module stdlib_linalg_lapack_d
               ! ==== iteration limit exceeded.  set info to show where
               ! .    the problem occurred and exit. ====
               info = kbot
-90            continue
+              90 continue
            end if
            ! ==== return the optimal value of lwork. ====
            work(1) = real(lwkopt,KIND=dp)
@@ -81367,7 +81367,7 @@ module stdlib_linalg_lapack_d
            integer(ilp),intent(out) :: info
            real(dp),intent(inout) :: a(lda,*),b(ldb,*),q(ldq,*),z(ldz,*),alphar( &
                       *),alphai(*),beta(*),work(*)
-           
+
            ! local scalars
            real(dp) :: smlnum,ulp,eshift,safmin,safmax,c1,s1,temp,swap
            integer(ilp) :: istart,istop,iiter,maxit,istart2,k,ld,nshifts,nblock,nw,nmin, &
@@ -81582,7 +81582,7 @@ module stdlib_linalg_lapack_d
                        end if
                        if (k2 < istop) then
                           call stdlib_dlartg(a(k2,k2 - 1),a(k2 + 1,k2 - 1),c1,s1,temp)
-                                    
+
                           a(k2,k2 - 1) = temp
                           a(k2 + 1,k2 - 1) = zero
                           call stdlib_drot(istopm - k2 + 1,a(k2,k2),lda,a(k2 + 1,k2),lda,c1, &
@@ -81605,7 +81605,7 @@ module stdlib_linalg_lapack_d
                                  istart2 + 1,istart2 + 1),ldb,c1,s1)
                        if (ilq) then
                           call stdlib_drot(n,q(1,istart2),1,q(1,istart2 + 1),1,c1,s1)
-                                    
+
                        end if
                     end if
                     istart2 = istart2 + 1
@@ -81715,7 +81715,7 @@ module stdlib_linalg_lapack_d
            integer(ilp),intent(out) :: ns,nd,info
            real(dp),intent(inout) :: qc(ldqc,*),zc(ldzc,*)
            real(dp),intent(out) :: work(*)
-           
+
            ! local scalars
            logical(lk) :: bulge
            integer(ilp) :: jw,kwtop,kwbot,istopm,istartm,k,k2,dtgexc_info,ifst,ilst, &
@@ -81775,7 +81775,7 @@ module stdlib_linalg_lapack_d
            ! store window in case of convergence failure
            call stdlib_dlacpy('ALL',jw,jw,a(kwtop,kwtop),lda,work,jw)
            call stdlib_dlacpy('ALL',jw,jw,b(kwtop,kwtop),ldb,work(jw**2 + 1),jw)
-                     
+
            ! transform window to real schur form
            call stdlib_dlaset('FULL',jw,jw,zero,one,qc,ldqc)
            call stdlib_dlaset('FULL',jw,jw,zero,one,zc,ldzc)
@@ -81788,7 +81788,7 @@ module stdlib_linalg_lapack_d
               ns = jw - qz_small_info
               call stdlib_dlacpy('ALL',jw,jw,work,jw,a(kwtop,kwtop),lda)
               call stdlib_dlacpy('ALL',jw,jw,work(jw**2 + 1),jw,b(kwtop,kwtop),ldb)
-                        
+
               return
            end if
            ! deflation detection loop
@@ -81820,7 +81820,7 @@ module stdlib_linalg_lapack_d
                        ilst = k2
                        call stdlib_dtgexc(.true.,.true.,jw,a(kwtop,kwtop),lda,b(kwtop, &
                        kwtop),ldb,qc,ldqc,zc,ldzc,ifst,ilst,work,lwork,dtgexc_info)
-                                 
+
                        k2 = k2 + 2
                     end if
                     k = k + 2
@@ -81840,7 +81840,7 @@ module stdlib_linalg_lapack_d
                        ilst = k2
                        call stdlib_dtgexc(.true.,.true.,jw,a(kwtop,kwtop),lda,b(kwtop, &
                        kwtop),ldb,qc,ldqc,zc,ldzc,ifst,ilst,work,lwork,dtgexc_info)
-                                 
+
                        k2 = k2 + 1
                     end if
                     k = k + 1
@@ -81882,9 +81882,9 @@ module stdlib_linalg_lapack_d
                  k2 = max(kwtop,k - 1)
                  call stdlib_drot(ihi - k2 + 1,a(k,k2),lda,a(k + 1,k2),lda,c1,s1)
                  call stdlib_drot(ihi - (k - 1) + 1,b(k,k - 1),ldb,b(k + 1,k - 1),ldb,c1,s1)
-                           
+
                  call stdlib_drot(jw,qc(1,k - kwtop + 1),1,qc(1,k + 1 - kwtop + 1),1,c1,s1)
-                           
+
               end do
               ! chase bulges down
               istartm = kwtop
@@ -81923,7 +81923,7 @@ module stdlib_linalg_lapack_d
                     end do
                     ! remove the shift
                     call stdlib_dlartg(b(kwbot,kwbot),b(kwbot,kwbot - 1),c1,s1,temp)
-                              
+
                     b(kwbot,kwbot) = temp
                     b(kwbot,kwbot - 1) = zero
                     call stdlib_drot(kwbot - istartm,b(istartm,kwbot),1,b(istartm,kwbot - 1), &
@@ -82016,7 +82016,7 @@ module stdlib_linalg_lapack_d
            integer(ilp),parameter :: allrng = 1
            integer(ilp),parameter :: indrng = 2
            integer(ilp),parameter :: valrng = 3
-           
+
            ! Local Scalars
            logical(lk) :: forceb,norep,usedqd
            integer(ilp) :: cnt,cnt1,cnt2,i,ibegin,idum,iend,iinfo,in,indl,indu,irange, &
@@ -82173,7 +82173,7 @@ module stdlib_linalg_lapack_d
                        goto 21
                     end if
                  end do
-21               continue
+                 21 continue
                  if (mb == 0) then
                     ! no eigenvalue in the current block lies in the desired range
                     ! e( iend ) holds the shift for the initial rrr
@@ -82222,7 +82222,7 @@ module stdlib_linalg_lapack_d
                  isleft = max(gl,w(wbegin) - werr(wbegin) - hndrd*eps*abs(w(wbegin) - werr( &
                            wbegin)))
                  isrght = min(gu,w(wend) + werr(wend) + hndrd*eps*abs(w(wend) + werr(wend)))
-                           
+
               end if
               ! decide whether the base representation for the current block
               ! l_jblk d_jblk l_jblk^t = t_jblk - sigma_jblk i
@@ -82371,7 +82371,7 @@ module stdlib_linalg_lapack_d
               ! found in maxtry iterations.
               info = 2
               return
-83            continue
+              83 continue
               ! at this point, we have found an initial base representation
               ! t - sigma i = l d l^t with not too much element growth.
               ! store the shift.
@@ -82507,7 +82507,7 @@ module stdlib_linalg_lapack_d
      !> and optionally, the singular vectors in compact form.
 
      pure subroutine stdlib_dlasd0(n,sqre,d,e,u,ldu,vt,ldvt,smlsiz,iwork,work,info)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -82661,7 +82661,7 @@ module stdlib_linalg_lapack_d
                      s(*),u(ldu,*),vt(ldu,*),work(*),z(ldu,*)
            real(dp),intent(inout) :: d(*),e(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,i1,ic,idxq,idxqi,im1,inode,itemp,iwk,j,lf,ll,lvl,lvl2, &
            m,ncc,nd,ndb1,ndiml,ndimr,nl,nlf,nlp1,nlvl,nr,nrf,nrp1,nru,nwork1, &
@@ -82738,7 +82738,7 @@ module stdlib_linalg_lapack_d
                  call stdlib_dlaset('A',nlp1,nlp1,zero,one,work(nwork1),smlszp)
                  call stdlib_dlasdq('U',sqrei,nl,nlp1,nru,ncc,d(nlf),e(nlf),work( &
                  nwork1),smlszp,work(nwork2),nl,work(nwork2),nl,work(nwork2),info)
-                           
+
                  itemp = nwork1 + nl*smlszp
                  call stdlib_dcopy(nlp1,work(nwork1),1,work(vfi),1)
                  call stdlib_dcopy(nlp1,work(itemp),1,work(vli),1)
@@ -82769,7 +82769,7 @@ module stdlib_linalg_lapack_d
                  call stdlib_dlaset('A',nrp1,nrp1,zero,one,work(nwork1),smlszp)
                  call stdlib_dlasdq('U',sqrei,nr,nrp1,nru,ncc,d(nrf),e(nrf),work( &
                  nwork1),smlszp,work(nwork2),nr,work(nwork2),nr,work(nwork2),info)
-                           
+
                  itemp = nwork1 + (nrp1 - 1)*smlszp
                  call stdlib_dcopy(nrp1,work(nwork1),1,work(vfi),1)
                  call stdlib_dcopy(nrp1,work(itemp),1,work(vli),1)
@@ -82865,7 +82865,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: c(ldc,*),d(*),e(*),u(ldu,*),vt(ldvt,*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: rotate
            integer(ilp) :: i,isub,iuplo,j,np1,sqre1
@@ -82959,26 +82959,26 @@ module stdlib_linalg_lapack_d
               if (nru > 0) then
                  if (sqre1 == 0) then
                     call stdlib_dlasr('R','V','F',nru,n,work(1),work(np1),u,ldu)
-                              
+
                  else
                     call stdlib_dlasr('R','V','F',nru,np1,work(1),work(np1),u,ldu)
-                              
+
                  end if
               end if
               if (ncc > 0) then
                  if (sqre1 == 0) then
                     call stdlib_dlasr('L','V','F',n,ncc,work(1),work(np1),c,ldc)
-                              
+
                  else
                     call stdlib_dlasr('L','V','F',np1,ncc,work(1),work(np1),c,ldc)
-                              
+
                  end if
               end if
            end if
            ! call stdlib_dbdsqr to compute the svd of the reduced real
            ! n-by-n upper bidiagonal matrix.
            call stdlib_dbdsqr('U',n,ncvt,nru,ncc,d,e,vt,ldvt,u,ldu,c,ldc,work,info)
-                     
+
            ! sort the singular values into ascending order (insertion sort on
            ! singular values, but only one transposition per singular vector)
            do i = 1,n
@@ -82996,7 +82996,7 @@ module stdlib_linalg_lapack_d
                  d(isub) = d(i)
                  d(i) = smin
                  if (ncvt > 0) call stdlib_dswap(ncvt,vt(isub,1),ldvt,vt(i,1),ldvt)
-                           
+
                  if (nru > 0) call stdlib_dswap(nru,u(1,isub),1,u(1,i),1)
                  if (ncc > 0) call stdlib_dswap(ncc,c(isub,1),ldc,c(i,1),ldc)
               end if
@@ -83026,7 +83026,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: d(*),e(*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,iinfo
            real(dp) :: eps,scale,safmin,sigmn,sigmx
@@ -83123,7 +83123,7 @@ module stdlib_linalg_lapack_d
            ! Parameters
            real(dp),parameter :: cbias = 1.50_dp
            real(dp),parameter :: hundrd = 100.0_dp
-           
+
            ! Local Scalars
            logical(lk) :: ieee
            integer(ilp) :: i0,i1,i4,iinfo,ipn4,iter,iwhila,iwhilb,k,kmin,n0,n1,nbig, &
@@ -83348,7 +83348,7 @@ module stdlib_linalg_lapack_d
                  emin = min(emin,z(i4 - 5))
               end do
               i4 = 4
-100           continue
+              100 continue
               i0 = i4/4
               pp = 0
               if (n0 - i0 > 1) then
@@ -83427,7 +83427,7 @@ module stdlib_linalg_lapack_d
               ! this might need to be done for several blocks
               i1 = i0
               n1 = n0
-145           continue
+              145 continue
               tempq = z(4*i0 - 3)
               z(4*i0 - 3) = z(4*i0 - 3) + sigma
               do k = i0 + 1,n0
@@ -83458,12 +83458,12 @@ module stdlib_linalg_lapack_d
               end do
               return
               ! end iwhilb
-150  continue
+              150 continue
            end do loop_160
            info = 3
            return
            ! end iwhila
-170  continue
+           170 continue
            ! move q's to the front.
            do k = 2,n
               z(k) = z(4*k - 3)
@@ -83506,7 +83506,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*),h(ldh,*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j,k,k1,i1,i2,mj
            real(dp) :: piv,alpha
@@ -83521,7 +83521,7 @@ module stdlib_linalg_lapack_d
               ! .....................................................
               ! factorize a as u**t*d*u using the upper triangle of a
               ! .....................................................
-10   continue
+              10 continue
               if (j > min(m,nb)) go to 20
               ! k is the column to be factorized
                ! when being called from stdlib_dsytrf_aa,
@@ -83575,7 +83575,7 @@ module stdlib_linalg_lapack_d
                     i1 = i1 + j - 1
                     i2 = i2 + j - 1
                     call stdlib_dswap(i2 - i1 - 1,a(j1 + i1 - 1,i1 + 1),lda,a(j1 + i1,i2),1)
-                              
+
                     ! swap a(i1, i2+1:m) with a(i2, i2+1:m)
                     if (i2 < m) call stdlib_dswap(m - i2,a(j1 + i1 - 1,i2 + 1),lda,a(j1 + i2 - 1,i2 + 1), &
                                lda)
@@ -83614,12 +83614,12 @@ module stdlib_linalg_lapack_d
               end if
               j = j + 1
               go to 10
-20            continue
+              20 continue
            else
               ! .....................................................
               ! factorize a as l*d*l**t using the lower triangle of a
               ! .....................................................
-30   continue
+              30 continue
               if (j > min(m,nb)) go to 40
               ! k is the column to be factorized
                ! when being called from stdlib_dsytrf_aa,
@@ -83673,7 +83673,7 @@ module stdlib_linalg_lapack_d
                     i1 = i1 + j - 1
                     i2 = i2 + j - 1
                     call stdlib_dswap(i2 - i1 - 1,a(i1 + 1,j1 + i1 - 1),1,a(i2,j1 + i1),lda)
-                              
+
                     ! swap a(i2+1:m, i1) with a(i2+1:m, i2)
                     if (i2 < m) call stdlib_dswap(m - i2,a(i2 + 1,j1 + i1 - 1),1,a(i2 + 1,j1 + i2 - 1), &
                               1)
@@ -83712,7 +83712,7 @@ module stdlib_linalg_lapack_d
               end if
               j = j + 1
               go to 30
-40            continue
+              40 continue
            end if
            return
      end subroutine stdlib_dlasyf_aa
@@ -83745,7 +83745,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: d(*),e(*),z(ldz,*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Arrays
            real(dp) :: c(1,1),vt(1,1)
            ! Local Scalars
@@ -83799,7 +83799,7 @@ module stdlib_linalg_lapack_d
               nru = 0
            end if
            call stdlib_dbdsqr('LOWER',n,0,nru,0,d,e,vt,1,z,ldz,c,1,work,info)
-                     
+
            ! square the singular values.
            if (info == 0) then
               do i = 1,n
@@ -83918,7 +83918,7 @@ module stdlib_linalg_lapack_d
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: minrgp = 1.0e-3_dp
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,lquery,valeig,wantz,zquery
            integer(ilp) :: i,ibegin,iend,ifirst,iil,iindbl,iindw,iindwk,iinfo,iinspl, &
@@ -83997,7 +83997,7 @@ module stdlib_linalg_lapack_d
                  nzcmin = n
               else if (wantz .and. valeig) then
                  call stdlib_dlarrc('T',n,vl,vu,d,e,safmin,nzcmin,itmp,itmp2,info)
-                           
+
               else if (wantz .and. indeig) then
                  nzcmin = iiu - iil + 1
               else
@@ -84167,7 +84167,7 @@ module stdlib_linalg_lapack_d
               call stdlib_dlarre(range,n,wl,wu,iil,iiu,d,e,work(inde2),rtol1,rtol2, &
               thresh,nsplit,iwork(iinspl),m,w,work(inderr),work(indgp),iwork(iindbl), &
               iwork(iindw),work(indgrs),pivmin,work(indwrk),iwork(iindwk),iinfo)
-                        
+
               if (iinfo /= 0) then
                  info = 10 + abs(iinfo)
                  return
@@ -84206,7 +84206,7 @@ module stdlib_linalg_lapack_d
                     in = iend - ibegin + 1
                     wend = wbegin - 1
                     ! check if any eigenvalues have to be refined in this block
-36   continue
+                    36 continue
                     if (wend < m) then
                        if (iwork(iindbl + wend) == jblk) then
                           wend = wend + 1
@@ -84324,7 +84324,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: d(*),e(*)
            real(dp),intent(out) :: w(*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,test,lquery,valeig,wantz,tryrac
            character :: order
@@ -84485,7 +84485,7 @@ module stdlib_linalg_lapack_d
                         iwork(indiwo),iwork(indifl),info)
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
-10   continue
+           10 continue
            if (iscale == 1) then
               if (info == 0) then
                  imax = m
@@ -84589,7 +84589,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: w(*),work(*),z(ldz,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,lower,lquery,valeig,wantz,tryrac
            character :: order
@@ -84796,7 +84796,7 @@ module stdlib_linalg_lapack_d
            end if
            call stdlib_dstebz(range,order,n,vll,vuu,il,iu,abstll,work(indd),work(inde &
            ),m,nsplit,w,iwork(indibl),iwork(indisp),work(indwk),iwork(indiwo),info)
-                     
+
            if (wantz) then
               call stdlib_dstein(n,work(indd),work(inde),m,w,iwork(indibl),iwork( &
                         indisp),z,ldz,work(indwk),iwork(indiwo),iwork(indifl),info)
@@ -84809,7 +84809,7 @@ module stdlib_linalg_lapack_d
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
         ! jump here if stdlib_dstemr/stdlib_dstein succeeded.
-30   continue
+        30 continue
            if (iscale == 1) then
               if (info == 0) then
                  imax = m
@@ -84857,7 +84857,7 @@ module stdlib_linalg_lapack_d
      !> form of A is then used to solve the system of equations A * X = B.
 
      pure subroutine stdlib_dsysv_aa(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -84911,7 +84911,7 @@ module stdlib_linalg_lapack_d
            if (info == 0) then
               ! solve the system a*x = b, overwriting b with x.
               call stdlib_dsytrs_aa(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-                        
+
            end if
            work(1) = lwkopt
            return
@@ -84937,7 +84937,7 @@ module stdlib_linalg_lapack_d
            real(dp),intent(inout) :: a(lda,*)
            real(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper
            integer(ilp) :: j,lwkopt
@@ -84993,7 +84993,7 @@ module stdlib_linalg_lapack_d
               ! jb, where jb is the number of columns factorized by stdlib_dlasyf;
               ! jb is either nb, or n-j+1 for the last block
               j = 0
-10            continue
+              10 continue
               if (j >= n) go to 20
               ! each step of the main loop
                ! j is the last column of the previous panel
@@ -85025,7 +85025,7 @@ module stdlib_linalg_lapack_d
                     alpha = a(j,j + 1)
                     a(j,j + 1) = one
                     call stdlib_dcopy(n - j,a(j - 1,j + 1),lda,work((j + 1 - j1 + 1) + jb*n),1)
-                              
+
                     call stdlib_dscal(n - j,alpha,work((j + 1 - j1 + 1) + jb*n),1)
                     ! k1 identifies if the previous column of the panel has been
                      ! explicitly stored, e.g., k1=1 and k2= 0 for the first panel,
@@ -85070,7 +85070,7 @@ module stdlib_linalg_lapack_d
               ! jb, where jb is the number of columns factorized by stdlib_dlasyf;
               ! jb is either nb, or n-j+1 for the last block
               j = 0
-11            continue
+              11 continue
               if (j >= n) go to 20
               ! each step of the main loop
                ! j is the last column of the previous panel
@@ -85136,7 +85136,7 @@ module stdlib_linalg_lapack_d
               end if
               go to 11
            end if
-20         continue
+           20 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_dsytrf_aa

--- a/src/stdlib_linalg_lapack_d.f90
+++ b/src/stdlib_linalg_lapack_d.f90
@@ -24107,7 +24107,7 @@ module stdlib_linalg_lapack_d
            return
      end function stdlib_dzsum1
 
-     !> DLAG2Q: converts a DOUBLE PRECISION matrix, SA, to a QUAD
+     !> DLAG2Q: converts a SINGLE PRECISION matrix, SA, to a DOUBLE
      !> PRECISION matrix, A.
      !> Note that while it is possible to overflow while converting
      !> from double to single, it is not possible to overflow when

--- a/src/stdlib_linalg_lapack_q.f90
+++ b/src/stdlib_linalg_lapack_q.f90
@@ -478,6 +478,7 @@ module stdlib_linalg_lapack_q
      public :: stdlib_qtrttp
      public :: stdlib_qtzrzf
      public :: stdlib_qzsum1
+     public :: stdlib_qlag2q
 
      ! 128-bit real constants
      real(qp),parameter,private :: negone = -1.00_qp
@@ -85111,5 +85112,35 @@ module stdlib_linalg_lapack_q
            stdlib_qzsum1 = stemp
            return
      end function stdlib_qzsum1
+
+     !> DLAG2Q: converts a SINGLE PRECISION matrix, SA, to a DOUBLE
+     !> PRECISION matrix, A.
+     !> Note that while it is possible to overflow while converting
+     !> from double to single, it is not possible to overflow when
+     !> converting from single to double.
+     !> This is an auxiliary routine so there is no argument checking.
+
+     pure subroutine stdlib_qlag2q(m,n,sa,ldsa,a,lda,info)
+        ! -- lapack auxiliary routine --
+        ! -- lapack is a software package provided by univ. of tennessee,    --
+        ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
+           ! Scalar Arguments
+           integer(ilp),intent(out) :: info
+           integer(ilp),intent(in) :: lda,ldsa,m,n
+           ! Array Arguments
+           real(qp),intent(in) :: sa(ldsa,*)
+           real(qp),intent(out) :: a(lda,*)
+        ! =====================================================================
+           ! Local Scalars
+           integer(ilp) :: i,j
+           ! Executable Statements
+           info = 0
+           do j = 1,n
+              do i = 1,m
+                 a(i,j) = sa(i,j)
+              end do
+           end do
+           return
+     end subroutine stdlib_qlag2q
 
 end module stdlib_linalg_lapack_q

--- a/src/stdlib_linalg_lapack_q.f90
+++ b/src/stdlib_linalg_lapack_q.f90
@@ -561,7 +561,7 @@ module stdlib_linalg_lapack_q
            real(qp),parameter :: hundred = 100.0_qp
            real(qp),parameter :: meighth = -0.125_qp
            real(qp),parameter :: piover2 = 1.57079632679489661923132169163975144210_qp
-           
+
            ! Local Scalars
            logical(lk) :: colmajor,lquery,restart11,restart12,restart21,restart22,wantu1, &
                      wantu2,wantv1t,wantv2t
@@ -711,9 +711,9 @@ module stdlib_linalg_lapack_q
               else
                  ! compute shifts for b11 and b21 and use the lesser
                  call stdlib_qlas2(b11d(imax - 1),b11e(imax - 1),b11d(imax),sigma11,dummy)
-                           
+
                  call stdlib_qlas2(b21d(imax - 1),b21e(imax - 1),b21d(imax),sigma21,dummy)
-                           
+
                  if (sigma11 <= sigma21) then
                     mu = sigma11
                     nu = sqrt(one - mu**2)
@@ -776,7 +776,7 @@ module stdlib_linalg_lapack_q
               work(iu2sn + imin - 1) = -work(iu2sn + imin - 1)
               temp = work(iu1cs + imin - 1)*b11e(imin) + work(iu1sn + imin - 1)*b11d(imin + 1)
               b11d(imin + 1) = work(iu1cs + imin - 1)*b11d(imin + 1) - work(iu1sn + imin - 1)*b11e(imin)
-                        
+
               b11e(imin) = temp
               if (imax > imin + 1) then
                  b11bulge = work(iu1sn + imin - 1)*b11e(imin + 1)
@@ -789,7 +789,7 @@ module stdlib_linalg_lapack_q
               b12d(imin + 1) = work(iu1cs + imin - 1)*b12d(imin + 1)
               temp = work(iu2cs + imin - 1)*b21e(imin) + work(iu2sn + imin - 1)*b21d(imin + 1)
               b21d(imin + 1) = work(iu2cs + imin - 1)*b21d(imin + 1) - work(iu2sn + imin - 1)*b21e(imin)
-                        
+
               b21e(imin) = temp
               if (imax > imin + 1) then
                  b21bulge = work(iu2sn + imin - 1)*b21e(imin + 1)
@@ -829,16 +829,16 @@ module stdlib_linalg_lapack_q
                               r)
                  else if (mu <= nu) then
                     call stdlib_qlartgs(b11d(i),b11e(i),mu,work(iv1tcs + i - 1),work(iv1tsn + i - 1))
-                              
+
                  else
                     call stdlib_qlartgs(b21d(i),b21e(i),nu,work(iv1tcs + i - 1),work(iv1tsn + i - 1))
-                              
+
                  end if
                  work(iv1tcs + i - 1) = -work(iv1tcs + i - 1)
                  work(iv1tsn + i - 1) = -work(iv1tsn + i - 1)
                  if (.not. restart12 .and. .not. restart22) then
                     call stdlib_qlartgp(y2,y1,work(iv2tsn + i - 1 - 1),work(iv2tcs + i - 1 - 1),r)
-                              
+
                  else if (.not. restart12 .and. restart22) then
                     call stdlib_qlartgp(b12bulge,b12d(i - 1),work(iv2tsn + i - 1 - 1),work(iv2tcs + i - 1 - &
                               1),r)
@@ -891,31 +891,31 @@ module stdlib_linalg_lapack_q
                     call stdlib_qlartgp(x2,x1,work(iu1sn + i - 1),work(iu1cs + i - 1),r)
                  else if (.not. restart11 .and. restart12) then
                     call stdlib_qlartgp(b11bulge,b11d(i),work(iu1sn + i - 1),work(iu1cs + i - 1),r)
-                              
+
                  else if (restart11 .and. .not. restart12) then
                     call stdlib_qlartgp(b12bulge,b12e(i - 1),work(iu1sn + i - 1),work(iu1cs + i - 1),r)
-                              
+
                  else if (mu <= nu) then
                     call stdlib_qlartgs(b11e(i),b11d(i + 1),mu,work(iu1cs + i - 1),work(iu1sn + i - 1))
-                              
+
                  else
                     call stdlib_qlartgs(b12d(i),b12e(i),nu,work(iu1cs + i - 1),work(iu1sn + i - 1))
-                              
+
                  end if
                  if (.not. restart21 .and. .not. restart22) then
                     call stdlib_qlartgp(y2,y1,work(iu2sn + i - 1),work(iu2cs + i - 1),r)
                  else if (.not. restart21 .and. restart22) then
                     call stdlib_qlartgp(b21bulge,b21d(i),work(iu2sn + i - 1),work(iu2cs + i - 1),r)
-                              
+
                  else if (restart21 .and. .not. restart22) then
                     call stdlib_qlartgp(b22bulge,b22e(i - 1),work(iu2sn + i - 1),work(iu2cs + i - 1),r)
-                              
+
                  else if (nu < mu) then
                     call stdlib_qlartgs(b21e(i),b21e(i + 1),nu,work(iu2cs + i - 1),work(iu2sn + i - 1))
-                              
+
                  else
                     call stdlib_qlartgs(b22d(i),b22e(i),mu,work(iu2cs + i - 1),work(iu2sn + i - 1))
-                              
+
                  end if
                  work(iu2cs + i - 1) = -work(iu2cs + i - 1)
                  work(iu2sn + i - 1) = -work(iu2sn + i - 1)
@@ -954,7 +954,7 @@ module stdlib_linalg_lapack_q
               restart22 = b22d(imax - 1)**2 + b22bulge**2 <= thresh**2
               if (.not. restart12 .and. .not. restart22) then
                  call stdlib_qlartgp(y2,y1,work(iv2tsn + imax - 1 - 1),work(iv2tcs + imax - 1 - 1),r)
-                           
+
               else if (.not. restart12 .and. restart22) then
                  call stdlib_qlartgp(b12bulge,b12d(imax - 1),work(iv2tsn + imax - 1 - 1),work(iv2tcs + &
                            imax - 1 - 1),r)
@@ -970,11 +970,11 @@ module stdlib_linalg_lapack_q
               end if
               temp = work(iv2tcs + imax - 1 - 1)*b12e(imax - 1) + work(iv2tsn + imax - 1 - 1)*b12d(imax)
               b12d(imax) = work(iv2tcs + imax - 1 - 1)*b12d(imax) - work(iv2tsn + imax - 1 - 1)*b12e(imax - 1)
-                        
+
               b12e(imax - 1) = temp
               temp = work(iv2tcs + imax - 1 - 1)*b22e(imax - 1) + work(iv2tsn + imax - 1 - 1)*b22d(imax)
               b22d(imax) = work(iv2tcs + imax - 1 - 1)*b22d(imax) - work(iv2tsn + imax - 1 - 1)*b22e(imax - 1)
-                        
+
               b22e(imax - 1) = temp
               ! update singular vectors
               if (wantu1) then
@@ -1109,9 +1109,9 @@ module stdlib_linalg_lapack_q
                     if (wantu1) call stdlib_qswap(p,u1(1,i),1,u1(1,mini),1)
                     if (wantu2) call stdlib_qswap(m - p,u2(1,i),1,u2(1,mini),1)
                     if (wantv1t) call stdlib_qswap(q,v1t(i,1),ldv1t,v1t(mini,1),ldv1t)
-                              
+
                     if (wantv2t) call stdlib_qswap(m - q,v2t(i,1),ldv2t,v2t(mini,1),ldv2t)
-                              
+
                  else
                     if (wantu1) call stdlib_qswap(p,u1(i,1),ldu1,u1(mini,1),ldu1)
                     if (wantu2) call stdlib_qswap(m - p,u2(i,1),ldu2,u2(mini,1),ldu2)
@@ -1157,7 +1157,7 @@ module stdlib_linalg_lapack_q
         ! changed dimension statement in comment describing e from (n) to
         ! (n-1).  sven, 17 feb 05.
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: difl,difr,givcol,givnum,givptr,i,ic,icompq,ierr,ii,is,iu, &
            iuplo,ivt,j,k,kk,mlvl,nm1,nsize,perm,poles,qstart,smlsiz,smlszp,sqre, &
@@ -1341,7 +1341,7 @@ module stdlib_linalg_lapack_q
            end do loop_30
            ! unscale
            call stdlib_qlascl('G',0,0,one,orgnrm,n,1,d,n,ierr)
-40         continue
+           40 continue
            ! use selection sort to minimize swaps of singular vectors
            do ii = 2,n
               i = ii - 1
@@ -1424,7 +1424,7 @@ module stdlib_linalg_lapack_q
            real(qp),parameter :: hndrd = 100.0_qp
            real(qp),parameter :: meigth = -0.125_qp
            integer(ilp),parameter :: maxitr = 6
-           
+
            ! Local Scalars
            logical(lk) :: lower,rotate
            integer(ilp) :: i,idir,isub,iter,iterdivn,j,ll,lll,m,maxitdivn,nm1,nm12, &
@@ -1490,9 +1490,9 @@ module stdlib_linalg_lapack_q
               end do
               ! update singular vectors if desired
               if (nru > 0) call stdlib_qlasr('R','V','F',nru,n,work(1),work(n),u,ldu)
-                        
+
               if (ncc > 0) call stdlib_qlasr('L','V','F',n,ncc,work(1),work(n),c,ldc)
-                        
+
            end if
            ! compute singular values to relative accuracy tol
            ! (by setting tol to be negative, algorithm will compute
@@ -1518,7 +1518,7 @@ module stdlib_linalg_lapack_q
                  sminoa = min(sminoa,mu)
                  if (sminoa == zero) go to 50
               end do
-50            continue
+              50 continue
               sminoa = sminoa/sqrt(real(n,KIND=qp))
               thresh = max(tol*sminoa,maxitr*(n*(n*unfl)))
            else
@@ -1536,7 +1536,7 @@ module stdlib_linalg_lapack_q
            ! m points to last element of unconverged part of matrix
            m = n
            ! begin main iteration loop
-60   continue
+           60 continue
            ! check for convergence or exceeding iteration count
            if (m <= 1) go to 160
            if (iter >= n) then
@@ -1559,7 +1559,7 @@ module stdlib_linalg_lapack_q
            end do
            ll = 0
            go to 90
-80         continue
+           80 continue
            e(ll) = zero
            ! matrix splits since e(ll) = 0
            if (ll == m - 1) then
@@ -1567,7 +1567,7 @@ module stdlib_linalg_lapack_q
               m = m - 1
               go to 60
            end if
-90         continue
+           90 continue
            ll = ll + 1
            ! e(ll) through e(m-1) are nonzero, e(ll-1) is zero
            if (ll == m - 1) then
@@ -1582,7 +1582,7 @@ module stdlib_linalg_lapack_q
                         )
               if (nru > 0) call stdlib_qrot(nru,u(1,m - 1),1,u(1,m),1,cosl,sinl)
               if (ncc > 0) call stdlib_qrot(ncc,c(m - 1,1),ldc,c(m,1),ldc,cosl,sinl)
-                        
+
               m = m - 2
               go to 60
            end if
@@ -1798,7 +1798,7 @@ module stdlib_linalg_lapack_q
            ! qr iteration finished, go back and check convergence
            go to 60
            ! all singular values converged, so make them positive
-160  continue
+           160 continue
            do i = 1,n
               if (d(i) < zero) then
                  d(i) = -d(i)
@@ -1823,20 +1823,20 @@ module stdlib_linalg_lapack_q
                  d(isub) = d(n + 1 - i)
                  d(n + 1 - i) = smin
                  if (ncvt > 0) call stdlib_qswap(ncvt,vt(isub,1),ldvt,vt(n + 1 - i,1),ldvt)
-                           
+
                  if (nru > 0) call stdlib_qswap(nru,u(1,isub),1,u(1,n + 1 - i),1)
                  if (ncc > 0) call stdlib_qswap(ncc,c(isub,1),ldc,c(n + 1 - i,1),ldc)
-                           
+
               end if
            end do
            go to 220
            ! maximum number of iterations exceeded, failure to converge
-200  continue
+           200 continue
            info = 0
            do i = 1,n - 1
               if (e(i) /= zero) info = info + 1
            end do
-220        continue
+           220 continue
            return
      end subroutine stdlib_qbdsqr
 
@@ -1866,7 +1866,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: d(*)
            real(qp),intent(out) :: sep(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: decr,eigen,incr,left,right,sing
            integer(ilp) :: i,k
@@ -1963,7 +1963,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: ab(ldab,*),c(ldc,*)
            real(qp),intent(out) :: d(*),e(*),pt(ldpt,*),q(ldq,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: wantb,wantc,wantpt,wantq
            integer(ilp) :: i,inca,j,j1,j2,kb,kb1,kk,klm,klu1,kun,l,minmn,ml,ml0,mn, &
@@ -2160,7 +2160,7 @@ module stdlib_linalg_lapack_q
                  end if
                  if (wantq) call stdlib_qrot(m,q(1,i),1,q(1,i + 1),1,rc,rs)
                  if (wantc) call stdlib_qrot(ncc,c(i,1),ldc,c(i + 1,1),ldc,rc,rs)
-                           
+
               end do
               if (m <= n) d(m) = ab(1,m)
            else if (ku > 0) then
@@ -2178,7 +2178,7 @@ module stdlib_linalg_lapack_q
                        e(i - 1) = rc*ab(ku,i)
                     end if
                     if (wantpt) call stdlib_qrot(n,pt(i,1),ldpt,pt(m + 1,1),ldpt,rc,rs)
-                              
+
                  end do
               else
                  ! copy off-diagonal elements to e and diagonal elements to d
@@ -2226,7 +2226,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: ab(ldab,*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lnoti,onenrm
            character :: normin
@@ -2277,7 +2277,7 @@ module stdlib_linalg_lapack_q
            kd = kl + ku + 1
            lnoti = kl > 0
            kase = 0
-10         continue
+           10 continue
            call stdlib_qlacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == kase1) then
@@ -2306,7 +2306,7 @@ module stdlib_linalg_lapack_q
                     do j = n - 1,1,-1
                        lm = min(kl,n - j)
                        work(j) = work(j) - stdlib_qdot(lm,ab(kd + 1,j),1,work(j + 1),1)
-                                 
+
                        jp = ipiv(j)
                        if (jp /= j) then
                           t = work(jp)
@@ -2327,7 +2327,7 @@ module stdlib_linalg_lapack_q
            end if
            ! compute the estimate of the reciprocal condition number.
            if (ainvnm /= zero) rcond = (one/ainvnm)/anorm
-40         continue
+           40 continue
            return
      end subroutine stdlib_qgbcon
 
@@ -2342,7 +2342,7 @@ module stdlib_linalg_lapack_q
      !> works well in practice.
 
      pure subroutine stdlib_qgbequ(m,n,kl,ku,ab,ldab,r,c,rowcnd,colcnd,amax,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -2354,7 +2354,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: ab(ldab,*)
            real(qp),intent(out) :: c(*),r(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,kd
            real(qp) :: bignum,rcmax,rcmin,smlnum
@@ -2478,7 +2478,7 @@ module stdlib_linalg_lapack_q
      !> between sqrt(radix) and 1/sqrt(radix).
 
      pure subroutine stdlib_qgbequb(m,n,kl,ku,ab,ldab,r,c,rowcnd,colcnd,amax,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -2490,7 +2490,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: ab(ldab,*)
            real(qp),intent(out) :: c(*),r(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,kd
            real(qp) :: bignum,rcmax,rcmin,smlnum,radix,logrdx
@@ -2628,7 +2628,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: notran
            character :: transt
@@ -2689,7 +2689,7 @@ module stdlib_linalg_lapack_q
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - op(a) * x,
               ! where op(a) = a, a**t, or a**h, depending on trans.
@@ -2741,7 +2741,7 @@ module stdlib_linalg_lapack_q
               if (berr(j) > eps .and. two*berr(j) <= lstres .and. count <= itmax) then
                  ! update solution and try again.
                  call stdlib_qgbtrs(trans,n,kl,ku,1,afb,ldafb,ipiv,work(n + 1),n,info)
-                           
+
                  call stdlib_qaxpy(n,one,work(n + 1),1,x(1,j),1)
                  lstres = berr(j)
                  count = count + 1
@@ -2772,9 +2772,9 @@ module stdlib_linalg_lapack_q
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_qlacn2(n,work(2*n + 1),work(n + 1),iwork,ferr(j),kase,isave)
-                        
+
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(op(a)**t).
@@ -2850,7 +2850,7 @@ module stdlib_linalg_lapack_q
            if (info == 0) then
               ! solve the system a*x = b, overwriting b with x.
               call stdlib_qgbtrs('NO TRANSPOSE',n,kl,ku,nrhs,ab,ldab,ipiv,b,ldb,info)
-                        
+
            end if
            return
      end subroutine stdlib_qgbsv
@@ -2879,7 +2879,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: ab(ldab,*),afb(ldafb,*),b(ldb,*),c(*),r(*)
            real(qp),intent(out) :: berr(*),ferr(*),work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: colequ,equil,nofact,notran,rowequ
            character :: norm
@@ -2969,11 +2969,11 @@ module stdlib_linalg_lapack_q
            if (equil) then
               ! compute row and column scalings to equilibrate the matrix a.
               call stdlib_qgbequ(n,n,kl,ku,ab,ldab,r,c,rowcnd,colcnd,amax,infequ)
-                        
+
               if (infequ == 0) then
                  ! equilibrate the matrix.
                  call stdlib_qlaqgb(n,n,kl,ku,ab,ldab,r,c,rowcnd,colcnd,amax,equed)
-                           
+
                  rowequ = stdlib_lsame(equed,'R') .or. stdlib_lsame(equed,'B')
                  colequ = stdlib_lsame(equed,'C') .or. stdlib_lsame(equed,'B')
               end if
@@ -3000,7 +3000,7 @@ module stdlib_linalg_lapack_q
                  j1 = max(j - ku,1)
                  j2 = min(j + kl,n)
                  call stdlib_qcopy(j2 - j1 + 1,ab(ku + 1 - j + j1,j),1,afb(kl + ku + 1 - j + j1,j),1)
-                           
+
               end do
               call stdlib_qgbtrf(n,n,kl,ku,afb,ldafb,ipiv,info)
               ! return if info is non-zero.
@@ -3041,7 +3041,7 @@ module stdlib_linalg_lapack_q
            end if
            ! compute the reciprocal of the condition number of a.
            call stdlib_qgbcon(norm,n,kl,ku,afb,ldafb,ipiv,anorm,rcond,work,iwork,info)
-                     
+
            ! compute the solution matrix x.
            call stdlib_qlacpy('FULL',n,nrhs,b,ldb,x,ldx)
            call stdlib_qgbtrs(trans,n,kl,ku,nrhs,afb,ldafb,ipiv,x,ldx,info)
@@ -3093,7 +3093,7 @@ module stdlib_linalg_lapack_q
            integer(ilp),intent(out) :: ipiv(*)
            real(qp),intent(inout) :: ab(ldab,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,jp,ju,km,kv
            ! Intrinsic Functions
@@ -3182,7 +3182,7 @@ module stdlib_linalg_lapack_q
            ! Parameters
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldwork = nbmax + 1
-           
+
            ! Local Scalars
            integer(ilp) :: i,i2,i3,ii,ip,j,j2,j3,jb,jj,jm,jp,ju,k2,km,kv,nb, &
                      nw
@@ -3314,7 +3314,7 @@ module stdlib_linalg_lapack_q
                     ! use stdlib_qlaswp to apply the row interchanges to a12, a22, and
                     ! a32.
                     call stdlib_qlaswp(j2,ab(kv + 1 - jb,j + jb),ldab - 1,1,jb,ipiv(j),1)
-                              
+
                     ! adjust the pivot indices.
                     do i = j,j + jb - 1
                        ipiv(i) = ipiv(i) + j - 1
@@ -3366,7 +3366,7 @@ module stdlib_linalg_lapack_q
                           ! update a23
                           call stdlib_qgemm('NO TRANSPOSE','NO TRANSPOSE',i2,j3,jb,-one,ab( &
                           kv + 1 + jb,j),ldab - 1,work13,ldwork,one,ab(1 + jb,j + kv),ldab - 1)
-                                    
+
                        end if
                        if (i3 > 0) then
                           ! update a33
@@ -3431,7 +3431,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: ab(ldab,*)
            real(qp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lnoti,notran
            integer(ilp) :: i,j,kd,l,lm
@@ -3523,7 +3523,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: scale(*)
            real(qp),intent(inout) :: v(ldv,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: leftv,rightv
            integer(ilp) :: i,ii,k
@@ -3578,7 +3578,7 @@ module stdlib_linalg_lapack_q
            ! backward permutation
            ! for  i = ilo-1 step -1 until 1,
                     ! ihi+1 step 1 until n do --
-30   continue
+                    30 continue
            if (stdlib_lsame(job,'P') .or. stdlib_lsame(job,'B')) then
               if (rightv) then
                  loop_40: do ii = 1,n
@@ -3628,7 +3628,7 @@ module stdlib_linalg_lapack_q
            ! Parameters
            real(qp),parameter :: sclfac = 2.0e+0_qp
            real(qp),parameter :: factor = 0.95e+0_qp
-           
+
            ! Local Scalars
            logical(lk) :: noconv
            integer(ilp) :: i,ica,iexc,ira,j,k,l,m
@@ -3662,18 +3662,18 @@ module stdlib_linalg_lapack_q
            ! permutation to isolate eigenvalues if possible
            go to 50
            ! row and column exchange.
-20   continue
+           20 continue
            scale(m) = j
            if (j == m) go to 30
            call stdlib_qswap(l,a(1,j),1,a(1,m),1)
            call stdlib_qswap(n - k + 1,a(j,k),lda,a(m,k),lda)
-30         continue
+           30 continue
            go to(40,80) iexc
            ! search for rows isolating an eigenvalue and push them down.
-40   continue
+           40 continue
            if (l == 1) go to 210
            l = l - 1
-50         continue
+           50 continue
            loop_70: do j = l,1,-1
               loop_60: do i = 1,l
                  if (i == j) cycle loop_60
@@ -3685,9 +3685,9 @@ module stdlib_linalg_lapack_q
            end do loop_70
            go to 90
            ! search for columns isolating an eigenvalue and push them left.
-80   continue
+           80 continue
            k = k + 1
-90         continue
+           90 continue
            loop_110: do j = k,l
               loop_100: do i = k,l
                  if (i == j) cycle loop_100
@@ -3697,7 +3697,7 @@ module stdlib_linalg_lapack_q
               iexc = 2
               go to 20
            end do loop_110
-120        continue
+           120 continue
            do i = k,l
               scale(i) = one
            end do
@@ -3708,7 +3708,7 @@ module stdlib_linalg_lapack_q
            sfmax1 = one/sfmin1
            sfmin2 = sfmin1*sclfac
            sfmax2 = one/sfmin2
-140        continue
+           140 continue
            noconv = .false.
            loop_200: do i = k,l
               c = stdlib_qnrm2(l - k + 1,a(k,i),1)
@@ -3722,7 +3722,7 @@ module stdlib_linalg_lapack_q
               g = r/sclfac
               f = one
               s = c + r
-160           continue
+              160 continue
               if (c >= g .or. max(f,c,ca) >= sfmax2 .or. min(r,g,ra) <= sfmin2) go to 170
                  if (stdlib_qisnan(c + f + ca + r + g + ra)) then
                  ! exit if nan to avoid infinite loop
@@ -3737,9 +3737,9 @@ module stdlib_linalg_lapack_q
               g = g/sclfac
               ra = ra/sclfac
               go to 160
-170           continue
+              170 continue
               g = c/sclfac
-180           continue
+              180 continue
               if (g < r .or. max(r,ra) >= sfmax2 .or. min(f,c,g,ca) <= sfmin2) go to 190
               f = f/sclfac
               c = c/sclfac
@@ -3749,7 +3749,7 @@ module stdlib_linalg_lapack_q
               ra = ra*sclfac
               go to 180
               ! now balance.
-190  continue
+              190 continue
               if ((c + r) >= factor*s) cycle loop_200
               if (f < one .and. scale(i) < one) then
                  if (f*scale(i) <= sfmin1) cycle loop_200
@@ -3764,7 +3764,7 @@ module stdlib_linalg_lapack_q
               call stdlib_qscal(l,f,a(1,i),1)
            end do loop_200
            if (noconv) go to 140
-210        continue
+           210 continue
            ilo = k
            ihi = l
            return
@@ -3785,7 +3785,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: d(*),e(*),taup(*),tauq(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            ! Intrinsic Functions
@@ -3809,7 +3809,7 @@ module stdlib_linalg_lapack_q
               do i = 1,n
                  ! generate elementary reflector h(i) to annihilate a(i+1:m,i)
                  call stdlib_qlarfg(m - i + 1,a(i,i),a(min(i + 1,m),i),1,tauq(i))
-                           
+
                  d(i) = a(i,i)
                  a(i,i) = one
                  ! apply h(i) to a(i:m,i+1:n) from the left
@@ -3820,7 +3820,7 @@ module stdlib_linalg_lapack_q
                     ! generate elementary reflector g(i) to annihilate
                     ! a(i,i+2:n)
                     call stdlib_qlarfg(n - i,a(i,i + 1),a(i,min(i + 2,n)),lda,taup(i))
-                              
+
                     e(i) = a(i,i + 1)
                     a(i,i + 1) = one
                     ! apply g(i) to a(i+1:m,i+1:n) from the right
@@ -3836,7 +3836,7 @@ module stdlib_linalg_lapack_q
               do i = 1,m
                  ! generate elementary reflector g(i) to annihilate a(i,i+1:n)
                  call stdlib_qlarfg(n - i + 1,a(i,i),a(i,min(i + 1,n)),lda,taup(i))
-                           
+
                  d(i) = a(i,i)
                  a(i,i) = one
                  ! apply g(i) to a(i+1:m,i:n) from the right
@@ -3847,7 +3847,7 @@ module stdlib_linalg_lapack_q
                     ! generate elementary reflector h(i) to annihilate
                     ! a(i+2:m,i)
                     call stdlib_qlarfg(m - i,a(i + 1,i),a(min(i + 2,m),i),1,tauq(i))
-                              
+
                     e(i) = a(i + 1,i)
                     a(i + 1,i) = one
                     ! apply h(i) to a(i+1:m,i+1:n) from the left
@@ -3877,7 +3877,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: d(*),e(*),taup(*),tauq(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,iinfo,j,ldwrkx,ldwrky,lwkopt,minmn,nb,nbmin,nx,ws
@@ -3989,7 +3989,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: onenrm
            character :: normin
@@ -4034,7 +4034,7 @@ module stdlib_linalg_lapack_q
               kase1 = 2
            end if
            kase = 0
-10         continue
+           10 continue
            call stdlib_qlacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == kase1) then
@@ -4064,7 +4064,7 @@ module stdlib_linalg_lapack_q
            end if
            ! compute the estimate of the reciprocal condition number.
            if (ainvnm /= zero) rcond = (one/ainvnm)/anorm
-20         continue
+           20 continue
            return
      end subroutine stdlib_qgecon
 
@@ -4090,7 +4090,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: a(lda,*)
            real(qp),intent(out) :: c(*),r(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(qp) :: bignum,rcmax,rcmin,smlnum
@@ -4219,7 +4219,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: a(lda,*)
            real(qp),intent(out) :: c(*),r(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(qp) :: bignum,rcmax,rcmin,smlnum,radix,logrdx
@@ -4360,7 +4360,7 @@ module stdlib_linalg_lapack_q
            ! Function Arguments
            procedure(stdlib_select_q) :: select
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: cursl,lastsl,lquery,lst2sl,scalea,wantst,wantvs
            integer(ilp) :: hswork,i,i1,i2,ibal,icond,ierr,ieval,ihi,ilo,inxt,ip,itau, &
@@ -4614,7 +4614,7 @@ module stdlib_linalg_lapack_q
            ! Function Arguments
            procedure(stdlib_select_q) :: select
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: cursl,lastsl,lquery,lst2sl,scalea,wantsb,wantse,wantsn,wantst, &
                      wantsv,wantvs
@@ -4894,7 +4894,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: vl(ldvl,*),vr(ldvr,*),wi(*),work(*),wr(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,scalea,wantvl,wantvr
            character :: side
@@ -5114,7 +5114,7 @@ module stdlib_linalg_lapack_q
               end do
            end if
            ! undo scaling if necessary
-50   continue
+           50 continue
            if (scalea) then
               call stdlib_qlascl('G',0,0,cscale,anrm,n - info,1,wr(info + 1),max(n - info,1 &
                         ),ierr)
@@ -5171,7 +5171,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(out) :: rconde(*),rcondv(*),scale(*),vl(ldvl,*),vr(ldvr,*),wi(*), &
                       work(*),wr(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,scalea,wantvl,wantvr,wntsnb,wntsne,wntsnn,wntsnv
            character :: job,side
@@ -5259,12 +5259,12 @@ module stdlib_linalg_lapack_q
                  else
                     minwrk = 3*n
                     if ((.not. wntsnn) .and. (.not. wntsne)) minwrk = max(minwrk,n*n + 6*n)
-                              
+
                     maxwrk = max(maxwrk,hswork)
                     maxwrk = max(maxwrk,n + (n - 1)*stdlib_ilaenv(1,'DORGHR',' ',n,1,n,- &
                               1))
                     if ((.not. wntsnn) .and. (.not. wntsne)) maxwrk = max(maxwrk,n*n + 6*n)
-                              
+
                     maxwrk = max(maxwrk,3*n)
                  end if
                  maxwrk = max(maxwrk,minwrk)
@@ -5423,7 +5423,7 @@ module stdlib_linalg_lapack_q
               end do
            end if
            ! undo scaling if necessary
-50   continue
+           50 continue
            if (scalea) then
               call stdlib_qlascl('G',0,0,cscale,anrm,n - info,1,wr(info + 1),max(n - info,1 &
                         ),ierr)
@@ -5455,7 +5455,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(qp) :: aii
@@ -5511,7 +5511,7 @@ module stdlib_linalg_lapack_q
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,iinfo,iwt,j,ldwork,lwkopt,nb,nbmin,nh,nx
@@ -5648,7 +5648,7 @@ module stdlib_linalg_lapack_q
            integer(ilp),intent(out) :: iwork(*)
            character,intent(in) :: joba,jobp,jobr,jobt,jobu,jobv
         ! ===========================================================================
-           
+
            ! Local Scalars
            real(qp) :: aapp,aaqq,aatmax,aatmin,big,big1,cond_ok,condr1,condr2,entra, &
                      entrat,epsln,maxprj,scalem,sconda,sfmin,small,temp1,uscal1,uscal2,xsc
@@ -6037,7 +6037,7 @@ module stdlib_linalg_lapack_q
                     go to 3002
                  end if
               end do
-3002          continue
+              3002 continue
            else if (l2rank) then
               ! .. similarly as above, only slightly more gentle (less aggressive).
               ! sudden drop on the diagonal of r1 is used as the criterion for
@@ -6048,7 +6048,7 @@ module stdlib_linalg_lapack_q
                            l2kill .and. (abs(a(p,p)) < temp1))) go to 3402
                  nr = nr + 1
               end do
-3402          continue
+              3402 continue
            else
               ! the goal is high relative accuracy. however, if the matrix
               ! has high scaled condition number the relative accuracy is in
@@ -6063,7 +6063,7 @@ module stdlib_linalg_lapack_q
                            3302
                  nr = nr + 1
               end do
-3302          continue
+              3302 continue
            end if
            almort = .false.
            if (nr == n) then
@@ -6187,7 +6187,7 @@ module stdlib_linalg_lapack_q
                  end do
                  call stdlib_qlaset('UPPER',nr - 1,nr - 1,zero,zero,v(1,2),ldv)
                  call stdlib_qgesvj('L','U','N',n,nr,v,ldv,sva,nr,a,lda,work,lwork,info)
-                           
+
                  scalem = work(1)
                  numrank = nint(work(2),KIND=ilp)
               else
@@ -6198,7 +6198,7 @@ module stdlib_linalg_lapack_q
                  call stdlib_qlacpy('LOWER',nr,nr,a,lda,v,ldv)
                  call stdlib_qlaset('UPPER',nr - 1,nr - 1,zero,zero,v(1,2),ldv)
                  call stdlib_qgeqrf(nr,nr,v,ldv,work(n + 1),work(2*n + 1),lwork - 2*n,ierr)
-                           
+
                  do p = 1,nr
                     call stdlib_qcopy(nr - p + 1,v(p,p),ldv,v(p,p),1)
                  end do
@@ -6316,7 +6316,7 @@ module stdlib_linalg_lapack_q
                     ! of a lower triangular matrix.
                     ! r1^t = q2 * r2
                     call stdlib_qgeqrf(n,nr,v,ldv,work(n + 1),work(2*n + 1),lwork - 2*n,ierr)
-                              
+
                     if (l2pert) then
                        xsc = sqrt(small)/epsln
                        do p = 2,nr
@@ -6854,7 +6854,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            real(qp) :: aii
@@ -6974,7 +6974,7 @@ module stdlib_linalg_lapack_q
                     ! apply h to a(i+ib:m,i:n) from the right
                     call stdlib_qlarfb('RIGHT','NO TRANSPOSE','FORWARD','ROWWISE',m - i - ib + 1,n - &
                     i + 1,ib,a(i,i),lda,work,ldwork,a(i + ib,i),lda,work(ib + 1),ldwork)
-                              
+
                  end if
               end do
            else
@@ -6982,7 +6982,7 @@ module stdlib_linalg_lapack_q
            end if
            ! use unblocked code to factor the last or only block.
            if (i <= k) call stdlib_qgelq2(m - i + 1,n - i + 1,a(i,i),lda,tau(i),work,iinfo)
-                     
+
            work(1) = iws
            return
      end subroutine stdlib_qgelqf
@@ -7054,7 +7054,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,i1,j,j1,m1,m2,iinfo
            ! Executable Statements
@@ -7096,7 +7096,7 @@ module stdlib_linalg_lapack_q
               call stdlib_qgemm('N','N',m2,n - m1,m1,-one,t(i1,1),ldt,a(1,i1),lda, &
                         one,a(i1,i1),lda)
               call stdlib_qtrmm('R','U','N','U',m2,m1,one,a,lda,t(i1,1),ldt)
-                        
+
               do i = 1,m2
                  do j = 1,m1
                     a(i + m1,j) = a(i + m1,j) - t(i + m1,j)
@@ -7116,7 +7116,7 @@ module stdlib_linalg_lapack_q
               call stdlib_qgemm('N','T',m1,m2,n - m,one,a(1,j1),lda,a(i1,j1),lda, &
                         one,t(1,i1),ldt)
               call stdlib_qtrmm('L','U','N','N',m1,m2,-one,t,ldt,t(1,i1),ldt)
-                        
+
               call stdlib_qtrmm('R','U','N','N',m1,m2,one,t(i1,i1),ldt,t(1,i1), &
                         ldt)
               ! y = (y1,y2); l = [ l1            0  ];  t = [t1 t3]
@@ -7156,7 +7156,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*),b(ldb,*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,tpsd
            integer(ilp) :: brow,i,iascl,ibscl,j,mn,nb,scllen,wsize
@@ -7337,7 +7337,7 @@ module stdlib_linalg_lapack_q
            else if (ibscl == 2) then
               call stdlib_qlascl('G',0,0,bignum,bnrm,scllen,nrhs,b,ldb,info)
            end if
-50         continue
+           50 continue
            work(1) = real(wsize,KIND=qp)
            return
      end subroutine stdlib_qgels
@@ -7382,7 +7382,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*),b(ldb,*)
            real(qp),intent(out) :: s(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: iascl,ibscl,ie,il,itau,itaup,itauq,ldwork,liwork,maxmn, &
@@ -7428,9 +7428,9 @@ module stdlib_linalg_lapack_q
                  ! path 1a - overdetermined, with many more rows than columns.
                  mm = n
                  maxwrk = max(maxwrk,n + n*stdlib_ilaenv(1,'DGEQRF',' ',m,n,-1,-1))
-                           
+
                  maxwrk = max(maxwrk,n + nrhs*stdlib_ilaenv(1,'DORMQR','LT',m,nrhs,n,-1))
-                           
+
               end if
               if (m >= n) then
                  ! path 1 - overdetermined or exactly determined.
@@ -7589,7 +7589,7 @@ module stdlib_linalg_lapack_q
               ! compute a=l*q.
               ! (workspace: need 2*m, prefer m+m*nb)
               call stdlib_qgelqf(m,n,a,lda,work(itau),work(nwork),lwork - nwork + 1,info)
-                        
+
               il = nwork
               ! copy l to work(il), zeroing out above its diagonal.
               call stdlib_qlacpy('L',m,m,a,lda,work(il),ldwork)
@@ -7659,7 +7659,7 @@ module stdlib_linalg_lapack_q
            else if (ibscl == 2) then
               call stdlib_qlascl('G',0,0,bignum,bnrm,n,nrhs,b,ldb,info)
            end if
-10         continue
+           10 continue
            work(1) = maxwrk
            iwork(1) = liwork
            return
@@ -7679,7 +7679,7 @@ module stdlib_linalg_lapack_q
      !> value.
 
      subroutine stdlib_qgelss(m,n,nrhs,a,lda,b,ldb,s,rcond,rank,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -7691,7 +7691,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*),b(ldb,*)
            real(qp),intent(out) :: s(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: bdspac,bl,chunk,i,iascl,ibscl,ie,il,itau,itaup,itauq,iwork, &
@@ -7939,7 +7939,7 @@ module stdlib_linalg_lapack_q
               ! (workspace: need n, prefer n*nrhs)
               if (lwork >= ldb*nrhs .and. nrhs > 1) then
                  call stdlib_qgemm('T','N',n,nrhs,n,one,a,lda,b,ldb,zero,work,ldb)
-                           
+
                  call stdlib_qlacpy('G',n,nrhs,work,ldb,b,ldb)
               else if (nrhs > 1) then
                  chunk = lwork/n
@@ -7964,7 +7964,7 @@ module stdlib_linalg_lapack_q
               ! compute a=l*q
               ! (workspace: need 2*m, prefer m+m*nb)
               call stdlib_qgelqf(m,n,a,lda,work(itau),work(iwork),lwork - iwork + 1,info)
-                        
+
               il = iwork
               ! copy l to work(il), zeroing out above it
               call stdlib_qlacpy('L',m,m,a,lda,work(il),ldwork)
@@ -8074,7 +8074,7 @@ module stdlib_linalg_lapack_q
               ! (workspace: need n, prefer n*nrhs)
               if (lwork >= ldb*nrhs .and. nrhs > 1) then
                  call stdlib_qgemm('T','N',n,nrhs,m,one,a,lda,b,ldb,zero,work,ldb)
-                           
+
                  call stdlib_qlacpy('F',n,nrhs,work,ldb,b,ldb)
               else if (nrhs > 1) then
                  chunk = lwork/n
@@ -8102,7 +8102,7 @@ module stdlib_linalg_lapack_q
            else if (ibscl == 2) then
               call stdlib_qlascl('G',0,0,bignum,bnrm,n,nrhs,b,ldb,info)
            end if
-70         continue
+           70 continue
            work(1) = maxwrk
            return
      end subroutine stdlib_qgelss
@@ -8141,7 +8141,7 @@ module stdlib_linalg_lapack_q
      !> more simple.
 
      subroutine stdlib_qgelsy(m,n,nrhs,a,lda,b,ldb,jpvt,rcond,rank,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -8157,7 +8157,7 @@ module stdlib_linalg_lapack_q
            ! Parameters
            integer(ilp),parameter :: imax = 1
            integer(ilp),parameter :: imin = 2
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,iascl,ibscl,ismax,ismin,j,lwkmin,lwkopt,mn,nb,nb1,nb2, &
@@ -8249,7 +8249,7 @@ module stdlib_linalg_lapack_q
            ! compute qr factorization with column pivoting of a:
               ! a * p = q * r
            call stdlib_qgeqp3(m,n,a,lda,jpvt,work(1),work(mn + 1),lwork - mn,info)
-                     
+
            wsize = mn + work(mn + 1)
            ! workspace: mn+2*n+nb*(n+1).
            ! details of householder rotations stored in work(1:mn).
@@ -8265,7 +8265,7 @@ module stdlib_linalg_lapack_q
            else
               rank = 1
            end if
-10         continue
+           10 continue
            if (rank < mn) then
               i = rank + 1
               call stdlib_qlaic1(imin,rank,work(ismin),smin,a(1,i),a(i,i),sminpr, &
@@ -8334,7 +8334,7 @@ module stdlib_linalg_lapack_q
            else if (ibscl == 2) then
               call stdlib_qlascl('G',0,0,bignum,bnrm,n,nrhs,b,ldb,info)
            end if
-70         continue
+           70 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_qgelsy
@@ -8447,7 +8447,7 @@ module stdlib_linalg_lapack_q
      !> Q is of order M if SIDE = 'L' and of order N  if SIDE = 'R'.
 
      pure subroutine stdlib_qgemlqt(side,trans,m,n,k,mb,v,ldv,t,ldt,c,ldc,work,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -8642,7 +8642,7 @@ module stdlib_linalg_lapack_q
      !> Q is of order M if SIDE = 'L' and of order N  if SIDE = 'R'.
 
      pure subroutine stdlib_qgemqrt(side,trans,m,n,k,nb,v,ldv,t,ldt,c,ldc,work,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -8743,7 +8743,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            real(qp) :: aii
@@ -8772,7 +8772,7 @@ module stdlib_linalg_lapack_q
               aii = a(m - k + i,n - k + i)
               a(m - k + i,n - k + i) = one
               call stdlib_qlarf('LEFT',m - k + i,n - k + i - 1,a(1,n - k + i),1,tau(i),a,lda,work)
-                        
+
               a(m - k + i,n - k + i) = aii
            end do
            return
@@ -8860,7 +8860,7 @@ module stdlib_linalg_lapack_q
                  ! compute the ql factorization of the current block
                  ! a(1:m-k+i+ib-1,n-k+i:n-k+i+ib-1)
                  call stdlib_qgeql2(m - k + i + ib - 1,ib,a(1,n - k + i),lda,tau(i),work,iinfo)
-                           
+
                  if (n - k + i > 1) then
                     ! form the triangular factor of the block reflector
                     ! h = h(i+ib-1) . . . h(i+1) h(i)
@@ -8869,7 +8869,7 @@ module stdlib_linalg_lapack_q
                     ! apply h**t to a(1:m-k+i+ib-1,1:n-k+i-1) from the left
                     call stdlib_qlarfb('LEFT','TRANSPOSE','BACKWARD','COLUMNWISE',m - k + i + ib - 1, &
                     n - k + i - 1,ib,a(1,n - k + i),lda,work,ldwork,a,lda,work(ib + 1),ldwork)
-                              
+
                  end if
               end do
               mu = m - k + i + nb - 1
@@ -8903,7 +8903,7 @@ module stdlib_linalg_lapack_q
            integer(ilp),parameter :: inb = 1
            integer(ilp),parameter :: inbmin = 2
            integer(ilp),parameter :: ixover = 3
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: fjb,iws,j,jb,lwkopt,minmn,minws,na,nb,nbmin,nfxd,nx,sm, &
@@ -8999,7 +8999,7 @@ module stdlib_linalg_lapack_q
                        ! determine the minimum value of nb.
                        nb = (lwork - 2*sn)/(sn + 1)
                        nbmin = max(2,stdlib_ilaenv(inbmin,'DGEQRF',' ',sm,sn,-1,-1))
-                                 
+
                     end if
                  end if
               end if
@@ -9014,7 +9014,7 @@ module stdlib_linalg_lapack_q
                  j = nfxd + 1
                  ! compute factorization: while loop.
                  topbmn = minmn - nx
-30               continue
+                 30 continue
                  if (j <= topbmn) then
                     jb = min(nb,topbmn - j + 1)
                     ! factorize jb columns among columns j:n.
@@ -9168,7 +9168,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            real(qp) :: aii
@@ -9224,7 +9224,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            real(qp) :: aii
@@ -9357,7 +9357,7 @@ module stdlib_linalg_lapack_q
            end if
            ! use unblocked code to factor the last or only block.
            if (i <= k) call stdlib_qgeqr2(m - i + 1,n - i + 1,a(i,i),lda,tau(i),work,iinfo)
-                     
+
            work(1) = iws
            return
      end subroutine stdlib_qgeqrf
@@ -9456,7 +9456,7 @@ module stdlib_linalg_lapack_q
            end if
            ! use unblocked code to factor the last or only block.
            if (i <= k) call stdlib_qgeqr2p(m - i + 1,n - i + 1,a(i,i),lda,tau(i),work,iinfo)
-                     
+
            work(1) = iws
            return
      end subroutine stdlib_qgeqrfp
@@ -9478,7 +9478,7 @@ module stdlib_linalg_lapack_q
            ! Local Scalars
            logical(lk),parameter :: use_recursive_qr = .true.
            integer(ilp) :: i,ib,iinfo,k
-           
+
            ! Executable Statements
            ! test the input arguments
            info = 0
@@ -9532,7 +9532,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            real(qp) :: aii,alpha
@@ -9602,7 +9602,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,i1,j,j1,n1,n2,iinfo
            ! Executable Statements
@@ -9662,7 +9662,7 @@ module stdlib_linalg_lapack_q
               call stdlib_qgemm('T','N',n1,n2,m - n,one,a(i1,1),lda,a(i1,j1),lda, &
                         one,t(1,j1),ldt)
               call stdlib_qtrmm('L','U','N','N',n1,n2,-one,t,ldt,t(1,j1),ldt)
-                        
+
               call stdlib_qtrmm('R','U','N','N',n1,n2,one,t(j1,j1),ldt,t(1,j1), &
                         ldt)
               ! y = (y1,y2); r = [ r1  a(1:n1,j1:n) ];  t = [t1 t3]
@@ -9693,7 +9693,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: notran
            character :: transt
@@ -9750,13 +9750,13 @@ module stdlib_linalg_lapack_q
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - op(a) * x,
               ! where op(a) = a, a**t, or a**h, depending on trans.
               call stdlib_qcopy(n,b(1,j),1,work(n + 1),1)
               call stdlib_qgemv(trans,n,n,-one,a,lda,x(1,j),1,one,work(n + 1),1)
-                        
+
               ! compute componentwise relative backward error from formula
               ! max(i) ( abs(r(i)) / ( abs(op(a))*abs(x) + abs(b) )(i) )
               ! where abs(z) is the componentwise absolute value of the matrix
@@ -9830,14 +9830,14 @@ module stdlib_linalg_lapack_q
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_qlacn2(n,work(2*n + 1),work(n + 1),iwork,ferr(j),kase,isave)
-                        
+
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(op(a)**t).
                     call stdlib_qgetrs(transt,n,1,af,ldaf,ipiv,work(n + 1),n,info)
-                              
+
                     do i = 1,n
                        work(n + i) = work(i)*work(n + i)
                     end do
@@ -9874,7 +9874,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            real(qp) :: aii
@@ -9991,7 +9991,7 @@ module stdlib_linalg_lapack_q
                  ! compute the rq factorization of the current block
                  ! a(m-k+i:m-k+i+ib-1,1:n-k+i+ib-1)
                  call stdlib_qgerq2(ib,n - k + i + ib - 1,a(m - k + i,1),lda,tau(i),work,iinfo)
-                           
+
                  if (m - k + i > 1) then
                     ! form the triangular factor of the block reflector
                     ! h = h(i+ib-1) . . . h(i+1) h(i)
@@ -10000,7 +10000,7 @@ module stdlib_linalg_lapack_q
                     ! apply h to a(1:m-k+i-1,1:n-k+i+ib-1) from the right
                     call stdlib_qlarfb('RIGHT','NO TRANSPOSE','BACKWARD','ROWWISE',m - k + i - 1,n - &
                     k + i + ib - 1,ib,a(m - k + i,1),lda,work,ldwork,a,lda,work(ib + 1),ldwork)
-                              
+
                  end if
               end do
               mu = m - k + i + nb - 1
@@ -10032,7 +10032,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: a(lda,*)
            real(qp),intent(inout) :: rhs(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(qp) :: bignum,eps,smlnum,temp
@@ -10094,7 +10094,7 @@ module stdlib_linalg_lapack_q
      !> without guard digits, but we know of none.
 
      subroutine stdlib_qgesdd(jobz,m,n,a,lda,s,u,ldu,vt,ldvt,work,lwork,iwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -10107,7 +10107,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: s(*),u(ldu,*),vt(ldvt,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wntqa,wntqas,wntqn,wntqo,wntqs
            integer(ilp) :: bdspac,blk,chunk,i,ie,ierr,il,ir,iscl,itau,itaup,itauq,iu, &
@@ -10275,7 +10275,7 @@ module stdlib_linalg_lapack_q
                            ierr)
                  lwork_qgebrd_mn = int(dum(1),KIND=ilp)
                  call stdlib_qgebrd(m,m,a,m,s,dum(1),dum(1),dum(1),dum(1),-1,ierr)
-                           
+
                  lwork_qgebrd_mm = int(dum(1),KIND=ilp)
                  call stdlib_qgelqf(m,n,a,m,dum(1),dum(1),-1,ierr)
                  lwork_qgelqf_mn = int(dum(1),KIND=ilp)
@@ -10490,7 +10490,7 @@ module stdlib_linalg_lapack_q
                        call stdlib_qgemm('N','N',chunk,n,n,one,a(i,1),lda,work(iu), &
                                  n,zero,work(ir),ldwrkr)
                        call stdlib_qlacpy('F',chunk,n,work(ir),ldwrkr,a(i,1),lda)
-                                 
+
                     end do
                  else if (wntqs) then
                     ! path 3 (m >> n, jobz='s')
@@ -10671,7 +10671,7 @@ module stdlib_linalg_lapack_q
                           call stdlib_qgemm('N','N',chunk,n,n,one,a(i,1),lda,work(iu) &
                                     ,ldwrku,zero,work(ir),ldwrkr)
                           call stdlib_qlacpy('F',chunk,n,work(ir),ldwrkr,a(i,1),lda)
-                                    
+
                        end do
                     end if
                  else if (wntqs) then
@@ -10809,7 +10809,7 @@ module stdlib_linalg_lapack_q
                        call stdlib_qgemm('N','N',m,blk,m,one,work(ivt),m,a(1,i),lda, &
                                   zero,work(il),ldwrkl)
                        call stdlib_qlacpy('F',m,blk,work(il),ldwrkl,a(1,i),lda)
-                                 
+
                     end do
                  else if (wntqs) then
                     ! path 3t (n >> m, jobz='s')
@@ -11105,7 +11105,7 @@ module stdlib_linalg_lapack_q
      !> Note that the routine returns V**T, not V.
 
      subroutine stdlib_qgesvd(jobu,jobvt,m,n,a,lda,s,u,ldu,vt,ldvt,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -11117,7 +11117,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: s(*),u(ldu,*),vt(ldvt,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wntua,wntuas,wntun,wntuo,wntus,wntva,wntvas,wntvn,wntvo, &
                       wntvs
@@ -11186,7 +11186,7 @@ module stdlib_linalg_lapack_q
                  lwork_qorgqr_m = int(dum(1),KIND=ilp)
                  ! compute space needed for stdlib_qgebrd
                  call stdlib_qgebrd(n,n,a,lda,s,dum(1),dum(1),dum(1),dum(1),-1,ierr)
-                           
+
                  lwork_qgebrd = int(dum(1),KIND=ilp)
                  ! compute space needed for stdlib_qorgbr p
                  call stdlib_qorgbr('P',n,n,n,a,lda,dum(1),dum(1),-1,ierr)
@@ -11286,7 +11286,7 @@ module stdlib_linalg_lapack_q
                  else
                     ! path 10 (m at least n, but not much larger)
                     call stdlib_qgebrd(m,n,a,lda,s,dum(1),dum(1),dum(1),dum(1),-1,ierr)
-                              
+
                     lwork_qgebrd = int(dum(1),KIND=ilp)
                     maxwrk = 3*n + lwork_qgebrd
                     if (wntus .or. wntuo) then
@@ -11319,7 +11319,7 @@ module stdlib_linalg_lapack_q
                  lwork_qorglq_m = int(dum(1),KIND=ilp)
                  ! compute space needed for stdlib_qgebrd
                  call stdlib_qgebrd(m,m,a,lda,s,dum(1),dum(1),dum(1),dum(1),-1,ierr)
-                           
+
                  lwork_qgebrd = int(dum(1),KIND=ilp)
                   ! compute space needed for stdlib_qorgbr p
                  call stdlib_qorgbr('P',m,m,m,a,n,dum(1),dum(1),-1,ierr)
@@ -11419,7 +11419,7 @@ module stdlib_linalg_lapack_q
                  else
                     ! path 10t(n greater than m, but not much larger)
                     call stdlib_qgebrd(m,n,a,lda,s,dum(1),dum(1),dum(1),dum(1),-1,ierr)
-                              
+
                     lwork_qgebrd = int(dum(1),KIND=ilp)
                     maxwrk = 3*m + lwork_qgebrd
                     if (wntvs .or. wntvo) then
@@ -11541,7 +11541,7 @@ module stdlib_linalg_lapack_q
                        ! copy r to work(ir) and zero out below it
                        call stdlib_qlacpy('U',n,n,a,lda,work(ir),ldwrkr)
                        call stdlib_qlaset('L',n - 1,n - 1,zero,zero,work(ir + 1),ldwrkr)
-                                 
+
                        ! generate q in a
                        ! (workspace: need n*n + 2*n, prefer n*n + n + n*nb)
                        call stdlib_qorgqr(m,n,n,a,lda,work(itau),work(iwork),lwork - &
@@ -11573,7 +11573,7 @@ module stdlib_linalg_lapack_q
                           call stdlib_qgemm('N','N',chunk,n,n,one,a(i,1),lda,work(ir) &
                                     ,ldwrkr,zero,work(iu),ldwrku)
                           call stdlib_qlacpy('F',chunk,n,work(iu),ldwrku,a(i,1),lda)
-                                    
+
                        end do
                     else
                        ! insufficient workspace for a fast algorithm
@@ -11625,7 +11625,7 @@ module stdlib_linalg_lapack_q
                        ! copy r to vt, zeroing out below it
                        call stdlib_qlacpy('U',n,n,a,lda,vt,ldvt)
                        if (n > 1) call stdlib_qlaset('L',n - 1,n - 1,zero,zero,vt(2,1),ldvt)
-                                 
+
                        ! generate q in a
                        ! (workspace: need n*n + 2*n, prefer n*n + n + n*nb)
                        call stdlib_qorgqr(m,n,n,a,lda,work(itau),work(iwork),lwork - &
@@ -11663,7 +11663,7 @@ module stdlib_linalg_lapack_q
                           call stdlib_qgemm('N','N',chunk,n,n,one,a(i,1),lda,work(ir) &
                                     ,ldwrkr,zero,work(iu),ldwrku)
                           call stdlib_qlacpy('F',chunk,n,work(iu),ldwrku,a(i,1),lda)
-                                    
+
                        end do
                     else
                        ! insufficient workspace for a fast algorithm
@@ -11676,7 +11676,7 @@ module stdlib_linalg_lapack_q
                        ! copy r to vt, zeroing out below it
                        call stdlib_qlacpy('U',n,n,a,lda,vt,ldvt)
                        if (n > 1) call stdlib_qlaset('L',n - 1,n - 1,zero,zero,vt(2,1),ldvt)
-                                 
+
                        ! generate q in a
                        ! (workspace: need 2*n, prefer n + n*nb)
                        call stdlib_qorgqr(m,n,n,a,lda,work(itau),work(iwork),lwork - &
@@ -11729,7 +11729,7 @@ module stdlib_linalg_lapack_q
                           ! copy r to work(ir), zeroing out below it
                           call stdlib_qlacpy('U',n,n,a,lda,work(ir),ldwrkr)
                           call stdlib_qlaset('L',n - 1,n - 1,zero,zero,work(ir + 1),ldwrkr)
-                                    
+
                           ! generate q in a
                           ! (workspace: need n*n + 2*n, prefer n*n + n + n*nb)
                           call stdlib_qorgqr(m,n,n,a,lda,work(itau),work(iwork),lwork - &
@@ -11777,7 +11777,7 @@ module stdlib_linalg_lapack_q
                           ! zero out below r in a
                           if (n > 1) then
                              call stdlib_qlaset('L',n - 1,n - 1,zero,zero,a(2,1),lda)
-                                       
+
                           end if
                           ! bidiagonalize r in a
                           ! (workspace: need 4*n, prefer 3*n + 2*n*nb)
@@ -11826,7 +11826,7 @@ module stdlib_linalg_lapack_q
                           ! copy r to work(iu), zeroing out below it
                           call stdlib_qlacpy('U',n,n,a,lda,work(iu),ldwrku)
                           call stdlib_qlaset('L',n - 1,n - 1,zero,zero,work(iu + 1),ldwrku)
-                                    
+
                           ! generate q in a
                           ! (workspace: need 2*n*n + 2*n, prefer 2*n*n + n + n*nb)
                           call stdlib_qorgqr(m,n,n,a,lda,work(itau),work(iwork),lwork - &
@@ -11842,7 +11842,7 @@ module stdlib_linalg_lapack_q
                           call stdlib_qgebrd(n,n,work(iu),ldwrku,s,work(ie),work(itauq &
                                     ),work(itaup),work(iwork),lwork - iwork + 1,ierr)
                           call stdlib_qlacpy('U',n,n,work(iu),ldwrku,work(ir),ldwrkr)
-                                    
+
                           ! generate left bidiagonalizing vectors in work(iu)
                           ! (workspace: need 2*n*n + 4*n, prefer 2*n*n + 3*n + n*nb)
                           call stdlib_qorgbr('Q',n,n,n,work(iu),ldwrku,work(itauq), &
@@ -11887,7 +11887,7 @@ module stdlib_linalg_lapack_q
                           ! zero out below r in a
                           if (n > 1) then
                              call stdlib_qlaset('L',n - 1,n - 1,zero,zero,a(2,1),lda)
-                                       
+
                           end if
                           ! bidiagonalize r in a
                           ! (workspace: need 4*n, prefer 3*n + 2*n*nb)
@@ -11933,7 +11933,7 @@ module stdlib_linalg_lapack_q
                           ! copy r to work(iu), zeroing out below it
                           call stdlib_qlacpy('U',n,n,a,lda,work(iu),ldwrku)
                           call stdlib_qlaset('L',n - 1,n - 1,zero,zero,work(iu + 1),ldwrku)
-                                    
+
                           ! generate q in a
                           ! (workspace: need n*n + 2*n, prefer n*n + n + n*nb)
                           call stdlib_qorgqr(m,n,n,a,lda,work(itau),work(iwork),lwork - &
@@ -12036,7 +12036,7 @@ module stdlib_linalg_lapack_q
                           ! copy r to work(ir), zeroing out below it
                           call stdlib_qlacpy('U',n,n,a,lda,work(ir),ldwrkr)
                           call stdlib_qlaset('L',n - 1,n - 1,zero,zero,work(ir + 1),ldwrkr)
-                                    
+
                           ! generate q in u
                           ! (workspace: need n*n + n + m, prefer n*n + n + m*nb)
                           call stdlib_qorgqr(m,m,n,u,ldu,work(itau),work(iwork),lwork - &
@@ -12086,7 +12086,7 @@ module stdlib_linalg_lapack_q
                           ! zero out below r in a
                           if (n > 1) then
                              call stdlib_qlaset('L',n - 1,n - 1,zero,zero,a(2,1),lda)
-                                       
+
                           end if
                           ! bidiagonalize r in a
                           ! (workspace: need 4*n, prefer 3*n + 2*n*nb)
@@ -12141,7 +12141,7 @@ module stdlib_linalg_lapack_q
                           ! copy r to work(iu), zeroing out below it
                           call stdlib_qlacpy('U',n,n,a,lda,work(iu),ldwrku)
                           call stdlib_qlaset('L',n - 1,n - 1,zero,zero,work(iu + 1),ldwrku)
-                                    
+
                           ie = itau
                           itauq = ie + n
                           itaup = itauq + n
@@ -12153,7 +12153,7 @@ module stdlib_linalg_lapack_q
                           call stdlib_qgebrd(n,n,work(iu),ldwrku,s,work(ie),work(itauq &
                                     ),work(itaup),work(iwork),lwork - iwork + 1,ierr)
                           call stdlib_qlacpy('U',n,n,work(iu),ldwrku,work(ir),ldwrkr)
-                                    
+
                           ! generate left bidiagonalizing vectors in work(iu)
                           ! (workspace: need 2*n*n + 4*n, prefer 2*n*n + 3*n + n*nb)
                           call stdlib_qorgbr('Q',n,n,n,work(iu),ldwrku,work(itauq), &
@@ -12199,7 +12199,7 @@ module stdlib_linalg_lapack_q
                           ! zero out below r in a
                           if (n > 1) then
                              call stdlib_qlaset('L',n - 1,n - 1,zero,zero,a(2,1),lda)
-                                       
+
                           end if
                           ! bidiagonalize r in a
                           ! (workspace: need 4*n, prefer 3*n + 2*n*nb)
@@ -12251,7 +12251,7 @@ module stdlib_linalg_lapack_q
                           ! copy r to work(iu), zeroing out below it
                           call stdlib_qlacpy('U',n,n,a,lda,work(iu),ldwrku)
                           call stdlib_qlaset('L',n - 1,n - 1,zero,zero,work(iu + 1),ldwrku)
-                                    
+
                           ie = itau
                           itauq = ie + n
                           itaup = itauq + n
@@ -12472,7 +12472,7 @@ module stdlib_linalg_lapack_q
                        ! copy l to work(ir) and zero out above it
                        call stdlib_qlacpy('L',m,m,a,lda,work(ir),ldwrkr)
                        call stdlib_qlaset('U',m - 1,m - 1,zero,zero,work(ir + ldwrkr),ldwrkr)
-                                 
+
                        ! generate q in a
                        ! (workspace: need m*m + 2*m, prefer m*m + m + m*nb)
                        call stdlib_qorglq(m,n,m,a,lda,work(itau),work(iwork),lwork - &
@@ -12504,7 +12504,7 @@ module stdlib_linalg_lapack_q
                           call stdlib_qgemm('N','N',m,blk,m,one,work(ir),ldwrkr,a(1,i &
                                     ),lda,zero,work(iu),ldwrku)
                           call stdlib_qlacpy('F',m,blk,work(iu),ldwrku,a(1,i),lda)
-                                    
+
                        end do
                     else
                        ! insufficient workspace for a fast algorithm
@@ -12596,7 +12596,7 @@ module stdlib_linalg_lapack_q
                           call stdlib_qgemm('N','N',m,blk,m,one,work(ir),ldwrkr,a(1,i &
                                     ),lda,zero,work(iu),ldwrku)
                           call stdlib_qlacpy('F',m,blk,work(iu),ldwrku,a(1,i),lda)
-                                    
+
                        end do
                     else
                        ! insufficient workspace for a fast algorithm
@@ -12773,7 +12773,7 @@ module stdlib_linalg_lapack_q
                           call stdlib_qgebrd(m,m,work(iu),ldwrku,s,work(ie),work(itauq &
                                     ),work(itaup),work(iwork),lwork - iwork + 1,ierr)
                           call stdlib_qlacpy('L',m,m,work(iu),ldwrku,work(ir),ldwrkr)
-                                    
+
                           ! generate right bidiagonalizing vectors in work(iu)
                           ! (workspace: need 2*m*m + 4*m-1,
                                       ! prefer 2*m*m+3*m+(m-1)*nb)
@@ -13078,7 +13078,7 @@ module stdlib_linalg_lapack_q
                           call stdlib_qgebrd(m,m,work(iu),ldwrku,s,work(ie),work(itauq &
                                     ),work(itaup),work(iwork),lwork - iwork + 1,ierr)
                           call stdlib_qlacpy('L',m,m,work(iu),ldwrku,work(ir),ldwrkr)
-                                    
+
                           ! generate right bidiagonalizing vectors in work(iu)
                           ! (workspace: need 2*m*m + 4*m-1,
                                       ! prefer 2*m*m+3*m+(m-1)*nb)
@@ -13374,7 +13374,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(out) :: s(*),rwork(*)
            integer(ilp),intent(out) :: iwork(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: ierr,iwoff,nr,n1,optratio,p,q
            integer(ilp) :: lwcon,lwqp3,lwrk_qgelqf,lwrk_qgesvd,lwrk_qgesvd2,lwrk_qgeqp3, &
@@ -13705,7 +13705,7 @@ module stdlib_linalg_lapack_q
                      ! .. to prevent overflow in the qr factorization, scale the
                      ! matrix by 1/sqrt(m) if too large entry detected
                      call stdlib_qlascl('G',0,0,sqrt(real(m,KIND=qp)),one,m,n,a,lda,ierr)
-                               
+
                      ascaled = .true.
                  end if
                  call stdlib_qlaswp(n,a,lda,1,m - 1,iwork(n + 1),1)
@@ -13725,7 +13725,7 @@ module stdlib_linalg_lapack_q
                    ! .. to prevent overflow in the qr factorization, scale the
                    ! matrix by 1/sqrt(m) if too large entry detected
                    call stdlib_qlascl('G',0,0,sqrt(real(m,KIND=qp)),one,m,n,a,lda,ierr)
-                             
+
                    ascaled = .true.
                end if
            end if
@@ -13755,7 +13755,7 @@ module stdlib_linalg_lapack_q
                  if (abs(a(p,p)) < (rtmp*abs(a(1,1)))) go to 3002
                     nr = nr + 1
               end do
-3002          continue
+              3002 continue
            elseif (acclm) then
               ! .. similarly as above, only slightly more gentle (less aggressive).
               ! sudden drop on the diagonal of r is used as the criterion for being
@@ -13769,7 +13769,7 @@ module stdlib_linalg_lapack_q
                            to 3402
                  nr = nr + 1
               end do
-3402          continue
+              3402 continue
            else
               ! Rrqr Not Authorized To Determine Numerical Rank Except In The
               ! obvious case of zero pivots.
@@ -13780,7 +13780,7 @@ module stdlib_linalg_lapack_q
                  if (abs(a(p,p)) == zero) go to 3502
                  nr = nr + 1
               end do
-3502          continue
+              3502 continue
               if (conda) then
                  ! estimate the scaled condition number of a. use the fact that it is
                  ! the same as the scaled condition number of r.
@@ -13868,7 +13868,7 @@ module stdlib_linalg_lapack_q
                   ! .. copy r into [u] and overwrite [u] with the left singular vectors
                   call stdlib_qlacpy('U',nr,n,a,lda,u,ldu)
                   if (nr > 1) call stdlib_qlaset('L',nr - 1,nr - 1,zero,zero,u(2,1),ldu)
-                            
+
                   ! .. the right singular vectors not computed, the nr left singular
                   ! vectors overwrite [u](1:nr,1:nr)
                      call stdlib_qgesvd('O','N',nr,n,u,ldu,s,u,ldu,v,ldv,work(n + 1), &
@@ -13948,7 +13948,7 @@ module stdlib_linalg_lapack_q
                   ! Copy R Into V And Overwrite V With The Right Singular Vectors
                   call stdlib_qlacpy('U',nr,n,a,lda,v,ldv)
                   if (nr > 1) call stdlib_qlaset('L',nr - 1,nr - 1,zero,zero,v(2,1),ldv)
-                            
+
                   ! .. the right singular vectors overwrite v, the nr left singular
                   ! vectors stored in u(1:nr,1:nr)
                   if (wntvr .or. (nr == n)) then
@@ -14036,7 +14036,7 @@ module stdlib_linalg_lapack_q
                            end do
                         end do
                         if (nr > 1) call stdlib_qlaset('U',nr - 1,nr - 1,zero,zero,v(1,2),ldv)
-                                  
+
                         call stdlib_qlaset('A',n,n - nr,zero,zero,v(1,nr + 1),ldv)
                         call stdlib_qgesvd('O','A',n,n,v,ldv,s,v,ldv,u,ldu,work(n + 1), &
                                   lwork - n,info)
@@ -14073,7 +14073,7 @@ module stdlib_linalg_lapack_q
                            end do
                         end do
                         if (nr > 1) call stdlib_qlaset('U',nr - 1,nr - 1,zero,zero,u(1,nr + 2),ldu)
-                                  
+
                         call stdlib_qgeqrf(n,nr,u(1,nr + 1),ldu,work(n + 1),work(n + nr + 1),lwork - &
                                   n - nr,ierr)
                         do p = 1,nr
@@ -14107,7 +14107,7 @@ module stdlib_linalg_lapack_q
                       ! .. copy r into [v] and overwrite v with the right singular vectors
                       call stdlib_qlacpy('U',nr,n,a,lda,v,ldv)
                      if (nr > 1) call stdlib_qlaset('L',nr - 1,nr - 1,zero,zero,v(2,1),ldv)
-                               
+
                      ! .. the right singular vectors of r overwrite [v], the nr left
                      ! singular vectors of r stored in [u](1:nr,1:nr)
                      call stdlib_qgesvd('S','O',nr,n,v,ldv,s,u,ldu,v,ldv,work(n + 1), &
@@ -14136,7 +14136,7 @@ module stdlib_linalg_lapack_q
                     if (optratio*nr > n) then
                        call stdlib_qlacpy('U',nr,n,a,lda,v,ldv)
                        if (nr > 1) call stdlib_qlaset('L',nr - 1,nr - 1,zero,zero,v(2,1),ldv)
-                                 
+
                     ! .. the right singular vectors of r overwrite [v], the nr left
                        ! singular vectors of r stored in [u](1:nr,1:nr)
                        call stdlib_qlaset('A',n - nr,n,zero,zero,v(nr + 1,1),ldv)
@@ -14158,7 +14158,7 @@ module stdlib_linalg_lapack_q
                     else
                        call stdlib_qlacpy('U',nr,n,a,lda,u(nr + 1,1),ldu)
                        if (nr > 1) call stdlib_qlaset('L',nr - 1,nr - 1,zero,zero,u(nr + 2,1),ldu)
-                                 
+
                        call stdlib_qgelqf(nr,n,u(nr + 1,1),ldu,work(n + 1),work(n + nr + 1),lwork - n - &
                                  nr,ierr)
                        call stdlib_qlacpy('L',nr,nr,u(nr + 1,1),ldu,v,ldv)
@@ -14199,7 +14199,7 @@ module stdlib_linalg_lapack_q
                if (s(q) > zero) go to 4002
                nr = nr - 1
            end do
-4002       continue
+           4002 continue
            ! .. if numerical rank deficiency is detected, the truncated
            ! singular values are set to zero.
            if (nr < n) call stdlib_qlaset('G',n - nr,1,zero,zero,s(nr + 1),n)
@@ -14243,7 +14243,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Local Parameters
            integer(ilp),parameter :: nsweep = 30
-           
+
            ! Local Scalars
            real(qp) :: aapp,aapp0,aapq,aaqq,apoaq,aqoap,big,bigtheta,cs,ctol,epsln, &
            large,mxaapq,mxsinj,rootbig,rooteps,rootsfmin,roottol,skl,sfmin,small,sn,t, &
@@ -14449,7 +14449,7 @@ module stdlib_linalg_lapack_q
        ! #:) quick return for one-column matrix
            if (n == 1) then
               if (lsvec) call stdlib_qlascl('G',0,0,sva(1),skl,m,1,a(1,1),lda,ierr)
-                        
+
               work(1) = one/skl
               if (sva(1) >= sfmin) then
                  work(2) = one
@@ -14569,12 +14569,12 @@ module stdlib_linalg_lapack_q
                            tol,2,work(n + 1),lwork - n,ierr)
                  call stdlib_qgsvj0(jobv,n2,n4,a(1,n4 + 1),lda,work(n4 + 1),sva(n4 + 1), &
                  mvl,v(n4*q + 1,n4 + 1),ldv,epsln,sfmin,tol,1,work(n + 1),lwork - n,ierr)
-                           
+
                  call stdlib_qgsvj1(jobv,n2,n2,n4,a,lda,work,sva,mvl,v,ldv,epsln, &
                            sfmin,tol,1,work(n + 1),lwork - n,ierr)
                  call stdlib_qgsvj0(jobv,n2 + n4,n4,a(1,n2 + 1),lda,work(n2 + 1),sva(n2 + 1), &
                   mvl,v(n2*q + 1,n2 + 1),ldv,epsln,sfmin,tol,1,work(n + 1),lwork - n,ierr)
-                            
+
               end if
            end if
            ! .. row-cyclic pivot strategy with de rijk's pivoting ..
@@ -14680,23 +14680,23 @@ module stdlib_linalg_lapack_q
                                          fastr(3) = t*work(p)/work(q)
                                          fastr(4) = -t*work(q)/work(p)
                                          call stdlib_qrotm(m,a(1,p),1,a(1,q),1,fastr)
-                                                   
+
                                          if (rsvec) call stdlib_qrotm(mvl,v(1,p),1,v(1,q), &
                                                     1,fastr)
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq))
                                          mxsinj = max(mxsinj,abs(t))
                                       else
                        ! Choose Correct Signum For Theta And Rotate
                                          thsign = -sign(one,aapq)
                                          t = one/(theta + thsign*sqrt(one + theta*theta))
-                                                   
+
                                          cs = sqrt(one/(one + t*t))
                                          sn = t*cs
                                          mxsinj = max(mxsinj,abs(sn))
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq))
                                          apoaq = work(p)/work(q)
                                          aqoap = work(q)/work(p)
@@ -14778,7 +14778,7 @@ module stdlib_linalg_lapack_q
                                                 lda,ierr)
                                       temp1 = -aapq*work(p)/work(q)
                                       call stdlib_qaxpy(m,temp1,work(n + 1),1,a(1,q),1)
-                                                
+
                                       call stdlib_qlascl('G',0,0,one,aaqq,m,1,a(1,q), &
                                                 lda,ierr)
                                       sva(q) = aaqq*sqrt(max(zero,one - aapq*aapq))
@@ -14790,7 +14790,7 @@ module stdlib_linalg_lapack_q
                                    if ((sva(q)/aaqq)**2 <= rooteps) then
                                       if ((aaqq < rootbig) .and. (aaqq > rootsfmin)) then
                                          sva(q) = stdlib_qnrm2(m,a(1,q),1)*work(q)
-                                                   
+
                                       else
                                          t = zero
                                          aaqq = one
@@ -14827,7 +14827,7 @@ module stdlib_linalg_lapack_q
                              end if
                           end do loop_2002
            ! end q-loop
-2103 continue
+           2103 continue
            ! bailed out of q-loop
                           sva(p) = aapp
                        else
@@ -14906,11 +14906,11 @@ module stdlib_linalg_lapack_q
                                          fastr(3) = t*work(p)/work(q)
                                          fastr(4) = -t*work(q)/work(p)
                                          call stdlib_qrotm(m,a(1,p),1,a(1,q),1,fastr)
-                                                   
+
                                          if (rsvec) call stdlib_qrotm(mvl,v(1,p),1,v(1,q), &
                                                     1,fastr)
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq))
                                          mxsinj = max(mxsinj,abs(t))
                                       else
@@ -14918,12 +14918,12 @@ module stdlib_linalg_lapack_q
                                          thsign = -sign(one,aapq)
                                          if (aaqq > aapp0) thsign = -thsign
                                          t = one/(theta + thsign*sqrt(one + theta*theta))
-                                                   
+
                                          cs = sqrt(one/(one + t*t))
                                          sn = t*cs
                                          mxsinj = max(mxsinj,abs(sn))
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq))
                                          apoaq = work(p)/work(q)
                                          aqoap = work(q)/work(p)
@@ -14999,7 +14999,7 @@ module stdlib_linalg_lapack_q
                                    else
                                       if (aapp > aaqq) then
                                          call stdlib_qcopy(m,a(1,p),1,work(n + 1),1)
-                                                   
+
                                          call stdlib_qlascl('G',0,0,aapp,one,m,1,work(n + 1 &
                                                    ),lda,ierr)
                                          call stdlib_qlascl('G',0,0,aaqq,one,m,1,a(1,q), &
@@ -15013,7 +15013,7 @@ module stdlib_linalg_lapack_q
                                          mxsinj = max(mxsinj,sfmin)
                                       else
                                          call stdlib_qcopy(m,a(1,q),1,work(n + 1),1)
-                                                   
+
                                          call stdlib_qlascl('G',0,0,aaqq,one,m,1,work(n + 1 &
                                                    ),lda,ierr)
                                          call stdlib_qlascl('G',0,0,aapp,one,m,1,a(1,p), &
@@ -15033,7 +15033,7 @@ module stdlib_linalg_lapack_q
                                    if ((sva(q)/aaqq)**2 <= rooteps) then
                                       if ((aaqq < rootbig) .and. (aaqq > rootsfmin)) then
                                          sva(q) = stdlib_qnrm2(m,a(1,q),1)*work(q)
-                                                   
+
                                       else
                                          t = zero
                                          aaqq = one
@@ -15076,7 +15076,7 @@ module stdlib_linalg_lapack_q
                              end if
                           end do loop_2200
               ! end of the q-loop
-2203 continue
+              2203 continue
                           sva(p) = aapp
                        else
                           if (aapp == zero) notrot = notrot + min(jgl + kbl - 1,n) - jgl + 1
@@ -15086,7 +15086,7 @@ module stdlib_linalg_lapack_q
            ! end of the p-loop
                  end do loop_2010
            ! end of the jbc-loop
-2011 continue
+           2011 continue
       ! 2011 bailed out of the jbc-loop
                  do p = igl,min(igl + kbl - 1,n)
                     sva(p) = abs(sva(p))
@@ -15115,12 +15115,12 @@ module stdlib_linalg_lapack_q
        ! #:( reaching this point means that the procedure has not converged.
            info = nsweep - 1
            go to 1995
-1994       continue
+           1994 continue
        ! #:) reaching this point means numerical convergence after the i-th
            ! sweep.
            info = 0
        ! #:) info = 0 confirms successful iterations.
-1995 continue
+       1995 continue
            ! sort the singular values and find how many are above
            ! the underflow threshold.
            n2 = 0
@@ -15218,7 +15218,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*),af(ldaf,*),b(ldb,*),c(*),r(*)
            real(qp),intent(out) :: berr(*),ferr(*),work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: colequ,equil,nofact,notran,rowequ
            character :: norm
@@ -15415,7 +15415,7 @@ module stdlib_linalg_lapack_q
            integer(ilp),intent(out) :: ipiv(*),jpiv(*)
            real(qp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,ip,ipv,j,jp,jpv
            real(qp) :: bignum,eps,smin,smlnum,xmax
@@ -15502,7 +15502,7 @@ module stdlib_linalg_lapack_q
            integer(ilp),intent(out) :: ipiv(*)
            real(qp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(qp) :: sfmin
            integer(ilp) :: i,j,jp
@@ -15575,7 +15575,7 @@ module stdlib_linalg_lapack_q
            integer(ilp),intent(out) :: ipiv(*)
            real(qp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,iinfo,j,jb,nb
            ! Intrinsic Functions
@@ -15625,7 +15625,7 @@ module stdlib_linalg_lapack_q
                        ! update trailing submatrix.
                        call stdlib_qgemm('NO TRANSPOSE','NO TRANSPOSE',m - j - jb + 1,n - j - jb + 1,jb,- &
                        one,a(j + jb,j),lda,a(j,j + jb),lda,one,a(j + jb,j + jb),lda)
-                                 
+
                     end if
                  end if
               end do
@@ -15664,7 +15664,7 @@ module stdlib_linalg_lapack_q
            integer(ilp),intent(out) :: ipiv(*)
            real(qp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(qp) :: sfmin,temp
            integer(ilp) :: i,iinfo,n1,n2
@@ -15731,7 +15731,7 @@ module stdlib_linalg_lapack_q
               call stdlib_qlaswp(n2,a(1,n1 + 1),lda,1,n1,ipiv,1)
               ! solve a12
               call stdlib_qtrsm('L','L','N','U',n1,n2,one,a,lda,a(1,n1 + 1),lda)
-                        
+
               ! update a22
               call stdlib_qgemm('N','N',m - n1,n2,n1,-one,a(n1 + 1,1),lda,a(1,n1 + 1), &
                         lda,one,a(n1 + 1,n1 + 1),lda)
@@ -15765,7 +15765,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,iws,j,jb,jj,jp,ldwork,lwkopt,nb,nbmin,nn
@@ -15868,7 +15868,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: a(lda,*)
            real(qp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran
            ! Intrinsic Functions
@@ -15950,7 +15950,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*),b(ldb,*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,tran
            integer(ilp) :: i,iascl,ibscl,j,maxmn,brow,scllen,tszo,tszm,lwo,lwm,lw1, &
@@ -16150,7 +16150,7 @@ module stdlib_linalg_lapack_q
            else if (ibscl == 2) then
              call stdlib_qlascl('G',0,0,bignum,bnrm,scllen,nrhs,b,ldb,info)
            end if
-50         continue
+           50 continue
            work(1) = real(tszo + lwo,KIND=qp)
            return
      end subroutine stdlib_qgetsls
@@ -16169,7 +16169,7 @@ module stdlib_linalg_lapack_q
      !> of DGEQRT for more details on the format.
 
      pure subroutine stdlib_qgetsqrhrt(m,n,mb1,nb1,nb2,a,lda,t,ldt,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -16180,7 +16180,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: t(ldt,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,iinfo,j,lw1,lw2,lwt,ldwt,lworkopt,nb1local,nb2local, &
@@ -16249,7 +16249,7 @@ module stdlib_linalg_lapack_q
            nb2local = min(nb2,n)
            ! (1) perform tsqr-factorization of the m-by-n matrix a.
            call stdlib_qlatsqr(m,n,mb1,nb1local,a,lda,work,ldwt,work(lwt + 1),lw1,iinfo)
-                     
+
            ! (2) copy the factor r_tsqr stored in the upper-triangular part
                ! of a into the square matrix in the work array
                ! work(lwt+1:lwt+n*n) column-by-column.
@@ -16263,7 +16263,7 @@ module stdlib_linalg_lapack_q
            ! (4) perform the reconstruction of householder vectors from
            ! the matrix q (stored in a) in place.
            call stdlib_qorhr_col(m,n,nb2local,a,lda,t,ldt,work(lwt + n*n + 1),iinfo)
-                     
+
            ! (5) copy the factor r_tsqr stored in the square matrix in the
            ! work array work(lwt+1:lwt+n*n) into the upper-triangular
            ! part of a.
@@ -16294,7 +16294,7 @@ module stdlib_linalg_lapack_q
      !> DGGBAL.
 
      pure subroutine stdlib_qggbak(job,side,n,ilo,ihi,lscale,rscale,m,v,ldv,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -16361,7 +16361,7 @@ module stdlib_linalg_lapack_q
               end if
            end if
            ! backward permutation
-30   continue
+           30 continue
            if (stdlib_lsame(job,'P') .or. stdlib_lsame(job,'B')) then
               ! backward permutation on right eigenvectors
               if (rightv) then
@@ -16371,7 +16371,7 @@ module stdlib_linalg_lapack_q
                     if (k == i) cycle loop_40
                     call stdlib_qswap(m,v(i,1),ldv,v(k,1),ldv)
                  end do loop_40
-50               continue
+                 50 continue
                  if (ihi == n) go to 70
                  loop_60: do i = ihi + 1,n
                     k = int(rscale(i),KIND=ilp)
@@ -16380,7 +16380,7 @@ module stdlib_linalg_lapack_q
                  end do loop_60
               end if
               ! backward permutation on left eigenvectors
-70   continue
+              70 continue
               if (leftv) then
                  if (ilo == 1) go to 90
                  loop_80: do i = ilo - 1,1,-1
@@ -16388,7 +16388,7 @@ module stdlib_linalg_lapack_q
                     if (k == i) cycle loop_80
                     call stdlib_qswap(m,v(i,1),ldv,v(k,1),ldv)
                  end do loop_80
-90               continue
+                 90 continue
                  if (ihi == n) go to 110
                  loop_100: do i = ihi + 1,n
                     k = int(lscale(i),KIND=ilp)
@@ -16397,7 +16397,7 @@ module stdlib_linalg_lapack_q
                  end do loop_100
               end if
            end if
-110        continue
+           110 continue
            return
      end subroutine stdlib_qggbak
 
@@ -16412,7 +16412,7 @@ module stdlib_linalg_lapack_q
      !> generalized eigenvalue problem A*x = lambda*B*x.
 
      pure subroutine stdlib_qggbal(job,n,a,lda,b,ldb,ilo,ihi,lscale,rscale,work,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -16426,7 +16426,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: sclfac = 1.0e+1_qp
-           
+
            ! Local Scalars
            integer(ilp) :: i,icab,iflow,ip1,ir,irab,it,j,jc,jp1,k,kount,l,lcab,lm1, &
                      lrab,lsfmax,lsfmin,m,nr,nrp2
@@ -16479,13 +16479,13 @@ module stdlib_linalg_lapack_q
            go to 30
            ! permute the matrices a and b to isolate the eigenvalues.
            ! find row with one nonzero in columns 1 through l
-20   continue
+           20 continue
            l = lm1
            if (l /= 1) go to 30
            rscale(1) = one
            lscale(1) = one
            go to 190
-30         continue
+           30 continue
            lm1 = l - 1
            loop_80: do i = l,1,-1
               do j = 1,lm1
@@ -16494,21 +16494,21 @@ module stdlib_linalg_lapack_q
               end do
               j = l
               go to 70
-50            continue
+              50 continue
               do j = jp1,l
                  if (a(i,j) /= zero .or. b(i,j) /= zero) cycle loop_80
               end do
               j = jp1 - 1
-70            continue
+              70 continue
               m = l
               iflow = 1
               go to 160
            end do loop_80
            go to 100
            ! find column with one nonzero in rows k through n
-90   continue
+           90 continue
            k = k + 1
-100        continue
+           100 continue
            loop_150: do j = k,l
               do i = k,lm1
                  ip1 = i + 1
@@ -16516,32 +16516,32 @@ module stdlib_linalg_lapack_q
               end do
               i = l
               go to 140
-120           continue
+              120 continue
               do i = ip1,l
                  if (a(i,j) /= zero .or. b(i,j) /= zero) cycle loop_150
               end do
               i = ip1 - 1
-140           continue
+              140 continue
               m = k
               iflow = 2
               go to 160
            end do loop_150
            go to 190
            ! permute rows m and i
-160  continue
+           160 continue
            lscale(m) = i
            if (i == m) go to 170
            call stdlib_qswap(n - k + 1,a(i,k),lda,a(m,k),lda)
            call stdlib_qswap(n - k + 1,b(i,k),ldb,b(m,k),ldb)
            ! permute columns m and j
-170  continue
+           170 continue
            rscale(m) = j
            if (j == m) go to 180
            call stdlib_qswap(l,a(1,j),1,a(1,m),1)
            call stdlib_qswap(l,b(1,j),1,b(1,m),1)
-180        continue
+           180 continue
            go to(20,90) iflow
-190        continue
+           190 continue
            ilo = k
            ihi = l
            if (stdlib_lsame(job,'P')) then
@@ -16572,10 +16572,10 @@ module stdlib_linalg_lapack_q
                  ta = a(i,j)
                  if (ta == zero) go to 210
                  ta = log10(abs(ta))/basl
-210              continue
+                 210 continue
                  if (tb == zero) go to 220
                  tb = log10(abs(tb))/basl
-220              continue
+                 220 continue
                  work(i + 4*n) = work(i + 4*n) - ta - tb
                  work(j + 5*n) = work(j + 5*n) - ta - tb
               end do
@@ -16587,7 +16587,7 @@ module stdlib_linalg_lapack_q
            beta = zero
            it = 1
            ! start generalized conjugate gradient iteration
-250  continue
+           250 continue
            gamma = stdlib_qdot(nr,work(ilo + 4*n),1,work(ilo + 4*n),1) + stdlib_qdot(nr, &
                      work(ilo + 5*n),1,work(ilo + 5*n),1)
            ew = zero
@@ -16617,7 +16617,7 @@ module stdlib_linalg_lapack_q
                  if (a(i,j) == zero) go to 280
                  kount = kount + 1
                  sum = sum + work(j)
-280              continue
+                 280 continue
                  if (b(i,j) == zero) cycle loop_290
                  kount = kount + 1
                  sum = sum + work(j)
@@ -16631,7 +16631,7 @@ module stdlib_linalg_lapack_q
                  if (a(i,j) == zero) go to 310
                  kount = kount + 1
                  sum = sum + work(i + n)
-310              continue
+                 310 continue
                  if (b(i,j) == zero) cycle loop_320
                  kount = kount + 1
                  sum = sum + work(i + n)
@@ -16658,7 +16658,7 @@ module stdlib_linalg_lapack_q
            it = it + 1
            if (it <= nrp2) go to 250
            ! end generalized conjugate gradient iteration
-350  continue
+           350 continue
            sfmin = stdlib_qlamch('S')
            sfmax = one/sfmin
            lsfmin = int(log10(sfmin)/basl + one,KIND=ilp)
@@ -16738,7 +16738,7 @@ module stdlib_linalg_lapack_q
            ! Function Arguments
            procedure(stdlib_selctg_q) :: selctg
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: cursl,ilascl,ilbscl,ilvsl,ilvsr,lastsl,lquery,lst2sl, &
                      wantst
@@ -16918,7 +16918,7 @@ module stdlib_linalg_lapack_q
                  call stdlib_qlascl('G',0,0,anrmto,anrm,n,1,alphai,n,ierr)
               end if
               if (ilbscl) call stdlib_qlascl('G',0,0,bnrmto,bnrm,n,1,beta,n,ierr)
-                        
+
               ! select eigenvalues
               do i = 1,n
                  bwork(i) = selctg(alphar(i),alphai(i),beta(i))
@@ -17008,7 +17008,7 @@ module stdlib_linalg_lapack_q
                  lastsl = cursl
               end do
            end if
-50         continue
+           50 continue
            work(1) = maxwrk
            return
      end subroutine stdlib_qgges
@@ -17057,7 +17057,7 @@ module stdlib_linalg_lapack_q
            ! Function Arguments
            procedure(stdlib_selctg_q) :: selctg
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: cursl,ilascl,ilbscl,ilvsl,ilvsr,lastsl,lquery,lst2sl, &
                      wantst
@@ -17134,7 +17134,7 @@ module stdlib_linalg_lapack_q
               if (wantst) then
                  call stdlib_qtgsen(0,ilvsl,ilvsr,bwork,n,a,lda,b,ldb,alphar,alphai, &
                  beta,vsl,ldvsl,vsr,ldvsr,sdim,pvsl,pvsr,dif,work,-1,idum,1,ierr)
-                           
+
                  lwkopt = max(lwkopt,2*n + int(work(1),KIND=ilp))
               end if
               work(1) = lwkopt
@@ -17233,7 +17233,7 @@ module stdlib_linalg_lapack_q
                  call stdlib_qlascl('G',0,0,anrmto,anrm,n,1,alphai,n,ierr)
               end if
               if (ilbscl) call stdlib_qlascl('G',0,0,bnrmto,bnrm,n,1,beta,n,ierr)
-                        
+
               ! select eigenvalues
               do i = 1,n
                  bwork(i) = selctg(alphar(i),alphai(i),beta(i))
@@ -17322,7 +17322,7 @@ module stdlib_linalg_lapack_q
                  lastsl = cursl
               end do
            end if
-50         continue
+           50 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_qgges3
@@ -17375,7 +17375,7 @@ module stdlib_linalg_lapack_q
            ! Function Arguments
            procedure(stdlib_selctg_q) :: selctg
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: cursl,ilascl,ilbscl,ilvsl,ilvsr,lastsl,lquery,lst2sl,wantsb, &
                      wantse,wantsn,wantst,wantsv
@@ -17585,7 +17585,7 @@ module stdlib_linalg_lapack_q
                  call stdlib_qlascl('G',0,0,anrmto,anrm,n,1,alphai,n,ierr)
               end if
               if (ilbscl) call stdlib_qlascl('G',0,0,bnrmto,bnrm,n,1,beta,n,ierr)
-                        
+
               ! select eigenvalues
               do i = 1,n
                  bwork(i) = selctg(alphar(i),alphai(i),beta(i))
@@ -17691,7 +17691,7 @@ module stdlib_linalg_lapack_q
                  lastsl = cursl
               end do
            end if
-60         continue
+           60 continue
            work(1) = maxwrk
            iwork(1) = liwmin
            return
@@ -17725,9 +17725,9 @@ module stdlib_linalg_lapack_q
            ! Array Arguments
            real(qp),intent(inout) :: a(lda,*),b(ldb,*)
            real(qp),intent(out) :: alphai(*),alphar(*),beta(*),vl(ldvl,*),vr(ldvr,*),work(*)
-                     
+
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: ilascl,ilbscl,ilv,ilvl,ilvr,lquery
            character :: chtemp
@@ -17790,10 +17790,10 @@ module stdlib_linalg_lapack_q
               minwrk = max(1,8*n)
               maxwrk = max(1,n*(7 + stdlib_ilaenv(1,'DGEQRF',' ',n,1,n,0)))
               maxwrk = max(maxwrk,n*(7 + stdlib_ilaenv(1,'DORMQR',' ',n,1,n,0)))
-                        
+
               if (ilvl) then
                  maxwrk = max(maxwrk,n*(7 + stdlib_ilaenv(1,'DORGQR',' ',n,1,n,-1)))
-                           
+
               end if
               work(1) = maxwrk
               if (lwork < minwrk .and. .not. lquery) info = -16
@@ -17983,7 +17983,7 @@ module stdlib_linalg_lapack_q
               ! end of eigenvector calculation
            end if
            ! undo scaling if necessary
-110  continue
+           110 continue
            if (ilascl) then
               call stdlib_qlascl('G',0,0,anrmto,anrm,n,1,alphar,n,ierr)
               call stdlib_qlascl('G',0,0,anrmto,anrm,n,1,alphai,n,ierr)
@@ -18023,9 +18023,9 @@ module stdlib_linalg_lapack_q
            ! Array Arguments
            real(qp),intent(inout) :: a(lda,*),b(ldb,*)
            real(qp),intent(out) :: alphai(*),alphar(*),beta(*),vl(ldvl,*),vr(ldvr,*),work(*)
-                     
+
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: ilascl,ilbscl,ilv,ilvl,ilvr,lquery
            character :: chtemp
@@ -18283,7 +18283,7 @@ module stdlib_linalg_lapack_q
               ! end of eigenvector calculation
            end if
            ! undo scaling if necessary
-110  continue
+           110 continue
            if (ilascl) then
               call stdlib_qlascl('G',0,0,anrmto,anrm,n,1,alphar,n,ierr)
               call stdlib_qlascl('G',0,0,anrmto,anrm,n,1,alphai,n,ierr)
@@ -18334,7 +18334,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(out) :: alphai(*),alphar(*),beta(*),lscale(*),rconde(*),rcondv(*) &
                      ,rscale(*),vl(ldvl,*),vr(ldvr,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: ilascl,ilbscl,ilv,ilvl,ilvr,lquery,noscl,pair,wantsb,wantse, &
                      wantsn,wantsv
@@ -18422,12 +18422,12 @@ module stdlib_linalg_lapack_q
                  end if
                  maxwrk = minwrk
                  maxwrk = max(maxwrk,n + n*stdlib_ilaenv(1,'DGEQRF',' ',n,1,n,0))
-                           
+
                  maxwrk = max(maxwrk,n + n*stdlib_ilaenv(1,'DORMQR',' ',n,1,n,0))
-                           
+
                  if (ilvl) then
                     maxwrk = max(maxwrk,n + n*stdlib_ilaenv(1,'DORGQR',' ',n,1,n,0))
-                              
+
                  end if
               end if
               work(1) = maxwrk
@@ -18475,7 +18475,7 @@ module stdlib_linalg_lapack_q
            ! permute and/or balance the matrix pair (a,b)
            ! (workspace: need 6*n if balanc = 's' or 'b', 1 otherwise)
            call stdlib_qggbal(balanc,n,a,lda,b,ldb,ilo,ihi,lscale,rscale,work,ierr)
-                     
+
            ! compute abnrm and bbnrm
            abnrm = stdlib_qlange('1',n,n,a,lda,work(1))
            if (ilascl) then
@@ -18621,7 +18621,7 @@ module stdlib_linalg_lapack_q
            ! (workspace: none needed)
            if (ilvl) then
               call stdlib_qggbak(balanc,'L',n,ilo,ihi,lscale,rscale,n,vl,ldvl,ierr)
-                        
+
               loop_70: do jc = 1,n
                  if (alphai(jc) < zero) cycle loop_70
                  temp = zero
@@ -18650,7 +18650,7 @@ module stdlib_linalg_lapack_q
            end if
            if (ilvr) then
               call stdlib_qggbak(balanc,'R',n,ilo,ihi,lscale,rscale,n,vr,ldvr,ierr)
-                        
+
               loop_120: do jc = 1,n
                  if (alphai(jc) < zero) cycle loop_120
                  temp = zero
@@ -18678,7 +18678,7 @@ module stdlib_linalg_lapack_q
               end do loop_120
            end if
            ! undo scaling if necessary
-130  continue
+           130 continue
            if (ilascl) then
               call stdlib_qlascl('G',0,0,anrmto,anrm,n,1,alphar,n,ierr)
               call stdlib_qlascl('G',0,0,anrmto,anrm,n,1,alphai,n,ierr)
@@ -18720,7 +18720,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*),b(ldb,*),d(*)
            real(qp),intent(out) :: work(*),x(*),y(*)
         ! ===================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,lopt,lwkmin,lwkopt,nb,nb1,nb2,nb3,nb4,np
@@ -18811,7 +18811,7 @@ module stdlib_linalg_lapack_q
            ! solve triangular system: r11*x = d1
            if (m > 0) then
               call stdlib_qtrtrs('UPPER','NO TRANSPOSE','NON UNIT',m,1,a,lda,d,m,info)
-                        
+
               if (info > 0) then
                  info = 2
                  return
@@ -18865,7 +18865,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*),b(ldb,*),q(ldq,*),z(ldz,*)
            real(qp),intent(out) :: work(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: blk22,initq,initz,lquery,wantq,wantz
            character :: compq2,compz2
@@ -19032,7 +19032,7 @@ module stdlib_linalg_lapack_q
                           call stdlib_qlartg(temp,b(jj + 1,jj),c,s,b(jj + 1,jj + 1))
                           b(jj + 1,jj) = zero
                           call stdlib_qrot(jj - top,b(top + 1,jj + 1),1,b(top + 1,jj),1,c,s)
-                                    
+
                           a(jj + 1,j) = c
                           b(jj + 1,j) = -s
                        end if
@@ -19092,7 +19092,7 @@ module stdlib_linalg_lapack_q
                                  len*nblst + 1),nblst,work(pw + len),1)
                        call stdlib_qgemv('TRANSPOSE',len,nblst - len,one,work((len + 1)*nblst - &
                        len + 1),nblst,a(jrow + nblst - len,j + 1),1,one,work(pw + len),1)
-                                 
+
                        ppw = pw
                        do i = jrow,jrow + nblst - 1
                           a(i,j + 1) = work(ppw)
@@ -19144,7 +19144,7 @@ module stdlib_linalg_lapack_q
                  call stdlib_qgemm('TRANSPOSE','NO TRANSPOSE',nblst,cola,nblst,one,work, &
                            nblst,a(j,jcol + nnb),lda,zero,work(pw),nblst)
                  call stdlib_qlacpy('ALL',nblst,cola,work(pw),nblst,a(j,jcol + nnb),lda)
-                           
+
                  ppwo = nblst*nblst + 1
                  j0 = j - nnb
                  do j = j0,jcol + 1,-nnb
@@ -19179,7 +19179,7 @@ module stdlib_linalg_lapack_q
                     call stdlib_qgemm('NO TRANSPOSE','NO TRANSPOSE',nh,nblst,nblst,one,q( &
                               topq,j),ldq,work,nblst,zero,work(pw),nh)
                     call stdlib_qlacpy('ALL',nh,nblst,work(pw),nh,q(topq,j),ldq)
-                              
+
                     ppwo = nblst*nblst + 1
                     j0 = j - nnb
                     do j = j0,jcol + 1,-nnb
@@ -19196,7 +19196,7 @@ module stdlib_linalg_lapack_q
                           call stdlib_qgemm('NO TRANSPOSE','NO TRANSPOSE',nh,2*nnb,2*nnb,one, &
                                      q(topq,j),ldq,work(ppwo),2*nnb,zero,work(pw),nh)
                           call stdlib_qlacpy('ALL',nh,2*nnb,work(pw),nh,q(topq,j),ldq)
-                                    
+
                        end if
                        ppwo = ppwo + 4*nnb*nnb
                     end do
@@ -19209,7 +19209,7 @@ module stdlib_linalg_lapack_q
                     pw = nblst*nblst + 1
                     do i = 1,n2nb
                        call stdlib_qlaset('ALL',2*nnb,2*nnb,zero,one,work(pw),2*nnb)
-                                 
+
                        pw = pw + 4*nnb*nnb
                     end do
                     ! accumulate givens rotations into workspace array.
@@ -19263,7 +19263,7 @@ module stdlib_linalg_lapack_q
                     call stdlib_qgemm('NO TRANSPOSE','NO TRANSPOSE',top,nblst,nblst,one,a( &
                               1,j),lda,work,nblst,zero,work(pw),top)
                     call stdlib_qlacpy('ALL',top,nblst,work(pw),top,a(1,j),lda)
-                              
+
                     ppwo = nblst*nblst + 1
                     j0 = j - nnb
                     do j = j0,jcol + 1,-nnb
@@ -19276,7 +19276,7 @@ module stdlib_linalg_lapack_q
                           call stdlib_qgemm('NO TRANSPOSE','NO TRANSPOSE',top,2*nnb,2*nnb, &
                                     one,a(1,j),lda,work(ppwo),2*nnb,zero,work(pw),top)
                           call stdlib_qlacpy('ALL',top,2*nnb,work(pw),top,a(1,j),lda)
-                                    
+
                        end if
                        ppwo = ppwo + 4*nnb*nnb
                     end do
@@ -19284,7 +19284,7 @@ module stdlib_linalg_lapack_q
                     call stdlib_qgemm('NO TRANSPOSE','NO TRANSPOSE',top,nblst,nblst,one,b( &
                               1,j),ldb,work,nblst,zero,work(pw),top)
                     call stdlib_qlacpy('ALL',top,nblst,work(pw),top,b(1,j),ldb)
-                              
+
                     ppwo = nblst*nblst + 1
                     j0 = j - nnb
                     do j = j0,jcol + 1,-nnb
@@ -19297,7 +19297,7 @@ module stdlib_linalg_lapack_q
                           call stdlib_qgemm('NO TRANSPOSE','NO TRANSPOSE',top,2*nnb,2*nnb, &
                                     one,b(1,j),ldb,work(ppwo),2*nnb,zero,work(pw),top)
                           call stdlib_qlacpy('ALL',top,2*nnb,work(pw),top,b(1,j),ldb)
-                                    
+
                        end if
                        ppwo = ppwo + 4*nnb*nnb
                     end do
@@ -19315,7 +19315,7 @@ module stdlib_linalg_lapack_q
                     call stdlib_qgemm('NO TRANSPOSE','NO TRANSPOSE',nh,nblst,nblst,one,z( &
                               topq,j),ldz,work,nblst,zero,work(pw),nh)
                     call stdlib_qlacpy('ALL',nh,nblst,work(pw),nh,z(topq,j),ldz)
-                              
+
                     ppwo = nblst*nblst + 1
                     j0 = j - nnb
                     do j = j0,jcol + 1,-nnb
@@ -19332,7 +19332,7 @@ module stdlib_linalg_lapack_q
                           call stdlib_qgemm('NO TRANSPOSE','NO TRANSPOSE',nh,2*nnb,2*nnb,one, &
                                      z(topq,j),ldz,work(ppwo),2*nnb,zero,work(pw),nh)
                           call stdlib_qlacpy('ALL',nh,2*nnb,work(pw),nh,z(topq,j),ldz)
-                                    
+
                        end if
                        ppwo = ppwo + 4*nnb*nnb
                     end do
@@ -19389,7 +19389,7 @@ module stdlib_linalg_lapack_q
            ! Array Arguments
            real(qp),intent(inout) :: a(lda,*),b(ldb,*),q(ldq,*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: ilq,ilz
            integer(ilp) :: icompq,icompz,jcol,jrow
@@ -19467,7 +19467,7 @@ module stdlib_linalg_lapack_q
                  call stdlib_qlartg(temp,a(jrow,jcol),c,s,a(jrow - 1,jcol))
                  a(jrow,jcol) = zero
                  call stdlib_qrot(n - jcol,a(jrow - 1,jcol + 1),lda,a(jrow,jcol + 1),lda,c,s)
-                           
+
                  call stdlib_qrot(n + 2 - jrow,b(jrow - 1,jrow - 1),ldb,b(jrow,jrow - 1),ldb,c, &
                            s)
                  if (ilq) call stdlib_qrot(n,q(1,jrow - 1),1,q(1,jrow),1,c,s)
@@ -19507,7 +19507,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*),b(ldb,*),c(*),d(*)
            real(qp),intent(out) :: work(*),x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: lopt,lwkmin,lwkopt,mn,nb,nb1,nb2,nb3,nb4,nr
@@ -19635,7 +19635,7 @@ module stdlib_linalg_lapack_q
      !> transpose of the matrix Z.
 
      pure subroutine stdlib_qggqrf(n,m,p,a,lda,taua,b,ldb,taub,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -19713,7 +19713,7 @@ module stdlib_linalg_lapack_q
      !> transpose of the matrix Z.
 
      pure subroutine stdlib_qggrqf(m,p,n,a,lda,taua,b,ldb,taub,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -19790,7 +19790,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*),sva(n),d(n),v(ldv,*)
            real(qp),intent(out) :: work(lwork)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(qp) :: aapp,aapp0,aapq,aaqq,apoaq,aqoap,big,bigtheta,cs,mxaapq,mxsinj, &
                      rootbig,rooteps,rootsfmin,roottol,small,sn,t,temp1,theta,thsign
@@ -19967,23 +19967,23 @@ module stdlib_linalg_lapack_q
                                          fastr(3) = t*d(p)/d(q)
                                          fastr(4) = -t*d(q)/d(p)
                                          call stdlib_qrotm(m,a(1,p),1,a(1,q),1,fastr)
-                                                   
+
                                          if (rsvec) call stdlib_qrotm(mvl,v(1,p),1,v(1,q), &
                                                     1,fastr)
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq))
                                          mxsinj = max(mxsinj,abs(t))
                                       else
                        ! Choose Correct Signum For Theta And Rotate
                                          thsign = -sign(one,aapq)
                                          t = one/(theta + thsign*sqrt(one + theta*theta))
-                                                   
+
                                          cs = sqrt(one/(one + t*t))
                                          sn = t*cs
                                          mxsinj = max(mxsinj,abs(sn))
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq))
                                          apoaq = d(p)/d(q)
                                          aqoap = d(q)/d(p)
@@ -20111,7 +20111,7 @@ module stdlib_linalg_lapack_q
                              end if
                           end do loop_2002
            ! end q-loop
-2103 continue
+           2103 continue
            ! bailed out of q-loop
                           sva(p) = aapp
                        else
@@ -20191,11 +20191,11 @@ module stdlib_linalg_lapack_q
                                          fastr(3) = t*d(p)/d(q)
                                          fastr(4) = -t*d(q)/d(p)
                                          call stdlib_qrotm(m,a(1,p),1,a(1,q),1,fastr)
-                                                   
+
                                          if (rsvec) call stdlib_qrotm(mvl,v(1,p),1,v(1,q), &
                                                     1,fastr)
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq))
                                          mxsinj = max(mxsinj,abs(t))
                                       else
@@ -20203,12 +20203,12 @@ module stdlib_linalg_lapack_q
                                          thsign = -sign(one,aapq)
                                          if (aaqq > aapp0) thsign = -thsign
                                          t = one/(theta + thsign*sqrt(one + theta*theta))
-                                                   
+
                                          cs = sqrt(one/(one + t*t))
                                          sn = t*cs
                                          mxsinj = max(mxsinj,abs(sn))
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq))
                                          apoaq = d(p)/d(q)
                                          aqoap = d(q)/d(p)
@@ -20290,7 +20290,7 @@ module stdlib_linalg_lapack_q
                                                     lda,ierr)
                                          temp1 = -aapq*d(p)/d(q)
                                          call stdlib_qaxpy(m,temp1,work,1,a(1,q),1)
-                                                   
+
                                          call stdlib_qlascl('G',0,0,one,aaqq,m,1,a(1,q), &
                                                     lda,ierr)
                                          sva(q) = aaqq*sqrt(max(zero,one - aapq*aapq))
@@ -20303,7 +20303,7 @@ module stdlib_linalg_lapack_q
                                                     lda,ierr)
                                          temp1 = -aapq*d(q)/d(p)
                                          call stdlib_qaxpy(m,temp1,work,1,a(1,p),1)
-                                                   
+
                                          call stdlib_qlascl('G',0,0,one,aapp,m,1,a(1,p), &
                                                     lda,ierr)
                                          sva(p) = aapp*sqrt(max(zero,one - aapq*aapq))
@@ -20357,7 +20357,7 @@ module stdlib_linalg_lapack_q
                              end if
                           end do loop_2200
               ! end of the q-loop
-2203 continue
+              2203 continue
                           sva(p) = aapp
                        else
                           if (aapp == zero) notrot = notrot + min(jgl + kbl - 1,n) - jgl + 1
@@ -20367,7 +20367,7 @@ module stdlib_linalg_lapack_q
            ! end of the p-loop
                  end do loop_2010
            ! end of the jbc-loop
-2011 continue
+           2011 continue
       ! 2011 bailed out of the jbc-loop
                  do p = igl,min(igl + kbl - 1,n)
                     sva(p) = abs(sva(p))
@@ -20396,12 +20396,12 @@ module stdlib_linalg_lapack_q
            ! number of iterations.
            info = nsweep - 1
            go to 1995
-1994       continue
+           1994 continue
        ! #:) reaching this point means that during the i-th sweep all pivots were
            ! below the given tolerance, causing early exit.
            info = 0
        ! #:) info = 0 confirms successful iterations.
-1995 continue
+       1995 continue
            ! sort the vector d.
            do p = 1,n - 1
               q = stdlib_iqamax(n - p + 1,sva(p),1) + p - 1
@@ -20458,7 +20458,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*),d(n),sva(n),v(ldv,*)
            real(qp),intent(out) :: work(lwork)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(qp) :: aapp,aapp0,aapq,aaqq,apoaq,aqoap,big,bigtheta,cs,large,mxaapq, &
            mxsinj,rootbig,rooteps,rootsfmin,roottol,small,sn,t,temp1,theta, &
@@ -20618,11 +20618,11 @@ module stdlib_linalg_lapack_q
                                          fastr(3) = t*d(p)/d(q)
                                          fastr(4) = -t*d(q)/d(p)
                                          call stdlib_qrotm(m,a(1,p),1,a(1,q),1,fastr)
-                                                   
+
                                          if (rsvec) call stdlib_qrotm(mvl,v(1,p),1,v(1,q), &
                                                     1,fastr)
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq))
                                          mxsinj = max(mxsinj,abs(t))
                                       else
@@ -20630,12 +20630,12 @@ module stdlib_linalg_lapack_q
                                          thsign = -sign(one,aapq)
                                          if (aaqq > aapp0) thsign = -thsign
                                          t = one/(theta + thsign*sqrt(one + theta*theta))
-                                                   
+
                                          cs = sqrt(one/(one + t*t))
                                          sn = t*cs
                                          mxsinj = max(mxsinj,abs(sn))
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq))
                                          apoaq = d(p)/d(q)
                                          aqoap = d(q)/d(p)
@@ -20717,7 +20717,7 @@ module stdlib_linalg_lapack_q
                                                     lda,ierr)
                                          temp1 = -aapq*d(p)/d(q)
                                          call stdlib_qaxpy(m,temp1,work,1,a(1,q),1)
-                                                   
+
                                          call stdlib_qlascl('G',0,0,one,aaqq,m,1,a(1,q), &
                                                     lda,ierr)
                                          sva(q) = aaqq*sqrt(max(zero,one - aapq*aapq))
@@ -20730,7 +20730,7 @@ module stdlib_linalg_lapack_q
                                                     lda,ierr)
                                          temp1 = -aapq*d(q)/d(p)
                                          call stdlib_qaxpy(m,temp1,work,1,a(1,p),1)
-                                                   
+
                                          call stdlib_qlascl('G',0,0,one,aapp,m,1,a(1,p), &
                                                     lda,ierr)
                                          sva(p) = aapp*sqrt(max(zero,one - aapq*aapq))
@@ -20786,7 +20786,7 @@ module stdlib_linalg_lapack_q
                              end if
                           end do loop_2200
               ! end of the q-loop
-2203 continue
+              2203 continue
                           sva(p) = aapp
                        else
                           if (aapp == zero) notrot = notrot + min(jgl + kbl - 1,n) - jgl + 1
@@ -20797,7 +20797,7 @@ module stdlib_linalg_lapack_q
            ! end of the p-loop
                  end do loop_2010
            ! end of the jbc-loop
-2011 continue
+           2011 continue
       ! 2011 bailed out of the jbc-loop
                  do p = igl,min(igl + kbl - 1,n)
                     sva(p) = abs(sva(p))
@@ -20827,12 +20827,12 @@ module stdlib_linalg_lapack_q
            ! number of sweeps.
            info = nsweep - 1
            go to 1995
-1994       continue
+           1994 continue
        ! #:) reaching this point means that during the i-th sweep all pivots were
            ! below the given threshold, causing early exit.
            info = 0
        ! #:) info = 0 confirms successful iterations.
-1995 continue
+       1995 continue
            ! sort the vector d
            do p = 1,n - 1
               q = stdlib_iqamax(n - p + 1,sva(p),1) + p - 1
@@ -20873,7 +20873,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: d(*),dl(*),du(*),du2(*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: onenrm
            integer(ilp) :: i,kase,kase1
@@ -20914,17 +20914,17 @@ module stdlib_linalg_lapack_q
               kase1 = 2
            end if
            kase = 0
-20         continue
+           20 continue
            call stdlib_qlacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == kase1) then
                  ! multiply by inv(u)*inv(l).
                  call stdlib_qgttrs('NO TRANSPOSE',n,1,dl,d,du,du2,ipiv,work,n,info)
-                           
+
               else
                  ! multiply by inv(l**t)*inv(u**t).
                  call stdlib_qgttrs('TRANSPOSE',n,1,dl,d,du,du2,ipiv,work,n,info)
-                           
+
               end if
               go to 20
            end if
@@ -20950,13 +20950,13 @@ module stdlib_linalg_lapack_q
            integer(ilp),intent(in) :: ipiv(*)
            integer(ilp),intent(out) :: iwork(*)
            real(qp),intent(in) :: b(ldb,*),d(*),df(*),dl(*),dlf(*),du(*),du2(*),duf(*)
-                     
+
            real(qp),intent(out) :: berr(*),ferr(*),work(*)
            real(qp),intent(inout) :: x(ldx,*)
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: notran
            character :: transn,transt
@@ -21011,7 +21011,7 @@ module stdlib_linalg_lapack_q
            loop_110: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - op(a) * x,
               ! where op(a) = a, a**t, or a**h, depending on trans.
@@ -21070,7 +21070,7 @@ module stdlib_linalg_lapack_q
               if (berr(j) > eps .and. two*berr(j) <= lstres .and. count <= itmax) then
                  ! update solution and try again.
                  call stdlib_qgttrs(trans,n,1,dlf,df,duf,du2,ipiv,work(n + 1),n,info)
-                           
+
                  call stdlib_qaxpy(n,one,work(n + 1),1,x(1,j),1)
                  lstres = berr(j)
                  count = count + 1
@@ -21101,9 +21101,9 @@ module stdlib_linalg_lapack_q
                  end if
               end do
               kase = 0
-70            continue
+              70 continue
               call stdlib_qlacn2(n,work(2*n + 1),work(n + 1),iwork,ferr(j),kase,isave)
-                        
+
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(op(a)**t).
@@ -21149,7 +21149,7 @@ module stdlib_linalg_lapack_q
            ! Array Arguments
            real(qp),intent(inout) :: b(ldb,*),d(*),dl(*),du(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(qp) :: fact,temp
@@ -21287,12 +21287,12 @@ module stdlib_linalg_lapack_q
            ! back solve with the matrix u from the factorization.
            if (nrhs <= 2) then
               j = 1
-70            continue
+              70 continue
               b(n,j) = b(n,j)/d(n)
               if (n > 1) b(n - 1,j) = (b(n - 1,j) - du(n - 1)*b(n,j))/d(n - 1)
               do i = n - 2,1,-1
                  b(i,j) = (b(i,j) - du(i)*b(i + 1,j) - dl(i)*b(i + 2,j))/d(i)
-                           
+
               end do
               if (j < nrhs) then
                  j = j + 1
@@ -21304,7 +21304,7 @@ module stdlib_linalg_lapack_q
                  if (n > 1) b(n - 1,j) = (b(n - 1,j) - du(n - 1)*b(n,j))/d(n - 1)
                  do i = n - 2,1,-1
                     b(i,j) = (b(i,j) - du(i)*b(i + 1,j) - dl(i)*b(i + 2,j))/d(i)
-                              
+
                  end do
               end do
            end if
@@ -21335,7 +21335,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(out) :: berr(*),ferr(*),work(*),x(ldx,*)
            real(qp),intent(inout) :: df(*),dlf(*),du2(*),duf(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nofact,notran
            character :: norm
@@ -21387,7 +21387,7 @@ module stdlib_linalg_lapack_q
            anorm = stdlib_qlangt(norm,n,dl,d,du)
            ! compute the reciprocal of the condition number of a.
            call stdlib_qgtcon(norm,n,dlf,df,duf,du2,ipiv,anorm,rcond,work,iwork,info)
-                     
+
            ! compute the solution vectors x.
            call stdlib_qlacpy('FULL',n,nrhs,b,ldb,x,ldx)
            call stdlib_qgttrs(trans,n,nrhs,dlf,df,duf,du2,ipiv,x,ldx,info)
@@ -21420,7 +21420,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: d(*),dl(*),du(*)
            real(qp),intent(out) :: du2(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(qp) :: fact,temp
@@ -21488,7 +21488,7 @@ module stdlib_linalg_lapack_q
                  go to 50
               end if
            end do
-50         continue
+           50 continue
            return
      end subroutine stdlib_qgttrf
 
@@ -21583,7 +21583,7 @@ module stdlib_linalg_lapack_q
               ! overwriting each right hand side vector with its solution.
               if (nrhs <= 1) then
                  j = 1
-10               continue
+                 10 continue
                  ! solve l*x = b.
                  do i = 1,n - 1
                     ip = ipiv(i)
@@ -21596,7 +21596,7 @@ module stdlib_linalg_lapack_q
                  if (n > 1) b(n - 1,j) = (b(n - 1,j) - du(n - 1)*b(n,j))/d(n - 1)
                  do i = n - 2,1,-1
                     b(i,j) = (b(i,j) - du(i)*b(i + 1,j) - du2(i)*b(i + 2,j))/d(i)
-                              
+
                  end do
                  if (j < nrhs) then
                     j = j + 1
@@ -21619,7 +21619,7 @@ module stdlib_linalg_lapack_q
                     if (n > 1) b(n - 1,j) = (b(n - 1,j) - du(n - 1)*b(n,j))/d(n - 1)
                     do i = n - 2,1,-1
                        b(i,j) = (b(i,j) - du(i)*b(i + 1,j) - du2(i)*b(i + 2,j))/d(i)
-                                 
+
                     end do
                  end do
               end if
@@ -21628,7 +21628,7 @@ module stdlib_linalg_lapack_q
               if (nrhs <= 1) then
                  ! solve u**t*x = b.
                  j = 1
-70               continue
+                 70 continue
                  b(1,j) = b(1,j)/d(1)
                  if (n > 1) b(2,j) = (b(2,j) - du(1)*b(1,j))/d(2)
                  do i = 3,n
@@ -21729,7 +21729,7 @@ module stdlib_linalg_lapack_q
            ! Parameters
            real(qp),parameter :: safety = 1.0e+2_qp
           ! $                     safety = one )
-           
+
            ! Local Scalars
            logical(lk) :: ilazr2,ilazro,ilpivt,ilq,ilschr,ilz,lquery
            integer(ilp) :: icompq,icompz,ifirst,ifrstm,iiter,ilast,ilastm,in,ischur, &
@@ -21944,7 +21944,7 @@ module stdlib_linalg_lapack_q
                           call stdlib_qrot(ilastm - jch,t(jch,jch + 1),ldt,t(jch + 1,jch + 1), &
                                     ldt,c,s)
                           if (ilq) call stdlib_qrot(n,q(1,jch),1,q(1,jch + 1),1,c,s)
-                                    
+
                           if (ilazr2) h(jch,jch - 1) = h(jch,jch - 1)*c
                           ilazr2 = .false.
                           if (abs(t(jch + 1,jch + 1)) >= btol) then
@@ -21964,24 +21964,24 @@ module stdlib_linalg_lapack_q
                        do jch = j,ilast - 1
                           temp = t(jch,jch + 1)
                           call stdlib_qlartg(temp,t(jch + 1,jch + 1),c,s,t(jch,jch + 1))
-                                    
+
                           t(jch + 1,jch + 1) = zero
                           if (jch < ilastm - 1) call stdlib_qrot(ilastm - jch - 1,t(jch,jch + 2),ldt, &
                                     t(jch + 1,jch + 2),ldt,c,s)
                           call stdlib_qrot(ilastm - jch + 2,h(jch,jch - 1),ldh,h(jch + 1,jch - 1), &
                                     ldh,c,s)
                           if (ilq) call stdlib_qrot(n,q(1,jch),1,q(1,jch + 1),1,c,s)
-                                    
+
                           temp = h(jch + 1,jch)
                           call stdlib_qlartg(temp,h(jch + 1,jch - 1),c,s,h(jch + 1,jch))
-                                    
+
                           h(jch + 1,jch - 1) = zero
                           call stdlib_qrot(jch + 1 - ifrstm,h(ifrstm,jch),1,h(ifrstm,jch - 1), &
                                     1,c,s)
                           call stdlib_qrot(jch - ifrstm,t(ifrstm,jch),1,t(ifrstm,jch - 1),1, &
                                      c,s)
                           if (ilz) call stdlib_qrot(n,z(1,jch),1,z(1,jch - 1),1,c,s)
-                                    
+
                        end do
                        go to 70
                     end if
@@ -21997,7 +21997,7 @@ module stdlib_linalg_lapack_q
               go to 420
               ! t(ilast,ilast)=0 -- clear h(ilast,ilast-1) to split off a
               ! 1x1 block.
-70   continue
+              70 continue
               temp = h(ilast,ilast)
               call stdlib_qlartg(temp,h(ilast,ilast - 1),c,s,h(ilast,ilast))
               h(ilast,ilast - 1) = zero
@@ -22008,7 +22008,7 @@ module stdlib_linalg_lapack_q
               if (ilz) call stdlib_qrot(n,z(1,ilast),1,z(1,ilast - 1),1,c,s)
               ! h(ilast,ilast-1)=0 -- standardize b, set alphar, alphai,
                                     ! and beta
-80   continue
+                                    80 continue
               if (t(ilast,ilast) < zero) then
                  if (ilschr) then
                     do j = ifrstm,ilast
@@ -22042,7 +22042,7 @@ module stdlib_linalg_lapack_q
               ! qz step
               ! this iteration only involves rows/columns ifirst:ilast. we
               ! assume ifirst < ilast, and that the diagonal of b is non-zero.
-110  continue
+              110 continue
               iiter = iiter + 1
               if (.not. ilschr) then
                  ifrstm = ifirst
@@ -22104,7 +22104,7 @@ module stdlib_linalg_lapack_q
                  if (abs((ascale*h(j + 1,j))*temp) <= (ascale*atol)*temp2) go to 130
               end do
               istart = ifirst
-130           continue
+              130 continue
               ! do an implicit single-shift qz sweep.
               ! initial q
               temp = s1*h(istart,istart) - wr*t(istart,istart)
@@ -22159,7 +22159,7 @@ module stdlib_linalg_lapack_q
                     ! but only if the block is at least 3x3.
                     ! this code may break if this point is reached with
                     ! a 2x2 block with real eigenvalues.
-200  continue
+                    200 continue
               if (ifirst + 1 == ilast) then
                  ! special case -- 2x2 block with complex eigenvectors
                  ! step 1: standardize, that is, rotate so that
@@ -22183,9 +22183,9 @@ module stdlib_linalg_lapack_q
                  if (ifrstm < ilast - 1) call stdlib_qrot(ifirst - ifrstm,t(ifrstm,ilast - 1),1,t( &
                            ifrstm,ilast),1,cr,sr)
                  if (ilq) call stdlib_qrot(n,q(1,ilast - 1),1,q(1,ilast),1,cl,sl)
-                           
+
                  if (ilz) call stdlib_qrot(n,z(1,ilast - 1),1,z(1,ilast),1,cr,sr)
-                           
+
                  t(ilast - 1,ilast - 1) = b11
                  t(ilast - 1,ilast) = zero
                  t(ilast,ilast - 1) = zero
@@ -22324,11 +22324,11 @@ module stdlib_linalg_lapack_q
                  ad11l = (ascale*h(ifirst,ifirst))/(bscale*t(ifirst,ifirst))
                  ad21l = (ascale*h(ifirst + 1,ifirst))/(bscale*t(ifirst,ifirst))
                  ad12l = (ascale*h(ifirst,ifirst + 1))/(bscale*t(ifirst + 1,ifirst + 1))
-                           
+
                  ad22l = (ascale*h(ifirst + 1,ifirst + 1))/(bscale*t(ifirst + 1,ifirst + 1))
-                           
+
                  ad32l = (ascale*h(ifirst + 2,ifirst + 1))/(bscale*t(ifirst + 1,ifirst + 1))
-                           
+
                  u12l = t(ifirst,ifirst + 1)/t(ifirst + 1,ifirst + 1)
                  v(1) = (ad11 - ad11l)*(ad22 - ad11l) - ad12*ad21 + ad21*u12*ad11l + (ad12l - &
                            ad11l*u12l)*ad21l
@@ -22364,7 +22364,7 @@ module stdlib_linalg_lapack_q
                     if (ilq) then
                        do jr = 1,n
                           temp = tau*(q(jr,j) + v(2)*q(jr,j + 1) + v(3)*q(jr,j + 2))
-                                    
+
                           q(jr,j) = q(jr,j) - temp
                           q(jr,j + 1) = q(jr,j + 1) - temp*v(2)
                           q(jr,j + 2) = q(jr,j + 2) - temp*v(3)
@@ -22423,7 +22423,7 @@ module stdlib_linalg_lapack_q
                     ! solve
                     u2 = (scale*u2)/w22
                     u1 = (scale*u1 - w12*u2)/w11
-250                 continue
+                    250 continue
                     if (ilpivt) then
                        temp = u2
                        u2 = u1
@@ -22452,7 +22452,7 @@ module stdlib_linalg_lapack_q
                     if (ilz) then
                        do jr = 1,n
                           temp = tau*(z(jr,j) + v(2)*z(jr,j + 1) + v(3)*z(jr,j + 2))
-                                    
+
                           z(jr,j) = z(jr,j) - temp
                           z(jr,j + 1) = z(jr,j + 1) - temp*v(2)
                           z(jr,j + 2) = z(jr,j + 2) - temp*v(3)
@@ -22507,13 +22507,13 @@ module stdlib_linalg_lapack_q
               end if
               go to 350
               ! end of iteration loop
-350  continue
+              350 continue
            end do loop_360
            ! drop-through = non-convergence
            info = ilast
            go to 420
            ! successful completion of all qz steps
-380  continue
+           380 continue
            ! set eigenvalues 1:ilo-1
            do j = 1,ilo - 1
               if (t(j,j) < zero) then
@@ -22539,7 +22539,7 @@ module stdlib_linalg_lapack_q
            ! normal termination
            info = 0
            ! exit (other than argument error) -- return optimal workspace size
-420  continue
+           420 continue
            work(1) = real(n,KIND=qp)
            return
      end subroutine stdlib_qhgeqz
@@ -22567,7 +22567,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: vl(ldvl,*),vr(ldvr,*),wr(*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: bothv,fromqr,leftv,noinit,pair,rightv
            integer(ilp) :: i,iinfo,k,kl,kln,kr,ksi,ksr,ldwork
@@ -22654,13 +22654,13 @@ module stdlib_linalg_lapack_q
                     do i = k,kl + 1,-1
                        if (h(i,i - 1) == zero) go to 30
                     end do
-30                  continue
+                    30 continue
                     kl = i
                     if (k > kr) then
                        do i = k,n - 1
                           if (h(i + 1,i) == zero) go to 50
                        end do
-50                     continue
+                       50 continue
                        kr = i
                     end if
                  end if
@@ -22683,7 +22683,7 @@ module stdlib_linalg_lapack_q
                  ! h(kl:kr,kl:kr). close roots are modified by eps3.
                  wkr = wr(k)
                  wki = wi(k)
-60               continue
+                 60 continue
                  do i = k - 1,kl,-1
                     if (select(i) .and. abs(wr(i) - wkr) + abs(wi(i) - wki) < eps3) &
                               then
@@ -22769,7 +22769,7 @@ module stdlib_linalg_lapack_q
      !> by the orthogonal matrix Q:  A = Q*H*Q**T = (QZ)*T*(QZ)**T.
 
      subroutine stdlib_qhseqr(job,compz,n,ilo,ihi,h,ldh,wr,wi,z,ldz,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -22787,14 +22787,14 @@ module stdlib_linalg_lapack_q
            ! ==== matrices of order ntiny or smaller must be processed by
            ! .    stdlib_qlahqr because of insufficient subdiagonal scratch space.
            ! .    (this is a hard limit.) ====
-           
+
            ! ==== nl allocates some local workspace to help small matrices
            ! .    through a rare stdlib_qlahqr failure.  nl > ntiny = 15 is
            ! .    required and nl <= nmin = stdlib_ilaenv(ispec=12,...) is recom-
            ! .    mended.  (the default value of nmin is 75.)  using nl = 49
            ! .    allows up to six simultaneous shifts and a 16-by-16
            ! .    deflation window.  ====
-           
+
            ! Local Arrays
            real(qp) :: hl(nl,nl),workl(nl)
            ! Local Scalars
@@ -22862,7 +22862,7 @@ module stdlib_linalg_lapack_q
               end if
               ! ==== stdlib_qlahqr/stdlib_qlaqr0 crossover point ====
               nmin = stdlib_ilaenv(12,'DHSEQR',job(:1)//compz(:1),n,ilo,ihi,lwork)
-                        
+
               nmin = max(ntiny,nmin)
               ! ==== stdlib_qlaqr0 for big matrices; stdlib_qlahqr for small ones ====
               if (n > nmin) then
@@ -22892,7 +22892,7 @@ module stdlib_linalg_lapack_q
                        call stdlib_qlaqr0(wantt,wantz,nl,ilo,kbot,hl,nl,wr,wi,ilo,ihi, &
                                  z,ldz,workl,nl,info)
                        if (wantt .or. info /= 0) call stdlib_qlacpy('A',n,n,hl,nl,h,ldh)
-                                 
+
                     end if
                  end if
               end if
@@ -22936,7 +22936,7 @@ module stdlib_linalg_lapack_q
      !> in computing that entry have at least one zero multiplicand.
 
      subroutine stdlib_qla_gbamv(trans,m,n,kl,ku,alpha,ab,ldab,x,incx,beta,y,incy)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -22947,7 +22947,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: ab(ldab,*),x(*)
            real(qp),intent(inout) :: y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: symb_wero
            real(qp) :: temp,safe1
@@ -23210,7 +23210,7 @@ module stdlib_linalg_lapack_q
            ! estimate the norm of inv(op(a)).
            ainvnm = zero
            kase = 0
-10         continue
+           10 continue
            call stdlib_qlacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == 2) then
@@ -23330,7 +23330,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: a(lda,*),x(*)
            real(qp),intent(inout) :: y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: symb_wero
            real(qp) :: temp,safe1
@@ -23581,7 +23581,7 @@ module stdlib_linalg_lapack_q
            ! estimate the norm of inv(op(a)).
            ainvnm = zero
            kase = 0
-10         continue
+           10 continue
            call stdlib_qlacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == 2) then
@@ -23591,7 +23591,7 @@ module stdlib_linalg_lapack_q
                  end do
                  if (notrans) then
                     call stdlib_qgetrs('NO TRANSPOSE',n,1,af,ldaf,ipiv,work,n,info)
-                              
+
                  else
                     call stdlib_qgetrs('TRANSPOSE',n,1,af,ldaf,ipiv,work,n,info)
                  end if
@@ -23620,7 +23620,7 @@ module stdlib_linalg_lapack_q
                     call stdlib_qgetrs('TRANSPOSE',n,1,af,ldaf,ipiv,work,n,info)
                  else
                     call stdlib_qgetrs('NO TRANSPOSE',n,1,af,ldaf,ipiv,work,n,info)
-                              
+
                  end if
                  ! multiply by r.
                  do i = 1,n
@@ -23725,7 +23725,7 @@ module stdlib_linalg_lapack_q
      !> infinity-norm condition number.
 
      real(qp) function stdlib_qla_porcond(uplo,n,a,lda,af,ldaf,cmode,c,info,work,iwork)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -23822,7 +23822,7 @@ module stdlib_linalg_lapack_q
            ! estimate the norm of inv(op(a)).
            ainvnm = zero
            kase = 0
-10         continue
+           10 continue
            call stdlib_qlacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == 2) then
@@ -23985,7 +23985,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: a(lda,*),x(*)
            real(qp),intent(inout) :: y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: symb_wero
            real(qp) :: temp,safe1
@@ -24266,7 +24266,7 @@ module stdlib_linalg_lapack_q
            ainvnm = zero
            normin = 'N'
            kase = 0
-10         continue
+           10 continue
            call stdlib_qlacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == 2) then
@@ -24524,7 +24524,7 @@ module stdlib_linalg_lapack_q
              s = (s + s) - s
              y(i) = ((x(i) - s) + w(i)) + y(i)
              x(i) = s
-10           continue
+             10 continue
            return
      end subroutine stdlib_qla_wwaddw
 
@@ -24574,7 +24574,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: d(*),e(*),taup(*),tauq(*),x(ldx,*),y(ldy,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            ! Intrinsic Functions
@@ -24592,7 +24592,7 @@ module stdlib_linalg_lapack_q
                             one,a(i,i),1)
                  ! generate reflection q(i) to annihilate a(i+1:m,i)
                  call stdlib_qlarfg(m - i + 1,a(i,i),a(min(i + 1,m),i),1,tauq(i))
-                           
+
                  d(i) = a(i,i)
                  if (i < n) then
                     a(i,i) = one
@@ -24615,7 +24615,7 @@ module stdlib_linalg_lapack_q
                               ldx,one,a(i,i + 1),lda)
                     ! generate reflection p(i) to annihilate a(i,i+2:n)
                     call stdlib_qlarfg(n - i,a(i,i + 1),a(i,min(i + 2,n)),lda,taup(i))
-                              
+
                     e(i) = a(i,i + 1)
                     a(i,i + 1) = one
                     ! compute x(i+1:m,i)
@@ -24642,7 +24642,7 @@ module stdlib_linalg_lapack_q
                            one,a(i,i),lda)
                  ! generate reflection p(i) to annihilate a(i,i+1:n)
                  call stdlib_qlarfg(n - i + 1,a(i,i),a(i,min(i + 1,n)),lda,taup(i))
-                           
+
                  d(i) = a(i,i)
                  if (i < m) then
                     a(i,i) = one
@@ -24665,7 +24665,7 @@ module stdlib_linalg_lapack_q
                               1,one,a(i + 1,i),1)
                     ! generate reflection q(i) to annihilate a(i+2:m,i)
                     call stdlib_qlarfg(m - i,a(i + 1,i),a(min(i + 2,m),i),1,tauq(i))
-                              
+
                     e(i) = a(i + 1,i)
                     a(i + 1,i) = one
                     ! compute y(i+1:n,i)
@@ -24705,7 +24705,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            integer(ilp) :: i,jlast
            real(qp) :: altsgn,estold,temp,xs
@@ -24723,7 +24723,7 @@ module stdlib_linalg_lapack_q
            go to(20,40,70,110,140) isave(1)
            ! ................ entry   (isave( 1 ) = 1)
            ! first iteration.  x has been overwritten by a*x.
-20   continue
+           20 continue
            if (n == 1) then
               v(1) = x(1)
               est = abs(v(1))
@@ -24744,11 +24744,11 @@ module stdlib_linalg_lapack_q
            return
            ! ................ entry   (isave( 1 ) = 2)
            ! first iteration.  x has been overwritten by transpose(a)*x.
-40   continue
+           40 continue
            isave(2) = stdlib_iqamax(n,x,1)
            isave(3) = 2
            ! main loop - iterations 2,3,...,itmax.
-50   continue
+           50 continue
            do i = 1,n
               x(i) = zero
            end do
@@ -24758,7 +24758,7 @@ module stdlib_linalg_lapack_q
            return
            ! ................ entry   (isave( 1 ) = 3)
            ! x has been overwritten by a*x.
-70   continue
+           70 continue
            call stdlib_qcopy(n,x,1,v,1)
            estold = est
            est = stdlib_qasum(n,v,1)
@@ -24772,7 +24772,7 @@ module stdlib_linalg_lapack_q
            end do
            ! repeated sign vector detected, hence algorithm has converged.
            go to 120
-90         continue
+           90 continue
            ! test for cycling.
            if (est <= estold) go to 120
            do i = 1,n
@@ -24788,7 +24788,7 @@ module stdlib_linalg_lapack_q
            return
            ! ................ entry   (isave( 1 ) = 4)
            ! x has been overwritten by transpose(a)*x.
-110  continue
+           110 continue
            jlast = isave(2)
            isave(2) = stdlib_iqamax(n,x,1)
            if ((x(jlast) /= abs(x(isave(2)))) .and. (isave(3) < itmax)) then
@@ -24796,7 +24796,7 @@ module stdlib_linalg_lapack_q
               go to 50
            end if
            ! iteration complete.  final stage.
-120  continue
+           120 continue
            altsgn = one
            do i = 1,n
               x(i) = altsgn*(one + real(i - 1,KIND=qp)/real(n - 1,KIND=qp))
@@ -24807,13 +24807,13 @@ module stdlib_linalg_lapack_q
            return
            ! ................ entry   (isave( 1 ) = 5)
            ! x has been overwritten by a*x.
-140  continue
+           140 continue
            temp = two*(stdlib_qasum(n,x,1)/real(3*n,KIND=qp))
            if (temp > est) then
               call stdlib_qcopy(n,x,1,v,1)
               est = temp
            end if
-150        continue
+           150 continue
            kase = 0
            return
      end subroutine stdlib_qlacn2
@@ -24836,7 +24836,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            integer(ilp) :: i,iter,j,jlast,jump
            real(qp) :: altsgn,estold,temp
@@ -24856,7 +24856,7 @@ module stdlib_linalg_lapack_q
            go to(20,40,70,110,140) jump
            ! ................ entry   (jump = 1)
            ! first iteration.  x has been overwritten by a*x.
-20   continue
+           20 continue
            if (n == 1) then
               v(1) = x(1)
               est = abs(v(1))
@@ -24873,11 +24873,11 @@ module stdlib_linalg_lapack_q
            return
            ! ................ entry   (jump = 2)
            ! first iteration.  x has been overwritten by transpose(a)*x.
-40   continue
+           40 continue
            j = stdlib_iqamax(n,x,1)
            iter = 2
            ! main loop - iterations 2,3,...,itmax.
-50   continue
+           50 continue
            do i = 1,n
               x(i) = zero
            end do
@@ -24887,7 +24887,7 @@ module stdlib_linalg_lapack_q
            return
            ! ................ entry   (jump = 3)
            ! x has been overwritten by a*x.
-70   continue
+           70 continue
            call stdlib_qcopy(n,x,1,v,1)
            estold = est
            est = stdlib_qasum(n,v,1)
@@ -24896,7 +24896,7 @@ module stdlib_linalg_lapack_q
            end do
            ! repeated sign vector detected, hence algorithm has converged.
            go to 120
-90         continue
+           90 continue
            ! test for cycling.
            if (est <= estold) go to 120
            do i = 1,n
@@ -24908,7 +24908,7 @@ module stdlib_linalg_lapack_q
            return
            ! ................ entry   (jump = 4)
            ! x has been overwritten by transpose(a)*x.
-110  continue
+           110 continue
            jlast = j
            j = stdlib_iqamax(n,x,1)
            if ((x(jlast) /= abs(x(j))) .and. (iter < itmax)) then
@@ -24916,7 +24916,7 @@ module stdlib_linalg_lapack_q
               go to 50
            end if
            ! iteration complete.  final stage.
-120  continue
+           120 continue
            altsgn = one
            do i = 1,n
               x(i) = altsgn*(one + real(i - 1,KIND=qp)/real(n - 1,KIND=qp))
@@ -24927,13 +24927,13 @@ module stdlib_linalg_lapack_q
            return
            ! ................ entry   (jump = 5)
            ! x has been overwritten by a*x.
-140  continue
+           140 continue
            temp = two*(stdlib_qasum(n,x,1)/real(3*n,KIND=qp))
            if (temp > est) then
               call stdlib_qcopy(n,x,1,v,1)
               est = temp
            end if
-150        continue
+           150 continue
            kase = 0
            return
      end subroutine stdlib_qlacon
@@ -24997,7 +24997,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: bs = 2.0_qp
-           
+
            ! Local Scalars
            real(qp) :: aa,bb,cc,dd,ab,cd,s,ov,un,be,eps
            ! Intrinsic Functions
@@ -25054,7 +25054,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: b,c,d
            real(qp),intent(out) :: p,q
         ! =====================================================================
-           
+
            ! Local Scalars
            real(qp) :: r,t
            ! Executable Statements
@@ -25073,7 +25073,7 @@ module stdlib_linalg_lapack_q
            ! Scalar Arguments
            real(qp),intent(in) :: a,b,c,d,r,t
         ! =====================================================================
-           
+
            ! Local Scalars
            real(qp) :: br
            ! Executable Statements
@@ -25104,7 +25104,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: a,b,c
            real(qp),intent(out) :: rt1,rt2
        ! =====================================================================
-           
+
            ! Local Scalars
            real(qp) :: ab,acmn,acmx,adf,df,rt,sm,tb
            ! Intrinsic Functions
@@ -25199,7 +25199,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: d(*),e(*),e2(*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: itmp1,itmp2,j,ji,jit,jp,kf,kfnew,kl,klnew
            real(qp) :: tmp1,tmp2
@@ -25416,7 +25416,7 @@ module stdlib_linalg_lapack_q
               if (kf > kl) go to 140
            end do loop_130
            ! converged
-140  continue
+           140 continue
            info = max(kl + 1 - kf,0)
            mout = kl
            return
@@ -25438,7 +25438,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: d(*),e(*),q(ldq,*)
            real(qp),intent(out) :: qstore(ldqs,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: curlvl,curprb,curr,i,igivcl,igivnm,igivpt,indxq,iperm,iprmpt, &
            iq,iqptr,iwrem,j,k,lgn,matsiz,msd2,smlsiz,smm1,spm1,spm2,submat,subpbs, &
@@ -25472,7 +25472,7 @@ module stdlib_linalg_lapack_q
            iwork(1) = n
            subpbs = 1
            tlvls = 0
-10         continue
+           10 continue
            if (iwork(subpbs) > smlsiz) then
               do j = subpbs,1,-1
                  iwork(2*j) = (iwork(j) + 1)/2
@@ -25539,7 +25539,7 @@ module stdlib_linalg_lapack_q
                  if (icompq == 1) then
                     call stdlib_qgemm('N','N',qsiz,matsiz,matsiz,one,q(1,submat),ldq, &
                     work(iq - 1 + iwork(iqptr + curr)),matsiz,zero,qstore(1,submat),ldqs)
-                              
+
                  end if
                  iwork(iqptr + curr + 1) = iwork(iqptr + curr) + matsiz**2
                  curr = curr + 1
@@ -25554,7 +25554,7 @@ module stdlib_linalg_lapack_q
            ! into eigensystem for the corresponding larger matrix.
            ! while ( subpbs > 1 )
            curlvl = 1
-80         continue
+           80 continue
            if (subpbs > 1) then
               spm2 = subpbs - 2
               loop_90: do i = 0,spm2,2
@@ -25579,13 +25579,13 @@ module stdlib_linalg_lapack_q
                  if (icompq == 2) then
                     call stdlib_qlaed1(matsiz,d(submat),q(submat,submat),ldq,iwork( &
                     indxq + submat),e(submat + msd2 - 1),msd2,work,iwork(subpbs + 1),info)
-                              
+
                  else
                     call stdlib_qlaed7(icompq,matsiz,qsiz,tlvls,curlvl,curprb,d(submat), &
                     qstore(1,submat),ldqs,iwork(indxq + submat),e(submat + msd2 - 1),msd2, &
                     work(iq),iwork(iqptr),iwork(iprmpt),iwork(iperm),iwork(igivpt), &
                     iwork(igivcl),work(igivnm),work(iwrem),iwork(subpbs + 1),info)
-                              
+
                  end if
                  if (info /= 0) go to 130
                  iwork(i/2 + 1) = iwork(i + 2)
@@ -25620,9 +25620,9 @@ module stdlib_linalg_lapack_q
               call stdlib_qcopy(n,work,1,d,1)
            end if
            go to 140
-130        continue
+           130 continue
            info = submat*(n + 1) + submat + matsiz - 1
-140        continue
+           140 continue
            return
      end subroutine stdlib_qlaed0
 
@@ -25725,7 +25725,7 @@ module stdlib_linalg_lapack_q
                  indxq(i) = i
               end do
            end if
-20         continue
+           20 continue
            return
      end subroutine stdlib_qlaed1
 
@@ -25753,7 +25753,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: mone = -1.0_qp
-           
+
            ! Local Arrays
            integer(ilp) :: ctot(4),psm(4)
            ! Local Scalars
@@ -25847,7 +25847,7 @@ module stdlib_linalg_lapack_q
                  go to 80
               end if
            end do
-80         continue
+           80 continue
            j = j + 1
            nj = indx(j)
            if (j > n) go to 100
@@ -25878,7 +25878,7 @@ module stdlib_linalg_lapack_q
                  d(pj) = t
                  k2 = k2 - 1
                  i = 1
-90               continue
+                 90 continue
                  if (k2 + i <= n) then
                     if (d(pj) < d(indxp(k2 + i))) then
                        indxp(k2 + i - 1) = indxp(k2 + i)
@@ -25901,7 +25901,7 @@ module stdlib_linalg_lapack_q
               end if
            end if
            go to 80
-100        continue
+           100 continue
            ! record the last eigenvalue.
            k = k + 1
            dlamda(k) = d(pj)
@@ -25982,7 +25982,7 @@ module stdlib_linalg_lapack_q
            do j = 1,4
               coltyp(j) = ctot(j)
            end do
-190        continue
+           190 continue
            return
      end subroutine stdlib_qlaed2
 
@@ -26000,7 +26000,7 @@ module stdlib_linalg_lapack_q
      !> without guard digits, but we know of none.
 
      pure subroutine stdlib_qlaed3(k,n,n1,d,q,ldq,rho,dlamda,q2,indx,ctot,w,s,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -26014,7 +26014,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: dlamda(*),w(*)
            real(qp),intent(in) :: q2(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,ii,iq2,j,n12,n2,n23
            real(qp) :: temp
@@ -26099,7 +26099,7 @@ module stdlib_linalg_lapack_q
               end do
            end do
            ! compute the updated eigenvectors.
-110  continue
+           110 continue
            n2 = n - n1
            n12 = ctot(1) + ctot(2)
            n23 = ctot(2) + ctot(3)
@@ -26117,7 +26117,7 @@ module stdlib_linalg_lapack_q
            else
               call stdlib_qlaset('A',n1,k,zero,zero,q(1,1),ldq)
            end if
-120        continue
+           120 continue
            return
      end subroutine stdlib_qlaed3
 
@@ -26147,7 +26147,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: maxit = 30
-           
+
            ! Local Scalars
            logical(lk) :: orgati,swtch,swtch3
            integer(ilp) :: ii,iim1,iip1,ip1,iter,j,niter
@@ -26244,7 +26244,7 @@ module stdlib_linalg_lapack_q
               phi = z(n)*temp
               dphi = temp*temp
               erretm = eight*(-phi - psi) + erretm - phi + rhoinv + abs(tau)*(dpsi + dphi)
-                        
+
               w = rhoinv + phi + psi
               ! test for convergence
               if (abs(w) <= eps*erretm) then
@@ -26305,7 +26305,7 @@ module stdlib_linalg_lapack_q
               phi = z(n)*temp
               dphi = temp*temp
               erretm = eight*(-phi - psi) + erretm - phi + rhoinv + abs(tau)*(dpsi + dphi)
-                        
+
               w = rhoinv + phi + psi
               ! main loop to update the values of the array   delta
               iter = niter + 1
@@ -26363,7 +26363,7 @@ module stdlib_linalg_lapack_q
                  phi = z(n)*temp
                  dphi = temp*temp
                  erretm = eight*(-phi - psi) + erretm - phi + rhoinv + abs(tau)*(dpsi + dphi)
-                           
+
                  w = rhoinv + phi + psi
               end do loop_90
               ! return with info = 1, niter = maxit and not converged
@@ -26624,7 +26624,7 @@ module stdlib_linalg_lapack_q
                           if (.not. swtch) then
                              if (orgati) then
                                 a = z(i)*z(i) + delta(ip1)*delta(ip1)*(dpsi + dphi)
-                                          
+
                              else
                                 a = z(ip1)*z(ip1) + delta(i)*delta(i)*(dpsi + dphi)
                              end if
@@ -26721,7 +26721,7 @@ module stdlib_linalg_lapack_q
                  dlam = d(ip1) + tau
               end if
            end if
-250        continue
+           250 continue
            return
      end subroutine stdlib_qlaed4
 
@@ -26745,7 +26745,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: d(2),z(2)
            real(qp),intent(out) :: delta(2)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(qp) :: b,c,del,tau,temp,w
            ! Intrinsic Functions
@@ -26823,7 +26823,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: maxit = 40
-           
+
            ! Local Arrays
            real(qp) :: dscale(3),zscale(3)
            ! Local Scalars
@@ -26893,7 +26893,7 @@ module stdlib_linalg_lapack_q
            eps = stdlib_qlamch('EPSILON')
            base = stdlib_qlamch('BASE')
            small1 = base**(int(log(stdlib_qlamch('SAFMIN'))/log(base)/three,KIND=ilp))
-                     
+
            sminv1 = one/small1
            small2 = small1*small1
            sminv2 = sminv1*sminv1
@@ -27015,7 +27015,7 @@ module stdlib_linalg_lapack_q
               end if
            end do loop_50
            info = 1
-60         continue
+           60 continue
            ! undo scaling
            if (scale) tau = tau*sclinv
            return
@@ -27059,12 +27059,12 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: rho
            ! Array Arguments
            integer(ilp),intent(inout) :: givcol(2,*),givptr(*),perm(*),prmptr(*),qptr(*)
-                     
+
            integer(ilp),intent(out) :: indxq(*),iwork(*)
            real(qp),intent(inout) :: d(*),givnum(2,*),q(ldq,*),qstore(*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: coltyp,curr,i,idlmda,indx,indxc,indxp,iq2,is,iw,iz,k,ldq2, &
                      n1,n2,ptr
@@ -27151,7 +27151,7 @@ module stdlib_linalg_lapack_q
                  indxq(i) = i
               end do
            end if
-30         continue
+           30 continue
            return
      end subroutine stdlib_qlaed7
 
@@ -27179,7 +27179,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: mone = -1.0_qp
-           
+
            ! Local Scalars
            integer(ilp) :: i,imax,j,jlam,jmax,jp,k2,n1,n1p1,n2
            real(qp) :: c,eps,s,t,tau,tol
@@ -27281,7 +27281,7 @@ module stdlib_linalg_lapack_q
                  go to 80
               end if
            end do
-80         continue
+           80 continue
            j = j + 1
            if (j > n) go to 100
            if (rho*abs(z(j)) <= tol) then
@@ -27317,7 +27317,7 @@ module stdlib_linalg_lapack_q
                  d(jlam) = t
                  k2 = k2 - 1
                  i = 1
-90               continue
+                 90 continue
                  if (k2 + i <= n) then
                     if (d(jlam) < d(indxp(k2 + i))) then
                        indxp(k2 + i - 1) = indxp(k2 + i)
@@ -27340,13 +27340,13 @@ module stdlib_linalg_lapack_q
               end if
            end if
            go to 80
-100        continue
+           100 continue
            ! record the last eigenvalue.
            k = k + 1
            w(k) = z(jlam)
            dlamda(k) = d(jlam)
            indxp(k) = jlam
-110        continue
+           110 continue
            ! sort the eigenvalues and corresponding eigenvectors into dlamda
            ! and q2 respectively.  the eigenvalues/vectors which were not
            ! deflated go into the first k slots of dlamda and q2 respectively,
@@ -27384,7 +27384,7 @@ module stdlib_linalg_lapack_q
      !> eigenvectors for use in calculating the next level of Z vectors.
 
      pure subroutine stdlib_qlaed9(k,kstart,kstop,n,d,q,ldq,rho,dlamda,w,s,lds,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -27480,7 +27480,7 @@ module stdlib_linalg_lapack_q
                  s(i,j) = q(i,j)/temp
               end do
            end do
-120        continue
+           120 continue
            return
      end subroutine stdlib_qlaed9
 
@@ -27501,7 +27501,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: givnum(2,*),q(*)
            real(qp),intent(out) :: z(*),ztemp(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: bsiz1,bsiz2,curr,i,k,mid,psiz1,psiz2,ptr,zptr1
            ! Intrinsic Functions
@@ -27530,7 +27530,7 @@ module stdlib_linalg_lapack_q
            ! roots.
            bsiz1 = int(half + sqrt(real(qptr(curr + 1) - qptr(curr),KIND=qp)),KIND=ilp)
            bsiz2 = int(half + sqrt(real(qptr(curr + 2) - qptr(curr + 1),KIND=qp)),KIND=ilp)
-                     
+
            do k = 1,mid - bsiz1 - 1
               z(k) = zero
            end do
@@ -27570,9 +27570,9 @@ module stdlib_linalg_lapack_q
               ! the sqrt in case the machine underestimates one of these
               ! square roots.
               bsiz1 = int(half + sqrt(real(qptr(curr + 1) - qptr(curr),KIND=qp)),KIND=ilp)
-                        
+
               bsiz2 = int(half + sqrt(real(qptr(curr + 2) - qptr(curr + 1),KIND=qp)),KIND=ilp)
-                        
+
               if (bsiz1 > 0) then
                  call stdlib_qgemv('T',bsiz1,bsiz1,one,q(qptr(curr)),bsiz1,ztemp(1), &
                            1,zero,z(zptr1),1)
@@ -27583,7 +27583,7 @@ module stdlib_linalg_lapack_q
                            psiz1 + 1),1,zero,z(mid),1)
               end if
               call stdlib_qcopy(psiz2 - bsiz2,ztemp(psiz1 + bsiz2 + 1),1,z(mid + bsiz2),1)
-                        
+
               ptr = ptr + 2**(tlvls - k)
            end do loop_70
            return
@@ -27610,7 +27610,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: tenth = 1.0e-1_qp
-           
+
            ! Local Scalars
            character :: normin,trans
            integer(ilp) :: i,i1,i2,i3,ierr,its,j
@@ -27721,7 +27721,7 @@ module stdlib_linalg_lapack_q
               end do
               ! failure to find eigenvector in n iterations.
               info = 1
-120           continue
+              120 continue
               ! normalize eigenvector.
               i = stdlib_iqamax(n,vr,1)
               call stdlib_qscal(n,one/abs(vr(i)),vr,1)
@@ -27736,7 +27736,7 @@ module stdlib_linalg_lapack_q
               else
                  ! scale supplied initial vector.
                  norm = stdlib_qlapy2(stdlib_qnrm2(n,vr,1),stdlib_qnrm2(n,vi,1))
-                           
+
                  rec = (eps3*rootn)/max(norm,nrmsml)
                  call stdlib_qscal(n,rec,vr,1)
                  call stdlib_qscal(n,rec,vi,1)
@@ -27893,7 +27893,7 @@ module stdlib_linalg_lapack_q
                        end if
                        ! divide by diagonal element of b.
                        call stdlib_qladiv(xr,xi,b(i,i),b(i + 1,i),vr(i),vi(i))
-                                 
+
                        vmax = max(abs(vr(i)) + abs(vi(i)),vmax)
                        vcrit = bignum/vmax
                     else
@@ -27923,7 +27923,7 @@ module stdlib_linalg_lapack_q
               end do loop_270
               ! failure to find eigenvector in n iterations
               info = 1
-280           continue
+              280 continue
               ! normalize eigenvector.
               vnorm = zero
               do i = 1,n
@@ -27952,7 +27952,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: a,b,c
            real(qp),intent(out) :: cs1,rt1,rt2,sn1
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: sgn1,sgn2
            real(qp) :: ab,acmn,acmx,acs,adf,cs,ct,df,rt,sm,tb,tn
@@ -28054,7 +28054,7 @@ module stdlib_linalg_lapack_q
            ! Parameters
            integer(ilp),parameter :: ldd = 4
            integer(ilp),parameter :: ldx = 2
-           
+
            ! Local Scalars
            integer(ilp) :: ierr,j2,j3,j4,k,nd
            real(qp) :: cs,dnorm,eps,scale,smlnum,sn,t11,t22,t33,tau,tau1,tau2,temp, &
@@ -28079,7 +28079,7 @@ module stdlib_linalg_lapack_q
               call stdlib_qlartg(t(j1,j2),t22 - t11,cs,sn,temp)
               ! apply transformation to the matrix t.
               if (j3 <= n) call stdlib_qrot(n - j1 - 1,t(j1,j3),ldt,t(j2,j3),ldt,cs,sn)
-                        
+
               call stdlib_qrot(j1 - 1,t(1,j1),1,t(1,j2),1,cs,sn)
               t(j1,j1) = t22
               t(j2,j2) = t11
@@ -28105,7 +28105,7 @@ module stdlib_linalg_lapack_q
               ! swap the adjacent diagonal blocks.
               k = n1 + n1 + n2 - 3
               go to(10,20,30) k
-10            continue
+              10 continue
               ! n1 = 1, n2 = 2: generate elementary reflector h so that:
               ! ( scale, x11, x12 ) h = ( 0, 0, * )
               u(1) = scale
@@ -28131,7 +28131,7 @@ module stdlib_linalg_lapack_q
                  call stdlib_qlarfx('R',n,3,u,tau,q(1,j1),ldq,work)
               end if
               go to 40
-20            continue
+              20 continue
               ! n1 = 2, n2 = 1: generate elementary reflector h so that:
               ! h (  -x11 ) = ( * )
                 ! (  -x21 ) = ( 0 )
@@ -28159,7 +28159,7 @@ module stdlib_linalg_lapack_q
                  call stdlib_qlarfx('R',n,3,u,tau,q(1,j1),ldq,work)
               end if
               go to 40
-30            continue
+              30 continue
               ! n1 = 2, n2 = 2: generate elementary reflectors h(1) and h(2) so
               ! that:
               ! h(2) h(1) (  -x11  -x12 ) = (  *  * )
@@ -28199,7 +28199,7 @@ module stdlib_linalg_lapack_q
                  call stdlib_qlarfx('R',n,3,u1,tau1,q(1,j1),ldq,work)
                  call stdlib_qlarfx('R',n,3,u2,tau2,q(1,j2),ldq,work)
               end if
-40            continue
+              40 continue
               if (n2 == 2) then
                  ! standardize new 2-by-2 block t11
                  call stdlib_qlanv2(t(j1,j1),t(j1,j2),t(j2,j1),t(j2,j2),wr1,wi1, &
@@ -28222,7 +28222,7 @@ module stdlib_linalg_lapack_q
            end if
            return
            ! exit with info = 1 if swap was rejected.
-50   continue
+           50 continue
            info = 1
            return
      end subroutine stdlib_qlaexc
@@ -28247,7 +28247,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: fuzzy1 = one + 1.0e-5_qp
-           
+
            ! Local Scalars
            real(qp) :: a11,a12,a21,a22,abi22,anorm,as11,as12,as22,ascale,b11,b12,b22, &
            binv11,binv22,bmin,bnorm,bscale,bsize,c1,c2,c3,c4,c5,diff,discr,pp,qq,r, &
@@ -28372,7 +28372,7 @@ module stdlib_linalg_lapack_q
            ! scale first eigenvalue
            wabs = abs(wr1) + abs(wi)
            wsize = max(safmin,c1,fuzzy1*(wabs*c2 + c3),min(c4,half*max(wabs,c5)))
-                     
+
            if (wsize /= one) then
               wscale = one/wsize
               if (wsize > one) then
@@ -28442,7 +28442,7 @@ module stdlib_linalg_lapack_q
               end do
            end do
            info = 0
-30         continue
+           30 continue
            return
      end subroutine stdlib_qlag2s
 
@@ -28465,7 +28465,7 @@ module stdlib_linalg_lapack_q
      !> Z**T denotes the transpose of Z.
 
      pure subroutine stdlib_qlags2(upper,a1,a2,a3,b1,b2,b3,csu,snu,csv,snv,csq,snq)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -28474,7 +28474,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: a1,a2,a3,b1,b2,b3
            real(qp),intent(out) :: csq,csu,csv,snq,snu,snv
         ! =====================================================================
-           
+
            ! Local Scalars
            real(qp) :: a,aua11,aua12,aua21,aua22,avb11,avb12,avb21,avb22,b,c,csl,csr, &
            d,r,s1,s2,snl,snr,ua11,ua11r,ua12,ua21,ua22,ua22r,vb11,vb11r,vb12,vb21, &
@@ -28632,7 +28632,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(*),b(*),c(*)
            real(qp),intent(out) :: d(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: k
            real(qp) :: eps,mult,piv1,piv2,scale1,scale2,temp,tl
@@ -28704,7 +28704,7 @@ module stdlib_linalg_lapack_q
      !> 0., 1., or -1.
 
      pure subroutine stdlib_qlagtm(trans,n,nrhs,alpha,dl,d,du,x,ldx,beta,b,ldb)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -28716,7 +28716,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: b(ldb,*)
            real(qp),intent(in) :: d(*),dl(*),du(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            ! Executable Statements
@@ -28822,7 +28822,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: a(*),b(*),c(*),d(*)
            real(qp),intent(inout) :: y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: k
            real(qp) :: absak,ak,bignum,eps,pert,sfmin,temp
@@ -28902,7 +28902,7 @@ module stdlib_linalg_lapack_q
                     end if
                     ak = a(k)
                     pert = sign(tol,ak)
-40                  continue
+                    40 continue
                     absak = abs(ak)
                     if (absak < one) then
                        if (absak < sfmin) then
@@ -28963,7 +28963,7 @@ module stdlib_linalg_lapack_q
                     end if
                     ak = a(k)
                     pert = sign(tol,ak)
-70                  continue
+                    70 continue
                     absak = abs(ak)
                     if (absak < one) then
                        if (absak < sfmin) then
@@ -29015,7 +29015,7 @@ module stdlib_linalg_lapack_q
      !> where b11 >= b22 > 0.
 
      pure subroutine stdlib_qlagv2(a,lda,b,ldb,alphar,alphai,beta,csl,snl,csr,snr)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -29026,7 +29026,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*),b(ldb,*)
            real(qp),intent(out) :: alphai(2),alphar(2),beta(2)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(qp) :: anorm,ascale,bnorm,bscale,h1,h2,h3,qq,r,rr,safmin,scale1, &
                      scale2,t,ulp,wi,wr1,wr2
@@ -29104,9 +29104,9 @@ module stdlib_linalg_lapack_q
                  call stdlib_qrot(2,b(1,1),1,b(1,2),1,csr,snr)
                  ! compute inf norms of a and b
                  h1 = max(abs(a(1,1)) + abs(a(1,2)),abs(a(2,1)) + abs(a(2,2)))
-                           
+
                  h2 = max(abs(b(1,1)) + abs(b(1,2)),abs(b(2,1)) + abs(b(2,2)))
-                           
+
                  if ((scale1*h1) >= abs(wr1)*h2) then
                     ! find left rotation matrix q to zero out b(2,1)
                     call stdlib_qlartg(b(1,1),b(2,1),csl,snl,r)
@@ -29122,7 +29122,7 @@ module stdlib_linalg_lapack_q
                  ! a pair of complex conjugate eigenvalues
                  ! first compute the svd of the matrix b
                  call stdlib_qlasv2(b(1,1),b(1,2),b(2,2),r,t,snr,csr,snl,csl)
-                           
+
                  ! form (a,b) := q(a,b)z**t where q is left rotation matrix and
                  ! z is right rotation matrix computed from stdlib_qlasv2
                  call stdlib_qrot(2,a(1,1),lda,a(2,1),lda,csl,snl)
@@ -29182,7 +29182,7 @@ module stdlib_linalg_lapack_q
            real(qp),parameter :: dat1 = 3.0_qp/4.0_qp
            real(qp),parameter :: dat2 = -0.4375_qp
            integer(ilp),parameter :: kexsh = 10
-           
+
            ! Local Scalars
            real(qp) :: aa,ab,ba,bb,cs,det,h11,h12,h21,h21s,h22,rt1i,rt1r,rt2i,rt2r, &
                      rtdisc,s,safmax,safmin,smlnum,sn,sum,t1,t2,t3,tr,tst,ulp,v2,v3
@@ -29231,7 +29231,7 @@ module stdlib_linalg_lapack_q
            ! eigenvalues i+1 to ihi have already converged. either l = ilo or
            ! h(l,l-1) is negligible so that the matrix splits.
            i = ihi
-20         continue
+           20 continue
            l = ilo
            if (i < ilo) go to 160
            ! perform qr iterations on rows and columns ilo to i until a
@@ -29259,7 +29259,7 @@ module stdlib_linalg_lapack_q
                     if (ba*(ab/s) <= max(smlnum,ulp*(bb*(aa/s)))) go to 40
                  end if
               end do
-40            continue
+              40 continue
               l = k
               if (l > ilo) then
                  ! h(l,l-1) is negligible
@@ -29353,7 +29353,7 @@ module stdlib_linalg_lapack_q
                  if (abs(h(m,m - 1))*(abs(v(2)) + abs(v(3))) <= ulp*abs(v(1))*(abs( &
                            h(m - 1,m - 1)) + abs(h(m,m)) + abs(h(m + 1,m + 1)))) go to 60
               end do
-60            continue
+              60 continue
               ! double-shift qr step
               loop_130: do k = m,i - 1
                  ! the first iteration of this loop determines a reflection g
@@ -29436,7 +29436,7 @@ module stdlib_linalg_lapack_q
            ! failure to converge in remaining number of iterations
            info = i
            return
-150        continue
+           150 continue
            if (l == i) then
               ! h(i,i-1) is negligible: one eigenvalue has converged.
               wr(i) = h(i,i)
@@ -29450,7 +29450,7 @@ module stdlib_linalg_lapack_q
               if (wantt) then
                  ! apply the transformation to the rest of h.
                  if (i2 > i) call stdlib_qrot(i2 - i,h(i - 1,i + 1),ldh,h(i,i + 1),ldh,cs,sn)
-                           
+
                  call stdlib_qrot(i - i1 - 1,h(i1,i - 1),1,h(i1,i),1,cs,sn)
               end if
               if (wantz) then
@@ -29463,7 +29463,7 @@ module stdlib_linalg_lapack_q
            ! return to start of the main loop with new value of i.
            i = l - 1
            go to 20
-160        continue
+           160 continue
            return
      end subroutine stdlib_qlahqr
 
@@ -29484,7 +29484,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: t(ldt,nb),tau(nb),y(ldy,nb)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(qp) :: ei
@@ -29513,7 +29513,7 @@ module stdlib_linalg_lapack_q
                            1,one,t(1,nb),1)
                  ! w := t**t * w
                  call stdlib_qtrmv('UPPER','TRANSPOSE','NON-UNIT',i - 1,t,ldt,t(1,nb),1)
-                           
+
                  ! b2 := b2 - v2*w
                  call stdlib_qgemv('NO TRANSPOSE',n - k - i + 1,i - 1,-one,a(k + i,1),lda,t(1,nb) &
                            ,1,one,a(k + i,i),1)
@@ -29526,7 +29526,7 @@ module stdlib_linalg_lapack_q
               ! generate the elementary reflector h(i) to annihilate
               ! a(k+i+1:n,i)
               call stdlib_qlarfg(n - k - i + 1,a(k + i,i),a(min(k + i + 1,n),i),1,tau(i))
-                        
+
               ei = a(k + i,i)
               a(k + i,i) = one
               ! compute  y(k+1:n,i)
@@ -29540,7 +29540,7 @@ module stdlib_linalg_lapack_q
               ! compute t(1:i,i)
               call stdlib_qscal(i - 1,-tau(i),t(1,i),1)
               call stdlib_qtrmv('UPPER','NO TRANSPOSE','NON-UNIT',i - 1,t,ldt,t(1,i),1)
-                        
+
               t(i,i) = tau(i)
            end do loop_10
            a(k + nb,nb) = ei
@@ -29587,7 +29587,7 @@ module stdlib_linalg_lapack_q
            ! Array Arguments
            real(qp),intent(in) :: w(j),x(j)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(qp) :: absalp,absest,absgam,alpha,b,cosine,eps,norma,s1,s2,sine,t, &
                      test,tmp,zeta1,zeta2
@@ -29733,7 +29733,7 @@ module stdlib_linalg_lapack_q
                  zeta1 = alpha/absest
                  zeta2 = gamma/absest
                  norma = max(one + zeta1*zeta1 + abs(zeta1*zeta2),abs(zeta1*zeta2) + zeta2*zeta2)
-                           
+
                  ! see if root is closer to zero or to one
                  test = one + two*(zeta1 - zeta2)*(zeta1 + zeta2)
                  if (test >= zero) then
@@ -29831,7 +29831,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: a(lda,*),b(ldb,*)
            real(qp),intent(out) :: x(ldx,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: icmax,j
            real(qp) :: bbnd,bi1,bi2,bignum,bnorm,br1,br2,ci21,ci22,cmax,cnorm,cr21, &
@@ -30152,7 +30152,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: difl(*),difr(ldgnum,*),givnum(ldgnum,*),poles(ldgnum,*),z( &
                      *)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,m,n,nlp1
            real(qp) :: diflj,difrj,dj,dsigj,dsigjp,temp
@@ -30243,9 +30243,9 @@ module stdlib_linalg_lapack_q
                     work(1) = negone
                     temp = stdlib_qnrm2(k,work,1)
                     call stdlib_qgemv('T',k,nrhs,one,bx,ldbx,work,1,zero,b(j,1),ldb)
-                              
+
                     call stdlib_qlascl('G',0,0,temp,one,1,nrhs,b(j,1),ldb,info)
-                              
+
                  end do loop_50
               end if
               ! move the deflated rows of bx to b also.
@@ -30264,7 +30264,7 @@ module stdlib_linalg_lapack_q
                        work(j) = zero
                     else
                        work(j) = -z(j)/difl(j)/(dsigj + poles(j,1))/difr(j,2)
-                                 
+
                     end if
                     do i = 1,j - 1
                        if (z(j) == zero) then
@@ -30283,7 +30283,7 @@ module stdlib_linalg_lapack_q
                        end if
                     end do
                     call stdlib_qgemv('T',k,nrhs,one,b,ldb,work,1,zero,bx(j,1),ldbx)
-                              
+
                  end do
               end if
               ! step (2r): if sqre = 1, apply back the rotation that is
@@ -30337,7 +30337,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: c(*),difl(ldu,*),difr(ldu,*),givnum(ldu,*),poles(ldu,*),s( &
                      *),u(ldu,*),vt(ldu,*),z(ldu,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,i1,ic,im1,inode,j,lf,ll,lvl,lvl2,nd,ndb1,ndiml,ndimr, &
                      nl,nlf,nlp1,nlvl,nr,nrf,nrp1,sqre
@@ -30435,7 +30435,7 @@ module stdlib_linalg_lapack_q
            end do
            go to 90
            ! icompq = 1: applying back the right singular vector factors.
-50   continue
+           50 continue
            ! first now go through the right singular vector matrices of all
            ! the tree nodes top-down.
            j = 0
@@ -30491,7 +30491,7 @@ module stdlib_linalg_lapack_q
               call stdlib_qgemm('T','N',nrp1,nrhs,nrp1,one,vt(nrf,1),ldu,b(nrf,1), &
                         ldb,zero,bx(nrf,1),ldbx)
            end do
-90         continue
+           90 continue
            return
      end subroutine stdlib_qlalsa
 
@@ -30525,7 +30525,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: b(ldb,*),d(*),e(*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: bx,bxst,c,difl,difr,givcol,givnum,givptr,i,icmpq1,icmpq2, &
            iwk,j,k,nlvl,nm1,nsize,nsub,nwork,perm,poles,s,sizei,smlszp,sqre,st,st1, &
@@ -30617,7 +30617,7 @@ module stdlib_linalg_lapack_q
                     call stdlib_qlaset('A',1,nrhs,zero,zero,b(i,1),ldb)
                  else
                     call stdlib_qlascl('G',0,0,d(i),one,1,nrhs,b(i,1),ldb,info)
-                              
+
                     rank = rank + 1
                  end if
               end do
@@ -30700,7 +30700,7 @@ module stdlib_linalg_lapack_q
                        return
                     end if
                     call stdlib_qlacpy('A',nsize,nrhs,b(st,1),ldb,work(bx + st1),n)
-                              
+
                  else
                     ! a large problem. solve it using divide and conquer.
                     call stdlib_qlasda(icmpq1,smlsiz,nsize,sqre,d(st),e(st),work(u + st1 &
@@ -30734,7 +30734,7 @@ module stdlib_linalg_lapack_q
               else
                  rank = rank + 1
                  call stdlib_qlascl('G',0,0,d(i),one,1,nrhs,work(bx + i - 1),n,info)
-                           
+
               end if
               d(i) = abs(d(i))
            end do
@@ -30777,7 +30777,7 @@ module stdlib_linalg_lapack_q
            ! Scalar Arguments
            character,intent(in) :: cmach
        ! =====================================================================
-           
+
            ! Local Scalars
            real(qp) :: rnd,eps,sfmin,small,rmach
            ! Intrinsic Functions
@@ -30866,7 +30866,7 @@ module stdlib_linalg_lapack_q
            end if
            i = 1
            ! while ( (n1sv > 0)
-10   continue
+           10 continue
            if (n1sv > 0 .and. n2sv > 0) then
               if (a(ind1) <= a(ind2)) then
                  index(i) = ind1
@@ -30973,7 +30973,7 @@ module stdlib_linalg_lapack_q
            end if
            if ((nb <= k) .or. (nb >= max(m,n,k))) then
              call stdlib_qgemlqt(side,trans,m,n,k,mb,a,lda,t,ldt,c,ldc,work,info)
-                       
+
              return
            end if
            if (left .and. tran) then
@@ -31135,7 +31135,7 @@ module stdlib_linalg_lapack_q
            end if
            if ((mb <= k) .or. (mb >= max(m,n,k))) then
              call stdlib_qgemqrt(side,trans,m,n,k,nb,a,lda,t,ldt,c,ldc,work,info)
-                       
+
              return
             end if
            if (left .and. notran) then
@@ -31247,13 +31247,13 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: blklen = 128
-           
+
            ! some architectures propagate infinities and nans very slowly, so
            ! the code computes counts in blklen chunks.  then a nan can
            ! propagate at most blklen columns before being detected.  this is
            ! not a general tuning parameter; it needs only to be just large
            ! enough that the overhead is tiny in common cases.
-           
+
            ! Local Scalars
            integer(ilp) :: bj,j,neg1,neg2,negcnt
            real(qp) :: bsav,dminus,dplus,gamma,p,t,tmp
@@ -31339,7 +31339,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: ab(ldab,*)
            real(qp),intent(out) :: work(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,k,l
            real(qp) :: scale,sum,value,temp
@@ -31414,7 +31414,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: a(lda,*)
            real(qp),intent(out) :: work(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(qp) :: scale,sum,value,temp
@@ -31485,7 +31485,7 @@ module stdlib_linalg_lapack_q
            ! Array Arguments
            real(qp),intent(in) :: d(*),dl(*),du(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(qp) :: anorm,scale,sum,temp
@@ -31499,11 +31499,11 @@ module stdlib_linalg_lapack_q
               anorm = abs(d(n))
               do i = 1,n - 1
                  if (anorm < abs(dl(i)) .or. stdlib_qisnan(abs(dl(i)))) anorm = abs(dl(i))
-                           
+
                  if (anorm < abs(d(i)) .or. stdlib_qisnan(abs(d(i)))) anorm = abs(d(i))
-                           
+
                  if (anorm < abs(du(i)) .or. stdlib_qisnan(abs(du(i)))) anorm = abs(du(i))
-                           
+
               end do
            else if (stdlib_lsame(norm,'O') .or. norm == '1') then
               ! find norm1(a).
@@ -31562,7 +31562,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: a(lda,*)
            real(qp),intent(out) :: work(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(qp) :: scale,sum,value
@@ -31634,7 +31634,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: ab(ldab,*)
            real(qp),intent(out) :: work(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,l
            real(qp) :: absa,scale,sum,value
@@ -31704,7 +31704,7 @@ module stdlib_linalg_lapack_q
                  if (stdlib_lsame(uplo,'U')) then
                     do j = 2,n
                        call stdlib_qlassq(min(j - 1,k),ab(max(k + 2 - j,1),j),1,scale,sum)
-                                 
+
                     end do
                     l = k + 1
                  else
@@ -31739,7 +31739,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: a(0:*)
            real(qp),intent(out) :: work(0:*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,ifm,ilu,noe,n1,k,l,lda
            real(qp) :: scale,s,value,aa,temp
@@ -31856,7 +31856,7 @@ module stdlib_linalg_lapack_q
                           end do
                           work(j) = work(j) + s
                        end do
-10                     continue
+                       10 continue
                        value = work(0)
                        do i = 1,n - 1
                           temp = work(i)
@@ -32443,7 +32443,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: ap(*)
            real(qp),intent(out) :: work(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,k
            real(qp) :: absa,scale,sum,value
@@ -32566,7 +32566,7 @@ module stdlib_linalg_lapack_q
            ! Array Arguments
            real(qp),intent(in) :: d(*),e(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(qp) :: anorm,scale,sum
@@ -32629,7 +32629,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: a(lda,*)
            real(qp),intent(out) :: work(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(qp) :: absa,scale,sum,value
@@ -32725,7 +32725,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: ab(ldab,*)
            real(qp),intent(out) :: work(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: udiag
            integer(ilp) :: i,j,l
@@ -32877,7 +32877,7 @@ module stdlib_linalg_lapack_q
                     sum = one
                     do j = 1,n
                        call stdlib_qlassq(min(j,k + 1),ab(max(k + 2 - j,1),j),1,scale,sum)
-                                 
+
                     end do
                  end if
               else
@@ -32918,7 +32918,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: ap(*)
            real(qp),intent(out) :: work(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: udiag
            integer(ilp) :: i,j,k
@@ -33124,7 +33124,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: a(lda,*)
            real(qp),intent(out) :: work(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: udiag
            integer(ilp) :: i,j
@@ -33314,7 +33314,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: multpl = 4.0e+0_qp
-           
+
            ! Local Scalars
            real(qp) :: aa,bb,bcmax,bcmis,cc,cs1,dd,eps,p,sab,sac,scale,sigma,sn1, &
                      tau,temp,z,safmin,safmn2,safmx2
@@ -33367,7 +33367,7 @@ module stdlib_linalg_lapack_q
                  ! make diagonal elements equal.
                  count = 0
                  sigma = b + c
-10               continue
+                 10 continue
                  count = count + 1
                  scale = max(abs(temp),abs(sigma))
                  if (scale >= safmx2) then
@@ -33485,7 +33485,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: d(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: iinfo,j,jb,nb
            ! Intrinsic Functions
@@ -33517,7 +33517,7 @@ module stdlib_linalg_lapack_q
                  jb = min(min(m,n) - j + 1,nb)
                  ! factor diagonal and subdiagonal blocks.
                  call stdlib_qlaorhr_col_getrfnp2(m - j + 1,jb,a(j,j),lda,d(j),iinfo)
-                           
+
                  if (j + jb <= n) then
                     ! compute block row of u.
                     call stdlib_qtrsm('LEFT','LOWER','NO TRANSPOSE','UNIT',jb,n - j - jb + 1,one, &
@@ -33526,7 +33526,7 @@ module stdlib_linalg_lapack_q
                        ! update trailing submatrix.
                        call stdlib_qgemm('NO TRANSPOSE','NO TRANSPOSE',m - j - jb + 1,n - j - jb + 1,jb,- &
                        one,a(j + jb,j),lda,a(j,j + jb),lda,one,a(j + jb,j + jb),lda)
-                                 
+
                     end if
                  end if
               end do
@@ -33594,7 +33594,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: d(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(qp) :: sfmin
            integer(ilp) :: i,iinfo,n1,n2
@@ -33649,17 +33649,17 @@ module stdlib_linalg_lapack_q
               call stdlib_qlaorhr_col_getrfnp2(n1,n1,a,lda,d,iinfo)
               ! solve for b21
               call stdlib_qtrsm('R','U','N','N',m - n1,n1,one,a,lda,a(n1 + 1,1),lda)
-                        
+
               ! solve for b12
               call stdlib_qtrsm('L','L','N','U',n1,n2,one,a,lda,a(1,n1 + 1),lda)
-                        
+
               ! update b22, i.e. compute the schur complement
               ! b22 := b22 - b21*b12
               call stdlib_qgemm('N','N',m - n1,n2,n1,-one,a(n1 + 1,1),lda,a(1,n1 + 1), &
                         lda,one,a(n1 + 1,n1 + 1),lda)
               ! factor b22, recursive call
               call stdlib_qlaorhr_col_getrfnp2(m - n1,n2,a(n1 + 1,n1 + 1),lda,d(n1 + 1),iinfo)
-                        
+
            end if
            return
      end subroutine stdlib_qlaorhr_col_getrfnp2
@@ -33681,7 +33681,7 @@ module stdlib_linalg_lapack_q
            ! Array Arguments
            real(qp),intent(inout) :: x(*),y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(qp) :: a11,a12,a22,c,ssmax,tau
            ! Executable Statements
@@ -33737,7 +33737,7 @@ module stdlib_linalg_lapack_q
                  j = i
                  k(j) = -k(j)
                  in = k(j)
-20               continue
+                 20 continue
                  if (k(in) > 0) go to 40
                  do jj = 1,n
                     temp = x(j,jj)
@@ -33748,7 +33748,7 @@ module stdlib_linalg_lapack_q
                  j = in
                  in = k(in)
                  go to 20
-40               continue
+                 40 continue
               end do
            else
               ! backward permutation
@@ -33756,7 +33756,7 @@ module stdlib_linalg_lapack_q
                  if (k(i) > 0) go to 80
                  k(i) = -k(i)
                  j = k(i)
-60               continue
+                 60 continue
                  if (j == i) go to 80
                  do jj = 1,n
                     temp = x(i,jj)
@@ -33766,7 +33766,7 @@ module stdlib_linalg_lapack_q
                  k(j) = -k(j)
                  j = k(j)
                  go to 60
-80               continue
+                 80 continue
               end do
            end if
            return
@@ -33805,7 +33805,7 @@ module stdlib_linalg_lapack_q
                  j = i
                  k(j) = -k(j)
                  in = k(j)
-20               continue
+                 20 continue
                  if (k(in) > 0) go to 40
                  do ii = 1,m
                     temp = x(ii,j)
@@ -33816,7 +33816,7 @@ module stdlib_linalg_lapack_q
                  j = in
                  in = k(in)
                  go to 20
-40               continue
+                 40 continue
               end do
            else
               ! backward permutation
@@ -33824,7 +33824,7 @@ module stdlib_linalg_lapack_q
                  if (k(i) > 0) go to 80
                  k(i) = -k(i)
                  j = k(i)
-60               continue
+                 60 continue
                  if (j == i) go to 80
                  do ii = 1,m
                     temp = x(ii,i)
@@ -33834,7 +33834,7 @@ module stdlib_linalg_lapack_q
                  k(j) = -k(j)
                  j = k(j)
                  go to 60
-80               continue
+                 80 continue
               end do
            end if
            return
@@ -33850,7 +33850,7 @@ module stdlib_linalg_lapack_q
            ! Scalar Arguments
            real(qp),intent(in) :: x,y
         ! =====================================================================
-           
+
            ! Local Scalars
            real(qp) :: w,xabs,yabs,z,hugeval
            logical(lk) :: x_is_nan,y_is_nan
@@ -33886,7 +33886,7 @@ module stdlib_linalg_lapack_q
            ! Scalar Arguments
            real(qp),intent(in) :: x,y,z
         ! =====================================================================
-           
+
            ! Local Scalars
            real(qp) :: w,xabs,yabs,zabs,hugeval
            ! Intrinsic Functions
@@ -33913,7 +33913,7 @@ module stdlib_linalg_lapack_q
      !> in the vectors R and C.
 
      pure subroutine stdlib_qlaqgb(m,n,kl,ku,ab,ldab,r,c,rowcnd,colcnd,amax,equed)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -33927,7 +33927,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: thresh = 0.1e+0_qp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(qp) :: cj,large,small
@@ -33995,7 +33995,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: thresh = 0.1e+0_qp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(qp) :: cj,large,small
@@ -34059,7 +34059,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*),vn1(*),vn2(*)
            real(qp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,itemp,j,mn,offpi,pvt
            real(qp) :: aii,temp,temp2,tol3z
@@ -34084,7 +34084,7 @@ module stdlib_linalg_lapack_q
               ! generate elementary reflector h(i).
               if (offpi < m) then
                  call stdlib_qlarfg(m - offpi + 1,a(offpi,i),a(offpi + 1,i),1,tau(i))
-                           
+
               else
                  call stdlib_qlarfg(1,a(m,i),a(m,i),1,tau(i))
               end if
@@ -34143,7 +34143,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*),auxv(*),f(ldf,*),vn1(*),vn2(*)
            real(qp),intent(out) :: tau(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: itemp,j,k,lastrk,lsticc,pvt,rk
            real(qp) :: akk,temp,temp2,tol3z
@@ -34155,7 +34155,7 @@ module stdlib_linalg_lapack_q
            k = 0
            tol3z = sqrt(stdlib_qlamch('EPSILON'))
            ! beginning of while loop.
-10   continue
+           10 continue
            if ((k < nb) .and. (lsticc == 0)) then
               k = k + 1
               rk = offset + k
@@ -34241,7 +34241,7 @@ module stdlib_linalg_lapack_q
                         lda,f(kb + 1,1),ldf,one,a(rk + 1,kb + 1),lda)
            end if
            ! recomputation of difficult columns.
-40   continue
+           40 continue
            if (lsticc > 0) then
               itemp = nint(vn2(lsticc),KIND=ilp)
               vn1(lsticc) = stdlib_qnrm2(m - rk,a(rk + 1,lsticc),1)
@@ -34286,18 +34286,18 @@ module stdlib_linalg_lapack_q
            ! ==== matrices of order ntiny or smaller must be processed by
            ! .    stdlib_qlahqr because of insufficient subdiagonal scratch space.
            ! .    (this is a hard limit.) ====
-           
+
            ! ==== exceptional deflation windows:  try to cure rare
            ! .    slow convergence by varying the size of the
            ! .    deflation window after kexnw iterations. ====
-           
+
            ! ==== exceptional shifts: try to cure rare slow convergence
            ! .    with ad-hoc exceptional shifts every kexsh iterations.
            ! .    ====
-           
+
            ! ==== the constants wilk1 and wilk2 are used to form the
            ! .    exceptional shifts. ====
-           
+
            ! Local Scalars
            real(qp) :: aa,bb,cc,cs,dd,sn,ss,swap
            integer(ilp) :: i,inf,it,itmax,k,kacc22,kbot,kdu,ks,kt,ktop,ku,kv,kwh, &
@@ -34397,7 +34397,7 @@ module stdlib_linalg_lapack_q
                     if (h(k,k - 1) == zero) go to 20
                  end do
                  k = ilo
-20               continue
+                 20 continue
                  ktop = k
                  ! ==== select deflation window size:
                  ! .    typical case:
@@ -34504,7 +34504,7 @@ module stdlib_linalg_lapack_q
                           ks = kbot - ns + 1
                           kt = n - ns + 1
                           call stdlib_qlacpy('A',ns,ns,h(ks,ks),ldh,h(kt,1),ldh)
-                                    
+
                           if (ns > nmin) then
                              call stdlib_qlaqr4(.false.,.false.,ns,1,ns,h(kt,1),ldh,wr( &
                                        ks),wi(ks),1,1,zdum,1,work,lwork,inf)
@@ -34547,7 +34547,7 @@ module stdlib_linalg_lapack_q
                                 end if
                              end do
                           end do
-60                        continue
+                          60 continue
                        end if
                        ! ==== shuffle shifts into pairs of real shifts
                        ! .    and pairs of complex conjugate shifts
@@ -34618,7 +34618,7 @@ module stdlib_linalg_lapack_q
               ! ==== iteration limit exceeded.  set info to show where
               ! .    the problem occurred and exit. ====
               info = kbot
-90            continue
+              90 continue
            end if
            ! ==== return the optimal value of lwork. ====
            work(1) = real(lwkopt,KIND=qp)
@@ -34646,7 +34646,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: h(ldh,*)
            real(qp),intent(out) :: v(*)
         ! ================================================================
-           
+
            ! Local Scalars
            real(qp) :: h21s,h31s,s
            ! Intrinsic Functions
@@ -34710,7 +34710,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: h(ldh,*),z(ldz,*)
            real(qp),intent(out) :: si(*),sr(*),t(ldt,*),v(ldv,*),work(*),wv(ldwv,*)
         ! ================================================================
-           
+
            ! Local Scalars
            real(qp) :: aa,bb,beta,cc,cs,dd,evi,evk,foo,s,safmax,safmin,smlnum,sn, &
                      tau,ulp
@@ -34730,7 +34730,7 @@ module stdlib_linalg_lapack_q
               lwk1 = int(work(1),KIND=ilp)
               ! ==== workspace query call to stdlib_qormhr ====
               call stdlib_qormhr('R','N',jw,jw,1,jw - 1,t,ldt,work,v,ldv,work,-1,info)
-                        
+
               lwk2 = int(work(1),KIND=ilp)
               ! ==== optimal workspace ====
               lwkopt = jw + max(lwk1,lwk2)
@@ -34795,7 +34795,7 @@ module stdlib_linalg_lapack_q
            ! ==== deflation detection loop ====
            ns = jw
            ilst = infqr + 1
-20         continue
+           20 continue
            if (ilst <= ns) then
               if (ns == 1) then
                  bulge = .false.
@@ -34846,7 +34846,7 @@ module stdlib_linalg_lapack_q
               ! .    exchange failures. ====
               sorted = .false.
               i = ns + 1
-30            continue
+              30 continue
               if (sorted) go to 50
               sorted = .true.
               kend = i - 1
@@ -34858,13 +34858,13 @@ module stdlib_linalg_lapack_q
               else
                  k = i + 2
               end if
-40            continue
+              40 continue
               if (k <= kend) then
                  if (k == i + 1) then
                     evi = abs(t(i,i))
                  else
                     evi = abs(t(i,i)) + sqrt(abs(t(i + 1,i)))*sqrt(abs(t(i,i + 1)))
-                              
+
                  end if
                  if (k == kend) then
                     evk = abs(t(k,k))
@@ -34872,7 +34872,7 @@ module stdlib_linalg_lapack_q
                     evk = abs(t(k,k))
                  else
                     evk = abs(t(k,k)) + sqrt(abs(t(k + 1,k)))*sqrt(abs(t(k,k + 1)))
-                              
+
                  end if
                  if (evi >= evk) then
                     i = k
@@ -34897,11 +34897,11 @@ module stdlib_linalg_lapack_q
                  go to 40
               end if
               go to 30
-50            continue
+              50 continue
            end if
            ! ==== restore shift/eigenvalue array from t ====
            i = jw
-60         continue
+           60 continue
            if (i >= infqr + 1) then
               if (i == infqr + 1) then
                  sr(kwtop + i - 1) = t(i,i)
@@ -34934,7 +34934,7 @@ module stdlib_linalg_lapack_q
                  call stdlib_qlarf('R',ns,ns,work,1,tau,t,ldt,work(jw + 1))
                  call stdlib_qlarf('R',jw,ns,work,1,tau,v,ldv,work(jw + 1))
                  call stdlib_qgehrd(jw,1,ns,t,ldt,work,work(jw + 1),lwork - jw,info)
-                           
+
               end if
               ! ==== copy updated reduced window into place ====
               if (kwtop > 1) h(kwtop,kwtop - 1) = s*v(1,1)
@@ -35011,7 +35011,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: h(ldh,*),z(ldz,*)
            real(qp),intent(out) :: si(*),sr(*),t(ldt,*),v(ldv,*),work(*),wv(ldwv,*)
         ! ================================================================
-           
+
            ! Local Scalars
            real(qp) :: aa,bb,beta,cc,cs,dd,evi,evk,foo,s,safmax,safmin,smlnum,sn, &
                      tau,ulp
@@ -35031,7 +35031,7 @@ module stdlib_linalg_lapack_q
               lwk1 = int(work(1),KIND=ilp)
               ! ==== workspace query call to stdlib_qormhr ====
               call stdlib_qormhr('R','N',jw,jw,1,jw - 1,t,ldt,work,v,ldv,work,-1,info)
-                        
+
               lwk2 = int(work(1),KIND=ilp)
               ! ==== workspace query call to stdlib_qlaqr4 ====
               call stdlib_qlaqr4(.true.,.true.,jw,1,jw,t,ldt,sr,si,1,jw,v,ldv,work,- &
@@ -35106,7 +35106,7 @@ module stdlib_linalg_lapack_q
            ! ==== deflation detection loop ====
            ns = jw
            ilst = infqr + 1
-20         continue
+           20 continue
            if (ilst <= ns) then
               if (ns == 1) then
                  bulge = .false.
@@ -35157,7 +35157,7 @@ module stdlib_linalg_lapack_q
               ! .    exchange failures. ====
               sorted = .false.
               i = ns + 1
-30            continue
+              30 continue
               if (sorted) go to 50
               sorted = .true.
               kend = i - 1
@@ -35169,13 +35169,13 @@ module stdlib_linalg_lapack_q
               else
                  k = i + 2
               end if
-40            continue
+              40 continue
               if (k <= kend) then
                  if (k == i + 1) then
                     evi = abs(t(i,i))
                  else
                     evi = abs(t(i,i)) + sqrt(abs(t(i + 1,i)))*sqrt(abs(t(i,i + 1)))
-                              
+
                  end if
                  if (k == kend) then
                     evk = abs(t(k,k))
@@ -35183,7 +35183,7 @@ module stdlib_linalg_lapack_q
                     evk = abs(t(k,k))
                  else
                     evk = abs(t(k,k)) + sqrt(abs(t(k + 1,k)))*sqrt(abs(t(k,k + 1)))
-                              
+
                  end if
                  if (evi >= evk) then
                     i = k
@@ -35208,11 +35208,11 @@ module stdlib_linalg_lapack_q
                  go to 40
               end if
               go to 30
-50            continue
+              50 continue
            end if
            ! ==== restore shift/eigenvalue array from t ====
            i = jw
-60         continue
+           60 continue
            if (i >= infqr + 1) then
               if (i == infqr + 1) then
                  sr(kwtop + i - 1) = t(i,i)
@@ -35245,7 +35245,7 @@ module stdlib_linalg_lapack_q
                  call stdlib_qlarf('R',ns,ns,work,1,tau,t,ldt,work(jw + 1))
                  call stdlib_qlarf('R',jw,ns,work,1,tau,v,ldv,work(jw + 1))
                  call stdlib_qgehrd(jw,1,ns,t,ldt,work,work(jw + 1),lwork - jw,info)
-                           
+
               end if
               ! ==== copy updated reduced window into place ====
               if (kwtop > 1) h(kwtop,kwtop - 1) = s*v(1,1)
@@ -35335,18 +35335,18 @@ module stdlib_linalg_lapack_q
            ! ==== matrices of order ntiny or smaller must be processed by
            ! .    stdlib_qlahqr because of insufficient subdiagonal scratch space.
            ! .    (this is a hard limit.) ====
-           
+
            ! ==== exceptional deflation windows:  try to cure rare
            ! .    slow convergence by varying the size of the
            ! .    deflation window after kexnw iterations. ====
-           
+
            ! ==== exceptional shifts: try to cure rare slow convergence
            ! .    with ad-hoc exceptional shifts every kexsh iterations.
            ! .    ====
-           
+
            ! ==== the constants wilk1 and wilk2 are used to form the
            ! .    exceptional shifts. ====
-           
+
            ! Local Scalars
            real(qp) :: aa,bb,cc,cs,dd,sn,ss,swap
            integer(ilp) :: i,inf,it,itmax,k,kacc22,kbot,kdu,ks,kt,ktop,ku,kv,kwh, &
@@ -35446,7 +35446,7 @@ module stdlib_linalg_lapack_q
                     if (h(k,k - 1) == zero) go to 20
                  end do
                  k = ilo
-20               continue
+                 20 continue
                  ktop = k
                  ! ==== select deflation window size:
                  ! .    typical case:
@@ -35553,7 +35553,7 @@ module stdlib_linalg_lapack_q
                           ks = kbot - ns + 1
                           kt = n - ns + 1
                           call stdlib_qlacpy('A',ns,ns,h(ks,ks),ldh,h(kt,1),ldh)
-                                    
+
                           call stdlib_qlahqr(.false.,.false.,ns,1,ns,h(kt,1),ldh,wr(ks &
                                     ),wi(ks),1,1,zdum,1,inf)
                           ks = ks + inf
@@ -35591,7 +35591,7 @@ module stdlib_linalg_lapack_q
                                 end if
                              end do
                           end do
-60                        continue
+                          60 continue
                        end if
                        ! ==== shuffle shifts into pairs of real shifts
                        ! .    and pairs of complex conjugate shifts
@@ -35662,7 +35662,7 @@ module stdlib_linalg_lapack_q
               ! ==== iteration limit exceeded.  set info to show where
               ! .    the problem occurred and exit. ====
               info = kbot
-90            continue
+              90 continue
            end if
            ! ==== return the optimal value of lwork. ====
            work(1) = real(lwkopt,KIND=qp)
@@ -35684,7 +35684,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: h(ldh,*),si(*),sr(*),z(ldz,*)
            real(qp),intent(out) :: u(ldu,*),v(ldv,*),wh(ldwh,*),wv(ldwv,*)
         ! ================================================================
-           
+
            ! Local Scalars
            real(qp) :: alpha,beta,h11,h12,h21,h22,refsum,safmax,safmin,scl,smlnum,swap, &
                       tst1,tst2,ulp
@@ -35833,9 +35833,9 @@ module stdlib_linalg_lapack_q
                              h12 = max(abs(h(k + 1,k)),abs(h(k,k + 1)))
                              h21 = min(abs(h(k + 1,k)),abs(h(k,k + 1)))
                              h11 = max(abs(h(k + 1,k + 1)),abs(h(k,k) - h(k + 1,k + 1)))
-                                       
+
                              h22 = min(abs(h(k + 1,k + 1)),abs(h(k,k) - h(k + 1,k + 1)))
-                                       
+
                              scl = h11 + h12
                              tst2 = h22*(h11/scl)
                              if (tst2 == zero .or. h21*(h12/scl) <= max(smlnum,ulp*tst2)) &
@@ -36051,7 +36051,7 @@ module stdlib_linalg_lapack_q
                     call stdlib_qgemm('C','N',nu,jlen,nu,one,u(k1,k1),ldu,h(incol + k1, &
                               jcol),ldh,zero,wh,ldwh)
                     call stdlib_qlacpy('ALL',nu,jlen,wh,ldwh,h(incol + k1,jcol),ldh)
-                              
+
                  end do
                  ! ==== vertical multiply ====
                  do jrow = jtop,max(ktop,incol) - 1,nv
@@ -36059,7 +36059,7 @@ module stdlib_linalg_lapack_q
                     call stdlib_qgemm('N','N',jlen,nu,nu,one,h(jrow,incol + k1),ldh,u( &
                               k1,k1),ldu,zero,wv,ldwv)
                     call stdlib_qlacpy('ALL',jlen,nu,wv,ldwv,h(jrow,incol + k1),ldh)
-                              
+
                  end do
                  ! ==== z multiply (also vertical) ====
                  if (wantz) then
@@ -36068,7 +36068,7 @@ module stdlib_linalg_lapack_q
                        call stdlib_qgemm('N','N',jlen,nu,nu,one,z(jrow,incol + k1),ldz,u( &
                                   k1,k1),ldu,zero,wv,ldwv)
                        call stdlib_qlacpy('ALL',jlen,nu,wv,ldwv,z(jrow,incol + k1),ldz)
-                                 
+
                     end do
                  end if
               end if
@@ -36093,7 +36093,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: thresh = 0.1e+0_qp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(qp) :: cj,large,small
@@ -36153,7 +36153,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: thresh = 0.1e+0_qp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,jc
            real(qp) :: cj,large,small
@@ -36215,7 +36215,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: thresh = 0.1e+0_qp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(qp) :: cj,large,small
@@ -36289,7 +36289,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(out) :: work(*)
            real(qp),intent(inout) :: x(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran
            integer(ilp) :: i,ierr,j,j1,j2,jnext,k,n1,n2
@@ -36311,7 +36311,7 @@ module stdlib_linalg_lapack_q
            bignum = one/smlnum
            xnorm = stdlib_qlange('M',n,n,t,ldt,d)
            if (.not. lreal) xnorm = max(xnorm,abs(w),stdlib_qlange('M',n,1,b,n,d))
-                     
+
            smin = max(smlnum,eps*xnorm)
            ! compute 1-norm of each column of strictly upper triangular
            ! part of t to control overflow in triangular solver.
@@ -36628,7 +36628,7 @@ module stdlib_linalg_lapack_q
                        end if
                        x(j1) = x(j1) - stdlib_qdot(j1 - 1,t(1,j1),1,x,1)
                        x(n + j1) = x(n + j1) - stdlib_qdot(j1 - 1,t(1,j1),1,x(n + 1),1)
-                                 
+
                        if (j1 > 1) then
                           x(j1) = x(j1) - b(j1)*x(n + 1)
                           x(n + j1) = x(n + j1) + b(j1)*x(1)
@@ -36662,7 +36662,7 @@ module stdlib_linalg_lapack_q
                        ! scale if necessary to avoid overflow in forming the
                        ! right-hand side element by inner product.
                        xj = max(abs(x(j1)) + abs(x(n + j1)),abs(x(j2)) + abs(x(n + j2)))
-                                 
+
                        if (xmax > one) then
                           rec = one/xmax
                           if (max(work(j1),work(j2)) > (bignum - xj)/xmax) then
@@ -36674,9 +36674,9 @@ module stdlib_linalg_lapack_q
                        d(1,1) = x(j1) - stdlib_qdot(j1 - 1,t(1,j1),1,x,1)
                        d(2,1) = x(j2) - stdlib_qdot(j1 - 1,t(1,j2),1,x,1)
                        d(1,2) = x(n + j1) - stdlib_qdot(j1 - 1,t(1,j1),1,x(n + 1),1)
-                                 
+
                        d(2,2) = x(n + j2) - stdlib_qdot(j1 - 1,t(1,j2),1,x(n + 1),1)
-                                 
+
                        d(1,1) = d(1,1) - b(j1)*x(n + 1)
                        d(2,1) = d(2,1) - b(j2)*x(n + 1)
                        d(1,2) = d(1,2) + b(j1)*x(1)
@@ -36758,7 +36758,7 @@ module stdlib_linalg_lapack_q
            integer(ilp),intent(out) :: info
            real(qp),intent(inout) :: a(lda,*),b(ldb,*),q(ldq,*),z(ldz,*),alphar( &
                       *),alphai(*),beta(*),work(*)
-           
+
            ! local scalars
            real(qp) :: smlnum,ulp,eshift,safmin,safmax,c1,s1,temp,swap
            integer(ilp) :: istart,istop,iiter,maxit,istart2,k,ld,nshifts,nblock,nw,nmin, &
@@ -36973,7 +36973,7 @@ module stdlib_linalg_lapack_q
                        end if
                        if (k2 < istop) then
                           call stdlib_qlartg(a(k2,k2 - 1),a(k2 + 1,k2 - 1),c1,s1,temp)
-                                    
+
                           a(k2,k2 - 1) = temp
                           a(k2 + 1,k2 - 1) = zero
                           call stdlib_qrot(istopm - k2 + 1,a(k2,k2),lda,a(k2 + 1,k2),lda,c1, &
@@ -36996,7 +36996,7 @@ module stdlib_linalg_lapack_q
                                  istart2 + 1,istart2 + 1),ldb,c1,s1)
                        if (ilq) then
                           call stdlib_qrot(n,q(1,istart2),1,q(1,istart2 + 1),1,c1,s1)
-                                    
+
                        end if
                     end if
                     istart2 = istart2 + 1
@@ -37108,7 +37108,7 @@ module stdlib_linalg_lapack_q
            integer(ilp),intent(in) :: lda,ldb
            real(qp),intent(in) :: a(lda,*),b(ldb,*),sr1,sr2,si,beta1,beta2
            real(qp),intent(out) :: v(*)
-           
+
            ! local scalars
            real(qp) :: w(2),safmin,safmax,scale1,scale2
            safmin = stdlib_qlamch('SAFE MINIMUM')
@@ -37157,7 +37157,7 @@ module stdlib_linalg_lapack_q
            integer(ilp),intent(in) :: k,lda,ldb,ldq,ldz,istartm,istopm,nq,nz,qstart, &
                      zstart,ihi
            real(qp),intent(inout) :: a(lda,*),b(ldb,*),q(ldq,*),z(ldz,*)
-           
+
            ! local variables
            real(qp) :: h(2,3),c1,s1,c2,s2,temp
            if (k + 2 == ihi) then
@@ -37202,7 +37202,7 @@ module stdlib_linalg_lapack_q
               b(ihi,ihi) = temp
               b(ihi,ihi - 1) = zero
               call stdlib_qrot(ihi - istartm,b(istartm,ihi),1,b(istartm,ihi - 1),1,c1,s1)
-                        
+
               call stdlib_qrot(ihi - istartm + 1,a(istartm,ihi),1,a(istartm,ihi - 1),1,c1, &
                         s1)
               if (ilz) then
@@ -37223,18 +37223,18 @@ module stdlib_linalg_lapack_q
               call stdlib_qlartg(h(1,2),h(1,1),c2,s2,temp)
               ! apply transformations from the right
               call stdlib_qrot(k + 3 - istartm + 1,a(istartm,k + 2),1,a(istartm,k + 1),1,c1,s1)
-                        
+
               call stdlib_qrot(k + 3 - istartm + 1,a(istartm,k + 1),1,a(istartm,k),1,c2,s2)
-                        
+
               call stdlib_qrot(k + 2 - istartm + 1,b(istartm,k + 2),1,b(istartm,k + 1),1,c1,s1)
-                        
+
               call stdlib_qrot(k + 2 - istartm + 1,b(istartm,k + 1),1,b(istartm,k),1,c2,s2)
-                        
+
               if (ilz) then
                  call stdlib_qrot(nz,z(1,k + 2 - zstart + 1),1,z(1,k + 1 - zstart + 1),1,c1,s1)
-                           
+
                  call stdlib_qrot(nz,z(1,k + 1 - zstart + 1),1,z(1,k - zstart + 1),1,c2,s2)
-                           
+
               end if
               b(k + 1,k) = zero
               b(k + 2,k) = zero
@@ -37252,9 +37252,9 @@ module stdlib_linalg_lapack_q
               call stdlib_qrot(istopm - k,b(k + 1,k + 1),ldb,b(k + 2,k + 1),ldb,c2,s2)
               if (ilq) then
                  call stdlib_qrot(nq,q(1,k + 2 - qstart + 1),1,q(1,k + 3 - qstart + 1),1,c1,s1)
-                           
+
                  call stdlib_qrot(nq,q(1,k + 1 - qstart + 1),1,q(1,k + 2 - qstart + 1),1,c2,s2)
-                           
+
               end if
            end if
      end subroutine stdlib_qlaqz2
@@ -37272,7 +37272,7 @@ module stdlib_linalg_lapack_q
            integer(ilp),intent(out) :: ns,nd,info
            real(qp),intent(inout) :: qc(ldqc,*),zc(ldzc,*)
            real(qp),intent(out) :: work(*)
-           
+
            ! local scalars
            logical(lk) :: bulge
            integer(ilp) :: jw,kwtop,kwbot,istopm,istartm,k,k2,dtgexc_info,ifst,ilst, &
@@ -37332,7 +37332,7 @@ module stdlib_linalg_lapack_q
            ! store window in case of convergence failure
            call stdlib_qlacpy('ALL',jw,jw,a(kwtop,kwtop),lda,work,jw)
            call stdlib_qlacpy('ALL',jw,jw,b(kwtop,kwtop),ldb,work(jw**2 + 1),jw)
-                     
+
            ! transform window to real schur form
            call stdlib_qlaset('FULL',jw,jw,zero,one,qc,ldqc)
            call stdlib_qlaset('FULL',jw,jw,zero,one,zc,ldzc)
@@ -37345,7 +37345,7 @@ module stdlib_linalg_lapack_q
               ns = jw - qz_small_info
               call stdlib_qlacpy('ALL',jw,jw,work,jw,a(kwtop,kwtop),lda)
               call stdlib_qlacpy('ALL',jw,jw,work(jw**2 + 1),jw,b(kwtop,kwtop),ldb)
-                        
+
               return
            end if
            ! deflation detection loop
@@ -37377,7 +37377,7 @@ module stdlib_linalg_lapack_q
                        ilst = k2
                        call stdlib_qtgexc(.true.,.true.,jw,a(kwtop,kwtop),lda,b(kwtop, &
                        kwtop),ldb,qc,ldqc,zc,ldzc,ifst,ilst,work,lwork,dtgexc_info)
-                                 
+
                        k2 = k2 + 2
                     end if
                     k = k + 2
@@ -37397,7 +37397,7 @@ module stdlib_linalg_lapack_q
                        ilst = k2
                        call stdlib_qtgexc(.true.,.true.,jw,a(kwtop,kwtop),lda,b(kwtop, &
                        kwtop),ldb,qc,ldqc,zc,ldzc,ifst,ilst,work,lwork,dtgexc_info)
-                                 
+
                        k2 = k2 + 1
                     end if
                     k = k + 1
@@ -37439,9 +37439,9 @@ module stdlib_linalg_lapack_q
                  k2 = max(kwtop,k - 1)
                  call stdlib_qrot(ihi - k2 + 1,a(k,k2),lda,a(k + 1,k2),lda,c1,s1)
                  call stdlib_qrot(ihi - (k - 1) + 1,b(k,k - 1),ldb,b(k + 1,k - 1),ldb,c1,s1)
-                           
+
                  call stdlib_qrot(jw,qc(1,k - kwtop + 1),1,qc(1,k + 1 - kwtop + 1),1,c1,s1)
-                           
+
               end do
               ! chase bulges down
               istartm = kwtop
@@ -37480,7 +37480,7 @@ module stdlib_linalg_lapack_q
                     end do
                     ! remove the shift
                     call stdlib_qlartg(b(kwbot,kwbot),b(kwbot,kwbot - 1),c1,s1,temp)
-                              
+
                     b(kwbot,kwbot) = temp
                     b(kwbot,kwbot - 1) = zero
                     call stdlib_qrot(kwbot - istartm,b(istartm,kwbot),1,b(istartm,kwbot - 1), &
@@ -37542,7 +37542,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*),b(ldb,*),q(ldq,*),z(ldz,*),qc( &
                      ldqc,*),zc(ldzc,*),work(*),sr(*),si(*),ss(*)
            integer(ilp),intent(out) :: info
-           
+
            ! local scalars
            integer(ilp) :: i,j,ns,istartm,istopm,sheight,swidth,k,np,istartb,istopb, &
                      ishift,nblock,npos
@@ -37636,11 +37636,11 @@ module stdlib_linalg_lapack_q
               call stdlib_qgemm('T','N',sheight,swidth,sheight,one,qc,ldqc,a(ilo,ilo + ns &
                         ),lda,zero,work,sheight)
               call stdlib_qlacpy('ALL',sheight,swidth,work,sheight,a(ilo,ilo + ns),lda)
-                        
+
               call stdlib_qgemm('T','N',sheight,swidth,sheight,one,qc,ldqc,b(ilo,ilo + ns &
                         ),ldb,zero,work,sheight)
               call stdlib_qlacpy('ALL',sheight,swidth,work,sheight,b(ilo,ilo + ns),ldb)
-                        
+
            end if
            if (ilq) then
               call stdlib_qgemm('N','N',n,sheight,sheight,one,q(1,ilo),ldq,qc,ldqc, &
@@ -37655,11 +37655,11 @@ module stdlib_linalg_lapack_q
               call stdlib_qgemm('N','N',sheight,swidth,swidth,one,a(istartm,ilo),lda, &
                         zc,ldzc,zero,work,sheight)
               call stdlib_qlacpy('ALL',sheight,swidth,work,sheight,a(istartm,ilo),lda)
-                        
+
               call stdlib_qgemm('N','N',sheight,swidth,swidth,one,b(istartm,ilo),ldb, &
                         zc,ldzc,zero,work,sheight)
               call stdlib_qlacpy('ALL',sheight,swidth,work,sheight,b(istartm,ilo),ldb)
-                        
+
            end if
            if (ilz) then
               call stdlib_qgemm('N','N',n,swidth,swidth,one,z(1,ilo),ldz,zc,ldzc, &
@@ -37719,11 +37719,11 @@ module stdlib_linalg_lapack_q
                  call stdlib_qgemm('N','N',sheight,swidth,swidth,one,a(istartm,k),lda, &
                            zc,ldzc,zero,work,sheight)
                  call stdlib_qlacpy('ALL',sheight,swidth,work,sheight,a(istartm,k),lda)
-                           
+
                  call stdlib_qgemm('N','N',sheight,swidth,swidth,one,b(istartm,k),ldb, &
                            zc,ldzc,zero,work,sheight)
                  call stdlib_qlacpy('ALL',sheight,swidth,work,sheight,b(istartm,k),ldb)
-                           
+
               end if
               if (ilz) then
                  call stdlib_qgemm('N','N',n,nblock,nblock,one,z(1,k),ldz,zc,ldzc, &
@@ -37822,7 +37822,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(out) :: work(*)
            real(qp),intent(inout) :: z(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: sawnan1,sawnan2
            integer(ilp) :: i,indlpl,indp,inds,indumn,neg1,neg2,r1,r2
@@ -37870,7 +37870,7 @@ module stdlib_linalg_lapack_q
               s = work(inds + i) - lambda
            end do
            sawnan1 = stdlib_qisnan(s)
-60         continue
+           60 continue
            if (sawnan1) then
               ! runs a slower version of the above loop if a nan is detected
               neg1 = 0
@@ -37955,7 +37955,7 @@ module stdlib_linalg_lapack_q
                  end if
                  ztz = ztz + z(i)*z(i)
               end do
-220           continue
+              220 continue
            else
               ! run slower loop if nan occurred.
               do i = r - 1,b1,-1
@@ -37971,7 +37971,7 @@ module stdlib_linalg_lapack_q
                  end if
                  ztz = ztz + z(i)*z(i)
               end do
-240           continue
+              240 continue
            end if
            ! compute the fp vector downwards from r in blocks of size blksiz
            if (.not. sawnan1 .and. .not. sawnan2) then
@@ -37984,7 +37984,7 @@ module stdlib_linalg_lapack_q
                  end if
                  ztz = ztz + z(i + 1)*z(i + 1)
               end do
-260           continue
+              260 continue
            else
               ! run slower loop if nan occurred.
               do i = r,bn - 1
@@ -38000,7 +38000,7 @@ module stdlib_linalg_lapack_q
                  end if
                  ztz = ztz + z(i + 1)*z(i + 1)
               end do
-280           continue
+              280 continue
            end if
            ! compute quantities for convergence test
            tmp = one/ztz
@@ -38072,7 +38072,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: v(*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: applyleft
            integer(ilp) :: i,lastv,lastc
@@ -38146,7 +38146,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: t(ldt,*),v(ldv,*)
            real(qp),intent(out) :: work(ldwork,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            character :: transt
            integer(ilp) :: i,j
@@ -38461,7 +38461,7 @@ module stdlib_linalg_lapack_q
      !> arrays A, B and T. See Further Details section.
 
      pure subroutine stdlib_qlarfb_gett(ident,m,n,k,t,ldt,a,lda,b,ldb,work,ldwork)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -38473,7 +38473,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: t(ldt,*)
            real(qp),intent(out) :: work(ldwork,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lnotident
            integer(ilp) :: i,j
@@ -38614,7 +38614,7 @@ module stdlib_linalg_lapack_q
            ! Array Arguments
            real(qp),intent(inout) :: x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j,knt
            real(qp) :: beta,rsafmn,safmin,xnorm
@@ -38637,7 +38637,7 @@ module stdlib_linalg_lapack_q
               if (abs(beta) < safmin) then
                  ! xnorm, beta may be inaccurate; scale x and recompute them
                  rsafmn = one/safmin
-10               continue
+                 10 continue
                  knt = knt + 1
                  call stdlib_qscal(n - 1,rsafmn,x,incx)
                  beta = beta*rsafmn
@@ -38682,7 +38682,7 @@ module stdlib_linalg_lapack_q
            ! Array Arguments
            real(qp),intent(inout) :: x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j,knt
            real(qp) :: beta,bignum,savealpha,smlnum,xnorm
@@ -38718,7 +38718,7 @@ module stdlib_linalg_lapack_q
               if (abs(beta) < smlnum) then
                  ! xnorm, beta may be inaccurate; scale x and recompute them
                  bignum = one/smlnum
-10               continue
+                 10 continue
                  knt = knt + 1
                  call stdlib_qscal(n - 1,bignum,x,incx)
                  beta = beta*bignum
@@ -38788,7 +38788,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(out) :: t(ldt,*)
            real(qp),intent(in) :: tau(*),v(ldv,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,prevlastv,lastv
            ! Executable Statements
@@ -38914,7 +38914,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: v(*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j
            real(qp) :: sum,t1,t10,t2,t3,t4,t5,t6,t7,t8,t9,v1,v10,v2,v3,v4,v5,v6, &
@@ -38927,14 +38927,14 @@ module stdlib_linalg_lapack_q
               ! code for general m
               call stdlib_qlarf(side,m,n,v,1,tau,c,ldc,work)
               go to 410
-10            continue
+              10 continue
               ! special code for 1 x 1 householder
               t1 = one - tau*v(1)*v(1)
               do j = 1,n
                  c(1,j) = t1*c(1,j)
               end do
               go to 410
-30            continue
+              30 continue
               ! special code for 2 x 2 householder
               v1 = v(1)
               t1 = tau*v1
@@ -38946,7 +38946,7 @@ module stdlib_linalg_lapack_q
                  c(2,j) = c(2,j) - sum*t2
               end do
               go to 410
-50            continue
+              50 continue
               ! special code for 3 x 3 householder
               v1 = v(1)
               t1 = tau*v1
@@ -38961,7 +38961,7 @@ module stdlib_linalg_lapack_q
                  c(3,j) = c(3,j) - sum*t3
               end do
               go to 410
-70            continue
+              70 continue
               ! special code for 4 x 4 householder
               v1 = v(1)
               t1 = tau*v1
@@ -38979,7 +38979,7 @@ module stdlib_linalg_lapack_q
                  c(4,j) = c(4,j) - sum*t4
               end do
               go to 410
-90            continue
+              90 continue
               ! special code for 5 x 5 householder
               v1 = v(1)
               t1 = tau*v1
@@ -38993,7 +38993,7 @@ module stdlib_linalg_lapack_q
               t5 = tau*v5
               do j = 1,n
                  sum = v1*c(1,j) + v2*c(2,j) + v3*c(3,j) + v4*c(4,j) + v5*c(5,j)
-                           
+
                  c(1,j) = c(1,j) - sum*t1
                  c(2,j) = c(2,j) - sum*t2
                  c(3,j) = c(3,j) - sum*t3
@@ -39001,7 +39001,7 @@ module stdlib_linalg_lapack_q
                  c(5,j) = c(5,j) - sum*t5
               end do
               go to 410
-110           continue
+              110 continue
               ! special code for 6 x 6 householder
               v1 = v(1)
               t1 = tau*v1
@@ -39026,7 +39026,7 @@ module stdlib_linalg_lapack_q
                  c(6,j) = c(6,j) - sum*t6
               end do
               go to 410
-130           continue
+              130 continue
               ! special code for 7 x 7 householder
               v1 = v(1)
               t1 = tau*v1
@@ -39054,7 +39054,7 @@ module stdlib_linalg_lapack_q
                  c(7,j) = c(7,j) - sum*t7
               end do
               go to 410
-150           continue
+              150 continue
               ! special code for 8 x 8 householder
               v1 = v(1)
               t1 = tau*v1
@@ -39085,7 +39085,7 @@ module stdlib_linalg_lapack_q
                  c(8,j) = c(8,j) - sum*t8
               end do
               go to 410
-170           continue
+              170 continue
               ! special code for 9 x 9 householder
               v1 = v(1)
               t1 = tau*v1
@@ -39119,7 +39119,7 @@ module stdlib_linalg_lapack_q
                  c(9,j) = c(9,j) - sum*t9
               end do
               go to 410
-190           continue
+              190 continue
               ! special code for 10 x 10 householder
               v1 = v(1)
               t1 = tau*v1
@@ -39162,14 +39162,14 @@ module stdlib_linalg_lapack_q
               ! code for general n
               call stdlib_qlarf(side,m,n,v,1,tau,c,ldc,work)
               go to 410
-210           continue
+              210 continue
               ! special code for 1 x 1 householder
               t1 = one - tau*v(1)*v(1)
               do j = 1,m
                  c(j,1) = t1*c(j,1)
               end do
               go to 410
-230           continue
+              230 continue
               ! special code for 2 x 2 householder
               v1 = v(1)
               t1 = tau*v1
@@ -39181,7 +39181,7 @@ module stdlib_linalg_lapack_q
                  c(j,2) = c(j,2) - sum*t2
               end do
               go to 410
-250           continue
+              250 continue
               ! special code for 3 x 3 householder
               v1 = v(1)
               t1 = tau*v1
@@ -39196,7 +39196,7 @@ module stdlib_linalg_lapack_q
                  c(j,3) = c(j,3) - sum*t3
               end do
               go to 410
-270           continue
+              270 continue
               ! special code for 4 x 4 householder
               v1 = v(1)
               t1 = tau*v1
@@ -39214,7 +39214,7 @@ module stdlib_linalg_lapack_q
                  c(j,4) = c(j,4) - sum*t4
               end do
               go to 410
-290           continue
+              290 continue
               ! special code for 5 x 5 householder
               v1 = v(1)
               t1 = tau*v1
@@ -39228,7 +39228,7 @@ module stdlib_linalg_lapack_q
               t5 = tau*v5
               do j = 1,m
                  sum = v1*c(j,1) + v2*c(j,2) + v3*c(j,3) + v4*c(j,4) + v5*c(j,5)
-                           
+
                  c(j,1) = c(j,1) - sum*t1
                  c(j,2) = c(j,2) - sum*t2
                  c(j,3) = c(j,3) - sum*t3
@@ -39236,7 +39236,7 @@ module stdlib_linalg_lapack_q
                  c(j,5) = c(j,5) - sum*t5
               end do
               go to 410
-310           continue
+              310 continue
               ! special code for 6 x 6 householder
               v1 = v(1)
               t1 = tau*v1
@@ -39261,7 +39261,7 @@ module stdlib_linalg_lapack_q
                  c(j,6) = c(j,6) - sum*t6
               end do
               go to 410
-330           continue
+              330 continue
               ! special code for 7 x 7 householder
               v1 = v(1)
               t1 = tau*v1
@@ -39289,7 +39289,7 @@ module stdlib_linalg_lapack_q
                  c(j,7) = c(j,7) - sum*t7
               end do
               go to 410
-350           continue
+              350 continue
               ! special code for 8 x 8 householder
               v1 = v(1)
               t1 = tau*v1
@@ -39320,7 +39320,7 @@ module stdlib_linalg_lapack_q
                  c(j,8) = c(j,8) - sum*t8
               end do
               go to 410
-370           continue
+              370 continue
               ! special code for 9 x 9 householder
               v1 = v(1)
               t1 = tau*v1
@@ -39354,7 +39354,7 @@ module stdlib_linalg_lapack_q
                  c(j,9) = c(j,9) - sum*t9
               end do
               go to 410
-390           continue
+              390 continue
               ! special code for 10 x 10 householder
               v1 = v(1)
               t1 = tau*v1
@@ -39392,7 +39392,7 @@ module stdlib_linalg_lapack_q
               end do
               go to 410
            end if
-410        continue
+           410 continue
            return
      end subroutine stdlib_qlarfx
 
@@ -39416,7 +39416,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: v(*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(qp) :: alpha
            ! Executable Statements
@@ -39445,7 +39445,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(out) :: c(*)
            real(qp),intent(inout) :: x(*),y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,ic,ix,iy
            real(qp) :: f,g,t,tt
@@ -39500,7 +39500,7 @@ module stdlib_linalg_lapack_q
            ! Parameters
            integer(ilp),parameter :: lv = 128
            real(qp),parameter :: twopi = 6.28318530717958647692528676655900576839e+0_qp
-           
+
            ! Local Scalars
            integer(ilp) :: i,il,il2,iv
            ! Local Arrays
@@ -39534,7 +39534,7 @@ module stdlib_linalg_lapack_q
                     x(iv + i - 1) = sqrt(-two*log(u(2*i - 1)))*cos(twopi*u(2*i))
                  end do
               end if
-40            continue
+              40 continue
            return
      end subroutine stdlib_qlarnv
 
@@ -39554,7 +39554,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: d(*)
            real(qp),intent(inout) :: e(*),e2(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(qp) :: eabs,tmp1
@@ -39620,7 +39620,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: w(*),werr(*),wgap(*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            integer(ilp) :: maxitr
            ! Local Scalars
            integer(ilp) :: i,i1,ii,ip,iter,k,negcnt,next,nint,olnint,prev,r
@@ -39661,7 +39661,7 @@ module stdlib_linalg_lapack_q
               ! compute negcount from dstqds facto l+d+l+^t = l d l^t - left
               ! do while( negcnt(left)>i-1 )
               back = werr(ii)
-20            continue
+              20 continue
               negcnt = stdlib_qlaneg(n,d,lld,left,pivmin,r)
               if (negcnt > i - 1) then
                  left = left - back
@@ -39671,7 +39671,7 @@ module stdlib_linalg_lapack_q
               ! do while( negcnt(right)<i )
               ! compute negcount from dstqds facto l+d+l+^t = l d l^t - right
               back = werr(ii)
-50            continue
+              50 continue
               negcnt = stdlib_qlaneg(n,d,lld,right,pivmin,r)
                if (negcnt < i) then
                   right = right + back
@@ -39703,7 +39703,7 @@ module stdlib_linalg_lapack_q
            ! do while( nint>0 ), i.e. there are still unconverged intervals
            ! and while (iter<maxitr)
            iter = 0
-80         continue
+           80 continue
            prev = i1 - 1
            i = i1
            olnint = nint
@@ -39774,7 +39774,7 @@ module stdlib_linalg_lapack_q
      !> if JOBT = 'L'.
 
      pure subroutine stdlib_qlarrc(jobt,n,vl,vu,d,e,pivmin,eigcnt,lcnt,rcnt,info)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -39786,7 +39786,7 @@ module stdlib_linalg_lapack_q
            ! Array Arguments
            real(qp),intent(in) :: d(*),e(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            logical(lk) :: matt
@@ -39897,7 +39897,7 @@ module stdlib_linalg_lapack_q
            integer(ilp),parameter :: allrng = 1
            integer(ilp),parameter :: valrng = 2
            integer(ilp),parameter :: indrng = 3
-           
+
            ! Local Scalars
            logical(lk) :: ncnvrg,toofew
            integer(ilp) :: i,ib,ibegin,idiscl,idiscu,ie,iend,iinfo,im,in,ioff,iout, &
@@ -40374,7 +40374,7 @@ module stdlib_linalg_lapack_q
            integer(ilp),parameter :: allrng = 1
            integer(ilp),parameter :: indrng = 2
            integer(ilp),parameter :: valrng = 3
-           
+
            ! Local Scalars
            logical(lk) :: forceb,norep,usedqd
            integer(ilp) :: cnt,cnt1,cnt2,i,ibegin,idum,iend,iinfo,in,indl,indu,irange, &
@@ -40531,7 +40531,7 @@ module stdlib_linalg_lapack_q
                        goto 21
                     end if
                  end do
-21               continue
+                 21 continue
                  if (mb == 0) then
                     ! no eigenvalue in the current block lies in the desired range
                     ! e( iend ) holds the shift for the initial rrr
@@ -40580,7 +40580,7 @@ module stdlib_linalg_lapack_q
                  isleft = max(gl,w(wbegin) - werr(wbegin) - hndrd*eps*abs(w(wbegin) - werr( &
                            wbegin)))
                  isrght = min(gu,w(wend) + werr(wend) + hndrd*eps*abs(w(wend) + werr(wend)))
-                           
+
               end if
               ! decide whether the base representation for the current block
               ! l_jblk d_jblk l_jblk^t = t_jblk - sigma_jblk i
@@ -40729,7 +40729,7 @@ module stdlib_linalg_lapack_q
               ! found in maxtry iterations.
               info = 2
               return
-83            continue
+              83 continue
               ! at this point, we have found an initial base representation
               ! t - sigma i = l d l^t with not too much element growth.
               ! store the shift.
@@ -40884,7 +40884,7 @@ module stdlib_linalg_lapack_q
            integer(ilp),parameter :: ktrymax = 1
            integer(ilp),parameter :: sleft = 1
            integer(ilp),parameter :: sright = 2
-           
+
            ! Local Scalars
            logical(lk) :: dorrr1,forcer,nofail,sawnan1,sawnan2,tryrrr1
            integer(ilp) :: i,indx,ktry,shift
@@ -40940,7 +40940,7 @@ module stdlib_linalg_lapack_q
            ! while (ktry <= ktrymax)
            ktry = 0
            growthbound = maxgrowth1*spdiam
-5          continue
+           5 continue
            sawnan1 = .false.
            sawnan2 = .false.
            ! ensure that we do not back off too much of the initial shifts
@@ -41082,7 +41082,7 @@ module stdlib_linalg_lapack_q
               end if
            end if
            end if
-50         continue
+           50 continue
            if (ktry < ktrymax) then
               ! if we are here, both shifts failed also the rrr test.
               ! back off to the outside
@@ -41105,7 +41105,7 @@ module stdlib_linalg_lapack_q
                  return
               end if
            end if
-100        continue
+           100 continue
            if (shift == sleft) then
            elseif (shift == sright) then
               ! store new l and d back into dplus, lplus
@@ -41138,7 +41138,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: w(*),werr(*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            integer(ilp) :: maxitr
            ! Local Scalars
            integer(ilp) :: cnt,i,i1,i2,ii,iter,j,k,next,nint,olnint,p,prev, &
@@ -41189,7 +41189,7 @@ module stdlib_linalg_lapack_q
                  ! make sure that [left,right] contains the desired eigenvalue
                  ! do while( cnt(left)>i-1 )
                  fac = one
-20               continue
+                 20 continue
                  cnt = 0
                  s = left
                  dplus = d(1) - s
@@ -41205,7 +41205,7 @@ module stdlib_linalg_lapack_q
                  end if
                  ! do while( cnt(right)<i )
                  fac = one
-50               continue
+                 50 continue
                  cnt = 0
                  s = right
                  dplus = d(1) - s
@@ -41230,7 +41230,7 @@ module stdlib_linalg_lapack_q
            ! do while( nint>0 ), i.e. there are still unconverged intervals
            ! and while (iter<maxitr)
            iter = 0
-80         continue
+           80 continue
            prev = i1 - 1
            i = i1
            olnint = nint
@@ -41317,7 +41317,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: fudge = two
-           
+
            ! Local Scalars
            integer(ilp) :: i,it,itmax,negcnt
            real(qp) :: atoli,eps,left,mid,right,rtoli,tmp1,tmp2,tnorm
@@ -41339,7 +41339,7 @@ module stdlib_linalg_lapack_q
            left = gl - fudge*tnorm*eps*n - fudge*two*pivmin
            right = gu + fudge*tnorm*eps*n + fudge*two*pivmin
            it = 0
-10         continue
+           10 continue
            ! check if interval converged or maximum number of iterations reached
            tmp1 = abs(right - left)
            tmp2 = max(abs(right),abs(left))
@@ -41366,7 +41366,7 @@ module stdlib_linalg_lapack_q
               left = mid
            end if
            goto 10
-30         continue
+           30 continue
            ! converged or maximum number of iterations reached
            w = half*(left + right)
            werr = half*abs(right - left)
@@ -41390,7 +41390,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: relcond = 0.999_qp
-           
+
            ! Local Scalars
            integer(ilp) :: i
            logical(lk) :: yesrel
@@ -41438,7 +41438,7 @@ module stdlib_linalg_lapack_q
               tmp = tmp2
               offdig = offdig2
            end do
-11         continue
+           11 continue
            if (yesrel) then
               info = 0
               return
@@ -41479,7 +41479,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: maxitr = 10
-           
+
            ! Local Scalars
            logical(lk) :: eskip,needbs,stp2ii,tryrqc,usedbs,usedrq
            integer(ilp) :: done,i,ibegin,idone,iend,ii,iindc1,iindc2,iindr,iindwk,iinfo, &
@@ -41558,7 +41558,7 @@ module stdlib_linalg_lapack_q
               ! find the eigenvectors of the submatrix indexed ibegin
               ! through iend.
               wend = wbegin - 1
-15            continue
+              15 continue
               if (wend < m) then
                  if (iblock(wend + 1) == jblk) then
                     wend = wend + 1
@@ -41626,7 +41626,7 @@ module stdlib_linalg_lapack_q
               ! loop while( idone<im )
               ! generate the representation tree for the current block and
               ! compute the eigenvectors
-40   continue
+              40 continue
               if (idone < im) then
                  ! this is a crude protection against infinitely deep trees
                  if (ndepth > m) then
@@ -41714,7 +41714,7 @@ module stdlib_linalg_lapack_q
                        if (oldfst > 1) then
                           wgap(wbegin + oldfst - 2) = max(wgap(wbegin + oldfst - 2),w(wbegin + oldfst - 1) - &
                           werr(wbegin + oldfst - 1) - w(wbegin + oldfst - 2) - werr(wbegin + oldfst - 2))
-                                    
+
                        end if
                        if (wbegin + oldlst - 1 < wend) then
                           wgap(wbegin + oldlst - 1) = max(wgap(wbegin + oldlst - 1),w(wbegin + oldlst) - &
@@ -41915,7 +41915,7 @@ module stdlib_linalg_lapack_q
                           usedrq = .false.
                           ! bisection is initially turned off unless it is forced
                           needbs = .not. tryrqc
-120                       continue
+                          120 continue
                           ! check if bisection should be used to refine eigenvalue
                           if (needbs) then
                              ! take the bisection as new iterate
@@ -42049,7 +42049,7 @@ module stdlib_linalg_lapack_q
                              end do
                           end if
                           call stdlib_qscal(zto - zfrom + 1,nrminv,z(zfrom,windex),1)
-125                       continue
+                          125 continue
                           ! update w
                           w(windex) = lambda + sigma
                           ! recompute the gaps on the left and right
@@ -42071,7 +42071,7 @@ module stdlib_linalg_lapack_q
                           idone = idone + 1
                        end if
                        ! here ends the code for the current child
-139  continue
+                       139 continue
                        ! proceed to any remaining child nodes
                        newfst = j + 1
                     end do loop_140
@@ -42172,7 +42172,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(out) :: cs,r,sn
            real(qp),intent(in) :: f,g
         ! =====================================================================
-           
+
            ! Local Scalars
            ! logical            first
            integer(ilp) :: count,i
@@ -42206,7 +42206,7 @@ module stdlib_linalg_lapack_q
               scale = max(abs(f1),abs(g1))
               if (scale >= safmx2) then
                  count = 0
-10               continue
+                 10 continue
                  count = count + 1
                  f1 = f1*safmn2
                  g1 = g1*safmn2
@@ -42220,7 +42220,7 @@ module stdlib_linalg_lapack_q
                  end do
               else if (scale <= safmn2) then
                  count = 0
-30               continue
+                 30 continue
                  count = count + 1
                  f1 = f1*safmx2
                  g1 = g1*safmx2
@@ -42263,7 +42263,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(out) :: cs,sn
            real(qp),intent(in) :: sigma,x,y
         ! ===================================================================
-           
+
            ! Local Scalars
            real(qp) :: r,s,thresh,w,z
            thresh = stdlib_qlamch('E')
@@ -42354,7 +42354,7 @@ module stdlib_linalg_lapack_q
            integer(ilp),parameter :: lv = 128
            integer(ilp),parameter :: ipw2 = 4096
            real(qp),parameter :: r = one/ipw2
-           
+
            ! Local Scalars
            integer(ilp) :: i,i1,i2,i3,i4,it1,it2,it3,it4,j
            ! Local Arrays
@@ -42496,7 +42496,7 @@ module stdlib_linalg_lapack_q
            i3 = iseed(3)
            i4 = iseed(4)
            loop_10: do i = 1,min(n,lv)
-20         continue
+           20 continue
               ! multiply the seed by i-th power of the multiplier modulo 2**48
               it4 = i4*mm(i,4)
               it3 = it4/ipw2
@@ -42557,7 +42557,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: v(*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Executable Statements
            if (stdlib_lsame(side,'L')) then
               ! form  h * c
@@ -42607,7 +42607,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: c(ldc,*),t(ldt,*),v(ldv,*)
            real(qp),intent(out) :: work(ldwork,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            character :: transt
            integer(ilp) :: i,info,j
@@ -42705,7 +42705,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: tau(*)
            real(qp),intent(inout) :: v(ldv,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,info,j
            ! Executable Statements
@@ -42756,7 +42756,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: f,g,h
            real(qp),intent(out) :: ssmax,ssmin
         ! ====================================================================
-           
+
            ! Local Scalars
            real(qp) :: as,at,au,c,fa,fhmn,fhmx,ga,ha
            ! Intrinsic Functions
@@ -42773,7 +42773,7 @@ module stdlib_linalg_lapack_q
                  ssmax = ga
               else
                  ssmax = max(fhmx,ga)*sqrt(one + (min(fhmx,ga)/max(fhmx,ga))**2)
-                           
+
               end if
            else
               if (ga < fhmx) then
@@ -42822,7 +42822,7 @@ module stdlib_linalg_lapack_q
            ! Array Arguments
            real(qp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: done
            integer(ilp) :: i,itype,j,k1,k2,k3,k4
@@ -42883,7 +42883,7 @@ module stdlib_linalg_lapack_q
            bignum = one/smlnum
            cfromc = cfrom
            ctoc = cto
-10         continue
+           10 continue
            cfrom1 = cfromc*smlnum
            if (cfrom1 == cfromc) then
               ! cfromc is an inf.  multiply by a correctly signed zero for
@@ -42983,7 +42983,7 @@ module stdlib_linalg_lapack_q
      !> and optionally, the singular vectors in compact form.
 
      pure subroutine stdlib_qlasd0(n,sqre,d,e,u,ldu,vt,ldvt,smlsiz,iwork,work,info)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -43158,7 +43158,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: d(*),u(ldu,*),vt(ldvt,*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: coltyp,i,idx,idxc,idxp,iq,isigma,iu2,ivt2,iz,k,ldq,ldu2, &
                      ldvt2,m,n,n1,n2
@@ -43251,7 +43251,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: d(*),u(ldu,*),vt(ldvt,*)
            real(qp),intent(out) :: dsigma(*),u2(ldu2,*),vt2(ldvt2,*),z(*)
         ! =====================================================================
-           
+
            ! Local Arrays
            integer(ilp) :: ctot(4),psm(4)
            ! Local Scalars
@@ -43357,9 +43357,9 @@ module stdlib_linalg_lapack_q
                  go to 90
               end if
            end do
-90         continue
+           90 continue
            j = jprev
-100        continue
+           100 continue
            j = j + 1
            if (j > n) go to 110
            if (abs(z(j)) <= tol) then
@@ -43408,13 +43408,13 @@ module stdlib_linalg_lapack_q
               end if
            end if
            go to 100
-110        continue
+           110 continue
            ! record the last singular value.
            k = k + 1
            u2(k,1) = z(jprev)
            dsigma(k) = d(jprev)
            idxp(k) = jprev
-120        continue
+           120 continue
            ! count up the total number of the various types of columns, then
            ! form a permutation which positions the four column types into
            ! four groups of uniform structure (although one or more of these
@@ -43539,7 +43539,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: dsigma(*),vt2(ldvt2,*),z(*)
            real(qp),intent(in) :: u2(ldu2,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: ctemp,i,j,jc,ktemp,m,n,nlp1,nlp2,nrp1
            real(qp) :: rho,temp
@@ -43617,7 +43617,7 @@ module stdlib_linalg_lapack_q
            ! find the new singular values.
            do j = 1,k
               call stdlib_qlasd4(k,j,dsigma,z,u(1,j),rho,d(j),vt(1,j),info)
-                        
+
               ! if the zero finder fails, report the convergence failure.
               if (info /= 0) then
                  return
@@ -43678,7 +43678,7 @@ module stdlib_linalg_lapack_q
            call stdlib_qgemm('N','N',nr,k,ctemp,one,u2(nlp2,ktemp),ldu2,q(ktemp,1), &
                      ldq,zero,u(nlp2,1),ldu)
            ! generate the right singular vectors.
-100  continue
+           100 continue
            do i = 1,k
               temp = stdlib_qnrm2(k,vt(1,i),1)
               q(i,1) = vt(1,i)/temp
@@ -43690,7 +43690,7 @@ module stdlib_linalg_lapack_q
            ! update the right singular vector matrix.
            if (k == 2) then
               call stdlib_qgemm('N','N',k,m,k,one,q,ldq,vt2,ldvt2,zero,vt,ldvt)
-                        
+
               return
            end if
            ktemp = 1 + ctot(1)
@@ -43742,7 +43742,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: maxit = 400
-           
+
            ! Local Scalars
            logical(lk) :: orgati,swtch,swtch3,geomavg
            integer(ilp) :: ii,iim1,iip1,ip1,iter,j,niter
@@ -44438,7 +44438,7 @@ module stdlib_linalg_lapack_q
               ! return with info = 1, niter = maxit and not converged
               info = 1
            end if
-240        continue
+           240 continue
            return
      end subroutine stdlib_qlasd4
 
@@ -44463,7 +44463,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: d(2),z(2)
            real(qp),intent(out) :: delta(2),work(2)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(qp) :: b,c,del,delsq,tau,w
            ! Intrinsic Functions
@@ -44575,7 +44575,7 @@ module stdlib_linalg_lapack_q
 
      pure subroutine stdlib_qlasd6(icompq,nl,nr,sqre,d,vf,vl,alpha,beta,idxq,perm, &
      givptr,givcol,ldgcol,givnum,ldgnum,poles,difl,difr,z,k,c,s,work,iwork,info)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -44591,7 +44591,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(out) :: difl(*),difr(*),givnum(ldgnum,*),poles(ldgnum,*),work(*), &
                      z(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,idx,idxc,idxp,isigma,ivfw,ivlw,iw,m,n,n1,n2
            real(qp) :: orgnrm
@@ -44675,7 +44675,7 @@ module stdlib_linalg_lapack_q
 
      pure subroutine stdlib_qlasd7(icompq,nl,nr,sqre,k,d,z,zw,vf,vfw,vl,vlw,alpha, &
      beta,dsigma,idx,idxp,idxq,perm,givptr,givcol,ldgcol,givnum,ldgnum,c,s,info)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -44689,9 +44689,9 @@ module stdlib_linalg_lapack_q
            integer(ilp),intent(inout) :: idxq(*)
            real(qp),intent(inout) :: d(*),vf(*),vl(*)
            real(qp),intent(out) :: dsigma(*),givnum(ldgnum,*),vfw(*),vlw(*),z(*),zw(*)
-                     
+
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,idxi,idxj,idxjp,j,jp,jprev,k2,m,n,nlp1,nlp2
            real(qp) :: eps,hlftol,tau,tol,z1
@@ -44793,9 +44793,9 @@ module stdlib_linalg_lapack_q
                  go to 70
               end if
            end do
-70         continue
+           70 continue
            j = jprev
-80         continue
+           80 continue
            j = j + 1
            if (j > n) go to 90
            if (abs(z(j)) <= tol) then
@@ -44845,13 +44845,13 @@ module stdlib_linalg_lapack_q
               end if
            end if
            go to 80
-90         continue
+           90 continue
            ! record the last singular value.
            k = k + 1
            zw(k) = z(jprev)
            dsigma(k) = d(jprev)
            idxp(k) = jprev
-100        continue
+           100 continue
            ! sort the singular values into dsigma. the singular values which
            ! were not deflated go into the first k slots of dsigma, except
            ! that dsigma(1) is treated separately.
@@ -44924,7 +44924,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(out) :: d(*),difl(*),difr(lddifr,*),work(*)
            real(qp),intent(inout) :: dsigma(*),vf(*),vl(*),z(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,iwk1,iwk2,iwk2i,iwk3,iwk3i,j
            real(qp) :: diflj,difrj,dj,dsigj,dsigjp,rho,temp
@@ -44989,7 +44989,7 @@ module stdlib_linalg_lapack_q
            ! and the updated z.
            do j = 1,k
               call stdlib_qlasd4(k,j,dsigma,z,work(iwk1),rho,d(j),work(iwk2),info)
-                        
+
               ! if the root finder fails, report the convergence failure.
               if (info /= 0) then
                  return
@@ -45064,7 +45064,7 @@ module stdlib_linalg_lapack_q
                      s(*),u(ldu,*),vt(ldu,*),work(*),z(ldu,*)
            real(qp),intent(inout) :: d(*),e(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,i1,ic,idxq,idxqi,im1,inode,itemp,iwk,j,lf,ll,lvl,lvl2, &
            m,ncc,nd,ndb1,ndiml,ndimr,nl,nlf,nlp1,nlvl,nr,nrf,nrp1,nru,nwork1, &
@@ -45141,7 +45141,7 @@ module stdlib_linalg_lapack_q
                  call stdlib_qlaset('A',nlp1,nlp1,zero,one,work(nwork1),smlszp)
                  call stdlib_qlasdq('U',sqrei,nl,nlp1,nru,ncc,d(nlf),e(nlf),work( &
                  nwork1),smlszp,work(nwork2),nl,work(nwork2),nl,work(nwork2),info)
-                           
+
                  itemp = nwork1 + nl*smlszp
                  call stdlib_qcopy(nlp1,work(nwork1),1,work(vfi),1)
                  call stdlib_qcopy(nlp1,work(itemp),1,work(vli),1)
@@ -45172,7 +45172,7 @@ module stdlib_linalg_lapack_q
                  call stdlib_qlaset('A',nrp1,nrp1,zero,one,work(nwork1),smlszp)
                  call stdlib_qlasdq('U',sqrei,nr,nrp1,nru,ncc,d(nrf),e(nrf),work( &
                  nwork1),smlszp,work(nwork2),nr,work(nwork2),nr,work(nwork2),info)
-                           
+
                  itemp = nwork1 + (nrp1 - 1)*smlszp
                  call stdlib_qcopy(nrp1,work(nwork1),1,work(vfi),1)
                  call stdlib_qcopy(nrp1,work(itemp),1,work(vli),1)
@@ -45268,7 +45268,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: c(ldc,*),d(*),e(*),u(ldu,*),vt(ldvt,*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: rotate
            integer(ilp) :: i,isub,iuplo,j,np1,sqre1
@@ -45362,26 +45362,26 @@ module stdlib_linalg_lapack_q
               if (nru > 0) then
                  if (sqre1 == 0) then
                     call stdlib_qlasr('R','V','F',nru,n,work(1),work(np1),u,ldu)
-                              
+
                  else
                     call stdlib_qlasr('R','V','F',nru,np1,work(1),work(np1),u,ldu)
-                              
+
                  end if
               end if
               if (ncc > 0) then
                  if (sqre1 == 0) then
                     call stdlib_qlasr('L','V','F',n,ncc,work(1),work(np1),c,ldc)
-                              
+
                  else
                     call stdlib_qlasr('L','V','F',np1,ncc,work(1),work(np1),c,ldc)
-                              
+
                  end if
               end if
            end if
            ! call stdlib_qbdsqr to compute the svd of the reduced real
            ! n-by-n upper bidiagonal matrix.
            call stdlib_qbdsqr('U',n,ncvt,nru,ncc,d,e,vt,ldvt,u,ldu,c,ldc,work,info)
-                     
+
            ! sort the singular values into ascending order (insertion sort on
            ! singular values, but only one transposition per singular vector)
            do i = 1,n
@@ -45399,7 +45399,7 @@ module stdlib_linalg_lapack_q
                  d(isub) = d(i)
                  d(i) = smin
                  if (ncvt > 0) call stdlib_qswap(ncvt,vt(isub,1),ldvt,vt(i,1),ldvt)
-                           
+
                  if (nru > 0) call stdlib_qswap(nru,u(1,isub),1,u(1,i),1)
                  if (ncc > 0) call stdlib_qswap(ncc,c(isub,1),ldc,c(i,1),ldc)
               end if
@@ -45420,7 +45420,7 @@ module stdlib_linalg_lapack_q
            ! Array Arguments
            integer(ilp),intent(out) :: inode(*),ndiml(*),ndimr(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,il,ir,llst,maxn,ncrnt,nlvl
            real(qp) :: temp
@@ -45530,7 +45530,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: d(*),e(*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,iinfo
            real(qp) :: eps,scale,safmin,sigmn,sigmx
@@ -45627,7 +45627,7 @@ module stdlib_linalg_lapack_q
            ! Parameters
            real(qp),parameter :: cbias = 1.50_qp
            real(qp),parameter :: hundrd = 100.0_qp
-           
+
            ! Local Scalars
            logical(lk) :: ieee
            integer(ilp) :: i0,i1,i4,iinfo,ipn4,iter,iwhila,iwhilb,k,kmin,n0,n1,nbig, &
@@ -45852,7 +45852,7 @@ module stdlib_linalg_lapack_q
                  emin = min(emin,z(i4 - 5))
               end do
               i4 = 4
-100           continue
+              100 continue
               i0 = i4/4
               pp = 0
               if (n0 - i0 > 1) then
@@ -45931,7 +45931,7 @@ module stdlib_linalg_lapack_q
               ! this might need to be done for several blocks
               i1 = i0
               n1 = n0
-145           continue
+              145 continue
               tempq = z(4*i0 - 3)
               z(4*i0 - 3) = z(4*i0 - 3) + sigma
               do k = i0 + 1,n0
@@ -45962,12 +45962,12 @@ module stdlib_linalg_lapack_q
               end do
               return
               ! end iwhilb
-150  continue
+              150 continue
            end do loop_160
            info = 3
            return
            ! end iwhila
-170  continue
+           170 continue
            ! move q's to the front.
            do k = 2,n
               z(k) = z(4*k - 3)
@@ -46009,7 +46009,7 @@ module stdlib_linalg_lapack_q
            real(qp),parameter :: cbias = 1.50_qp
            real(qp),parameter :: qurtr = 0.250_qp
            real(qp),parameter :: hundrd = 100.0_qp
-           
+
            ! Local Scalars
            integer(ilp) :: ipn4,j4,n0in,nn
            integer(ilp),intent(inout) :: ttype
@@ -46022,7 +46022,7 @@ module stdlib_linalg_lapack_q
            tol = eps*hundrd
            tol2 = tol**2
            ! check for deflation.
-10   continue
+           10 continue
            if (n0 < i0) return
            if (n0 == i0) go to 20
            nn = 4*n0 + pp
@@ -46030,14 +46030,14 @@ module stdlib_linalg_lapack_q
            ! check whether e(n0-1) is negligible, 1 eigenvalue.
            if (z(nn - 5) > tol2*(sigma + z(nn - 3)) .and. z(nn - 2*pp - 4) > tol2*z(nn - 7)) go to &
                      30
-20         continue
+                     20 continue
            z(4*n0 - 3) = z(4*n0 + pp - 3) + sigma
            n0 = n0 - 1
            go to 10
            ! check  whether e(n0-2) is negligible, 2 eigenvalues.
-30   continue
+           30 continue
            if (z(nn - 9) > tol2*sigma .and. z(nn - 2*pp - 8) > tol2*z(nn - 11)) go to 50
-40         continue
+           40 continue
            if (z(nn - 3) > z(nn - 7)) then
               s = z(nn - 3)
               z(nn - 3) = z(nn - 7)
@@ -46059,7 +46059,7 @@ module stdlib_linalg_lapack_q
            z(4*n0 - 3) = z(nn - 3) + sigma
            n0 = n0 - 2
            go to 10
-50         continue
+           50 continue
            if (pp == 2) pp = 0
            ! reverse the qd-array, if warranted.
            if (dmin <= zero .or. n0 < n0in) then
@@ -46094,7 +46094,7 @@ module stdlib_linalg_lapack_q
            call stdlib_qlasq4(i0,n0,z,pp,n0in,dmin,dmin1,dmin2,dn,dn1,dn2,tau,ttype, &
                      g)
            ! call dqds until dmin > 0.
-70   continue
+           70 continue
            call stdlib_qlasq5(i0,n0,z,pp,tau,sigma,dmin,dmin1,dmin2,dn,dn1,dn2,ieee, &
                      eps)
            ndiv = ndiv + (n0 - i0 + 2)
@@ -46138,12 +46138,12 @@ module stdlib_linalg_lapack_q
               go to 80
            end if
            ! risk of underflow.
-80   continue
+           80 continue
            call stdlib_qlasq6(i0,n0,z,pp,dmin,dmin1,dmin2,dn,dn1,dn2)
            ndiv = ndiv + (n0 - i0 + 2)
            iter = iter + 1
            tau = zero
-90         continue
+           90 continue
            if (tau < sigma) then
               desig = desig + tau
               t = sigma + desig
@@ -46180,7 +46180,7 @@ module stdlib_linalg_lapack_q
            real(qp),parameter :: qurtr = 0.250_qp
            real(qp),parameter :: third = 0.3330_qp
            real(qp),parameter :: hundrd = 100.0_qp
-           
+
            ! Local Scalars
            integer(ilp) :: i4,nn,np
            real(qp) :: a2,b1,b2,gam,gap1,gap2,s
@@ -46248,7 +46248,7 @@ module stdlib_linalg_lapack_q
                        a2 = a2 + b2
                        if (hundrd*max(b2,b1) < a2 .or. cnst1 < a2) go to 20
                     end do
-20                  continue
+                    20 continue
                     a2 = cnst3*a2
                     ! rayleigh quotient residual bound.
                     if (a2 < cnst1) s = gam*(one - sqrt(a2))/(one + a2)
@@ -46276,7 +46276,7 @@ module stdlib_linalg_lapack_q
                        a2 = a2 + b2
                        if (hundrd*max(b2,b1) < a2 .or. cnst1 < a2) go to 40
                     end do
-40                  continue
+                    40 continue
                     a2 = cnst3*a2
                  end if
                  if (a2 < cnst1) s = gam*(one - sqrt(a2))/(one + a2)
@@ -46309,7 +46309,7 @@ module stdlib_linalg_lapack_q
                     b2 = b2 + b1
                     if (hundrd*max(b1,a2) < b2) go to 60
                  end do
-60               continue
+                 60 continue
                  b2 = sqrt(cnst3*b2)
                  a2 = dmin1/(one + b2**2)
                  gap2 = half*dmin2 - a2
@@ -46341,7 +46341,7 @@ module stdlib_linalg_lapack_q
                     b2 = b2 + b1
                     if (hundrd*b1 < b2) go to 80
                  end do
-80               continue
+                 80 continue
                  b2 = sqrt(cnst3*b2)
                  a2 = dmin2/(one + b2**2)
                  gap2 = z(nn - 7) + z(nn - 9) - sqrt(z(nn - 11))*sqrt(z(nn - 9)) - a2
@@ -46380,7 +46380,7 @@ module stdlib_linalg_lapack_q
            ! Array Arguments
            real(qp),intent(inout) :: z(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j4,j4p2
            real(qp) :: d,emin,temp,dthresh
@@ -46604,7 +46604,7 @@ module stdlib_linalg_lapack_q
            ! Array Arguments
            real(qp),intent(inout) :: z(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j4,j4p2
            real(qp) :: d,emin,safmin,temp
@@ -46764,7 +46764,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(in) :: c(*),s(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,info,j
            real(qp) :: ctemp,stemp,temp
@@ -46978,7 +46978,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: select = 20
-           
+
            ! Local Scalars
            integer(ilp) :: dir,endd,i,j,start,stkpnt
            real(qp) :: d1,d2,d3,dmnmx,tmp
@@ -47007,7 +47007,7 @@ module stdlib_linalg_lapack_q
            stkpnt = 1
            stack(1,1) = 1
            stack(2,1) = n
-10         continue
+           10 continue
            start = stack(1,stkpnt)
            endd = stack(2,stkpnt)
            stkpnt = stkpnt - 1
@@ -47068,11 +47068,11 @@ module stdlib_linalg_lapack_q
                  ! sort into decreasing order
                  i = start - 1
                  j = endd + 1
-60               continue
-70               continue
+                 60 continue
+                 70 continue
                  j = j - 1
                  if (d(j) < dmnmx) go to 70
-80               continue
+                 80 continue
                  i = i + 1
                  if (d(i) > dmnmx) go to 80
                  if (i < j) then
@@ -47100,11 +47100,11 @@ module stdlib_linalg_lapack_q
                  ! sort into increasing order
                  i = start - 1
                  j = endd + 1
-90               continue
-100              continue
+                 90 continue
+                 100 continue
                  j = j - 1
                  if (d(j) > dmnmx) go to 100
-110              continue
+                 110 continue
                  i = i + 1
                  if (d(i) < dmnmx) go to 110
                  if (i < j) then
@@ -47269,7 +47269,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(out) :: csl,csr,snl,snr,ssmax,ssmin
            real(qp),intent(in) :: f,g,h
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: gasmal,swap
            integer(ilp) :: pmax
@@ -47562,7 +47562,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: b(ldb,*),tl(ldtl,*),tr(ldtr,*)
            real(qp),intent(out) :: x(ldx,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: bswap,xswap
            integer(ilp) :: i,ip,ipiv,ipsv,j,jp,jpsv,k
@@ -47592,7 +47592,7 @@ module stdlib_linalg_lapack_q
            k = n1 + n1 + n2 - 2
            go to(10,20,30,50) k
            ! 1 by 1: tl11*x + sgn*x*tr11 = b11
-10   continue
+           10 continue
            tau1 = tl(1,1) + sgn*tr(1,1)
            bet = abs(tau1)
            if (bet <= smlnum) then
@@ -47609,7 +47609,7 @@ module stdlib_linalg_lapack_q
            ! 1 by 2:
            ! tl11*[x11 x12] + isgn*[x11 x12]*op[tr11 tr12]  = [b11 b12]
                                              ! [tr21 tr22]
-20   continue
+                                             20 continue
            smin = max(eps*max(abs(tl(1,1)),abs(tr(1,1)),abs(tr(1,2)),abs(tr( &
                      2,1)),abs(tr(2,2))),smlnum)
            tmp(1) = tl(1,1) + sgn*tr(1,1)
@@ -47627,7 +47627,7 @@ module stdlib_linalg_lapack_q
            ! 2 by 1:
                 ! op[tl11 tl12]*[x11] + isgn* [x11]*tr11  = [b11]
                   ! [tl21 tl22] [x21]         [x21]         [b21]
-30   continue
+                  30 continue
            smin = max(eps*max(abs(tr(1,1)),abs(tl(1,1)),abs(tl(1,2)),abs(tl( &
                      2,1)),abs(tl(2,2))),smlnum)
            tmp(1) = tl(1,1) + sgn*tr(1,1)
@@ -47641,7 +47641,7 @@ module stdlib_linalg_lapack_q
            end if
            btmp(1) = b(1,1)
            btmp(2) = b(2,1)
-40         continue
+           40 continue
            ! solve 2 by 2 system using complete pivoting.
            ! set pivots less than smin to smin.
            ipiv = stdlib_iqamax(4,tmp,1)
@@ -47694,9 +47694,9 @@ module stdlib_linalg_lapack_q
              ! [tl21 tl22] [x21 x22]        [x21 x22]   [tr21 tr22]   [b21 b22]
            ! solve equivalent 4 by 4 system using complete pivoting.
            ! set pivots less than smin to smin.
-50   continue
+           50 continue
            smin = max(abs(tr(1,1)),abs(tr(1,2)),abs(tr(2,1)),abs(tr(2,2)))
-                     
+
            smin = max(smin,abs(tl(1,1)),abs(tl(1,2)),abs(tl(2,1)),abs(tl(2, &
                      2)))
            smin = max(eps*smin,smlnum)
@@ -47830,7 +47830,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: sevten = 17.0e+0_qp
-           
+
            ! Local Scalars
            integer(ilp) :: imax,j,jb,jj,jmax,jp,k,kk,kkw,kp,kstep,kw
            real(qp) :: absakk,alpha,colmax,d11,d21,d22,r1,rowmax,t
@@ -47847,7 +47847,7 @@ module stdlib_linalg_lapack_q
               ! k is the main loop index, decreasing from n in steps of 1 or 2
               ! kw is the column of w which corresponds to column k of a
               k = n
-10            continue
+              10 continue
               kw = nb + k - n
               ! exit from loop
               if ((k <= n - nb + 1 .and. nb < n) .or. k < 1) go to 30
@@ -47880,7 +47880,7 @@ module stdlib_linalg_lapack_q
                     ! copy column imax to column kw-1 of w and update it
                     call stdlib_qcopy(imax,a(1,imax),1,w(1,kw - 1),1)
                     call stdlib_qcopy(k - imax,a(imax,imax + 1),lda,w(imax + 1,kw - 1),1)
-                              
+
                     if (k < n) call stdlib_qgemv('NO TRANSPOSE',k,n - k,-one,a(1,k + 1),lda,w( &
                               imax,kw + 1),ldw,one,w(1,kw - 1),1)
                     ! jmax is the column-index of the largest off-diagonal
@@ -48001,7 +48001,7 @@ module stdlib_linalg_lapack_q
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-30            continue
+              30 continue
               ! update the upper triangle of a11 (= a(1:k,1:k)) as
               ! a11 := a11 - u12*d*u12**t = a11 - u12*w**t
               ! computing blocks of nb columns at a time
@@ -48019,7 +48019,7 @@ module stdlib_linalg_lapack_q
               ! put u12 in standard form by partially undoing the interchanges
               ! in columns k+1:n looping backwards from k+1 to n
               j = k + 1
-60            continue
+              60 continue
                  ! undo the interchanges (if any) of rows jj and jp at each
                  ! step j
                  ! (here, j is a diagonal index)
@@ -48044,7 +48044,7 @@ module stdlib_linalg_lapack_q
               ! for use in updating a22
               ! k is the main loop index, increasing from 1 in steps of 1 or 2
               k = 1
-70            continue
+              70 continue
               ! exit from loop
               if ((k >= nb .and. nb < n) .or. k > n) go to 90
               ! copy column k of a to column k of w and update it
@@ -48115,7 +48115,7 @@ module stdlib_linalg_lapack_q
                     a(kp,kp) = a(kk,kk)
                     call stdlib_qcopy(kp - kk - 1,a(kk + 1,kk),1,a(kp,kk + 1),lda)
                     if (kp < n) call stdlib_qcopy(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     ! interchange rows kk and kp in first k-1 columns of a
                     ! (columns k (or k and k+1 for 2-by-2 pivot) of a will be
                     ! later overwritten). interchange rows kk and kp
@@ -48197,7 +48197,7 @@ module stdlib_linalg_lapack_q
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 70
-90            continue
+              90 continue
               ! update the lower triangle of a22 (= a(k:n,k:n)) as
               ! a22 := a22 - l21*d*l21**t = a22 - l21*w**t
               ! computing blocks of nb columns at a time
@@ -48215,7 +48215,7 @@ module stdlib_linalg_lapack_q
               ! put l21 in standard form by partially undoing the interchanges
               ! of rows in columns 1:k-1 looping backwards from k-1 to 1
               j = k - 1
-120           continue
+              120 continue
                  ! undo the interchanges (if any) of rows jj and jp at each
                  ! step j
                  ! (here, j is a diagonal index)
@@ -48230,7 +48230,7 @@ module stdlib_linalg_lapack_q
                  ! of the rows to swap back doesn't include diagonal element)
                  j = j - 1
                  if (jp /= jj .and. j >= 1) call stdlib_qswap(j,a(jp,1),lda,a(jj,1),lda)
-                           
+
               if (j > 1) go to 120
               ! set kb to the number of columns factorized
               kb = k - 1
@@ -48261,7 +48261,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*),h(ldh,*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j,k,k1,i1,i2,mj
            real(qp) :: piv,alpha
@@ -48276,7 +48276,7 @@ module stdlib_linalg_lapack_q
               ! .....................................................
               ! factorize a as u**t*d*u using the upper triangle of a
               ! .....................................................
-10   continue
+              10 continue
               if (j > min(m,nb)) go to 20
               ! k is the column to be factorized
                ! when being called from stdlib_qsytrf_aa,
@@ -48330,7 +48330,7 @@ module stdlib_linalg_lapack_q
                     i1 = i1 + j - 1
                     i2 = i2 + j - 1
                     call stdlib_qswap(i2 - i1 - 1,a(j1 + i1 - 1,i1 + 1),lda,a(j1 + i1,i2),1)
-                              
+
                     ! swap a(i1, i2+1:m) with a(i2, i2+1:m)
                     if (i2 < m) call stdlib_qswap(m - i2,a(j1 + i1 - 1,i2 + 1),lda,a(j1 + i2 - 1,i2 + 1), &
                                lda)
@@ -48369,12 +48369,12 @@ module stdlib_linalg_lapack_q
               end if
               j = j + 1
               go to 10
-20            continue
+              20 continue
            else
               ! .....................................................
               ! factorize a as l*d*l**t using the lower triangle of a
               ! .....................................................
-30   continue
+              30 continue
               if (j > min(m,nb)) go to 40
               ! k is the column to be factorized
                ! when being called from stdlib_qsytrf_aa,
@@ -48428,7 +48428,7 @@ module stdlib_linalg_lapack_q
                     i1 = i1 + j - 1
                     i2 = i2 + j - 1
                     call stdlib_qswap(i2 - i1 - 1,a(i1 + 1,j1 + i1 - 1),1,a(i2,j1 + i1),lda)
-                              
+
                     ! swap a(i2+1:m, i1) with a(i2+1:m, i2)
                     if (i2 < m) call stdlib_qswap(m - i2,a(i2 + 1,j1 + i1 - 1),1,a(i2 + 1,j1 + i2 - 1), &
                               1)
@@ -48467,7 +48467,7 @@ module stdlib_linalg_lapack_q
               end if
               j = j + 1
               go to 30
-40            continue
+              40 continue
            end if
            return
      end subroutine stdlib_qlasyf_aa
@@ -48500,7 +48500,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: sevten = 17.0e+0_qp
-           
+
            ! Local Scalars
            logical(lk) :: done
            integer(ilp) :: imax,itemp,j,jb,jj,jmax,k,kk,kw,kkw,kp,kstep,p,ii
@@ -48523,7 +48523,7 @@ module stdlib_linalg_lapack_q
               e(1) = zero
               ! k is the main loop index, decreasing from n in steps of 1 or 2
               k = n
-10            continue
+              10 continue
               ! kw is the column of w which corresponds to column k of a
               kw = nb + k - n
               ! exit from loop
@@ -48564,12 +48564,12 @@ module stdlib_linalg_lapack_q
                  else
                     done = .false.
                     ! loop until pivot found
-12   continue
+                    12 continue
                        ! begin pivot search loop body
                        ! copy column imax to column kw-1 of w and update it
                        call stdlib_qcopy(imax,a(1,imax),1,w(1,kw - 1),1)
                        call stdlib_qcopy(k - imax,a(imax,imax + 1),lda,w(imax + 1,kw - 1),1)
-                                 
+
                        if (k < n) call stdlib_qgemv('NO TRANSPOSE',k,n - k,-one,a(1,k + 1),lda, &
                                  w(imax,kw + 1),ldw,one,w(1,kw - 1),1)
                        ! jmax is the column-index of the largest off-diagonal
@@ -48698,7 +48698,7 @@ module stdlib_linalg_lapack_q
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-30            continue
+              30 continue
               ! update the upper triangle of a11 (= a(1:k,1:k)) as
               ! a11 := a11 - u12*d*u12**t = a11 - u12*w**t
               ! computing blocks of nb columns at a time
@@ -48723,7 +48723,7 @@ module stdlib_linalg_lapack_q
               e(n) = zero
               ! k is the main loop index, increasing from 1 in steps of 1 or 2
               k = 1
-70            continue
+              70 continue
               ! exit from loop
               if ((k >= nb .and. nb < n) .or. k > n) go to 90
               kstep = 1
@@ -48762,7 +48762,7 @@ module stdlib_linalg_lapack_q
                  else
                     done = .false.
                     ! loop until pivot found
-72   continue
+                    72 continue
                        ! begin pivot search loop body
                        ! copy column imax to column k+1 of w and update it
                        call stdlib_qcopy(imax - k,a(imax,k),lda,w(k,k + 1),1)
@@ -48891,7 +48891,7 @@ module stdlib_linalg_lapack_q
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 70
-90            continue
+              90 continue
               ! update the lower triangle of a22 (= a(k:n,k:n)) as
               ! a22 := a22 - l21*d*l21**t = a22 - l21*w**t
               ! computing blocks of nb columns at a time
@@ -48940,7 +48940,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: sevten = 17.0e+0_qp
-           
+
            ! Local Scalars
            logical(lk) :: done
            integer(ilp) :: imax,itemp,j,jb,jj,jmax,jp1,jp2,k,kk,kw,kkw,kp,kstep,p, &
@@ -48961,7 +48961,7 @@ module stdlib_linalg_lapack_q
               ! for use in updating a11
               ! k is the main loop index, decreasing from n in steps of 1 or 2
               k = n
-10            continue
+              10 continue
               ! kw is the column of w which corresponds to column k of a
               kw = nb + k - n
               ! exit from loop
@@ -49000,12 +49000,12 @@ module stdlib_linalg_lapack_q
                  else
                     done = .false.
                     ! loop until pivot found
-12   continue
+                    12 continue
                        ! begin pivot search loop body
                        ! copy column imax to column kw-1 of w and update it
                        call stdlib_qcopy(imax,a(1,imax),1,w(1,kw - 1),1)
                        call stdlib_qcopy(k - imax,a(imax,imax + 1),lda,w(imax + 1,kw - 1),1)
-                                 
+
                        if (k < n) call stdlib_qgemv('NO TRANSPOSE',k,n - k,-one,a(1,k + 1),lda, &
                                  w(imax,kw + 1),ldw,one,w(1,kw - 1),1)
                        ! jmax is the column-index of the largest off-diagonal
@@ -49127,7 +49127,7 @@ module stdlib_linalg_lapack_q
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-30            continue
+              30 continue
               ! update the upper triangle of a11 (= a(1:k,1:k)) as
               ! a11 := a11 - u12*d*u12**t = a11 - u12*w**t
               ! computing blocks of nb columns at a time
@@ -49145,7 +49145,7 @@ module stdlib_linalg_lapack_q
               ! put u12 in standard form by partially undoing the interchanges
               ! in columns k+1:n
               j = k + 1
-60            continue
+              60 continue
                  kstep = 1
                  jp1 = 1
                  jj = j
@@ -49171,7 +49171,7 @@ module stdlib_linalg_lapack_q
               ! for use in updating a22
               ! k is the main loop index, increasing from 1 in steps of 1 or 2
               k = 1
-70            continue
+              70 continue
               ! exit from loop
               if ((k >= nb .and. nb < n) .or. k > n) go to 90
               kstep = 1
@@ -49208,7 +49208,7 @@ module stdlib_linalg_lapack_q
                  else
                     done = .false.
                     ! loop until pivot found
-72   continue
+                    72 continue
                        ! begin pivot search loop body
                        ! copy column imax to column k+1 of w and update it
                        call stdlib_qcopy(imax - k,a(imax,k),lda,w(k,k + 1),1)
@@ -49330,7 +49330,7 @@ module stdlib_linalg_lapack_q
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 70
-90            continue
+              90 continue
               ! update the lower triangle of a22 (= a(k:n,k:n)) as
               ! a22 := a22 - l21*d*l21**t = a22 - l21*w**t
               ! computing blocks of nb columns at a time
@@ -49348,7 +49348,7 @@ module stdlib_linalg_lapack_q
               ! put l21 in standard form by partially undoing the interchanges
               ! in columns 1:k-1
               j = k - 1
-120           continue
+              120 continue
                  kstep = 1
                  jp1 = 1
                  jj = j
@@ -49361,7 +49361,7 @@ module stdlib_linalg_lapack_q
                  end if
                  j = j - 1
                  if (jp2 /= jj .and. j >= 1) call stdlib_qswap(j,a(jp2,1),lda,a(jj,1),lda)
-                           
+
                  jj = j + 1
                  if (jp1 /= jj .and. kstep == 2) call stdlib_qswap(j,a(jp1,1),lda,a(jj,1), &
                            lda)
@@ -49419,7 +49419,7 @@ module stdlib_linalg_lapack_q
                  end do
               end do
            end if
-50         continue
+           50 continue
            return
      end subroutine stdlib_qlat2s
 
@@ -49448,7 +49448,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: ab(ldab,*)
            real(qp),intent(inout) :: cnorm(*),x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            integer(ilp) :: i,imax,j,jfirst,jinc,jlast,jlen,maind
@@ -49573,7 +49573,7 @@ module stdlib_linalg_lapack_q
                     grow = grow*(one/(one + cnorm(j)))
                  end do
               end if
-50            continue
+              50 continue
            else
               ! compute the growth in a**t * x = b.
               if (upper) then
@@ -49620,7 +49620,7 @@ module stdlib_linalg_lapack_q
                     grow = grow/xj
                  end do
               end if
-80            continue
+              80 continue
            end if
            if ((grow*tscal) > smlnum) then
               ! use the level 2 blas solve if the reciprocal of the bound on
@@ -49688,7 +49688,7 @@ module stdlib_linalg_lapack_q
                        scale = zero
                        xmax = zero
                     end if
-100                 continue
+                    100 continue
                     ! scale x if necessary to avoid overflow when adding a
                     ! multiple of column j of a.
                     if (xj > one) then
@@ -49764,7 +49764,7 @@ module stdlib_linalg_lapack_q
                        else
                           jlen = min(kd,n - j)
                           if (jlen > 0) sumj = stdlib_qdot(jlen,ab(2,j),1,x(j + 1),1)
-                                    
+
                        end if
                     else
                        ! otherwise, use in-line code for the dot product.
@@ -49825,7 +49825,7 @@ module stdlib_linalg_lapack_q
                           scale = zero
                           xmax = zero
                        end if
-150                    continue
+                       150 continue
                     else
                        ! compute x(j) := x(j) / a(j,j) - sumj if the dot
                        ! product has already been divided by 1/a(j,j).
@@ -49865,7 +49865,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: maxdim = 8
-           
+
            ! Local Scalars
            integer(ilp) :: i,info,j,k
            real(qp) :: bm,bp,pmone,sminu,splus,temp
@@ -49964,7 +49964,7 @@ module stdlib_linalg_lapack_q
      !> then s is set to 0 and a non-trivial solution to A*x = 0 is returned.
 
      pure subroutine stdlib_qlatps(uplo,trans,diag,normin,n,ap,x,scale,cnorm,info)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -49977,7 +49977,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: ap(*)
            real(qp),intent(inout) :: cnorm(*),x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            integer(ilp) :: i,imax,ip,j,jfirst,jinc,jlast,jlen
@@ -50099,7 +50099,7 @@ module stdlib_linalg_lapack_q
                     grow = grow*(one/(one + cnorm(j)))
                  end do
               end if
-50            continue
+              50 continue
            else
               ! compute the growth in a**t * x = b.
               if (upper) then
@@ -50148,7 +50148,7 @@ module stdlib_linalg_lapack_q
                     grow = grow/xj
                  end do
               end if
-80            continue
+              80 continue
            end if
            if ((grow*tscal) > smlnum) then
               ! use the level 2 blas solve if the reciprocal of the bound on
@@ -50217,7 +50217,7 @@ module stdlib_linalg_lapack_q
                        scale = zero
                        xmax = zero
                     end if
-100                 continue
+                    100 continue
                     ! scale x if necessary to avoid overflow when adding a
                     ! multiple of column j of a.
                     if (xj > one) then
@@ -50247,7 +50247,7 @@ module stdlib_linalg_lapack_q
                           ! compute the update
                              ! x(j+1:n) := x(j+1:n) - x(j) * a(j+1:n,j)
                           call stdlib_qaxpy(n - j,-x(j)*tscal,ap(ip + 1),1,x(j + 1),1)
-                                    
+
                           i = j + stdlib_iqamax(n - j,x(j + 1),1)
                           xmax = abs(x(i))
                        end if
@@ -50350,7 +50350,7 @@ module stdlib_linalg_lapack_q
                           scale = zero
                           xmax = zero
                        end if
-150                    continue
+                       150 continue
                     else
                        ! compute x(j) := x(j) / a(j,j)  - sumj if the dot
                        ! product has already been divided by 1/a(j,j).
@@ -50391,7 +50391,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: e(*),tau(*),w(ldw,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,iw
            real(qp) :: alpha
@@ -50432,7 +50432,7 @@ module stdlib_linalg_lapack_q
                     end if
                     call stdlib_qscal(i - 1,tau(i - 1),w(1,iw),1)
                     alpha = -half*tau(i - 1)*stdlib_qdot(i - 1,w(1,iw),1,a(1,i),1)
-                              
+
                     call stdlib_qaxpy(i - 1,alpha,a(1,i),1,w(1,iw),1)
                  end if
               end do loop_10
@@ -50448,7 +50448,7 @@ module stdlib_linalg_lapack_q
                     ! generate elementary reflector h(i) to annihilate
                     ! a(i+2:n,i)
                     call stdlib_qlarfg(n - i,a(i + 1,i),a(min(i + 2,n),i),1,tau(i))
-                              
+
                     e(i) = a(i + 1,i)
                     a(i + 1,i) = one
                     ! compute w(i+1:n,i)
@@ -50464,7 +50464,7 @@ module stdlib_linalg_lapack_q
                                1,one,w(i + 1,i),1)
                     call stdlib_qscal(n - i,tau(i),w(i + 1,i),1)
                     alpha = -half*tau(i)*stdlib_qdot(n - i,w(i + 1,i),1,a(i + 1,i),1)
-                              
+
                     call stdlib_qaxpy(n - i,alpha,a(i + 1,i),1,w(i + 1,i),1)
                  end if
               end do
@@ -50484,7 +50484,7 @@ module stdlib_linalg_lapack_q
      !> non-trivial solution to A*x = 0 is returned.
 
      pure subroutine stdlib_qlatrs(uplo,trans,diag,normin,n,a,lda,x,scale,cnorm,info)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -50497,7 +50497,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: a(lda,*)
            real(qp),intent(inout) :: cnorm(*),x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            integer(ilp) :: i,imax,j,jfirst,jinc,jlast
@@ -50613,7 +50613,7 @@ module stdlib_linalg_lapack_q
                     grow = grow*(one/(one + cnorm(j)))
                  end do
               end if
-50            continue
+              50 continue
            else
               ! compute the growth in a**t * x = b.
               if (upper) then
@@ -50658,7 +50658,7 @@ module stdlib_linalg_lapack_q
                     grow = grow/xj
                  end do
               end if
-80            continue
+              80 continue
            end if
            if ((grow*tscal) > smlnum) then
               ! use the level 2 blas solve if the reciprocal of the bound on
@@ -50726,7 +50726,7 @@ module stdlib_linalg_lapack_q
                        scale = zero
                        xmax = zero
                     end if
-100                 continue
+                    100 continue
                     ! scale x if necessary to avoid overflow when adding a
                     ! multiple of column j of a.
                     if (xj > one) then
@@ -50755,7 +50755,7 @@ module stdlib_linalg_lapack_q
                           ! compute the update
                              ! x(j+1:n) := x(j+1:n) - x(j) * a(j+1:n,j)
                           call stdlib_qaxpy(n - j,-x(j)*tscal,a(j + 1,j),1,x(j + 1),1)
-                                    
+
                           i = j + stdlib_iqamax(n - j,x(j + 1),1)
                           xmax = abs(x(i))
                        end if
@@ -50855,7 +50855,7 @@ module stdlib_linalg_lapack_q
                           scale = zero
                           xmax = zero
                        end if
-150                    continue
+                       150 continue
                     else
                        ! compute x(j) := x(j) / a(j,j)  - sumj if the dot
                        ! product has already been divided by 1/a(j,j).
@@ -50888,7 +50888,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            ! Executable Statements
@@ -51018,7 +51018,7 @@ module stdlib_linalg_lapack_q
            ! Array Arguments
            real(qp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i
@@ -51090,7 +51090,7 @@ module stdlib_linalg_lapack_q
            ! Array Arguments
            real(qp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,ib,nb
@@ -51171,7 +51171,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: ap(*),tau(*)
            real(qp),intent(out) :: q(ldq,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,iinfo,ij,j
@@ -51264,7 +51264,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: tau(*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: forwrd,left,notran,upper
            integer(ilp) :: i,i1,i2,i3,ic,ii,jc,mi,ni,nq
@@ -51375,7 +51375,7 @@ module stdlib_linalg_lapack_q
                  end if
                  ! apply h(i)
                  call stdlib_qlarf(side,mi,ni,ap(ii),1,tau(i),c(ic,jc),ldc,work)
-                           
+
                  ap(ii) = aii
                  if (forwrd) then
                     ii = ii + nq - i + 1
@@ -51417,11 +51417,11 @@ module stdlib_linalg_lapack_q
            real(qp),intent(out) :: phi(*),theta(*)
            real(qp),intent(out) :: taup1(*),taup2(*),tauq1(*),tauq2(*),work(*)
            real(qp),intent(inout) :: x11(ldx11,*),x12(ldx12,*),x21(ldx21,*),x22(ldx22,*)
-                     
+
         ! ====================================================================
            ! Parameters
            real(qp),parameter :: realone = 1.0_qp
-           
+
            ! Local Scalars
            logical(lk) :: colmajor,lquery
            integer(ilp) :: i,lworkmin,lworkopt
@@ -51491,7 +51491,7 @@ module stdlib_linalg_lapack_q
                  else
                     call stdlib_qscal(p - i + 1,z1*cos(phi(i - 1)),x11(i,i),1)
                     call stdlib_qaxpy(p - i + 1,-z1*z3*z4*sin(phi(i - 1)),x12(i,i - 1),1,x11(i,i),1)
-                              
+
                  end if
                  if (i == 1) then
                     call stdlib_qscal(m - p - i + 1,z2,x21(i,i),1)
@@ -51553,7 +51553,7 @@ module stdlib_linalg_lapack_q
                        call stdlib_qlarfgp(m - q - i + 1,x12(i,i),x12(i,i),ldx12,tauq2(i))
                     else
                        call stdlib_qlarfgp(m - q - i + 1,x12(i,i),x12(i,i + 1),ldx12,tauq2(i))
-                                 
+
                     end if
                  end if
                  x12(i,i) = one
@@ -51593,7 +51593,7 @@ module stdlib_linalg_lapack_q
                  call stdlib_qscal(m - p - q - i + 1,z2*z4,x22(q + i,p + i),ldx22)
                  if (i == m - p - q) then
                     call stdlib_qlarfgp(m - p - q - i + 1,x22(q + i,p + i),x22(q + i,p + i),ldx22,tauq2(p + i))
-                              
+
                  else
                     call stdlib_qlarfgp(m - p - q - i + 1,x22(q + i,p + i),x22(q + i,p + i + 1),ldx22,tauq2(p + i) &
                                )
@@ -51650,11 +51650,11 @@ module stdlib_linalg_lapack_q
                  if (i < q) then
                     call stdlib_qscal(q - i,-z1*z3*sin(theta(i)),x11(i + 1,i),1)
                     call stdlib_qaxpy(q - i,z2*z3*cos(theta(i)),x21(i + 1,i),1,x11(i + 1,i),1)
-                              
+
                  end if
                  call stdlib_qscal(m - q - i + 1,-z1*z4*sin(theta(i)),x12(i,i),1)
                  call stdlib_qaxpy(m - q - i + 1,z2*z4*cos(theta(i)),x22(i,i),1,x12(i,i),1)
-                           
+
                  if (i < q) phi(i) = atan2(stdlib_qnrm2(q - i,x11(i + 1,i),1),stdlib_qnrm2(m - q - &
                            i + 1,x12(i,i),1))
                  if (i < q) then
@@ -51701,10 +51701,10 @@ module stdlib_linalg_lapack_q
                  call stdlib_qscal(m - p - q - i + 1,z2*z4,x22(p + i,q + i),1)
                  if (m - p - q == i) then
                     call stdlib_qlarfgp(m - p - q - i + 1,x22(p + i,q + i),x22(p + i,q + i),1,tauq2(p + i))
-                              
+
                  else
                     call stdlib_qlarfgp(m - p - q - i + 1,x22(p + i,q + i),x22(p + i + 1,q + i),1,tauq2(p + i))
-                              
+
                     call stdlib_qlarf('L',m - p - q - i + 1,m - p - q - i,x22(p + i,q + i),1,tauq2(p + i),x22(p + &
                               i,q + i + 1),ldx22,work)
                  end if
@@ -51743,7 +51743,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(out) :: taup1(*),taup2(*),tauq1(*),work(*)
            real(qp),intent(inout) :: x11(ldx11,*),x21(ldx21,*)
         ! ====================================================================
-           
+
            ! Local Scalars
            real(qp) :: c,s
            integer(ilp) :: childinfo,i,ilarf,iorbdb5,llarf,lorbdb5,lworkmin, &
@@ -51846,7 +51846,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(out) :: taup1(*),taup2(*),tauq1(*),work(*)
            real(qp),intent(inout) :: x11(ldx11,*),x21(ldx21,*)
         ! ====================================================================
-           
+
            ! Local Scalars
            real(qp) :: c,s
            integer(ilp) :: childinfo,i,ilarf,iorbdb5,llarf,lorbdb5,lworkmin, &
@@ -51959,7 +51959,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(out) :: taup1(*),taup2(*),tauq1(*),work(*)
            real(qp),intent(inout) :: x11(ldx11,*),x21(ldx21,*)
         ! ====================================================================
-           
+
            ! Local Scalars
            real(qp) :: c,s
            integer(ilp) :: childinfo,i,ilarf,iorbdb5,llarf,lorbdb5,lworkmin, &
@@ -52071,7 +52071,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(out) :: phantom(*),taup1(*),taup2(*),tauq1(*),work(*)
            real(qp),intent(inout) :: x11(ldx11,*),x21(ldx21,*)
         ! ====================================================================
-           
+
            ! Local Scalars
            real(qp) :: c,s
            integer(ilp) :: childinfo,i,ilarf,iorbdb5,j,llarf,lorbdb5,lworkmin, &
@@ -52131,7 +52131,7 @@ module stdlib_linalg_lapack_q
                  phantom(1) = one
                  phantom(p + 1) = one
                  call stdlib_qlarf('L',p,q,phantom(1),1,taup1(1),x11,ldx11,work(ilarf))
-                           
+
                  call stdlib_qlarf('L',m - p,q,phantom(p + 1),1,taup2(1),x21,ldx21,work(ilarf) &
                             )
               else
@@ -52176,7 +52176,7 @@ module stdlib_linalg_lapack_q
            ! reduce the bottom-right portion of x21 to [ 0 i ]
            do i = p + 1,q
               call stdlib_qlarfgp(q - i + 1,x21(m - q + i - p,i),x21(m - q + i - p,i + 1),ldx21,tauq1(i))
-                        
+
               x21(m - q + i - p,i) = one
               call stdlib_qlarf('R',q - i,q - i + 1,x21(m - q + i - p,i),ldx21,tauq1(i),x21(m - q + i - p + 1,i) &
                         ,ldx21,work(ilarf))
@@ -52209,7 +52209,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(out) :: work(*)
            real(qp),intent(inout) :: x1(*),x2(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: childinfo,i,j
            ! Intrinsic Function
@@ -52310,7 +52310,7 @@ module stdlib_linalg_lapack_q
            real(qp),parameter :: alphasq = 0.01_qp
            real(qp),parameter :: realone = 1.0_qp
            real(qp),parameter :: realzero = 0.0_qp
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(qp) :: normsq1,normsq2,scl1,scl2,ssq1,ssq2
@@ -52439,11 +52439,11 @@ module stdlib_linalg_lapack_q
            integer(ilp),intent(out) :: iwork(*)
            real(qp),intent(out) :: theta(*)
            real(qp),intent(out) :: u1(ldu1,*),u2(ldu2,*),v1t(ldv1t,*),v2t(ldv2t,*),work(*)
-                     
+
            real(qp),intent(inout) :: x11(ldx11,*),x12(ldx12,*),x21(ldx21,*),x22(ldx22,*)
-                     
+
         ! ===================================================================
-           
+
            ! Local Scalars
            character :: transt,signst
            integer(ilp) :: childinfo,i,ib11d,ib11e,ib12d,ib12e,ib21d,ib21e,ib22d,ib22e, &
@@ -52641,7 +52641,7 @@ module stdlib_linalg_lapack_q
               if (wantv2t .and. m - q > 0) then
                  call stdlib_qlacpy('L',m - q,p,x12,ldx12,v2t,ldv2t)
                  call stdlib_qlacpy('L',m - p - q,m - p - q,x22(p + 1,q + 1),ldx22,v2t(p + 1,p + 1),ldv2t)
-                           
+
                  call stdlib_qorgqr(m - q,m - q,m - q,v2t,ldv2t,work(itauq2),work(iorgqr), &
                            lorgqrwork,info)
               end if
@@ -52716,7 +52716,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: x11(ldx11,*),x21(ldx21,*)
            integer(ilp),intent(out) :: iwork(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: childinfo,i,ib11d,ib11e,ib12d,ib12e,ib21d,ib21e,ib22d,ib22e, &
            ibbcsd,iorbdb,iorglq,iorgqr,iphi,itaup1,itaup2,itauq1,j,lbbcsd,lorbdb, &
@@ -52801,13 +52801,13 @@ module stdlib_linalg_lapack_q
                  end if
                  if (wantu2 .and. m - p > 0) then
                     call stdlib_qorgqr(m - p,m - p,q,u2,ldu2,dum1,work(1),-1,childinfo)
-                              
+
                     lorgqrmin = max(lorgqrmin,m - p)
                     lorgqropt = max(lorgqropt,int(work(1),KIND=ilp))
                  end if
                  if (wantv1t .and. q > 0) then
                     call stdlib_qorglq(q - 1,q - 1,q - 1,v1t,ldv1t,dum1,work(1),-1,childinfo)
-                              
+
                     lorglqmin = max(lorglqmin,q - 1)
                     lorglqopt = max(lorglqopt,int(work(1),KIND=ilp))
                  end if
@@ -52827,7 +52827,7 @@ module stdlib_linalg_lapack_q
                  end if
                  if (wantu2 .and. m - p > 0) then
                     call stdlib_qorgqr(m - p,m - p,q,u2,ldu2,dum1,work(1),-1,childinfo)
-                              
+
                     lorgqrmin = max(lorgqrmin,m - p)
                     lorgqropt = max(lorgqropt,int(work(1),KIND=ilp))
                  end if
@@ -52875,7 +52875,7 @@ module stdlib_linalg_lapack_q
                  end if
                  if (wantu2 .and. m - p > 0) then
                     call stdlib_qorgqr(m - p,m - p,m - q,u2,ldu2,dum1,work(1),-1,childinfo)
-                              
+
                     lorgqrmin = max(lorgqrmin,m - p)
                     lorgqropt = max(lorgqropt,int(work(1),KIND=ilp))
                  end if
@@ -53044,7 +53044,7 @@ module stdlib_linalg_lapack_q
               ! simultaneously bidiagonalize x11 and x21
               call stdlib_qorbdb4(m,p,q,x11,ldx11,x21,ldx21,theta,work(iphi),work(itaup1) &
               ,work(itaup2),work(itauq1),work(iorbdb),work(iorbdb + m),lorbdb - m,childinfo)
-                        
+
               ! accumulate householder reflectors
               if (wantu2 .and. m - p > 0) then
                  call stdlib_qcopy(m - p,work(iorbdb + p),1,u2,1)
@@ -53071,7 +53071,7 @@ module stdlib_linalg_lapack_q
                  call stdlib_qlacpy('U',p - (m - q),q - (m - q),x11(m - q + 1,m - q + 1),ldx11,v1t(m - q + 1,m - q + &
                            1),ldv1t)
                  call stdlib_qlacpy('U',-p + q,q - p,x21(m - q + 1,p + 1),ldx21,v1t(p + 1,p + 1),ldv1t)
-                           
+
                  call stdlib_qorglq(q,q,q,v1t,ldv1t,work(itauq1),work(iorglq),lorglq, &
                            childinfo)
               end if
@@ -53118,7 +53118,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: tau(*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,ii,j,l
            ! Intrinsic Functions
@@ -53153,7 +53153,7 @@ module stdlib_linalg_lapack_q
               ! apply h(i) to a(1:m-k+i,1:n-k+i) from the left
               a(m - n + ii,ii) = one
               call stdlib_qlarf('LEFT',m - n + ii,ii - 1,a(1,ii),1,tau(i),a,lda,work)
-                        
+
               call stdlib_qscal(m - n + ii - 1,-tau(i),a(1,ii),1)
               a(m - n + ii,ii) = one - tau(i)
               ! set a(m-k+i+1:m,n-k+i) to zero
@@ -53182,7 +53182,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: tau(*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,l
            ! Intrinsic Functions
@@ -53259,7 +53259,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: tau(*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wantq
            integer(ilp) :: i,iinfo,j,lwkopt,mn
@@ -53343,7 +53343,7 @@ module stdlib_linalg_lapack_q
                  if (m > 1) then
                     ! form q(2:m,2:m)
                     call stdlib_qorgqr(m - 1,m - 1,m - 1,a(2,2),lda,tau,work,lwork,iinfo)
-                              
+
                  end if
               end if
            else
@@ -53370,7 +53370,7 @@ module stdlib_linalg_lapack_q
                  if (n > 1) then
                     ! form p**t(2:n,2:n)
                     call stdlib_qorglq(n - 1,n - 1,n - 1,a(2,2),lda,tau,work,lwork,iinfo)
-                              
+
                  end if
               end if
            end if
@@ -53395,7 +53395,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: tau(*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,iinfo,j,lwkopt,nb,nh
@@ -53486,7 +53486,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: tau(*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,l
            ! Intrinsic Functions
@@ -53555,7 +53555,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: tau(*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,iinfo,iws,j,ki,kk,l,ldwork,lwkopt,nb,nbmin,nx
@@ -53637,7 +53637,7 @@ module stdlib_linalg_lapack_q
                     ! apply h**t to a(i+ib:m,i:n) from the right
                     call stdlib_qlarfb('RIGHT','TRANSPOSE','FORWARD','ROWWISE',m - i - ib + 1,n - i + &
                     1,ib,a(i,i),lda,work,ldwork,a(i + ib,i),lda,work(ib + 1),ldwork)
-                              
+
                  end if
                  ! apply h**t to columns i:n of current block
                  call stdlib_qorgl2(ib,n - i + 1,ib,a(i,i),lda,tau(i),work,iinfo)
@@ -53671,7 +53671,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: tau(*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,iinfo,iws,j,kk,l,ldwork,lwkopt,nb,nbmin,nx
@@ -53757,7 +53757,7 @@ module stdlib_linalg_lapack_q
                     ! apply h to a(1:m-k+i+ib-1,1:n-k+i-1) from the left
                     call stdlib_qlarfb('LEFT','NO TRANSPOSE','BACKWARD','COLUMNWISE',m - k + i + ib - &
                     1,n - k + i - 1,ib,a(1,n - k + i),lda,work,ldwork,a,lda,work(ib + 1),ldwork)
-                              
+
                  end if
                  ! apply h to rows 1:m-k+i+ib-1 of current block
                  call stdlib_qorg2l(m - k + i + ib - 1,ib,ib,a(1,n - k + i),lda,tau(i),work,iinfo &
@@ -53792,7 +53792,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: tau(*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,iinfo,iws,j,ki,kk,l,ldwork,lwkopt,nb,nbmin,nx
@@ -53908,7 +53908,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: tau(*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,ii,j,l
            ! Intrinsic Functions
@@ -53945,7 +53945,7 @@ module stdlib_linalg_lapack_q
               ! apply h(i) to a(1:m-k+i,1:n-k+i) from the right
               a(ii,n - m + ii) = one
               call stdlib_qlarf('RIGHT',ii - 1,n - m + ii,a(ii,1),lda,tau(i),a,lda,work)
-                        
+
               call stdlib_qscal(n - m + ii - 1,-tau(i),a(ii,1),lda)
               a(ii,n - m + ii) = one - tau(i)
               ! set a(m-k+i,n-k+i+1:n) to zero
@@ -53974,7 +53974,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: tau(*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,ii,iinfo,iws,j,kk,l,ldwork,lwkopt,nb,nbmin,nx
@@ -54064,7 +54064,7 @@ module stdlib_linalg_lapack_q
                  end if
                  ! apply h**t to columns 1:n-k+i+ib-1 of current block
                  call stdlib_qorgr2(ib,n - k + i + ib - 1,ib,a(ii,1),lda,tau(i),work,iinfo)
-                           
+
                  ! set columns n-k+i+ib:n of current block to zero
                  do l = n - k + i + ib,n
                     do j = ii,ii + ib - 1
@@ -54096,7 +54096,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: tau(*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper
            integer(ilp) :: i,iinfo,j,lwkopt,nb
@@ -54171,7 +54171,7 @@ module stdlib_linalg_lapack_q
               if (n > 1) then
                  ! generate q(2:n,2:n)
                  call stdlib_qorgqr(n - 1,n - 1,n - 1,a(2,2),lda,tau,work,lwork,iinfo)
-                           
+
               end if
            end if
            work(1) = lwkopt
@@ -54196,7 +54196,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: t(ldt,*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: iinfo,ldc,lworkopt,lc,lw,nblocal,j
@@ -54304,7 +54304,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: t(ldt,*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: nblocal,mb2,m_plus_one,itmp,ib_bottom,lworkopt, &
@@ -54440,7 +54440,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: d(*),t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,iinfo,j,jb,jbtemp1,jbtemp2,jnb,nplusone
            ! Intrinsic Functions
@@ -54480,7 +54480,7 @@ module stdlib_linalg_lapack_q
            ! (1-2) solve for v2.
            if (m > n) then
               call stdlib_qtrsm('R','U','N','N',m - n,n,one,a,lda,a(n + 1,1),lda)
-                        
+
            end if
            ! (2) reconstruct the block reflector t stored in t(1:nb, 1:n)
            ! as a sequence of upper-triangular blocks with nb-size column
@@ -54557,7 +54557,7 @@ module stdlib_linalg_lapack_q
      end subroutine stdlib_qorhr_col
 
      pure subroutine stdlib_qorm22(side,trans,m,n,n1,n2,q,ldq,c,ldc,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -54570,7 +54570,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: c(ldc,*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            integer(ilp) :: i,ldwork,len,lwkopt,nb,nq,nw
@@ -54629,12 +54629,12 @@ module stdlib_linalg_lapack_q
            ! degenerate cases (n1 = 0 or n2 = 0) are handled using stdlib_qtrmm.
            if (n1 == 0) then
               call stdlib_qtrmm(side,'UPPER',trans,'NON-UNIT',m,n,one,q,ldq,c,ldc)
-                        
+
               work(1) = one
               return
            else if (n2 == 0) then
               call stdlib_qtrmm(side,'LOWER',trans,'NON-UNIT',m,n,one,q,ldq,c,ldc)
-                        
+
               work(1) = one
               return
            end if
@@ -54654,7 +54654,7 @@ module stdlib_linalg_lapack_q
                                1,i),ldc,one,work,ldwork)
                     ! multiply top part of c by q21.
                     call stdlib_qlacpy('ALL',n2,len,c(1,i),ldc,work(n1 + 1),ldwork)
-                              
+
                     call stdlib_qtrmm('LEFT','UPPER','NO TRANSPOSE','NON-UNIT',n2,len,one, &
                               q(n1 + 1,1),ldq,work(n1 + 1),ldwork)
                     ! multiply bottom part of c by q22.
@@ -54676,7 +54676,7 @@ module stdlib_linalg_lapack_q
                                i),ldc,one,work,ldwork)
                     ! multiply top part of c by q12**t.
                     call stdlib_qlacpy('ALL',n1,len,c(1,i),ldc,work(n2 + 1),ldwork)
-                              
+
                     call stdlib_qtrmm('LEFT','LOWER','TRANSPOSE','NON-UNIT',n1,len,one,q( &
                               1,n2 + 1),ldq,work(n2 + 1),ldwork)
                     ! multiply bottom part of c by q22**t.
@@ -54761,7 +54761,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: tau(*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: left,notran
            integer(ilp) :: i,i1,i2,i3,mi,ni,nq
@@ -54855,7 +54855,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: tau(*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: left,notran
            integer(ilp) :: i,i1,i2,i3,ic,jc,mi,ni,nq
@@ -54924,7 +54924,7 @@ module stdlib_linalg_lapack_q
               aii = a(i,i)
               a(i,i) = one
               call stdlib_qlarf(side,mi,ni,a(i,i),1,tau(i),c(ic,jc),ldc,work)
-                        
+
               a(i,i) = aii
            end do
            return
@@ -55211,7 +55211,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: tau(*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: left,notran
            integer(ilp) :: i,i1,i2,i3,ic,jc,mi,ni,nq
@@ -55280,7 +55280,7 @@ module stdlib_linalg_lapack_q
               aii = a(i,i)
               a(i,i) = one
               call stdlib_qlarf(side,mi,ni,a(i,i),lda,tau(i),c(ic,jc),ldc,work)
-                        
+
               a(i,i) = aii
            end do
            return
@@ -55297,7 +55297,7 @@ module stdlib_linalg_lapack_q
      !> if SIDE = 'R'.
 
      pure subroutine stdlib_qormlq(side,trans,m,n,k,a,lda,tau,c,ldc,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -55314,7 +55314,7 @@ module stdlib_linalg_lapack_q
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            character :: transt
@@ -55440,7 +55440,7 @@ module stdlib_linalg_lapack_q
      !> if SIDE = 'R'.
 
      pure subroutine stdlib_qormql(side,trans,m,n,k,a,lda,tau,c,ldc,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -55457,7 +55457,7 @@ module stdlib_linalg_lapack_q
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            integer(ilp) :: i,i1,i2,i3,ib,iinfo,iwt,ldwork,lwkopt,mi,nb,nbmin,ni,nq, &
@@ -55501,7 +55501,7 @@ module stdlib_linalg_lapack_q
                  lwkopt = 1
               else
                  nb = min(nbmax,stdlib_ilaenv(1,'DORMQL',side//trans,m,n,k,-1))
-                           
+
                  lwkopt = nw*nb + tsize
               end if
               work(1) = lwkopt
@@ -55577,7 +55577,7 @@ module stdlib_linalg_lapack_q
      !> if SIDE = 'R'.
 
      pure subroutine stdlib_qormqr(side,trans,m,n,k,a,lda,tau,c,ldc,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -55594,7 +55594,7 @@ module stdlib_linalg_lapack_q
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            integer(ilp) :: i,i1,i2,i3,ib,ic,iinfo,iwt,jc,ldwork,lwkopt,mi,nb,nbmin, &
@@ -55727,7 +55727,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: tau(*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: left,notran
            integer(ilp) :: i,i1,i2,i3,mi,ni,nq
@@ -55809,7 +55809,7 @@ module stdlib_linalg_lapack_q
      !> if SIDE = 'R'.
 
      pure subroutine stdlib_qormr3(side,trans,m,n,k,l,a,lda,tau,c,ldc,work,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -55907,7 +55907,7 @@ module stdlib_linalg_lapack_q
      !> if SIDE = 'R'.
 
      pure subroutine stdlib_qormrq(side,trans,m,n,k,a,lda,tau,c,ldc,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -55924,7 +55924,7 @@ module stdlib_linalg_lapack_q
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            character :: transt
@@ -55969,7 +55969,7 @@ module stdlib_linalg_lapack_q
                  lwkopt = 1
               else
                  nb = min(nbmax,stdlib_ilaenv(1,'DORMRQ',side//trans,m,n,k,-1))
-                           
+
                  lwkopt = nw*nb + tsize
               end if
               work(1) = lwkopt
@@ -56067,7 +56067,7 @@ module stdlib_linalg_lapack_q
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            character :: transt
@@ -56114,7 +56114,7 @@ module stdlib_linalg_lapack_q
                  lwkopt = 1
               else
                  nb = min(nbmax,stdlib_ilaenv(1,'DORMRQ',side//trans,m,n,k,-1))
-                           
+
                  lwkopt = nw*nb + tsize
               end if
               work(1) = lwkopt
@@ -56141,7 +56141,7 @@ module stdlib_linalg_lapack_q
            if (nb < nbmin .or. nb >= k) then
               ! use unblocked code
               call stdlib_qormr3(side,trans,m,n,k,l,a,lda,tau,c,ldc,work,iinfo)
-                        
+
            else
               ! use blocked code
               iwt = 1 + nw*nb
@@ -56315,7 +56315,7 @@ module stdlib_linalg_lapack_q
      !> condition number is computed as RCOND = 1 / (ANORM * norm(inv(A))).
 
      pure subroutine stdlib_qpbcon(uplo,n,kd,ab,ldab,anorm,rcond,work,iwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -56330,7 +56330,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: ab(ldab,*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            character :: normin
@@ -56371,7 +56371,7 @@ module stdlib_linalg_lapack_q
            ! estimate the 1-norm of the inverse.
            kase = 0
            normin = 'N'
-10         continue
+           10 continue
            call stdlib_qlacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               if (upper) then
@@ -56402,7 +56402,7 @@ module stdlib_linalg_lapack_q
            end if
            ! compute the estimate of the reciprocal condition number.
            if (ainvnm /= zero) rcond = (one/ainvnm)/anorm
-20         continue
+           20 continue
            return
      end subroutine stdlib_qpbcon
 
@@ -56428,7 +56428,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: ab(ldab,*)
            real(qp),intent(out) :: s(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,j
@@ -56515,7 +56515,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,j,k,kase,l,nz
@@ -56567,12 +56567,12 @@ module stdlib_linalg_lapack_q
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_qcopy(n,b(1,j),1,work(n + 1),1)
               call stdlib_qsbmv(uplo,n,kd,-one,ab,ldab,x(1,j),1,one,work(n + 1),1)
-                        
+
               ! compute componentwise relative backward error from formula
               ! max(i) ( abs(r(i)) / ( abs(a)*abs(x) + abs(b) )(i) )
               ! where abs(z) is the componentwise absolute value of the matrix
@@ -56654,9 +56654,9 @@ module stdlib_linalg_lapack_q
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_qlacn2(n,work(2*n + 1),work(n + 1),iwork,ferr(j),kase,isave)
-                        
+
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(a**t).
@@ -56704,7 +56704,7 @@ module stdlib_linalg_lapack_q
            ! Array Arguments
            real(qp),intent(inout) :: ab(ldab,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,kld,km,m
@@ -56746,7 +56746,7 @@ module stdlib_linalg_lapack_q
                  ! the leading submatrix within the band.
                  call stdlib_qscal(km,one/ajj,ab(kd + 1 - km,j),1)
                  call stdlib_qsyr('UPPER',km,-one,ab(kd + 1 - km,j),1,ab(kd + 1,j - km),kld)
-                           
+
               end do
               ! factorize the updated submatrix a(1:m,1:m) as u**t*u.
               do j = 1,m
@@ -56761,7 +56761,7 @@ module stdlib_linalg_lapack_q
                  if (km > 0) then
                     call stdlib_qscal(km,one/ajj,ab(kd,j + 1),kld)
                     call stdlib_qsyr('UPPER',km,-one,ab(kd,j + 1),kld,ab(kd + 1,j + 1),kld)
-                              
+
                  end if
               end do
            else
@@ -56777,7 +56777,7 @@ module stdlib_linalg_lapack_q
                  ! trailing submatrix within the band.
                  call stdlib_qscal(km,one/ajj,ab(km + 1,j - km),kld)
                  call stdlib_qsyr('LOWER',km,-one,ab(km + 1,j - km),kld,ab(1,j - km),kld)
-                           
+
               end do
               ! factorize the updated submatrix a(1:m,1:m) as u**t*u.
               do j = 1,m
@@ -56796,7 +56796,7 @@ module stdlib_linalg_lapack_q
               end do
            end if
            return
-50         continue
+           50 continue
            info = j
            return
      end subroutine stdlib_qpbstf
@@ -56879,7 +56879,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: ab(ldab,*),afb(ldafb,*),b(ldb,*),s(*)
            real(qp),intent(out) :: berr(*),ferr(*),work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: equil,nofact,rcequ,upper
            integer(ilp) :: i,infequ,j,j1,j2
@@ -56968,7 +56968,7 @@ module stdlib_linalg_lapack_q
                  do j = 1,n
                     j1 = max(j - kd,1)
                     call stdlib_qcopy(j - j1 + 1,ab(kd + 1 - j + j1,j),1,afb(kd + 1 - j + j1,j),1)
-                              
+
                  end do
               else
                  do j = 1,n
@@ -57031,7 +57031,7 @@ module stdlib_linalg_lapack_q
            ! Array Arguments
            real(qp),intent(inout) :: ab(ldab,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,kld,kn
@@ -57072,7 +57072,7 @@ module stdlib_linalg_lapack_q
                  if (kn > 0) then
                     call stdlib_qscal(kn,one/ajj,ab(kd,j + 1),kld)
                     call stdlib_qsyr('UPPER',kn,-one,ab(kd,j + 1),kld,ab(kd + 1,j + 1),kld)
-                              
+
                  end if
               end do
            else
@@ -57093,7 +57093,7 @@ module stdlib_linalg_lapack_q
               end do
            end if
            return
-30         continue
+           30 continue
            info = j
            return
      end subroutine stdlib_qpbtf2
@@ -57119,7 +57119,7 @@ module stdlib_linalg_lapack_q
            ! Parameters
            integer(ilp),parameter :: nbmax = 32
            integer(ilp),parameter :: ldwork = nbmax + 1
-           
+
            ! Local Scalars
            integer(ilp) :: i,i2,i3,ib,ii,j,jj,nb
            ! Local Arrays
@@ -57292,7 +57292,7 @@ module stdlib_linalg_lapack_q
               end if
            end if
            return
-150        continue
+           150 continue
            return
      end subroutine stdlib_qpbtrf
 
@@ -57383,7 +57383,7 @@ module stdlib_linalg_lapack_q
            ! Array Arguments
            real(qp),intent(inout) :: a(0:*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,nisodd,normaltransr
            integer(ilp) :: n1,n2,k
@@ -57435,7 +57435,7 @@ module stdlib_linalg_lapack_q
                     call stdlib_qpotrf('L',n1,a(0),n,info)
                     if (info > 0) return
                     call stdlib_qtrsm('R','L','T','N',n2,n1,one,a(0),n,a(n1),n)
-                              
+
                     call stdlib_qsyrk('U','N',n2,n1,-one,a(n1),n,one,a(n),n)
                     call stdlib_qpotrf('U',n2,a(n),n,info)
                     if (info > 0) info = info + n1
@@ -57446,7 +57446,7 @@ module stdlib_linalg_lapack_q
                     call stdlib_qpotrf('L',n1,a(n2),n,info)
                     if (info > 0) return
                     call stdlib_qtrsm('L','L','N','N',n1,n2,one,a(n2),n,a(0),n)
-                              
+
                     call stdlib_qsyrk('U','T',n2,n1,-one,a(0),n,one,a(n1),n)
                     call stdlib_qpotrf('U',n2,a(n1),n,info)
                     if (info > 0) info = info + n1
@@ -57462,7 +57462,7 @@ module stdlib_linalg_lapack_q
                     call stdlib_qtrsm('L','U','T','N',n1,n2,one,a(0),n1,a(n1*n1),n1 &
                               )
                     call stdlib_qsyrk('L','T',n2,n1,-one,a(n1*n1),n1,one,a(1),n1)
-                              
+
                     call stdlib_qpotrf('L',n2,a(1),n1,info)
                     if (info > 0) info = info + n1
                  else
@@ -57474,7 +57474,7 @@ module stdlib_linalg_lapack_q
                     call stdlib_qtrsm('R','U','N','N',n2,n1,one,a(n2*n2),n2,a(0),n2 &
                               )
                     call stdlib_qsyrk('L','N',n2,n1,-one,a(0),n2,one,a(n1*n2),n2)
-                              
+
                     call stdlib_qpotrf('L',n2,a(n1*n2),n2,info)
                     if (info > 0) info = info + n1
                  end if
@@ -57490,9 +57490,9 @@ module stdlib_linalg_lapack_q
                     call stdlib_qpotrf('L',k,a(1),n + 1,info)
                     if (info > 0) return
                     call stdlib_qtrsm('R','L','T','N',k,k,one,a(1),n + 1,a(k + 1),n + 1)
-                              
+
                     call stdlib_qsyrk('U','N',k,k,-one,a(k + 1),n + 1,one,a(0),n + 1)
-                              
+
                     call stdlib_qpotrf('U',k,a(0),n + 1,info)
                     if (info > 0) info = info + k
                  else
@@ -57502,9 +57502,9 @@ module stdlib_linalg_lapack_q
                     call stdlib_qpotrf('L',k,a(k + 1),n + 1,info)
                     if (info > 0) return
                     call stdlib_qtrsm('L','L','N','N',k,k,one,a(k + 1),n + 1,a(0),n + 1)
-                              
+
                     call stdlib_qsyrk('U','T',k,k,-one,a(0),n + 1,one,a(k),n + 1)
-                              
+
                     call stdlib_qpotrf('U',k,a(k),n + 1,info)
                     if (info > 0) info = info + k
                  end if
@@ -57519,7 +57519,7 @@ module stdlib_linalg_lapack_q
                     call stdlib_qtrsm('L','U','T','N',k,k,one,a(k),n1,a(k*(k + 1)), &
                               k)
                     call stdlib_qsyrk('L','T',k,k,-one,a(k*(k + 1)),k,one,a(0),k)
-                              
+
                     call stdlib_qpotrf('L',k,a(0),k,info)
                     if (info > 0) info = info + k
                  else
@@ -57554,7 +57554,7 @@ module stdlib_linalg_lapack_q
            ! Array Arguments
            real(qp),intent(inout) :: a(0:*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,nisodd,normaltransr
            integer(ilp) :: n1,n2,k
@@ -57610,7 +57610,7 @@ module stdlib_linalg_lapack_q
                     call stdlib_qlauum('L',n1,a(0),n,info)
                     call stdlib_qsyrk('L','T',n1,n2,one,a(n1),n,one,a(0),n)
                     call stdlib_qtrmm('L','U','N','N',n2,n1,one,a(n),n,a(n1),n)
-                              
+
                     call stdlib_qlauum('U',n2,a(n),n,info)
                  else
                     ! srpa for upper, normal and n is odd ( a(0:n-1,0:n2-1)
@@ -57619,7 +57619,7 @@ module stdlib_linalg_lapack_q
                     call stdlib_qlauum('L',n1,a(n2),n,info)
                     call stdlib_qsyrk('L','N',n1,n2,one,a(0),n,one,a(n2),n)
                     call stdlib_qtrmm('R','U','T','N',n1,n2,one,a(n1),n,a(0),n)
-                              
+
                     call stdlib_qlauum('U',n2,a(n1),n,info)
                  end if
               else
@@ -57629,7 +57629,7 @@ module stdlib_linalg_lapack_q
                     ! t1 -> a(0), t2 -> a(1), s -> a(0+n1*n1)
                     call stdlib_qlauum('U',n1,a(0),n1,info)
                     call stdlib_qsyrk('U','N',n1,n2,one,a(n1*n1),n1,one,a(0),n1)
-                              
+
                     call stdlib_qtrmm('R','L','N','N',n1,n2,one,a(1),n1,a(n1*n1),n1 &
                               )
                     call stdlib_qlauum('L',n2,a(1),n1,info)
@@ -57638,7 +57638,7 @@ module stdlib_linalg_lapack_q
                     ! t1 -> a(0+n2*n2), t2 -> a(0+n1*n2), s -> a(0)
                     call stdlib_qlauum('U',n1,a(n2*n2),n2,info)
                     call stdlib_qsyrk('U','T',n1,n2,one,a(0),n2,one,a(n2*n2),n2)
-                              
+
                     call stdlib_qtrmm('L','L','T','N',n2,n1,one,a(n1*n2),n2,a(0),n2 &
                               )
                     call stdlib_qlauum('L',n2,a(n1*n2),n2,info)
@@ -57654,9 +57654,9 @@ module stdlib_linalg_lapack_q
                     ! t1 -> a(1), t2 -> a(0), s -> a(k+1)
                     call stdlib_qlauum('L',k,a(1),n + 1,info)
                     call stdlib_qsyrk('L','T',k,k,one,a(k + 1),n + 1,one,a(1),n + 1)
-                              
+
                     call stdlib_qtrmm('L','U','N','N',k,k,one,a(0),n + 1,a(k + 1),n + 1)
-                              
+
                     call stdlib_qlauum('U',k,a(0),n + 1,info)
                  else
                     ! srpa for upper, normal, and n is even ( a(0:n,0:k-1) )
@@ -57664,9 +57664,9 @@ module stdlib_linalg_lapack_q
                     ! t1 -> a(k+1), t2 -> a(k), s -> a(0)
                     call stdlib_qlauum('L',k,a(k + 1),n + 1,info)
                     call stdlib_qsyrk('L','N',k,k,one,a(0),n + 1,one,a(k + 1),n + 1)
-                              
+
                     call stdlib_qtrmm('R','U','T','N',k,k,one,a(k),n + 1,a(0),n + 1)
-                              
+
                     call stdlib_qlauum('U',k,a(k),n + 1,info)
                  end if
               else
@@ -57677,7 +57677,7 @@ module stdlib_linalg_lapack_q
                     ! t1 -> a(0+k), t2 -> a(0+0), s -> a(0+k*(k+1)); lda=k
                     call stdlib_qlauum('U',k,a(k),k,info)
                     call stdlib_qsyrk('U','N',k,k,one,a(k*(k + 1)),k,one,a(k),k)
-                              
+
                     call stdlib_qtrmm('R','L','N','N',k,k,one,a(0),k,a(k*(k + 1)),k &
                               )
                     call stdlib_qlauum('L',k,a(0),k,info)
@@ -57687,9 +57687,9 @@ module stdlib_linalg_lapack_q
                     ! t1 -> a(0+k*(k+1)), t2 -> a(0+k*k), s -> a(0+0)); lda=k
                     call stdlib_qlauum('U',k,a(k*(k + 1)),k,info)
                     call stdlib_qsyrk('U','T',k,k,one,a(0),k,one,a(k*(k + 1)),k)
-                              
+
                     call stdlib_qtrmm('L','L','T','N',k,k,one,a(k*k),k,a(0),k)
-                              
+
                     call stdlib_qlauum('L',k,a(k*k),k,info)
                  end if
               end if
@@ -57713,7 +57713,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: a(0:*)
            real(qp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,normaltransr
            ! Intrinsic Functions
@@ -57772,7 +57772,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            character :: normin
@@ -57811,7 +57811,7 @@ module stdlib_linalg_lapack_q
            ! estimate the 1-norm of inv(a).
            kase = 0
            normin = 'N'
-10         continue
+           10 continue
            call stdlib_qlacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               if (upper) then
@@ -57842,7 +57842,7 @@ module stdlib_linalg_lapack_q
            end if
            ! compute the estimate of the reciprocal condition number.
            if (ainvnm /= zero) rcond = (one/ainvnm)/anorm
-20         continue
+           20 continue
            return
      end subroutine stdlib_qpocon
 
@@ -57867,7 +57867,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: a(lda,*)
            real(qp),intent(out) :: s(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(qp) :: smin
@@ -57946,7 +57946,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: a(lda,*)
            real(qp),intent(out) :: s(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(qp) :: smin,base,tmp
@@ -58024,7 +58024,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,j,k,kase,nz
@@ -58074,7 +58074,7 @@ module stdlib_linalg_lapack_q
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_qcopy(n,b(1,j),1,work(n + 1),1)
@@ -58158,9 +58158,9 @@ module stdlib_linalg_lapack_q
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_qlacn2(n,work(2*n + 1),work(n + 1),iwork,ferr(j),kase,isave)
-                        
+
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(a**t).
@@ -58262,7 +58262,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*),af(ldaf,*),b(ldb,*),s(*)
            real(qp),intent(out) :: berr(*),ferr(*),work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: equil,nofact,rcequ
            integer(ilp) :: i,infequ,j
@@ -58400,7 +58400,7 @@ module stdlib_linalg_lapack_q
            ! Array Arguments
            real(qp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j
@@ -58462,9 +58462,9 @@ module stdlib_linalg_lapack_q
               end do
            end if
            go to 40
-30         continue
+           30 continue
            info = j
-40         continue
+           40 continue
            return
      end subroutine stdlib_qpotf2
 
@@ -58487,7 +58487,7 @@ module stdlib_linalg_lapack_q
            ! Array Arguments
            real(qp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,jb,nb
@@ -58556,9 +58556,9 @@ module stdlib_linalg_lapack_q
               end if
            end if
            go to 40
-30         continue
+           30 continue
            info = info + j - 1
-40         continue
+           40 continue
            return
      end subroutine stdlib_qpotrf
 
@@ -58587,7 +58587,7 @@ module stdlib_linalg_lapack_q
            ! Array Arguments
            real(qp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: n1,n2,iinfo
@@ -58717,7 +58717,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: a(lda,*)
            real(qp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            ! Intrinsic Functions
@@ -58785,7 +58785,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: ap(*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            character :: normin
@@ -58822,7 +58822,7 @@ module stdlib_linalg_lapack_q
            ! estimate the 1-norm of the inverse.
            kase = 0
            normin = 'N'
-10         continue
+           10 continue
            call stdlib_qlacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               if (upper) then
@@ -58853,7 +58853,7 @@ module stdlib_linalg_lapack_q
            end if
            ! compute the estimate of the reciprocal condition number.
            if (ainvnm /= zero) rcond = (one/ainvnm)/anorm
-20         continue
+           20 continue
            return
      end subroutine stdlib_qppcon
 
@@ -58879,7 +58879,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: ap(*)
            real(qp),intent(out) :: s(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,jj
@@ -58972,7 +58972,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,ik,j,k,kase,kk,nz
@@ -59018,7 +59018,7 @@ module stdlib_linalg_lapack_q
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_qcopy(n,b(1,j),1,work(n + 1),1)
@@ -59109,9 +59109,9 @@ module stdlib_linalg_lapack_q
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_qlacn2(n,work(2*n + 1),work(n + 1),iwork,ferr(j),kase,isave)
-                        
+
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(a**t).
@@ -59211,7 +59211,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: afp(*),ap(*),b(ldb,*),s(*)
            real(qp),intent(out) :: berr(*),ferr(*),work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: equil,nofact,rcequ
            integer(ilp) :: i,infequ,j
@@ -59344,7 +59344,7 @@ module stdlib_linalg_lapack_q
            ! Array Arguments
            real(qp),intent(inout) :: ap(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,jc,jj
@@ -59405,9 +59405,9 @@ module stdlib_linalg_lapack_q
               end do
            end if
            go to 40
-30         continue
+           30 continue
            info = j
-40         continue
+           40 continue
            return
      end subroutine stdlib_qpptrf
 
@@ -59426,7 +59426,7 @@ module stdlib_linalg_lapack_q
            ! Array Arguments
            real(qp),intent(inout) :: ap(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,jc,jj,jjn
@@ -59520,14 +59520,14 @@ module stdlib_linalg_lapack_q
                  call stdlib_qtpsv('UPPER','TRANSPOSE','NON-UNIT',n,ap,b(1,i),1)
                  ! solve u*x = b, overwriting b with x.
                  call stdlib_qtpsv('UPPER','NO TRANSPOSE','NON-UNIT',n,ap,b(1,i),1)
-                           
+
               end do
            else
               ! solve a*x = b where a = l * l**t.
               do i = 1,nrhs
                  ! solve l*y = b, overwriting b with x.
                  call stdlib_qtpsv('LOWER','NO TRANSPOSE','NON-UNIT',n,ap,b(1,i),1)
-                           
+
                  ! solve l**t *x = y, overwriting b with x.
                  call stdlib_qtpsv('LOWER','TRANSPOSE','NON-UNIT',n,ap,b(1,i),1)
               end do
@@ -59559,7 +59559,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(out) :: work(2*n)
            integer(ilp),intent(out) :: piv(n)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(qp) :: ajj,dstop,dtemp
            integer(ilp) :: i,itemp,j,pvt
@@ -59637,7 +59637,7 @@ module stdlib_linalg_lapack_q
                     a(pvt,pvt) = a(j,j)
                     call stdlib_qswap(j - 1,a(1,j),1,a(1,pvt),1)
                     if (pvt < n) call stdlib_qswap(n - pvt,a(j,pvt + 1),lda,a(pvt,pvt + 1),lda)
-                              
+
                     call stdlib_qswap(pvt - j - 1,a(j,j + 1),lda,a(j + 1,pvt),1)
                     ! swap dot products and piv
                     dtemp = work(j)
@@ -59682,7 +59682,7 @@ module stdlib_linalg_lapack_q
                     a(pvt,pvt) = a(j,j)
                     call stdlib_qswap(j - 1,a(j,1),lda,a(pvt,1),lda)
                     if (pvt < n) call stdlib_qswap(n - pvt,a(pvt + 1,j),1,a(pvt + 1,pvt),1)
-                              
+
                     call stdlib_qswap(pvt - j - 1,a(j + 1,j),1,a(pvt,j + 1),lda)
                     ! swap dot products and piv
                     dtemp = work(j)
@@ -59705,12 +59705,12 @@ module stdlib_linalg_lapack_q
            ! ran to completion, a has full rank
            rank = n
            go to 170
-160        continue
+           160 continue
            ! rank is number of steps completed.  set info = 1 to signal
            ! that the factorization cannot be used to solve a system.
            rank = j - 1
            info = 1
-170        continue
+           170 continue
            return
      end subroutine stdlib_qpstf2
 
@@ -59738,7 +59738,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(out) :: work(2*n)
            integer(ilp),intent(out) :: piv(n)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(qp) :: ajj,dstop,dtemp
            integer(ilp) :: i,itemp,j,jb,k,nb,pvt
@@ -59916,12 +59916,12 @@ module stdlib_linalg_lapack_q
            ! ran to completion, a has full rank
            rank = n
            go to 200
-190        continue
+           190 continue
            ! rank is the number of steps completed.  set info = 1 to signal
            ! that the factorization cannot be used to solve a system.
            rank = j - 1
            info = 1
-200        continue
+           200 continue
            return
      end subroutine stdlib_qpstrf
 
@@ -59946,7 +59946,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: d(*),e(*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,ix
            real(qp) :: ainvnm
@@ -60026,7 +60026,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: d(*),e(*),z(ldz,*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Arrays
            real(qp) :: c(1,1),vt(1,1)
            ! Local Scalars
@@ -60080,7 +60080,7 @@ module stdlib_linalg_lapack_q
               nru = 0
            end if
            call stdlib_qbdsqr('LOWER',n,0,nru,0,d,e,vt,1,z,ldz,c,1,work,info)
-                     
+
            ! square the singular values.
            if (info == 0) then
               do i = 1,n
@@ -60098,7 +60098,7 @@ module stdlib_linalg_lapack_q
      !> estimates for the solution.
 
      pure subroutine stdlib_qptrfs(n,nrhs,d,e,df,ef,b,ldb,x,ldx,ferr,berr,work,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -60112,7 +60112,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            integer(ilp) :: count,i,ix,j,nz
            real(qp) :: bi,cx,dx,eps,ex,lstres,s,safe1,safe2,safmin
@@ -60152,7 +60152,7 @@ module stdlib_linalg_lapack_q
            loop_90: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x.  also compute
               ! abs(a)*abs(x) + abs(b) for use in the backward error bound.
@@ -60323,7 +60323,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(out) :: berr(*),ferr(*),work(*),x(ldx,*)
            real(qp),intent(inout) :: df(*),ef(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nofact
            real(qp) :: anorm
@@ -60369,7 +60369,7 @@ module stdlib_linalg_lapack_q
            ! use iterative refinement to improve the computed solutions and
            ! compute error bounds and backward error estimates for them.
            call stdlib_qptrfs(n,nrhs,d,e,df,ef,b,ldb,x,ldx,ferr,berr,work,info)
-                     
+
            ! set info = n+1 if the matrix is singular to working precision.
            if (rcond < stdlib_qlamch('EPSILON')) info = n + 1
            return
@@ -60389,7 +60389,7 @@ module stdlib_linalg_lapack_q
            ! Array Arguments
            real(qp),intent(inout) :: d(*),e(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,i4
            real(qp) :: ei
@@ -60454,7 +60454,7 @@ module stdlib_linalg_lapack_q
            end do loop_20
            ! check d(n) for positive definiteness.
            if (d(n) <= zero) info = n
-30         continue
+           30 continue
            return
      end subroutine stdlib_qpttrf
 
@@ -60568,7 +60568,7 @@ module stdlib_linalg_lapack_q
            ! Array Arguments
            real(qp),intent(inout) :: sx(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: done
            real(qp) :: bignum,cden,cden1,cnum,cnum1,mul,smlnum
@@ -60584,7 +60584,7 @@ module stdlib_linalg_lapack_q
            ! initialize the denominator to sa and the numerator to 1.
            cden = sa
            cnum = one
-10         continue
+           10 continue
            cden1 = cden*smlnum
            cnum1 = cnum/bignum
            if (abs(cden1) > abs(cnum) .and. cnum /= zero) then
@@ -60624,7 +60624,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: v(*),tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,j1,j2,lm,ln,vpos,taupos,dpos,ofdpos,ajeter
@@ -60713,7 +60713,7 @@ module stdlib_linalg_lapack_q
                        a(ofdpos + i,st - 1) = zero
                    end do
                    call stdlib_qlarfg(lm,a(ofdpos,st - 1),v(vpos + 1),1,tau(taupos))
-                             
+
                    lm = ed - st + 1
                    call stdlib_qlarfy(uplo,lm,v(vpos),1, (tau(taupos)),a(dpos,st), &
                              lda - 1,work)
@@ -60744,7 +60744,7 @@ module stdlib_linalg_lapack_q
                            a(dpos + nb + i,st) = zero
                        end do
                        call stdlib_qlarfg(lm,a(dpos + nb,st),v(vpos + 1),1,tau(taupos))
-                                 
+
                        call stdlib_qlarfx('LEFT',lm,ln - 1,v(vpos), (tau(taupos)),a(dpos + &
                                  nb - 1,st + 1),lda - 1,work)
                    end if
@@ -60768,7 +60768,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: ab(ldab,*)
            real(qp),intent(out) :: w(*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,wantz
            integer(ilp) :: iinfo,imax,inde,indwrk,iscale
@@ -60879,7 +60879,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: ab(ldab,*)
            real(qp),intent(out) :: w(*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,lquery,wantz
            integer(ilp) :: iinfo,inde,indwk2,indwrk,iscale,liwmin,llwrk2,lwmin
@@ -61007,7 +61007,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: ab(ldab,*)
            real(qp),intent(out) :: q(ldq,*),w(*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,lower,test,valeig,wantz
            character :: order
@@ -61138,7 +61138,7 @@ module stdlib_linalg_lapack_q
                  call stdlib_qlacpy('A',n,n,q,ldq,z,ldz)
                  call stdlib_qcopy(n - 1,work(inde),1,work(indee),1)
                  call stdlib_qsteqr(jobz,n,w,work(indee),z,ldz,work(indwrk),info)
-                           
+
                  if (info == 0) then
                     do i = 1,n
                        ifail(i) = 0
@@ -61174,7 +61174,7 @@ module stdlib_linalg_lapack_q
               end do
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
-30   continue
+           30 continue
            if (iscale == 1) then
               if (info == 0) then
                  imax = m
@@ -61222,7 +61222,7 @@ module stdlib_linalg_lapack_q
      !> bandwidth of A.
 
      pure subroutine stdlib_qsbgst(vect,uplo,n,ka,kb,ab,ldab,bb,ldbb,x,ldx,work,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -61235,7 +61235,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: bb(ldbb,*)
            real(qp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: update,upper,wantx
            integer(ilp) :: i,i0,i1,i2,inca,j,j1,j1t,j2,j2t,k,ka1,kb1,kbt,l,m,nr, &
@@ -61327,7 +61327,7 @@ module stdlib_linalg_lapack_q
            ! to avoid duplicating code, the two loops are merged.
            update = .true.
            i = n + 1
-10         continue
+           10 continue
            if (update) then
               i = i - 1
               kbt = min(kb,i - 1)
@@ -61364,13 +61364,13 @@ module stdlib_linalg_lapack_q
                     end do
                     do j = max(1,i - ka),i - kbt - 1
                        ab(j - k + ka1,k) = ab(j - k + ka1,k) - bb(k - i + kb1,i)*ab(j - i + ka1,i)
-                                 
+
                     end do
                  end do
                  do j = i,i1
                     do k = max(j - ka,i - kbt),i - 1
                        ab(k - j + ka1,j) = ab(k - j + ka1,j) - bb(k - i + kb1,i)*ab(i - j + ka1,j)
-                                 
+
                     end do
                  end do
                  if (wantx) then
@@ -61397,9 +61397,9 @@ module stdlib_linalg_lapack_q
                        ! band and store it in work(i-k)
                        t = -bb(kb1 - k,i)*ra1
                        work(i - k) = work(n + i - k + ka - m)*t - work(i - k + ka - m)*ab(1,i - k + ka)
-                                 
+
                        ab(1,i - k + ka) = work(i - k + ka - m)*t + work(n + i - k + ka - m)*ab(1,i - k + ka)
-                                 
+
                        ra1 = ra
                     end if
                  end if
@@ -61490,7 +61490,7 @@ module stdlib_linalg_lapack_q
                     ! generate rotations in 2nd set to annihilate elements
                     ! which have been created outside the band
                     call stdlib_qlargv(nr,ab(1,j2),inca,work(j2),ka1,work(n + j2),ka1)
-                              
+
                     ! apply rotations in 2nd set from the right
                     do l = 1,ka - 1
                        call stdlib_qlartv(nr,ab(ka1 - l,j2),inca,ab(ka - l,j2 + 1),inca,work( &
@@ -61580,7 +61580,7 @@ module stdlib_linalg_lapack_q
                        t = -bb(k + 1,i - k)*ra1
                        work(i - k) = work(n + i - k + ka - m)*t - work(i - k + ka - m)*ab(ka1,i - k)
                        ab(ka1,i - k) = work(i - k + ka - m)*t + work(n + i - k + ka - m)*ab(ka1,i - k)
-                                 
+
                        ra1 = ra
                     end if
                  end if
@@ -61713,7 +61713,7 @@ module stdlib_linalg_lapack_q
               end if
            end if
            go to 10
-480        continue
+           480 continue
            ! **************************** phase 2 *****************************
            ! the logical structure of this phase is:
            ! update = .true.
@@ -61728,7 +61728,7 @@ module stdlib_linalg_lapack_q
            ! to avoid duplicating code, the two loops are merged.
            update = .true.
            i = 0
-490        continue
+           490 continue
            if (update) then
               i = i + 1
               kbt = min(kb,m - i)
@@ -61770,13 +61770,13 @@ module stdlib_linalg_lapack_q
                     end do
                     do j = i + kbt + 1,min(n,i + ka)
                        ab(k - j + ka1,j) = ab(k - j + ka1,j) - bb(i - k + kb1,k)*ab(i - j + ka1,j)
-                                 
+
                     end do
                  end do
                  do j = i1,i
                     do k = i + 1,min(j + ka,i + kbt)
                        ab(j - k + ka1,k) = ab(j - k + ka1,k) - bb(i - k + kb1,k)*ab(j - i + ka1,i)
-                                 
+
                     end do
                  end do
                  if (wantx) then
@@ -61847,7 +61847,7 @@ module stdlib_linalg_lapack_q
                     ! post-multiply x by product of rotations in 1st set
                     do j = j1,j2,ka1
                        call stdlib_qrot(nx,x(1,j),1,x(1,j - 1),1,work(n + j),work(j))
-                                 
+
                     end do
                  end if
               end do loop_610
@@ -61985,9 +61985,9 @@ module stdlib_linalg_lapack_q
                        ! band and store it in work(m-kb+i+k)
                        t = -bb(k + 1,i)*ra1
                        work(m - kb + i + k) = work(n + i + k - ka)*t - work(i + k - ka)*ab(ka1,i + k - ka)
-                                 
+
                        ab(ka1,i + k - ka) = work(i + k - ka)*t + work(n + i + k - ka)*ab(ka1,i + k - ka)
-                                 
+
                        ra1 = ra
                     end if
                  end if
@@ -62032,7 +62032,7 @@ module stdlib_linalg_lapack_q
                     ! post-multiply x by product of rotations in 1st set
                     do j = j1,j2,ka1
                        call stdlib_qrot(nx,x(1,j),1,x(1,j - 1),1,work(n + j),work(j))
-                                 
+
                     end do
                  end if
               end do loop_840
@@ -62230,7 +62230,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: ab(ldab,*),bb(ldbb,*)
            real(qp),intent(out) :: w(*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper,wantz
            character :: vect
@@ -62297,7 +62297,7 @@ module stdlib_linalg_lapack_q
            indwk2 = indwrk + n*n
            llwrk2 = lwork - indwk2 + 1
            call stdlib_qsbgst(jobz,uplo,n,ka,kb,ab,ldab,bb,ldbb,z,ldz,work,iinfo)
-                     
+
            ! reduce to tridiagonal form.
            if (wantz) then
               vect = 'U'
@@ -62343,7 +62343,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: ab(ldab,*),bb(ldbb,*)
            real(qp),intent(out) :: q(ldq,*),w(*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,test,upper,valeig,wantz
            character :: order,vect
@@ -62409,7 +62409,7 @@ module stdlib_linalg_lapack_q
            end if
            ! transform problem to standard eigenvalue problem.
            call stdlib_qsbgst(jobz,uplo,n,ka,kb,ab,ldab,bb,ldbb,q,ldq,work,iinfo)
-                     
+
            ! reduce symmetric band matrix to tridiagonal form.
            indd = 1
            inde = indd + n
@@ -62439,7 +62439,7 @@ module stdlib_linalg_lapack_q
               else
                  call stdlib_qlacpy('A',n,n,q,ldq,z,ldz)
                  call stdlib_qsteqr(jobz,n,w,work(indee),z,ldz,work(indwrk),info)
-                           
+
                  if (info == 0) then
                     do i = 1,n
                        ifail(i) = 0
@@ -62464,7 +62464,7 @@ module stdlib_linalg_lapack_q
            indiwo = indisp + n
            call stdlib_qstebz(range,order,n,vl,vu,il,iu,abstol,work(indd),work(inde), &
             m,nsplit,w,iwork(indibl),iwork(indisp),work(indwrk),iwork(indiwo),info)
-                      
+
            if (wantz) then
               call stdlib_qstein(n,work(indd),work(inde),m,w,iwork(indibl),iwork( &
                         indisp),z,ldz,work(indwrk),iwork(indiwo),ifail,info)
@@ -62475,7 +62475,7 @@ module stdlib_linalg_lapack_q
                  call stdlib_qgemv('N',n,n,one,q,ldq,work,1,zero,z(1,j),1)
               end do
            end if
-30         continue
+           30 continue
            ! if eigenvalues are not in order, then sort them, along with
            ! eigenvectors.
            if (wantz) then
@@ -62522,7 +62522,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: ab(ldab,*),q(ldq,*)
            real(qp),intent(out) :: d(*),e(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: initq,upper,wantq
            integer(ilp) :: i,i2,ibl,inca,incx,iqaend,iqb,iqend,j,j1,j1end,j1inc,j2, &
@@ -62858,7 +62858,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: a(lda,*)
            real(qp),intent(inout) :: c(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,normaltransr,nisodd,notrans
            integer(ilp) :: info,nrowa,j,nk,n1,n2
@@ -62928,7 +62928,7 @@ module stdlib_linalg_lapack_q
                     if (notrans) then
                        ! n is odd, transr = 'n', uplo = 'l', and trans = 'n'
                        call stdlib_qsyrk('L','N',n1,k,alpha,a(1,1),lda,beta,c(1),n)
-                                 
+
                        call stdlib_qsyrk('U','N',n2,k,alpha,a(n1 + 1,1),lda,beta,c(n + 1) &
                                  ,n)
                        call stdlib_qgemm('N','T',n2,n1,k,alpha,a(n1 + 1,1),lda,a(1,1), &
@@ -62936,7 +62936,7 @@ module stdlib_linalg_lapack_q
                     else
                        ! n is odd, transr = 'n', uplo = 'l', and trans = 't'
                        call stdlib_qsyrk('L','T',n1,k,alpha,a(1,1),lda,beta,c(1),n)
-                                 
+
                        call stdlib_qsyrk('U','T',n2,k,alpha,a(1,n1 + 1),lda,beta,c(n + 1) &
                                  ,n)
                        call stdlib_qgemm('T','N',n2,n1,k,alpha,a(1,n1 + 1),lda,a(1,1), &
@@ -63122,7 +63122,7 @@ module stdlib_linalg_lapack_q
      !> respectively.
 
      subroutine stdlib_qsgesv(n,nrhs,a,lda,ipiv,b,ldb,x,ldx,work,swork,iter,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -63140,7 +63140,7 @@ module stdlib_linalg_lapack_q
            logical(lk),parameter :: doitref = .true.
            integer(ilp),parameter :: itermax = 30
            real(qp),parameter :: bwdmax = 1.0e+00_qp
-           
+
            ! Local Scalars
            integer(ilp) :: i,iiter,ptsa,ptsx
            real(qp) :: anrm,cte,eps,rnrm,xnrm
@@ -63220,7 +63220,7 @@ module stdlib_linalg_lapack_q
            ! stopping criterion. we are good to exit.
            iter = 0
            return
-10         continue
+           10 continue
            loop_30: do iiter = 1,itermax
               ! convert r (in work) from quad precision to double precision
               ! and store the result in sx.
@@ -63253,14 +63253,14 @@ module stdlib_linalg_lapack_q
               ! stopping criterion, we are good to exit.
               iter = iiter
               return
-20            continue
+              20 continue
            end do loop_30
            ! if we are at this place of the code, this is because we have
            ! performed iter=itermax iterations and never satisfied the
            ! stopping criterion, set up the iter flag accordingly and follow up
            ! on quad precision routine.
            iter = -itermax - 1
-40         continue
+           40 continue
            ! single-precision iterative refinement failed to converge to a
            ! satisfactory solution, so we resort to quad precision.
            call stdlib_qgetrf(n,n,a,lda,ipiv,info)
@@ -63292,7 +63292,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: ap(*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,ip,kase
@@ -63340,7 +63340,7 @@ module stdlib_linalg_lapack_q
            end if
            ! estimate the 1-norm of the inverse.
            kase = 0
-30         continue
+           30 continue
            call stdlib_qlacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               ! multiply by inv(l*d*l**t) or inv(u*d*u**t).
@@ -63367,7 +63367,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: ap(*)
            real(qp),intent(out) :: w(*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: wantz
            integer(ilp) :: iinfo,imax,inde,indtau,indwrk,iscale
@@ -63430,7 +63430,7 @@ module stdlib_linalg_lapack_q
            else
               indwrk = indtau + n
               call stdlib_qopgtr(uplo,n,ap,work(indtau),z,ldz,work(indwrk),iinfo)
-                        
+
               call stdlib_qsteqr(jobz,n,w,work(inde),z,ldz,work(indtau),info)
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
@@ -63456,7 +63456,7 @@ module stdlib_linalg_lapack_q
      !> without guard digits, but we know of none.
 
      subroutine stdlib_qspevd(jobz,uplo,n,ap,w,z,ldz,work,lwork,iwork,liwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -63469,7 +63469,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: ap(*)
            real(qp),intent(out) :: w(*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wantz
            integer(ilp) :: iinfo,inde,indtau,indwrk,iscale,liwmin,llwork,lwmin
@@ -63590,7 +63590,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: ap(*)
            real(qp),intent(out) :: w(*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,test,valeig,wantz
            character :: order
@@ -63689,7 +63689,7 @@ module stdlib_linalg_lapack_q
            indd = inde + n
            indwrk = indd + n
            call stdlib_qsptrd(uplo,n,ap,work(indd),work(inde),work(indtau),iinfo)
-                     
+
            ! if all eigenvalues are desired and abstol is less than or equal
            ! to zero, then call stdlib_qsterf or stdlib_qopgtr and stdlib_dsteqr.  if this fails
            ! for some eigenvalue, then try stdlib_qstebz.
@@ -63707,10 +63707,10 @@ module stdlib_linalg_lapack_q
                  call stdlib_qsterf(n,w,work(indee),info)
               else
                  call stdlib_qopgtr(uplo,n,ap,work(indtau),z,ldz,work(indwrk),iinfo)
-                           
+
                  call stdlib_qcopy(n - 1,work(inde),1,work(indee),1)
                  call stdlib_qsteqr(jobz,n,w,work(indee),z,ldz,work(indwrk),info)
-                           
+
                  if (info == 0) then
                     do i = 1,n
                        ifail(i) = 0
@@ -63744,7 +63744,7 @@ module stdlib_linalg_lapack_q
                          iinfo)
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
-20   continue
+           20 continue
            if (iscale == 1) then
               if (info == 0) then
                  imax = m
@@ -63803,7 +63803,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: ap(*)
            real(qp),intent(in) :: bp(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,j1,j1j1,jj,k,k1,k1k1,kk
@@ -63875,7 +63875,7 @@ module stdlib_linalg_lapack_q
                     akk = ap(kk)
                     bkk = bp(kk)
                     call stdlib_qtpmv(uplo,'NO TRANSPOSE','NON-UNIT',k - 1,bp,ap(k1),1)
-                              
+
                     ct = half*akk
                     call stdlib_qaxpy(k - 1,ct,bp(k1),1,ap(k1),1)
                     call stdlib_qspr2(uplo,k - 1,one,ap(k1),1,bp(k1),1,ap)
@@ -64077,7 +64077,7 @@ module stdlib_linalg_lapack_q
            ! transform problem to standard eigenvalue problem and solve.
            call stdlib_qspgst(itype,uplo,n,ap,bp,info)
            call stdlib_qspevd(jobz,uplo,n,ap,w,z,ldz,work,lwork,iwork,liwork,info)
-                     
+
            lwmin = max(real(lwmin,KIND=qp),real(work(1),KIND=qp))
            liwmin = max(real(liwmin,KIND=qp),real(iwork(1),KIND=qp))
            if (wantz) then
@@ -64255,7 +64255,7 @@ module stdlib_linalg_lapack_q
      !> respectively.
 
      subroutine stdlib_qsposv(uplo,n,nrhs,a,lda,b,ldb,x,ldx,work,swork,iter,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -64273,7 +64273,7 @@ module stdlib_linalg_lapack_q
            logical(lk),parameter :: doitref = .true.
            integer(ilp),parameter :: itermax = 30
            real(qp),parameter :: bwdmax = 1.0e+00_qp
-           
+
            ! Local Scalars
            integer(ilp) :: i,iiter,ptsa,ptsx
            real(qp) :: anrm,cte,eps,rnrm,xnrm
@@ -64353,7 +64353,7 @@ module stdlib_linalg_lapack_q
            ! stopping criterion. we are good to exit.
            iter = 0
            return
-10         continue
+           10 continue
            loop_30: do iiter = 1,itermax
               ! convert r (in work) from quad precision to double precision
               ! and store the result in sx.
@@ -64384,14 +64384,14 @@ module stdlib_linalg_lapack_q
               ! stopping criterion, we are good to exit.
               iter = iiter
               return
-20            continue
+              20 continue
            end do loop_30
            ! if we are at this place of the code, this is because we have
            ! performed iter=itermax iterations and never satisfied the
            ! stopping criterion, set up the iter flag accordingly and follow
            ! up on quad precision routine.
            iter = -itermax - 1
-40         continue
+           40 continue
            ! single-precision iterative refinement failed to converge to a
            ! satisfactory solution, so we resort to quad precision.
            call stdlib_qpotrf(uplo,n,a,lda,info)
@@ -64424,7 +64424,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,ik,j,k,kase,kk,nz
@@ -64470,7 +64470,7 @@ module stdlib_linalg_lapack_q
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_qcopy(n,b(1,j),1,work(n + 1),1)
@@ -64561,9 +64561,9 @@ module stdlib_linalg_lapack_q
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_qlacn2(n,work(2*n + 1),work(n + 1),iwork,ferr(j),kase,isave)
-                        
+
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(a**t).
@@ -64665,7 +64665,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: ap(*),b(ldb,*)
            real(qp),intent(out) :: berr(*),ferr(*),work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nofact
            real(qp) :: anorm
@@ -64735,7 +64735,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: ap(*)
            real(qp),intent(out) :: d(*),e(*),tau(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,i1,i1i1,ii
@@ -64804,7 +64804,7 @@ module stdlib_linalg_lapack_q
                     ! apply the transformation as a rank-2 update:
                        ! a := a - v * w**t - w * v**t
                     call stdlib_qspr2(uplo,n - i,-one,ap(ii + 1),1,tau(i),1,ap(i1i1))
-                              
+
                     ap(ii + 1) = e(i)
                  end if
                  d(i) = ap(ii)
@@ -64837,7 +64837,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: sevten = 17.0e+0_qp
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,imax,j,jmax,k,kc,kk,knc,kp,kpc,kstep,kx,npp
@@ -64866,7 +64866,7 @@ module stdlib_linalg_lapack_q
               ! 1 or 2
               k = n
               kc = (n - 1)*n/2 + 1
-10            continue
+              10 continue
               knc = kc
               ! if k < 1, exit from loop
               if (k < 1) go to 110
@@ -64969,9 +64969,9 @@ module stdlib_linalg_lapack_q
                        d12 = t/d12
                        do j = k - 2,1,-1
                           wkm1 = d12*(d11*ap(j + (k - 2)*(k - 1)/2) - ap(j + (k - 1)*k/2))
-                                    
+
                           wk = d12*(d22*ap(j + (k - 1)*k/2) - ap(j + (k - 2)*(k - 1)/2))
-                                    
+
                           do i = j,1,-1
                              ap(i + (j - 1)*j/2) = ap(i + (j - 1)*j/2) - ap(i + (k - 1)*k/2) &
                                        *wk - ap(i + (k - 2)*(k - 1)/2)*wkm1
@@ -65000,7 +65000,7 @@ module stdlib_linalg_lapack_q
               k = 1
               kc = 1
               npp = n*(n + 1)/2
-60            continue
+              60 continue
               knc = kc
               ! if k > n, exit from loop
               if (k > n) go to 110
@@ -65061,7 +65061,7 @@ module stdlib_linalg_lapack_q
                     ! interchange rows and columns kk and kp in the trailing
                     ! submatrix a(k:n,k:n)
                     if (kp < n) call stdlib_qswap(n - kp,ap(knc + kp - kk + 1),1,ap(kpc + 1),1)
-                              
+
                     kx = knc + kp - kk
                     do j = kk + 1,kp - 1
                        kx = kx + n - j + 1
@@ -65109,7 +65109,7 @@ module stdlib_linalg_lapack_q
                        d21 = t/d21
                        do j = k + 2,n
                           wk = d21*(d11*ap(j + (k - 1)*(2*n - k)/2) - ap(j + k*(2*n - k - 1)/2))
-                                    
+
                           wkp1 = d21*(d22*ap(j + k*(2*n - k - 1)/2) - ap(j + (k - 1)*(2*n - k)/2) &
                                      )
                           do i = j,n
@@ -65134,7 +65134,7 @@ module stdlib_linalg_lapack_q
               kc = knc + n - k + 2
               go to 60
            end if
-110        continue
+           110 continue
            return
      end subroutine stdlib_qsptrf
 
@@ -65155,7 +65155,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: ap(*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kc,kcnext,kp,kpc,kstep,kx,npp
@@ -65200,7 +65200,7 @@ module stdlib_linalg_lapack_q
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
               kc = 1
-30            continue
+              30 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               kcnext = kc + k
@@ -65235,9 +65235,9 @@ module stdlib_linalg_lapack_q
                               kcnext),1)
                     call stdlib_qcopy(k - 1,ap(kcnext),1,work,1)
                     call stdlib_qspmv(uplo,k - 1,-one,ap,work,1,zero,ap(kcnext),1)
-                              
+
                     ap(kcnext + k) = ap(kcnext + k) - stdlib_qdot(k - 1,work,1,ap(kcnext),1)
-                              
+
                  end if
                  kstep = 2
                  kcnext = kcnext + k + 1
@@ -65267,7 +65267,7 @@ module stdlib_linalg_lapack_q
               k = k + kstep
               kc = kcnext
               go to 30
-50            continue
+              50 continue
            else
               ! compute inv(a) from the factorization a = l*d*l**t.
               ! k is the main loop index, increasing from 1 to n in steps of
@@ -65275,7 +65275,7 @@ module stdlib_linalg_lapack_q
               npp = n*(n + 1)/2
               k = n
               kc = npp
-60            continue
+              60 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 80
               kcnext = kc - (n - k + 2)
@@ -65314,7 +65314,7 @@ module stdlib_linalg_lapack_q
                     call stdlib_qspmv(uplo,n - k,-one,ap(kc + (n - k + 1)),work,1,zero,ap( &
                               kcnext + 2),1)
                     ap(kcnext) = ap(kcnext) - stdlib_qdot(n - k,work,1,ap(kcnext + 2),1)
-                              
+
                  end if
                  kstep = 2
                  kcnext = kcnext - (n - k + 3)
@@ -65344,7 +65344,7 @@ module stdlib_linalg_lapack_q
               k = k - kstep
               kc = kcnext
               go to 60
-80            continue
+              80 continue
            end if
            return
      end subroutine stdlib_qsptri
@@ -65366,7 +65366,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: ap(*)
            real(qp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kc,kp
@@ -65398,7 +65398,7 @@ module stdlib_linalg_lapack_q
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
               kc = n*(n + 1)/2 + 1
-10            continue
+              10 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 30
               kc = kc - k
@@ -65410,7 +65410,7 @@ module stdlib_linalg_lapack_q
                  ! multiply by inv(u(k)), where u(k) is the transformation
                  ! stored in column k of a.
                  call stdlib_qger(k - 1,nrhs,-one,ap(kc),1,b(k,1),ldb,b(1,1),ldb)
-                           
+
                  ! multiply by the inverse of the diagonal block.
                  call stdlib_qscal(nrhs,one/ap(kc + k - 1),b(k,1),ldb)
                  k = k - 1
@@ -65422,7 +65422,7 @@ module stdlib_linalg_lapack_q
                  ! multiply by inv(u(k)), where u(k) is the transformation
                  ! stored in columns k-1 and k of a.
                  call stdlib_qger(k - 2,nrhs,-one,ap(kc),1,b(k,1),ldb,b(1,1),ldb)
-                           
+
                  call stdlib_qger(k - 2,nrhs,-one,ap(kc - (k - 1)),1,b(k - 1,1),ldb,b(1,1 &
                            ),ldb)
                  ! multiply by the inverse of the diagonal block.
@@ -65440,13 +65440,13 @@ module stdlib_linalg_lapack_q
                  k = k - 2
               end if
               go to 10
-30            continue
+              30 continue
               ! next solve u**t*x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
               kc = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               if (ipiv(k) > 0) then
@@ -65475,7 +65475,7 @@ module stdlib_linalg_lapack_q
                  k = k + 2
               end if
               go to 40
-50            continue
+              50 continue
            else
               ! solve a*x = b, where a = l*d*l**t.
               ! first solve l*d*x = b, overwriting b with x.
@@ -65483,7 +65483,7 @@ module stdlib_linalg_lapack_q
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
               kc = 1
-60            continue
+              60 continue
               ! if k > n, exit from loop.
               if (k > n) go to 80
               if (ipiv(k) > 0) then
@@ -65527,13 +65527,13 @@ module stdlib_linalg_lapack_q
                  k = k + 2
               end if
               go to 60
-80            continue
+              80 continue
               ! next solve l**t*x = b, overwriting b with x.
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
               kc = n*(n + 1)/2 + 1
-90            continue
+              90 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 100
               kc = kc - (n - k + 1)
@@ -65564,7 +65564,7 @@ module stdlib_linalg_lapack_q
                  k = k - 2
               end if
               go to 90
-100           continue
+              100 continue
            end if
            return
      end subroutine stdlib_qsptrs
@@ -65598,7 +65598,7 @@ module stdlib_linalg_lapack_q
            ! Parameters
            real(qp),parameter :: fudge = 2.1_qp
            real(qp),parameter :: relfac = 2.0_qp
-           
+
            ! Local Scalars
            logical(lk) :: ncnvrg,toofew
            integer(ilp) :: ib,ibegin,idiscl,idiscu,ie,iend,iinfo,im,in,ioff,iorder, &
@@ -65974,7 +65974,7 @@ module stdlib_linalg_lapack_q
      !> without guard digits, but we know of none.  See DLAED3 for details.
 
      pure subroutine stdlib_qstedc(compz,n,d,e,z,ldz,work,lwork,iwork,liwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -65987,7 +65987,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: d(*),e(*),z(ldz,*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: finish,i,icompz,ii,j,k,lgn,liwmin,lwmin,m,smlsiz,start, &
@@ -66090,7 +66090,7 @@ module stdlib_linalg_lapack_q
               eps = stdlib_qlamch('EPSILON')
               start = 1
               ! while ( start <= n )
-10   continue
+              10 continue
               if (start <= n) then
                  ! let finish be the position of the next subdiagonal entry
                  ! such that e( finish ) <= tiny or finish = n if no such
@@ -66098,7 +66098,7 @@ module stdlib_linalg_lapack_q
                  ! between start and finish constitutes an independent
                  ! sub-problem.
                  finish = start
-20               continue
+                 20 continue
                  if (finish < n) then
                     tiny = eps*sqrt(abs(d(finish)))*sqrt(abs(d(finish + 1)))
                     if (abs(e(finish)) > tiny) then
@@ -66117,7 +66117,7 @@ module stdlib_linalg_lapack_q
                     orgnrm = stdlib_qlanst('M',m,d(start),e(start))
                     call stdlib_qlascl('G',0,0,orgnrm,one,m,1,d(start),m,info)
                     call stdlib_qlascl('G',0,0,orgnrm,one,m - 1,1,e(start),m - 1,info)
-                              
+
                     if (icompz == 1) then
                        strtrw = 1
                     else
@@ -66140,7 +66140,7 @@ module stdlib_linalg_lapack_q
                        call stdlib_qsteqr('I',m,d(start),e(start),work,m,work(m*m + 1), &
                                  info)
                        call stdlib_qlacpy('A',n,m,z(1,start),ldz,work(storez),n)
-                                 
+
                        call stdlib_qgemm('N','N',n,m,m,one,work(storez),n,work,m,zero, &
                                  z(1,start),ldz)
                     else if (icompz == 2) then
@@ -66181,7 +66181,7 @@ module stdlib_linalg_lapack_q
                 end do
               end if
            end if
-50         continue
+           50 continue
            work(1) = lwmin
            iwork(1) = liwmin
            return
@@ -66254,7 +66254,7 @@ module stdlib_linalg_lapack_q
            real(qp),parameter :: odm1 = 1.0e-1_qp
            integer(ilp),parameter :: maxits = 5
            integer(ilp),parameter :: extra = 2
-           
+
            ! Local Scalars
            integer(ilp) :: b1,blksiz,bn,gpind,i,iinfo,indrv1,indrv2,indrv3,indrv4, &
                      indrv5,its,j,j1,jblk,jmax,nblk,nrmchk
@@ -66287,7 +66287,7 @@ module stdlib_linalg_lapack_q
                     go to 30
                  end if
               end do
-30            continue
+              30 continue
            end if
            if (info /= 0) then
               call stdlib_xerbla('DSTEIN',-info)
@@ -66334,7 +66334,7 @@ module stdlib_linalg_lapack_q
               ortol = odm3*onenrm
               dtpcrt = sqrt(odm1/blksiz)
               ! loop through eigenvalues of block nblk.
-60   continue
+              60 continue
               jblk = 0
               loop_150: do j = j1,m
                  if (iblock(j) /= nblk) then
@@ -66369,7 +66369,7 @@ module stdlib_linalg_lapack_q
                  call stdlib_qlagtf(blksiz,work(indrv4 + 1),xj,work(indrv2 + 2),work(indrv3 + &
                            1),tol,work(indrv5 + 1),iwork,iinfo)
                  ! update iteration count.
-70   continue
+                 70 continue
                  its = its + 1
                  if (its > maxits) go to 100
                  ! normalize and scale the righthand side vector pb.
@@ -66391,7 +66391,7 @@ module stdlib_linalg_lapack_q
                     end do
                  end if
                  ! check the infinity norm of the iterate.
-90   continue
+                 90 continue
                  jmax = stdlib_iqamax(blksiz,work(indrv1 + 1),1)
                  nrm = abs(work(indrv1 + jmax))
                  ! continue for additional iterations after norm reaches
@@ -66402,16 +66402,16 @@ module stdlib_linalg_lapack_q
                  go to 110
                  ! if stopping criterion was not satisfied, update info and
                  ! store eigenvector number in array ifail.
-100  continue
+                 100 continue
                  info = info + 1
                  ifail(info) = j
                  ! accept iterate as jth eigenvector.
-110  continue
+                 110 continue
                  scl = one/stdlib_qnrm2(blksiz,work(indrv1 + 1),1)
                  jmax = stdlib_iqamax(blksiz,work(indrv1 + 1),1)
                  if (work(indrv1 + jmax) < zero) scl = -scl
                  call stdlib_qscal(blksiz,scl,work(indrv1 + 1),1)
-120              continue
+                 120 continue
                  do i = 1,n
                     z(i,j) = zero
                  end do
@@ -66491,7 +66491,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: minrgp = 1.0e-3_qp
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,lquery,valeig,wantz,zquery
            integer(ilp) :: i,ibegin,iend,ifirst,iil,iindbl,iindw,iindwk,iinfo,iinspl, &
@@ -66570,7 +66570,7 @@ module stdlib_linalg_lapack_q
                  nzcmin = n
               else if (wantz .and. valeig) then
                  call stdlib_qlarrc('T',n,vl,vu,d,e,safmin,nzcmin,itmp,itmp2,info)
-                           
+
               else if (wantz .and. indeig) then
                  nzcmin = iiu - iil + 1
               else
@@ -66740,7 +66740,7 @@ module stdlib_linalg_lapack_q
               call stdlib_qlarre(range,n,wl,wu,iil,iiu,d,e,work(inde2),rtol1,rtol2, &
               thresh,nsplit,iwork(iinspl),m,w,work(inderr),work(indgp),iwork(iindbl), &
               iwork(iindw),work(indgrs),pivmin,work(indwrk),iwork(iindwk),iinfo)
-                        
+
               if (iinfo /= 0) then
                  info = 10 + abs(iinfo)
                  return
@@ -66779,7 +66779,7 @@ module stdlib_linalg_lapack_q
                     in = iend - ibegin + 1
                     wend = wbegin - 1
                     ! check if any eigenvalues have to be refined in this block
-36   continue
+                    36 continue
                     if (wend < m) then
                        if (iwork(iindbl + wend) == jblk) then
                           wend = wend + 1
@@ -66866,7 +66866,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: maxit = 30
-           
+
            ! Local Scalars
            integer(ilp) :: i,icompz,ii,iscale,j,jtot,k,l,l1,lend,lendm1,lendp1,lendsv, &
                       lm1,lsv,m,mm,mm1,nm1,nmaxit
@@ -66920,7 +66920,7 @@ module stdlib_linalg_lapack_q
            ! element is smaller.
            l1 = 1
            nm1 = n - 1
-10         continue
+           10 continue
            if (l1 > n) go to 160
            if (l1 > 1) e(l1 - 1) = zero
            if (l1 <= nm1) then
@@ -66934,7 +66934,7 @@ module stdlib_linalg_lapack_q
               end do
            end if
            m = n
-30         continue
+           30 continue
            l = l1
            lsv = l
            lend = m
@@ -66962,7 +66962,7 @@ module stdlib_linalg_lapack_q
            if (lend > l) then
               ! ql iteration
               ! look for small subdiagonal element.
-40   continue
+              40 continue
               if (l /= lend) then
                  lendm1 = lend - 1
                  do m = l,lendm1
@@ -66971,7 +66971,7 @@ module stdlib_linalg_lapack_q
                  end do
               end if
               m = lend
-60            continue
+              60 continue
               if (m < lend) e(m) = zero
               p = d(l)
               if (m == l) go to 80
@@ -67031,7 +67031,7 @@ module stdlib_linalg_lapack_q
               e(l) = g
               go to 40
               ! eigenvalue found.
-80   continue
+              80 continue
               d(l) = p
               l = l + 1
               if (l <= lend) go to 40
@@ -67039,7 +67039,7 @@ module stdlib_linalg_lapack_q
            else
               ! qr iteration
               ! look for small superdiagonal element.
-90   continue
+              90 continue
               if (l /= lend) then
                  lendp1 = lend + 1
                  do m = l,lendp1,-1
@@ -67048,7 +67048,7 @@ module stdlib_linalg_lapack_q
                  end do
               end if
               m = lend
-110           continue
+              110 continue
               if (m > lend) e(m - 1) = zero
               p = d(l)
               if (m == l) go to 130
@@ -67108,24 +67108,24 @@ module stdlib_linalg_lapack_q
               e(lm1) = g
               go to 90
               ! eigenvalue found.
-130  continue
+              130 continue
               d(l) = p
               l = l - 1
               if (l >= lend) go to 90
               go to 140
            end if
            ! undo scaling if necessary
-140  continue
+           140 continue
            if (iscale == 1) then
               call stdlib_qlascl('G',0,0,ssfmax,anorm,lendsv - lsv + 1,1,d(lsv),n,info)
-                        
+
               call stdlib_qlascl('G',0,0,ssfmax,anorm,lendsv - lsv,1,e(lsv),n,info)
-                        
+
            else if (iscale == 2) then
               call stdlib_qlascl('G',0,0,ssfmin,anorm,lendsv - lsv + 1,1,d(lsv),n,info)
-                        
+
               call stdlib_qlascl('G',0,0,ssfmin,anorm,lendsv - lsv,1,e(lsv),n,info)
-                        
+
            end if
            ! check for no convergence to an eigenvalue after a total
            ! of n*maxit iterations.
@@ -67135,7 +67135,7 @@ module stdlib_linalg_lapack_q
            end do
            go to 190
            ! order eigenvalues and eigenvectors.
-160  continue
+           160 continue
            if (icompz == 0) then
               ! use quick sort
               call stdlib_qlasrt('I',n,d,info)
@@ -67158,7 +67158,7 @@ module stdlib_linalg_lapack_q
                  end if
               end do
            end if
-190        continue
+           190 continue
            return
      end subroutine stdlib_qsteqr
 
@@ -67177,7 +67177,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: maxit = 30
-           
+
            ! Local Scalars
            integer(ilp) :: i,iscale,jtot,l,l1,lend,lendsv,lsv,m,nmaxit
            real(qp) :: alpha,anorm,bb,c,eps,eps2,gamma,oldc,oldgam,p,r,rt1,rt2,rte, &
@@ -67210,7 +67210,7 @@ module stdlib_linalg_lapack_q
            ! for each block, according to whether top or bottom diagonal
            ! element is smaller.
            l1 = 1
-10         continue
+           10 continue
            if (l1 > n) go to 170
            if (l1 > 1) e(l1 - 1) = zero
            do m = l1,n - 1
@@ -67221,7 +67221,7 @@ module stdlib_linalg_lapack_q
               end if
            end do
            m = n
-30         continue
+           30 continue
            l = l1
            lsv = l
            lend = m
@@ -67252,14 +67252,14 @@ module stdlib_linalg_lapack_q
            if (lend >= l) then
               ! ql iteration
               ! look for small subdiagonal element.
-50   continue
+              50 continue
               if (l /= lend) then
                  do m = l,lend - 1
                     if (abs(e(m)) <= eps2*abs(d(m)*d(m + 1))) go to 70
                  end do
               end if
               m = lend
-70            continue
+              70 continue
               if (m < lend) e(m) = zero
               p = d(l)
               if (m == l) go to 90
@@ -67308,7 +67308,7 @@ module stdlib_linalg_lapack_q
               d(l) = sigma + gamma
               go to 50
               ! eigenvalue found.
-90   continue
+              90 continue
               d(l) = p
               l = l + 1
               if (l <= lend) go to 50
@@ -67316,12 +67316,12 @@ module stdlib_linalg_lapack_q
            else
               ! qr iteration
               ! look for small superdiagonal element.
-100  continue
+              100 continue
               do m = l,lend + 1,-1
                  if (abs(e(m - 1)) <= eps2*abs(d(m)*d(m - 1))) go to 120
               end do
               m = lend
-120           continue
+              120 continue
               if (m > lend) e(m - 1) = zero
               p = d(l)
               if (m == l) go to 140
@@ -67370,14 +67370,14 @@ module stdlib_linalg_lapack_q
               d(l) = sigma + gamma
               go to 100
               ! eigenvalue found.
-140  continue
+              140 continue
               d(l) = p
               l = l - 1
               if (l >= lend) go to 100
               go to 150
            end if
            ! undo scaling if necessary
-150  continue
+           150 continue
            if (iscale == 1) call stdlib_qlascl('G',0,0,ssfmax,anorm,lendsv - lsv + 1,1,d(lsv), &
                      n,info)
            if (iscale == 2) call stdlib_qlascl('G',0,0,ssfmin,anorm,lendsv - lsv + 1,1,d(lsv), &
@@ -67390,9 +67390,9 @@ module stdlib_linalg_lapack_q
            end do
            go to 180
            ! sort eigenvalues in increasing order.
-170  continue
+           170 continue
            call stdlib_qlasrt('I',n,d,info)
-180        continue
+           180 continue
            return
      end subroutine stdlib_qsterf
 
@@ -67411,7 +67411,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: d(*),e(*)
            real(qp),intent(out) :: work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: wantz
            integer(ilp) :: imax,iscale
@@ -67490,7 +67490,7 @@ module stdlib_linalg_lapack_q
      !> without guard digits, but we know of none.
 
      pure subroutine stdlib_qstevd(jobz,n,d,e,z,ldz,work,lwork,iwork,liwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -67503,7 +67503,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: d(*),e(*)
            real(qp),intent(out) :: work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wantz
            integer(ilp) :: iscale,liwmin,lwmin
@@ -67635,7 +67635,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: d(*),e(*)
            real(qp),intent(out) :: w(*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,test,lquery,valeig,wantz,tryrac
            character :: order
@@ -67796,7 +67796,7 @@ module stdlib_linalg_lapack_q
                         iwork(indiwo),iwork(indifl),info)
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
-10   continue
+           10 continue
            if (iscale == 1) then
               if (info == 0) then
                  imax = m
@@ -67854,7 +67854,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: d(*),e(*)
            real(qp),intent(out) :: w(*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,test,valeig,wantz
            character :: order
@@ -67989,7 +67989,7 @@ module stdlib_linalg_lapack_q
                         indwrk),iwork(indiwo),ifail,info)
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
-20   continue
+           20 continue
            if (iscale == 1) then
               if (info == 0) then
                  imax = m
@@ -68035,7 +68035,7 @@ module stdlib_linalg_lapack_q
      !> condition number is computed as RCOND = 1 / (ANORM * norm(inv(A))).
 
      pure subroutine stdlib_qsycon(uplo,n,a,lda,ipiv,anorm,rcond,work,iwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -68051,7 +68051,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: a(lda,*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,kase
@@ -68099,7 +68099,7 @@ module stdlib_linalg_lapack_q
            end if
            ! estimate the 1-norm of the inverse.
            kase = 0
-30         continue
+           30 continue
            call stdlib_qlacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               ! multiply by inv(l*d*l**t) or inv(u*d*u**t).
@@ -68118,7 +68118,7 @@ module stdlib_linalg_lapack_q
      !> condition number is computed as RCOND = 1 / (ANORM * norm(inv(A))).
 
      pure subroutine stdlib_qsycon_rook(uplo,n,a,lda,ipiv,anorm,rcond,work,iwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -68134,7 +68134,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: a(lda,*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,kase
@@ -68182,7 +68182,7 @@ module stdlib_linalg_lapack_q
            end if
            ! estimate the 1-norm of the inverse.
            kase = 0
-30         continue
+           30 continue
            call stdlib_qlacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               ! multiply by inv(l*d*l**t) or inv(u*d*u**t).
@@ -68211,7 +68211,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: e(*)
         ! =====================================================================
-           
+
            ! External Subroutines
            logical(lk) :: upper,convert
            integer(ilp) :: i,ip,j
@@ -68427,7 +68427,7 @@ module stdlib_linalg_lapack_q
            integer(ilp),intent(inout) :: ipiv(*)
            real(qp),intent(inout) :: a(lda,*),e(*)
         ! =====================================================================
-           
+
            ! External Subroutines
            logical(lk) :: upper,convert
            integer(ilp) :: i,ip
@@ -68491,7 +68491,7 @@ module stdlib_linalg_lapack_q
                        if (i < n) then
                           if (ip /= (i - 1)) then
                              call stdlib_qswap(n - i,a(i - 1,i + 1),lda,a(ip,i + 1),lda)
-                                       
+
                           end if
                        end if
                        ! convert ipiv
@@ -68527,7 +68527,7 @@ module stdlib_linalg_lapack_q
                        if (i < n) then
                           if (ip /= (i - 1)) then
                              call stdlib_qswap(n - i,a(ip,i + 1),lda,a(i - 1,i + 1),lda)
-                                       
+
                           end if
                        end if
                        ! convert ipiv
@@ -68680,7 +68680,7 @@ module stdlib_linalg_lapack_q
            integer(ilp),intent(in) :: ipiv(*)
            real(qp),intent(inout) :: a(lda,*),e(*)
         ! =====================================================================
-           
+
            ! External Subroutines
            logical(lk) :: upper,convert
            integer(ilp) :: i,ip,ip2
@@ -68749,7 +68749,7 @@ module stdlib_linalg_lapack_q
                           end if
                           if (ip2 /= (i - 1)) then
                              call stdlib_qswap(n - i,a(i - 1,i + 1),lda,a(ip2,i + 1),lda)
-                                       
+
                           end if
                        end if
                        i = i - 1
@@ -68782,7 +68782,7 @@ module stdlib_linalg_lapack_q
                        if (i < n) then
                           if (ip2 /= (i - 1)) then
                              call stdlib_qswap(n - i,a(ip2,i + 1),lda,a(i - 1,i + 1),lda)
-                                       
+
                           end if
                           if (ip /= i) then
                              call stdlib_qswap(n - i,a(ip,i + 1),lda,a(i,i + 1),lda)
@@ -68930,7 +68930,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: max_iter = 100
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,iter
            real(qp) :: avg,std,tol,c0,c1,c2,t,u,si,d,base,smin,smax,smlnum,bignum, &
@@ -69066,7 +69066,7 @@ module stdlib_linalg_lapack_q
                  s(i) = si
               end do
            end do
-999        continue
+           999 continue
            smlnum = stdlib_qlamch('SAFEMIN')
            bignum = one/smlnum
            smin = bignum
@@ -69097,7 +69097,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: w(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,lquery,wantz
            integer(ilp) :: iinfo,imax,inde,indtau,indwrk,iscale,llwork,lwkopt,nb
@@ -69172,7 +69172,7 @@ module stdlib_linalg_lapack_q
               call stdlib_qsterf(n,w,work(inde),info)
            else
               call stdlib_qorgtr(uplo,n,a,lda,work(indtau),work(indwrk),llwork,iinfo)
-                        
+
               call stdlib_qsteqr(jobz,n,w,work(inde),a,lda,work(indtau),info)
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
@@ -69214,7 +69214,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: w(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,lquery,wantz
            integer(ilp) :: iinfo,inde,indtau,indwk2,indwrk,iscale,liopt,liwmin,llwork, &
@@ -69252,7 +69252,7 @@ module stdlib_linalg_lapack_q
                     lwmin = 2*n + 1
                  end if
                  lopt = max(lwmin,2*n + stdlib_ilaenv(1,'DSYTRD',uplo,n,-1,-1,-1))
-                           
+
                  liopt = liwmin
               end if
               work(1) = lopt
@@ -69389,7 +69389,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: w(*),work(*),z(ldz,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,lower,lquery,valeig,wantz,tryrac
            character :: order
@@ -69596,7 +69596,7 @@ module stdlib_linalg_lapack_q
            end if
            call stdlib_qstebz(range,order,n,vll,vuu,il,iu,abstll,work(indd),work(inde &
            ),m,nsplit,w,iwork(indibl),iwork(indisp),work(indwk),iwork(indiwo),info)
-                     
+
            if (wantz) then
               call stdlib_qstein(n,work(indd),work(inde),m,w,iwork(indibl),iwork( &
                         indisp),z,ldz,work(indwk),iwork(indiwo),iwork(indifl),info)
@@ -69609,7 +69609,7 @@ module stdlib_linalg_lapack_q
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
         ! jump here if stdlib_qstemr/stdlib_qstein succeeded.
-30   continue
+        30 continue
            if (iscale == 1) then
               if (info == 0) then
                  imax = m
@@ -69665,7 +69665,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: w(*),work(*),z(ldz,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,lower,lquery,test,valeig,wantz
            character :: order
@@ -69815,7 +69815,7 @@ module stdlib_linalg_lapack_q
                            iinfo)
                  call stdlib_qcopy(n - 1,work(inde),1,work(indee),1)
                  call stdlib_qsteqr(jobz,n,w,work(indee),z,ldz,work(indwrk),info)
-                           
+
                  if (info == 0) then
                     do i = 1,n
                        ifail(i) = 0
@@ -69851,7 +69851,7 @@ module stdlib_linalg_lapack_q
                         indwkn),llwrkn,iinfo)
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
-40   continue
+           40 continue
            if (iscale == 1) then
               if (info == 0) then
                  imax = m
@@ -69912,7 +69912,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(in) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: k
@@ -70001,11 +70001,11 @@ module stdlib_linalg_lapack_q
                     akk = a(k,k)
                     bkk = b(k,k)
                     call stdlib_qtrmv(uplo,'TRANSPOSE','NON-UNIT',k - 1,b,ldb,a(k,1),lda)
-                              
+
                     ct = half*akk
                     call stdlib_qaxpy(k - 1,ct,b(k,1),ldb,a(k,1),lda)
                     call stdlib_qsyr2(uplo,k - 1,one,a(k,1),lda,b(k,1),ldb,a,lda)
-                              
+
                     call stdlib_qaxpy(k - 1,ct,b(k,1),ldb,a(k,1),lda)
                     call stdlib_qscal(k - 1,bkk,a(k,1),lda)
                     a(k,k) = akk*bkk**2
@@ -70035,7 +70035,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(in) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: k,kb,nb
@@ -70076,7 +70076,7 @@ module stdlib_linalg_lapack_q
                        kb = min(n - k + 1,nb)
                        ! update the upper triangle of a(k:n,k:n)
                        call stdlib_qsygs2(itype,uplo,kb,a(k,k),lda,b(k,k),ldb,info)
-                                 
+
                        if (k + kb <= n) then
                           call stdlib_qtrsm('LEFT',uplo,'TRANSPOSE','NON-UNIT',kb,n - k - kb + 1, &
                                     one,b(k,k),ldb,a(k,k + kb),lda)
@@ -70096,7 +70096,7 @@ module stdlib_linalg_lapack_q
                        kb = min(n - k + 1,nb)
                        ! update the lower triangle of a(k:n,k:n)
                        call stdlib_qsygs2(itype,uplo,kb,a(k,k),lda,b(k,k),ldb,info)
-                                 
+
                        if (k + kb <= n) then
                           call stdlib_qtrsm('RIGHT',uplo,'TRANSPOSE','NON-UNIT',n - k - kb + 1,kb, &
                                     one,b(k,k),ldb,a(k + kb,k),lda)
@@ -70128,7 +70128,7 @@ module stdlib_linalg_lapack_q
                        call stdlib_qtrmm('RIGHT',uplo,'TRANSPOSE','NON-UNIT',k - 1,kb,one,b( &
                                  k,k),ldb,a(1,k),lda)
                        call stdlib_qsygs2(itype,uplo,kb,a(k,k),lda,b(k,k),ldb,info)
-                                 
+
                     end do
                  else
                     ! compute l**t*a*l
@@ -70146,7 +70146,7 @@ module stdlib_linalg_lapack_q
                        call stdlib_qtrmm('LEFT',uplo,'TRANSPOSE','NON-UNIT',kb,k - 1,one,b( &
                                  k,k),ldb,a(k,1),lda)
                        call stdlib_qsygs2(itype,uplo,kb,a(k,k),lda,b(k,k),ldb,info)
-                                 
+
                     end do
                  end if
               end if
@@ -70172,7 +70172,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*),b(ldb,*)
            real(qp),intent(out) :: w(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper,wantz
            character :: trans
@@ -70237,7 +70237,7 @@ module stdlib_linalg_lapack_q
                     trans = 'T'
                  end if
                  call stdlib_qtrsm('LEFT',uplo,trans,'NON-UNIT',n,neig,one,b,ldb,a,lda)
-                           
+
               else if (itype == 3) then
                  ! for b*a*x=(lambda)*x;
                  ! backtransform eigenvectors: x = l*y or u**t*y
@@ -70247,7 +70247,7 @@ module stdlib_linalg_lapack_q
                     trans = 'N'
                  end if
                  call stdlib_qtrmm('LEFT',uplo,trans,'NON-UNIT',n,neig,one,b,ldb,a,lda)
-                           
+
               end if
            end if
            work(1) = lwkopt
@@ -70280,7 +70280,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*),b(ldb,*)
            real(qp),intent(out) :: w(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper,wantz
            character :: trans
@@ -70357,7 +70357,7 @@ module stdlib_linalg_lapack_q
                     trans = 'T'
                  end if
                  call stdlib_qtrsm('LEFT',uplo,trans,'NON-UNIT',n,n,one,b,ldb,a,lda)
-                           
+
               else if (itype == 3) then
                  ! for b*a*x=(lambda)*x;
                  ! backtransform eigenvectors: x = l*y or u**t*y
@@ -70367,7 +70367,7 @@ module stdlib_linalg_lapack_q
                     trans = 'N'
                  end if
                  call stdlib_qtrmm('LEFT',uplo,trans,'NON-UNIT',n,n,one,b,ldb,a,lda)
-                           
+
               end if
            end if
            work(1) = lopt
@@ -70397,7 +70397,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*),b(ldb,*)
            real(qp),intent(out) :: w(*),work(*),z(ldz,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,lquery,upper,valeig,wantz
            character :: trans
@@ -70485,7 +70485,7 @@ module stdlib_linalg_lapack_q
                     trans = 'T'
                  end if
                  call stdlib_qtrsm('LEFT',uplo,trans,'NON-UNIT',n,m,one,b,ldb,z,ldz)
-                           
+
               else if (itype == 3) then
                  ! for b*a*x=(lambda)*x;
                  ! backtransform eigenvectors: x = l*y or u**t*y
@@ -70495,7 +70495,7 @@ module stdlib_linalg_lapack_q
                     trans = 'N'
                  end if
                  call stdlib_qtrmm('LEFT',uplo,trans,'NON-UNIT',n,m,one,b,ldb,z,ldz)
-                           
+
               end if
            end if
            ! set work(1) to optimal workspace size.
@@ -70525,7 +70525,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,j,k,kase,nz
@@ -70575,7 +70575,7 @@ module stdlib_linalg_lapack_q
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_qcopy(n,b(1,j),1,work(n + 1),1)
@@ -70659,9 +70659,9 @@ module stdlib_linalg_lapack_q
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_qlacn2(n,work(2*n + 1),work(n + 1),iwork,ferr(j),kase,isave)
-                        
+
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(a**t).
@@ -70778,7 +70778,7 @@ module stdlib_linalg_lapack_q
      !> form of A is then used to solve the system of equations A * X = B.
 
      pure subroutine stdlib_qsysv_aa(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -70832,7 +70832,7 @@ module stdlib_linalg_lapack_q
            if (info == 0) then
               ! solve the system a*x = b, overwriting b with x.
               call stdlib_qsytrs_aa(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-                        
+
            end if
            work(1) = lwkopt
            return
@@ -70854,7 +70854,7 @@ module stdlib_linalg_lapack_q
      !> the system of equations A * X = B by calling BLAS3 routine DSYTRS_3.
 
      pure subroutine stdlib_qsysv_rk(uplo,n,nrhs,a,lda,e,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -70933,7 +70933,7 @@ module stdlib_linalg_lapack_q
      !> of equations A * X = B by calling DSYTRS_ROOK.
 
      pure subroutine stdlib_qsysv_rook(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -71018,7 +71018,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: af(ldaf,*)
            real(qp),intent(out) :: berr(*),ferr(*),work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,nofact
            integer(ilp) :: lwkopt,nb
@@ -71174,7 +71174,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: d(*),e(*),tau(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i
@@ -71210,7 +71210,7 @@ module stdlib_linalg_lapack_q
                     a(i,i + 1) = one
                     ! compute  x := tau * a * v  storing x in tau(1:i)
                     call stdlib_qsymv(uplo,i,taui,a,lda,a(1,i + 1),1,zero,tau,1)
-                              
+
                     ! compute  w := x - 1/2 * tau * (x**t * v) * v
                     alpha = -half*taui*stdlib_qdot(i,tau,1,a(1,i + 1),1)
                     call stdlib_qaxpy(i,alpha,a(1,i + 1),1,tau,1)
@@ -71275,7 +71275,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: sevten = 17.0e+0_qp
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,imax,j,jmax,k,kk,kp,kstep
@@ -71305,7 +71305,7 @@ module stdlib_linalg_lapack_q
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 70
               kstep = 1
@@ -71420,7 +71420,7 @@ module stdlib_linalg_lapack_q
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop
               if (k > n) go to 70
               kstep = 1
@@ -71473,7 +71473,7 @@ module stdlib_linalg_lapack_q
                     ! interchange rows and columns kk and kp in the trailing
                     ! submatrix a(k:n,k:n)
                     if (kp < n) call stdlib_qswap(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     call stdlib_qswap(kp - kk - 1,a(kk + 1,kk),1,a(kp,kk + 1),lda)
                     t = a(kk,kk)
                     a(kk,kk) = a(kp,kp)
@@ -71494,7 +71494,7 @@ module stdlib_linalg_lapack_q
                        ! a := a - l(k)*d(k)*l(k)**t = a - w(k)*(1/d(k))*w(k)**t
                        d11 = one/a(k,k)
                        call stdlib_qsyr(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                 
+
                        ! store l(k) in column k
                        call stdlib_qscal(n - k,d11,a(k + 1,k),1)
                     end if
@@ -71533,7 +71533,7 @@ module stdlib_linalg_lapack_q
               k = k + kstep
               go to 40
            end if
-70         continue
+           70 continue
            return
      end subroutine stdlib_qsytf2
 
@@ -71562,7 +71562,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: sevten = 17.0e+0_qp
-           
+
            ! Local Scalars
            logical(lk) :: upper,done
            integer(ilp) :: i,imax,j,jmax,itemp,k,kk,kp,kstep,p,ii
@@ -71597,7 +71597,7 @@ module stdlib_linalg_lapack_q
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 34
               kstep = 1
@@ -71631,7 +71631,7 @@ module stdlib_linalg_lapack_q
                  else
                     done = .false.
                     ! loop until pivot found
-12   continue
+                    12 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -71681,7 +71681,7 @@ module stdlib_linalg_lapack_q
                     ! submatrix a(1:k,1:k) if we have a 2-by-2 pivot
                     if (p > 1) call stdlib_qswap(p - 1,a(1,k),1,a(1,p),1)
                     if (p < (k - 1)) call stdlib_qswap(k - p - 1,a(p + 1,k),1,a(p,p + 1),lda)
-                              
+
                     t = a(k,k)
                     a(k,k) = a(p,p)
                     a(p,p) = t
@@ -71784,7 +71784,7 @@ module stdlib_linalg_lapack_q
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-34            continue
+              34 continue
            else
               ! factorize a as l*d*l**t using the lower triangle of a
               ! initialize the unused last entry of the subdiagonal array e.
@@ -71792,7 +71792,7 @@ module stdlib_linalg_lapack_q
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop
               if (k > n) go to 64
               kstep = 1
@@ -71825,7 +71825,7 @@ module stdlib_linalg_lapack_q
                  else
                     done = .false.
                     ! loop until pivot found
-42   continue
+                    42 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -71875,7 +71875,7 @@ module stdlib_linalg_lapack_q
                     ! submatrix a(k:n,k:n) if we have a 2-by-2 pivot
                     if (p < n) call stdlib_qswap(n - p,a(p + 1,k),1,a(p + 1,p),1)
                     if (p > (k + 1)) call stdlib_qswap(p - k - 1,a(k + 1,k),1,a(p,k + 1),lda)
-                              
+
                     t = a(k,k)
                     a(k,k) = a(p,p)
                     a(p,p) = t
@@ -71889,7 +71889,7 @@ module stdlib_linalg_lapack_q
                     ! interchange rows and columns kk and kp in the trailing
                     ! submatrix a(k:n,k:n)
                     if (kp < n) call stdlib_qswap(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     if ((kk < n) .and. (kp > (kk + 1))) call stdlib_qswap(kp - kk - 1,a(kk + 1,kk), &
                               1,a(kp,kk + 1),lda)
                     t = a(kk,kk)
@@ -71918,7 +71918,7 @@ module stdlib_linalg_lapack_q
                              ! = a - w(k)*(1/d(k))*w(k)**t
                           d11 = one/a(k,k)
                           call stdlib_qsyr(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                           ! store l(k) in column k
                           call stdlib_qscal(n - k,d11,a(k + 1,k),1)
                        else
@@ -71932,7 +71932,7 @@ module stdlib_linalg_lapack_q
                              ! = a - w(k)*(1/d(k))*w(k)**t
                              ! = a - (w(k)/d(k))*(d(k))*(w(k)/d(k))**t
                           call stdlib_qsyr(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                        end if
                        ! store the subdiagonal element of d in array e
                        e(k) = zero
@@ -71983,7 +71983,7 @@ module stdlib_linalg_lapack_q
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 40
-64            continue
+              64 continue
            end if
            return
      end subroutine stdlib_qsytf2_rk
@@ -72010,7 +72010,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: sevten = 17.0e+0_qp
-           
+
            ! Local Scalars
            logical(lk) :: upper,done
            integer(ilp) :: i,imax,j,jmax,itemp,k,kk,kp,kstep,p,ii
@@ -72042,7 +72042,7 @@ module stdlib_linalg_lapack_q
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 70
               kstep = 1
@@ -72074,7 +72074,7 @@ module stdlib_linalg_lapack_q
                  else
                     done = .false.
                     ! loop until pivot found
-12   continue
+                    12 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -72124,7 +72124,7 @@ module stdlib_linalg_lapack_q
                     ! submatrix a(1:k,1:k) if we have a 2-by-2 pivot
                     if (p > 1) call stdlib_qswap(p - 1,a(1,k),1,a(1,p),1)
                     if (p < (k - 1)) call stdlib_qswap(k - p - 1,a(p + 1,k),1,a(p,p + 1),lda)
-                              
+
                     t = a(k,k)
                     a(k,k) = a(p,p)
                     a(p,p) = t
@@ -72218,7 +72218,7 @@ module stdlib_linalg_lapack_q
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop
               if (k > n) go to 70
               kstep = 1
@@ -72249,7 +72249,7 @@ module stdlib_linalg_lapack_q
                  else
                     done = .false.
                     ! loop until pivot found
-42   continue
+                    42 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -72299,7 +72299,7 @@ module stdlib_linalg_lapack_q
                     ! submatrix a(k:n,k:n) if we have a 2-by-2 pivot
                     if (p < n) call stdlib_qswap(n - p,a(p + 1,k),1,a(p + 1,p),1)
                     if (p > (k + 1)) call stdlib_qswap(p - k - 1,a(k + 1,k),1,a(p,k + 1),lda)
-                              
+
                     t = a(k,k)
                     a(k,k) = a(p,p)
                     a(p,p) = t
@@ -72310,7 +72310,7 @@ module stdlib_linalg_lapack_q
                     ! interchange rows and columns kk and kp in the trailing
                     ! submatrix a(k:n,k:n)
                     if (kp < n) call stdlib_qswap(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     if ((kk < n) .and. (kp > (kk + 1))) call stdlib_qswap(kp - kk - 1,a(kk + 1,kk), &
                               1,a(kp,kk + 1),lda)
                     t = a(kk,kk)
@@ -72336,7 +72336,7 @@ module stdlib_linalg_lapack_q
                              ! = a - w(k)*(1/d(k))*w(k)**t
                           d11 = one/a(k,k)
                           call stdlib_qsyr(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                           ! store l(k) in column k
                           call stdlib_qscal(n - k,d11,a(k + 1,k),1)
                        else
@@ -72350,7 +72350,7 @@ module stdlib_linalg_lapack_q
                              ! = a - w(k)*(1/d(k))*w(k)**t
                              ! = a - (w(k)/d(k))*(d(k))*(w(k)/d(k))**t
                           call stdlib_qsyr(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                        end if
                     end if
                  else
@@ -72394,7 +72394,7 @@ module stdlib_linalg_lapack_q
               k = k + kstep
               go to 40
            end if
-70         continue
+           70 continue
            return
      end subroutine stdlib_qsytf2_rook
 
@@ -72414,7 +72414,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: d(*),e(*),tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper
            integer(ilp) :: i,iinfo,iws,j,kk,ldwork,lwkopt,nb,nbmin,nx
@@ -72518,7 +72518,7 @@ module stdlib_linalg_lapack_q
               end do
               ! use unblocked code to reduce the last or only block
               call stdlib_qsytd2(uplo,n - i + 1,a(i,i),lda,d(i),e(i),tau(i),iinfo)
-                        
+
            end if
            work(1) = lwkopt
            return
@@ -72546,7 +72546,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: rzero = 0.0e+0_qp
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wantq,upper,afters1
            integer(ilp) :: i,m,k,ib,sweepid,myid,shift,stt,st,ed,stind,edind, &
@@ -72786,7 +72786,7 @@ module stdlib_linalg_lapack_q
      !> Q**T * A * Q = AB.
 
      pure subroutine stdlib_qsytrd_sy2sb(uplo,n,kd,a,lda,ab,ldab,tau,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -72800,7 +72800,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: rone = 1.0e+0_qp
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper
            integer(ilp) :: i,j,iinfo,lwmin,pn,pk,lk,ldt,ldw,lds2,lds1,ls2,ls1,lw,lt, &
@@ -72943,7 +72943,7 @@ module stdlib_linalg_lapack_q
                    ! do 45 j = i, i+pk-1
                       ! lk = min( kd, n-j ) + 1
                       ! call stdlib_qcopy( lk, ab( 1, j ), 1, a( j, j ), 1 )
-45   continue
+                      45 continue
                   ! ==================================================================
                end do loop_40
               ! copy the lower band to ab which is the band storage matrix
@@ -73027,7 +73027,7 @@ module stdlib_linalg_lapack_q
               ! kb, where kb is the number of columns factorized by stdlib_qlasyf;
               ! kb is either nb or nb-1, or k for the last block
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 40
               if (k > nb) then
@@ -73050,7 +73050,7 @@ module stdlib_linalg_lapack_q
               ! kb, where kb is the number of columns factorized by stdlib_qlasyf;
               ! kb is either nb or nb-1, or n-k+1 for the last block
               k = 1
-20            continue
+              20 continue
               ! if k > n, exit from loop
               if (k > n) go to 40
               if (k <= n - nb) then
@@ -73077,7 +73077,7 @@ module stdlib_linalg_lapack_q
               k = k + kb
               go to 20
            end if
-40         continue
+           40 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_qsytrf
@@ -73102,7 +73102,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper
            integer(ilp) :: j,lwkopt
@@ -73158,7 +73158,7 @@ module stdlib_linalg_lapack_q
               ! jb, where jb is the number of columns factorized by stdlib_qlasyf;
               ! jb is either nb, or n-j+1 for the last block
               j = 0
-10            continue
+              10 continue
               if (j >= n) go to 20
               ! each step of the main loop
                ! j is the last column of the previous panel
@@ -73190,7 +73190,7 @@ module stdlib_linalg_lapack_q
                     alpha = a(j,j + 1)
                     a(j,j + 1) = one
                     call stdlib_qcopy(n - j,a(j - 1,j + 1),lda,work((j + 1 - j1 + 1) + jb*n),1)
-                              
+
                     call stdlib_qscal(n - j,alpha,work((j + 1 - j1 + 1) + jb*n),1)
                     ! k1 identifies if the previous column of the panel has been
                      ! explicitly stored, e.g., k1=1 and k2= 0 for the first panel,
@@ -73235,7 +73235,7 @@ module stdlib_linalg_lapack_q
               ! jb, where jb is the number of columns factorized by stdlib_qlasyf;
               ! jb is either nb, or n-j+1 for the last block
               j = 0
-11            continue
+              11 continue
               if (j >= n) go to 20
               ! each step of the main loop
                ! j is the last column of the previous panel
@@ -73301,7 +73301,7 @@ module stdlib_linalg_lapack_q
               end if
               go to 11
            end if
-20         continue
+           20 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_qsytrf_aa
@@ -73378,14 +73378,14 @@ module stdlib_linalg_lapack_q
               ! kb, where kb is the number of columns factorized by stdlib_qlasyf_rk;
               ! kb is either nb or nb-1, or k for the last block
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 15
               if (k > nb) then
                  ! factorize columns k-kb+1:k of a and use blocked code to
                  ! update columns 1:k-kb
                  call stdlib_qlasyf_rk(uplo,k,nb,kb,a,lda,e,ipiv,work,ldwork,iinfo)
-                           
+
               else
                  ! use unblocked code to factorize columns 1:k of a
                  call stdlib_qsytf2_rk(uplo,k,a,lda,e,ipiv,iinfo)
@@ -73414,14 +73414,14 @@ module stdlib_linalg_lapack_q
               go to 10
               ! this label is the exit from main loop over k decreasing
               ! from n to 1 in steps of kb
-15   continue
+              15 continue
            else
               ! factorize a as l*d*l**t using the lower triangle of a
               ! k is the main loop index, increasing from 1 to n in steps of
               ! kb, where kb is the number of columns factorized by stdlib_qlasyf_rk;
               ! kb is either nb or nb-1, or n-k+1 for the last block
               k = 1
-20            continue
+              20 continue
               ! if k > n, exit from loop
               if (k > n) go to 35
               if (k <= n - nb) then
@@ -73432,7 +73432,7 @@ module stdlib_linalg_lapack_q
               else
                  ! use unblocked code to factorize columns k:n of a
                  call stdlib_qsytf2_rk(uplo,n - k + 1,a(k,k),lda,e(k),ipiv(k),iinfo)
-                           
+
                  kb = n - k + 1
               end if
               ! set info on the first occurrence of a zero pivot
@@ -73465,7 +73465,7 @@ module stdlib_linalg_lapack_q
               go to 20
               ! this label is the exit from main loop over k increasing
               ! from 1 to n in steps of kb
-35   continue
+              35 continue
            ! end lower
            end if
            work(1) = lwkopt
@@ -73543,14 +73543,14 @@ module stdlib_linalg_lapack_q
               ! kb, where kb is the number of columns factorized by stdlib_qlasyf_rook;
               ! kb is either nb or nb-1, or k for the last block
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 40
               if (k > nb) then
                  ! factorize columns k-kb+1:k of a and use blocked code to
                  ! update columns 1:k-kb
                  call stdlib_qlasyf_rook(uplo,k,nb,kb,a,lda,ipiv,work,ldwork,iinfo)
-                           
+
               else
                  ! use unblocked code to factorize columns 1:k of a
                  call stdlib_qsytf2_rook(uplo,k,a,lda,ipiv,iinfo)
@@ -73568,7 +73568,7 @@ module stdlib_linalg_lapack_q
               ! kb, where kb is the number of columns factorized by stdlib_qlasyf_rook;
               ! kb is either nb or nb-1, or n-k+1 for the last block
               k = 1
-20            continue
+              20 continue
               ! if k > n, exit from loop
               if (k > n) go to 40
               if (k <= n - nb) then
@@ -73595,7 +73595,7 @@ module stdlib_linalg_lapack_q
               k = k + kb
               go to 20
            end if
-40         continue
+           40 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_qsytrf_rook
@@ -73617,7 +73617,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: k,kp,kstep
@@ -73659,7 +73659,7 @@ module stdlib_linalg_lapack_q
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-30            continue
+              30 continue
               ! if k > n, exit from loop.
               if (k > n) go to 40
               if (ipiv(k) > 0) then
@@ -73670,7 +73670,7 @@ module stdlib_linalg_lapack_q
                  if (k > 1) then
                     call stdlib_qcopy(k - 1,a(1,k),1,work,1)
                     call stdlib_qsymv(uplo,k - 1,-one,a,lda,work,1,zero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - stdlib_qdot(k - 1,work,1,a(1,k),1)
                  end if
                  kstep = 1
@@ -73689,15 +73689,15 @@ module stdlib_linalg_lapack_q
                  if (k > 1) then
                     call stdlib_qcopy(k - 1,a(1,k),1,work,1)
                     call stdlib_qsymv(uplo,k - 1,-one,a,lda,work,1,zero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - stdlib_qdot(k - 1,work,1,a(1,k),1)
                     a(k,k + 1) = a(k,k + 1) - stdlib_qdot(k - 1,a(1,k),1,a(1,k + 1),1)
-                              
+
                     call stdlib_qcopy(k - 1,a(1,k + 1),1,work,1)
                     call stdlib_qsymv(uplo,k - 1,-one,a,lda,work,1,zero,a(1,k + 1),1)
-                              
+
                     a(k + 1,k + 1) = a(k + 1,k + 1) - stdlib_qdot(k - 1,work,1,a(1,k + 1),1)
-                              
+
                  end if
                  kstep = 2
               end if
@@ -73718,13 +73718,13 @@ module stdlib_linalg_lapack_q
               end if
               k = k + kstep
               go to 30
-40            continue
+              40 continue
            else
               ! compute inv(a) from the factorization a = l*d*l**t.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-50            continue
+              50 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 60
               if (ipiv(k) > 0) then
@@ -73757,12 +73757,12 @@ module stdlib_linalg_lapack_q
                               k),1)
                     a(k,k) = a(k,k) - stdlib_qdot(n - k,work,1,a(k + 1,k),1)
                     a(k,k - 1) = a(k,k - 1) - stdlib_qdot(n - k,a(k + 1,k),1,a(k + 1,k - 1),1)
-                              
+
                     call stdlib_qcopy(n - k,a(k + 1,k - 1),1,work,1)
                     call stdlib_qsymv(uplo,n - k,-one,a(k + 1,k + 1),lda,work,1,zero,a(k + 1, &
                               k - 1),1)
                     a(k - 1,k - 1) = a(k - 1,k - 1) - stdlib_qdot(n - k,work,1,a(k + 1,k - 1),1)
-                              
+
                  end if
                  kstep = 2
               end if
@@ -73783,7 +73783,7 @@ module stdlib_linalg_lapack_q
               end if
               k = k - kstep
               go to 50
-60            continue
+              60 continue
            end if
            return
      end subroutine stdlib_qsytri
@@ -73805,7 +73805,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: k,kp,kstep
@@ -73847,7 +73847,7 @@ module stdlib_linalg_lapack_q
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-30            continue
+              30 continue
               ! if k > n, exit from loop.
               if (k > n) go to 40
               if (ipiv(k) > 0) then
@@ -73858,7 +73858,7 @@ module stdlib_linalg_lapack_q
                  if (k > 1) then
                     call stdlib_qcopy(k - 1,a(1,k),1,work,1)
                     call stdlib_qsymv(uplo,k - 1,-one,a,lda,work,1,zero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - stdlib_qdot(k - 1,work,1,a(1,k),1)
                  end if
                  kstep = 1
@@ -73877,15 +73877,15 @@ module stdlib_linalg_lapack_q
                  if (k > 1) then
                     call stdlib_qcopy(k - 1,a(1,k),1,work,1)
                     call stdlib_qsymv(uplo,k - 1,-one,a,lda,work,1,zero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - stdlib_qdot(k - 1,work,1,a(1,k),1)
                     a(k,k + 1) = a(k,k + 1) - stdlib_qdot(k - 1,a(1,k),1,a(1,k + 1),1)
-                              
+
                     call stdlib_qcopy(k - 1,a(1,k + 1),1,work,1)
                     call stdlib_qsymv(uplo,k - 1,-one,a,lda,work,1,zero,a(1,k + 1),1)
-                              
+
                     a(k + 1,k + 1) = a(k + 1,k + 1) - stdlib_qdot(k - 1,work,1,a(1,k + 1),1)
-                              
+
                  end if
                  kstep = 2
               end if
@@ -73926,13 +73926,13 @@ module stdlib_linalg_lapack_q
               end if
               k = k + 1
               go to 30
-40            continue
+              40 continue
            else
               ! compute inv(a) from the factorization a = l*d*l**t.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-50            continue
+              50 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 60
               if (ipiv(k) > 0) then
@@ -73965,12 +73965,12 @@ module stdlib_linalg_lapack_q
                               k),1)
                     a(k,k) = a(k,k) - stdlib_qdot(n - k,work,1,a(k + 1,k),1)
                     a(k,k - 1) = a(k,k - 1) - stdlib_qdot(n - k,a(k + 1,k),1,a(k + 1,k - 1),1)
-                              
+
                     call stdlib_qcopy(n - k,a(k + 1,k - 1),1,work,1)
                     call stdlib_qsymv(uplo,n - k,-one,a(k + 1,k + 1),lda,work,1,zero,a(k + 1, &
                               k - 1),1)
                     a(k - 1,k - 1) = a(k - 1,k - 1) - stdlib_qdot(n - k,work,1,a(k + 1,k - 1),1)
-                              
+
                  end if
                  kstep = 2
               end if
@@ -74011,7 +74011,7 @@ module stdlib_linalg_lapack_q
               end if
               k = k - 1
               go to 50
-60            continue
+              60 continue
            end if
            return
      end subroutine stdlib_qsytri_rook
@@ -74033,7 +74033,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: a(lda,*)
            real(qp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kp
@@ -74066,7 +74066,7 @@ module stdlib_linalg_lapack_q
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 30
               if (ipiv(k) > 0) then
@@ -74077,7 +74077,7 @@ module stdlib_linalg_lapack_q
                  ! multiply by inv(u(k)), where u(k) is the transformation
                  ! stored in column k of a.
                  call stdlib_qger(k - 1,nrhs,-one,a(1,k),1,b(k,1),ldb,b(1,1),ldb)
-                           
+
                  ! multiply by the inverse of the diagonal block.
                  call stdlib_qscal(nrhs,one/a(k,k),b(k,1),ldb)
                  k = k - 1
@@ -74089,7 +74089,7 @@ module stdlib_linalg_lapack_q
                  ! multiply by inv(u(k)), where u(k) is the transformation
                  ! stored in columns k-1 and k of a.
                  call stdlib_qger(k - 2,nrhs,-one,a(1,k),1,b(k,1),ldb,b(1,1),ldb)
-                           
+
                  call stdlib_qger(k - 2,nrhs,-one,a(1,k - 1),1,b(k - 1,1),ldb,b(1,1), &
                            ldb)
                  ! multiply by the inverse of the diagonal block.
@@ -74106,12 +74106,12 @@ module stdlib_linalg_lapack_q
                  k = k - 2
               end if
               go to 10
-30            continue
+              30 continue
               ! next solve u**t *x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               if (ipiv(k) > 0) then
@@ -74138,14 +74138,14 @@ module stdlib_linalg_lapack_q
                  k = k + 2
               end if
               go to 40
-50            continue
+              50 continue
            else
               ! solve a*x = b, where a = l*d*l**t.
               ! first solve l*d*x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-60            continue
+              60 continue
               ! if k > n, exit from loop.
               if (k > n) go to 80
               if (ipiv(k) > 0) then
@@ -74187,12 +74187,12 @@ module stdlib_linalg_lapack_q
                  k = k + 2
               end if
               go to 60
-80            continue
+              80 continue
               ! next solve l**t *x = b, overwriting b with x.
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-90            continue
+              90 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 100
               if (ipiv(k) > 0) then
@@ -74221,7 +74221,7 @@ module stdlib_linalg_lapack_q
                  k = k - 2
               end if
               go to 90
-100           continue
+              100 continue
            end if
            return
      end subroutine stdlib_qsytrs
@@ -74243,7 +74243,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*),b(ldb,*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,iinfo,j,k,kp
@@ -74352,7 +74352,7 @@ module stdlib_linalg_lapack_q
                  ! interchange rows k and -ipiv(k+1).
                  kp = -ipiv(k + 1)
                  if (kp == -ipiv(k)) call stdlib_qswap(nrhs,b(k + 1,1),ldb,b(kp,1),ldb)
-                           
+
                  k = k + 2
               end if
              end do
@@ -74427,7 +74427,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: a(lda,*),e(*)
            real(qp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,j,k,kp
@@ -74566,7 +74566,7 @@ module stdlib_linalg_lapack_q
      !> A = L*T*L**T computed by DSYTRF_AA.
 
      pure subroutine stdlib_qsytrs_aa(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -74580,7 +74580,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: b(ldb,*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            logical(lk) :: lquery,upper
            integer(ilp) :: k,kp,lwkopt
            ! Intrinsic Functions
@@ -74697,7 +74697,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: a(lda,*)
            real(qp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kp
@@ -74730,7 +74730,7 @@ module stdlib_linalg_lapack_q
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 30
               if (ipiv(k) > 0) then
@@ -74741,7 +74741,7 @@ module stdlib_linalg_lapack_q
                  ! multiply by inv(u(k)), where u(k) is the transformation
                  ! stored in column k of a.
                  call stdlib_qger(k - 1,nrhs,-one,a(1,k),1,b(k,1),ldb,b(1,1),ldb)
-                           
+
                  ! multiply by the inverse of the diagonal block.
                  call stdlib_qscal(nrhs,one/a(k,k),b(k,1),ldb)
                  k = k - 1
@@ -74774,12 +74774,12 @@ module stdlib_linalg_lapack_q
                  k = k - 2
               end if
               go to 10
-30            continue
+              30 continue
               ! next solve u**t *x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               if (ipiv(k) > 0) then
@@ -74810,14 +74810,14 @@ module stdlib_linalg_lapack_q
                  k = k + 2
               end if
               go to 40
-50            continue
+              50 continue
            else
               ! solve a*x = b, where a = l*d*l**t.
               ! first solve l*d*x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-60            continue
+              60 continue
               ! if k > n, exit from loop.
               if (k > n) go to 80
               if (ipiv(k) > 0) then
@@ -74861,12 +74861,12 @@ module stdlib_linalg_lapack_q
                  k = k + 2
               end if
               go to 60
-80            continue
+              80 continue
               ! next solve l**t *x = b, overwriting b with x.
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-90            continue
+              90 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 100
               if (ipiv(k) > 0) then
@@ -74897,7 +74897,7 @@ module stdlib_linalg_lapack_q
                  k = k - 2
               end if
               go to 90
-100           continue
+              100 continue
            end if
            return
      end subroutine stdlib_qsytrs_rook
@@ -74910,7 +74910,7 @@ module stdlib_linalg_lapack_q
      !> RCOND = 1 / ( norm(A) * norm(inv(A)) ).
 
      subroutine stdlib_qtbcon(norm,uplo,diag,n,kd,ab,ldab,rcond,work,iwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -74924,7 +74924,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: ab(ldab,*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,onenrm,upper
            character :: normin
@@ -74977,7 +74977,7 @@ module stdlib_linalg_lapack_q
                  kase1 = 2
               end if
               kase = 0
-10            continue
+              10 continue
               call stdlib_qlacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
               if (kase /= 0) then
                  if (kase == kase1) then
@@ -75002,7 +75002,7 @@ module stdlib_linalg_lapack_q
               ! compute the estimate of the reciprocal condition number.
               if (ainvnm /= zero) rcond = (one/anorm)/ainvnm
            end if
-20         continue
+           20 continue
            return
      end subroutine stdlib_qtbcon
 
@@ -75027,7 +75027,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: ab(ldab,*),b(ldb,*),x(ldx,*)
            real(qp),intent(out) :: berr(*),ferr(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            character :: transt
@@ -75213,14 +75213,14 @@ module stdlib_linalg_lapack_q
                  end if
               end do
               kase = 0
-210           continue
+              210 continue
               call stdlib_qlacn2(n,work(2*n + 1),work(n + 1),iwork,ferr(j),kase,isave)
-                        
+
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(op(a)**t).
                     call stdlib_qtbsv(uplo,transt,diag,n,kd,ab,ldab,work(n + 1),1)
-                              
+
                     do i = 1,n
                        work(n + i) = work(i)*work(n + i)
                     end do
@@ -75249,7 +75249,7 @@ module stdlib_linalg_lapack_q
      !> N-by NRHS matrix.  A check is made to verify that A is nonsingular.
 
      pure subroutine stdlib_qtbtrs(uplo,trans,diag,n,kd,nrhs,ab,ldab,b,ldb,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -75261,7 +75261,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: ab(ldab,*)
            real(qp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,upper
            integer(ilp) :: j
@@ -75326,7 +75326,7 @@ module stdlib_linalg_lapack_q
      !> The matrix X is overwritten on B.
 
      pure subroutine stdlib_qtfsm(transr,side,uplo,trans,diag,m,n,alpha,a,b,ldb)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -75338,7 +75338,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: a(0:*)
            real(qp),intent(inout) :: b(0:ldb - 1,0:*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,lside,misodd,nisodd,normaltransr,notrans
            integer(ilp) :: m1,m2,n1,n2,k,info,i,j
@@ -75413,7 +75413,7 @@ module stdlib_linalg_lapack_q
                           ! trans = 'n'
                           if (m == 1) then
                              call stdlib_qtrsm('L','L','N',diag,m1,n,alpha,a,m,b,ldb)
-                                       
+
                           else
                              call stdlib_qtrsm('L','L','N',diag,m1,n,alpha,a(0),m,b, &
                                        ldb)
@@ -75456,7 +75456,7 @@ module stdlib_linalg_lapack_q
                           call stdlib_qgemm('N','N',m1,n,m2,-one,a(0),m,b(m1,0),ldb, &
                                      alpha,b,ldb)
                           call stdlib_qtrsm('L','L','T',diag,m1,n,one,a(m2),m,b,ldb)
-                                    
+
                        end if
                     end if
                  else
@@ -75538,7 +75538,7 @@ module stdlib_linalg_lapack_q
                           call stdlib_qgemm('T','N',k,n,k,-one,a(k + 1),m + 1,b(k,0), &
                                     ldb,alpha,b,ldb)
                           call stdlib_qtrsm('L','L','T',diag,k,n,one,a(1),m + 1,b,ldb)
-                                    
+
                        end if
                     else
                        ! side  ='l', n is even, transr = 'n', and uplo = 'u'
@@ -75570,7 +75570,7 @@ module stdlib_linalg_lapack_q
                           ! side  ='l', n is even, transr = 't', uplo = 'l',
                           ! and trans = 'n'
                           call stdlib_qtrsm('L','U','T',diag,k,n,alpha,a(k),k,b,ldb)
-                                    
+
                           call stdlib_qgemm('T','N',k,n,k,-one,a(k*(k + 1)),k,b,ldb, &
                                     alpha,b(k,0),ldb)
                           call stdlib_qtrsm('L','L','N',diag,k,n,one,a(0),k,b(k,0), &
@@ -75583,7 +75583,7 @@ module stdlib_linalg_lapack_q
                           call stdlib_qgemm('N','N',k,n,k,-one,a(k*(k + 1)),k,b(k,0), &
                                      ldb,alpha,b,ldb)
                           call stdlib_qtrsm('L','U','N',diag,k,n,one,a(k),k,b,ldb)
-                                    
+
                        end if
                     else
                        ! side  ='l', n is even, transr = 't', and uplo = 'u'
@@ -75833,7 +75833,7 @@ module stdlib_linalg_lapack_q
            ! Array Arguments
            real(qp),intent(inout) :: a(0:*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,nisodd,normaltransr
            integer(ilp) :: n1,n2,k
@@ -75888,12 +75888,12 @@ module stdlib_linalg_lapack_q
                     call stdlib_qtrtri('L',diag,n1,a(0),n,info)
                     if (info > 0) return
                     call stdlib_qtrmm('R','L','N',diag,n2,n1,-one,a(0),n,a(n1),n)
-                              
+
                     call stdlib_qtrtri('U',diag,n2,a(n),n,info)
                     if (info > 0) info = info + n1
                     if (info > 0) return
                     call stdlib_qtrmm('L','U','T',diag,n2,n1,one,a(n),n,a(n1),n)
-                              
+
                  else
                    ! srpa for upper, normal and n is odd ( a(0:n-1,0:n2-1)
                    ! t1 -> a(n1+1,0), t2 -> a(n1,0), s -> a(0,0)
@@ -75901,12 +75901,12 @@ module stdlib_linalg_lapack_q
                     call stdlib_qtrtri('L',diag,n1,a(n2),n,info)
                     if (info > 0) return
                     call stdlib_qtrmm('L','L','T',diag,n1,n2,-one,a(n2),n,a(0),n)
-                              
+
                     call stdlib_qtrtri('U',diag,n2,a(n1),n,info)
                     if (info > 0) info = info + n1
                     if (info > 0) return
                     call stdlib_qtrmm('R','U','N',diag,n1,n2,one,a(n1),n,a(0),n)
-                              
+
                  end if
               else
                  ! n is odd and transr = 't'
@@ -75952,7 +75952,7 @@ module stdlib_linalg_lapack_q
                     if (info > 0) info = info + k
                     if (info > 0) return
                     call stdlib_qtrmm('L','U','T',diag,k,k,one,a(0),n + 1,a(k + 1),n + 1)
-                              
+
                  else
                     ! srpa for upper, normal, and n is even ( a(0:n,0:k-1) )
                     ! t1 -> a(k+1,0) ,  t2 -> a(k,0),   s -> a(0,0)
@@ -75965,7 +75965,7 @@ module stdlib_linalg_lapack_q
                     if (info > 0) info = info + k
                     if (info > 0) return
                     call stdlib_qtrmm('R','U','N',diag,k,k,one,a(k),n + 1,a(0),n + 1)
-                              
+
                  end if
               else
                  ! n is even and transr = 't'
@@ -75994,7 +75994,7 @@ module stdlib_linalg_lapack_q
                     if (info > 0) info = info + k
                     if (info > 0) return
                     call stdlib_qtrmm('L','L','N',diag,k,k,one,a(k*k),k,a(0),k)
-                              
+
                  end if
               end if
            end if
@@ -76522,7 +76522,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: safety = 1.0e+2_qp
-           
+
            ! Local Scalars
            logical(lk) :: compl,compr,il2by2,ilabad,ilall,ilback,ilbbad,ilcomp,ilcplx, &
                      lsa,lsb
@@ -76740,7 +76740,7 @@ module stdlib_linalg_lapack_q
                     lsb = abs(salfar) >= safmin .and. abs(bcoefr) < small
                     if (lsa) scale = (small/abs(sbeta))*min(anorm,big)
                     if (lsb) scale = max(scale, (small/abs(salfar))*min(bnorm,big))
-                              
+
                     if (lsa .or. lsb) then
                        scale = min(scale,one/(safmin*max(one,abs(acoef),abs(bcoefr))) &
                                  )
@@ -76779,7 +76779,7 @@ module stdlib_linalg_lapack_q
                               ulp)/bcoefa)
                     if (safmin*acoefa > ascale) scale = ascale/(safmin*acoefa)
                     if (safmin*bcoefa > bscale) scale = min(scale,bscale/(safmin*bcoefa))
-                              
+
                     if (scale /= one) then
                        acoef = scale*acoef
                        acoefa = abs(acoef)
@@ -76830,7 +76830,7 @@ module stdlib_linalg_lapack_q
                     ! check whether scaling is necessary for dot products
                     xscale = one/max(one,xmax)
                     temp = max(work(j),work(n + j),acoefa*work(j) + bcoefa*work(n + j))
-                              
+
                     if (il2by2) temp = max(temp,work(j + 1),work(n + j + 1),acoefa*work(j + 1) + &
                               bcoefa*work(n + j + 1))
                     if (temp > bignum*xscale) then
@@ -76878,7 +76878,7 @@ module stdlib_linalg_lapack_q
                     ! with scaling and perturbation of the denominator
                     call stdlib_qlaln2(.true.,na,nw,dmin,acoef,s(j,j),lds,bdiag(1), &
                     bdiag(2),sum,2,bcoefr,bcoefi,work(2*n + j),n,scale,temp,iinfo)
-                              
+
                     if (scale < one) then
                        do jw = 0,nw - 1
                           do jr = je,j - 1
@@ -76994,7 +76994,7 @@ module stdlib_linalg_lapack_q
                     lsb = abs(salfar) >= safmin .and. abs(bcoefr) < small
                     if (lsa) scale = (small/abs(sbeta))*min(anorm,big)
                     if (lsb) scale = max(scale, (small/abs(salfar))*min(bnorm,big))
-                              
+
                     if (lsa .or. lsb) then
                        scale = min(scale,one/(safmin*max(one,abs(acoef),abs(bcoefr))) &
                                  )
@@ -77037,7 +77037,7 @@ module stdlib_linalg_lapack_q
                               ulp)/bcoefa)
                     if (safmin*acoefa > ascale) scale = ascale/(safmin*acoefa)
                     if (safmin*bcoefa > bscale) scale = min(scale,bscale/(safmin*bcoefa))
-                              
+
                     if (scale /= one) then
                        acoef = scale*acoef
                        acoefa = abs(acoef)
@@ -77104,7 +77104,7 @@ module stdlib_linalg_lapack_q
                     ! compute x(j) (and x(j+1), if 2-by-2 block)
                     call stdlib_qlaln2(.false.,na,nw,dmin,acoef,s(j,j),lds,bdiag(1), &
                     bdiag(2),work(2*n + j),n,bcoefr,bcoefi,sum,2,scale,temp,iinfo)
-                              
+
                     if (scale < one) then
                        do jw = 0,nw - 1
                           do jr = 1,je
@@ -77124,7 +77124,7 @@ module stdlib_linalg_lapack_q
                        xscale = one/max(one,xmax)
                        temp = acoefa*work(j) + bcoefa*work(n + j)
                        if (il2by2) temp = max(temp,acoefa*work(j + 1) + bcoefa*work(n + j + 1))
-                                 
+
                        temp = max(temp,acoefa,bcoefa)
                        if (temp > bignum*xscale) then
                           do jw = 0,nw - 1
@@ -77246,7 +77246,7 @@ module stdlib_linalg_lapack_q
            real(qp),parameter :: twenty = 2.0e+01_qp
            integer(ilp),parameter :: ldst = 4
            logical(lk),parameter :: wands = .true.
-           
+
            ! Local Scalars
            logical(lk) :: strong,weak
            integer(ilp) :: i,idum,linfo,m
@@ -77318,9 +77318,9 @@ module stdlib_linalg_lapack_q
                  call stdlib_qlartg(t(1,1),t(2,1),li(1,1),li(2,1),ddum)
               end if
               call stdlib_qrot(2,s(1,1),ldst,s(2,1),ldst,li(1,1),li(2,1))
-                        
+
               call stdlib_qrot(2,t(1,1),ldst,t(2,1),ldst,li(1,1),li(2,1))
-                        
+
               li(2,2) = li(1,1)
               li(1,2) = -li(2,1)
               ! weak stability test: |s21| <= o(eps f-norm((a)))
@@ -77334,7 +77334,7 @@ module stdlib_linalg_lapack_q
                      ! f-norm((b-ql**h*t*qr)) <= o(eps*f-norm((b)))
                  call stdlib_qlacpy('FULL',m,m,a(j1,j1),lda,work(m*m + 1),m)
                  call stdlib_qgemm('N','N',m,m,m,one,li,ldst,s,ldst,zero,work,m)
-                           
+
                  call stdlib_qgemm('N','T',m,m,m,-one,work,m,ir,ldst,one,work(m*m + 1), &
                             m)
                  dscale = zero
@@ -77343,7 +77343,7 @@ module stdlib_linalg_lapack_q
                  sa = dscale*sqrt(dsum)
                  call stdlib_qlacpy('FULL',m,m,b(j1,j1),ldb,work(m*m + 1),m)
                  call stdlib_qgemm('N','N',m,m,m,one,li,ldst,t,ldst,zero,work,m)
-                           
+
                  call stdlib_qgemm('N','T',m,m,m,-one,work,m,ir,ldst,one,work(m*m + 1), &
                             m)
                  dscale = zero
@@ -77356,9 +77356,9 @@ module stdlib_linalg_lapack_q
               ! update (a(j1:j1+m-1, m+j1:n), b(j1:j1+m-1, m+j1:n)) and
                      ! (a(1:j1-1, j1:j1+m), b(1:j1-1, j1:j1+m)).
               call stdlib_qrot(j1 + 1,a(1,j1),1,a(1,j1 + 1),1,ir(1,1),ir(2,1))
-                        
+
               call stdlib_qrot(j1 + 1,b(1,j1),1,b(1,j1 + 1),1,ir(1,1),ir(2,1))
-                        
+
               call stdlib_qrot(n - j1 + 1,a(j1,j1),lda,a(j1 + 1,j1),lda,li(1,1),li(2,1 &
                         ))
               call stdlib_qrot(n - j1 + 1,b(j1,j1),ldb,b(j1 + 1,j1),ldb,li(1,1),li(2,1 &
@@ -77382,7 +77382,7 @@ module stdlib_linalg_lapack_q
               ! for r and l. solutions in li and ir.
               call stdlib_qlacpy('FULL',n1,n2,t(1,n1 + 1),ldst,li,ldst)
               call stdlib_qlacpy('FULL',n1,n2,s(1,n1 + 1),ldst,ir(n2 + 1,n1 + 1),ldst)
-                        
+
               call stdlib_qtgsy2('N',0,n1,n2,s,ldst,s(n1 + 1,n1 + 1),ldst,ir(n2 + 1,n1 + 1), &
                ldst,t,ldst,t(n1 + 1,n1 + 1),ldst,li,ldst,scale,dsum,dscale,iwork,idum, &
                          linfo)
@@ -77440,9 +77440,9 @@ module stdlib_linalg_lapack_q
               call stdlib_qgeqr2(m,m,tcpy,ldst,taul,work,linfo)
               if (linfo /= 0) go to 70
               call stdlib_qorm2r('L','T',m,m,m,tcpy,ldst,taul,scpy,ldst,work,info)
-                        
+
               call stdlib_qorm2r('R','N',m,m,m,tcpy,ldst,taul,licop,ldst,work,info)
-                        
+
               if (linfo /= 0) go to 70
               ! compute f-norm(s21) in bqra21. (t21 is 0.)
               dscale = zero
@@ -77471,7 +77471,7 @@ module stdlib_linalg_lapack_q
                      ! f-norm((b-ql**h*t*qr)) <= o(eps*f-norm((b)))
                  call stdlib_qlacpy('FULL',m,m,a(j1,j1),lda,work(m*m + 1),m)
                  call stdlib_qgemm('N','N',m,m,m,one,li,ldst,s,ldst,zero,work,m)
-                           
+
                  call stdlib_qgemm('N','N',m,m,m,-one,work,m,ir,ldst,one,work(m*m + 1), &
                             m)
                  dscale = zero
@@ -77480,7 +77480,7 @@ module stdlib_linalg_lapack_q
                  sa = dscale*sqrt(dsum)
                  call stdlib_qlacpy('FULL',m,m,b(j1,j1),ldb,work(m*m + 1),m)
                  call stdlib_qgemm('N','N',m,m,m,one,li,ldst,t,ldst,zero,work,m)
-                           
+
                  call stdlib_qgemm('N','N',m,m,m,-one,work,m,ir,ldst,one,work(m*m + 1), &
                             m)
                  dscale = zero
@@ -77515,7 +77515,7 @@ module stdlib_linalg_lapack_q
               if (n1 > 1) then
                  call stdlib_qlagv2(a(j1 + n2,j1 + n2),lda,b(j1 + n2,j1 + n2),ldb,taur,taul, &
                  work(m*m + 1),work(n2*m + n2 + 1),work(n2*m + n2 + 2),t(n2 + 1,n2 + 1),t(m,m - 1))
-                           
+
                  work(m*m) = work(n2*m + n2 + 1)
                  work(m*m - 1) = -work(n2*m + n2 + 2)
                  t(m,m) = t(n2 + 1,n2 + 1)
@@ -77573,7 +77573,7 @@ module stdlib_linalg_lapack_q
               return
            end if
            ! exit with info = 1 if swap was rejected.
-70   continue
+           70 continue
            info = 1
            return
      end subroutine stdlib_qtgex2
@@ -77605,7 +77605,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*),b(ldb,*),q(ldq,*),z(ldz,*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: here,lwmin,nbf,nbl,nbnext
@@ -77673,7 +77673,7 @@ module stdlib_linalg_lapack_q
               if (nbf == 2 .and. nbl == 1) ilst = ilst - 1
               if (nbf == 1 .and. nbl == 2) ilst = ilst + 1
               here = ifst
-10            continue
+              10 continue
               ! swap with next one below.
               if (nbf == 1 .or. nbf == 2) then
                  ! current block either 1-by-1 or 2-by-2.
@@ -77748,7 +77748,7 @@ module stdlib_linalg_lapack_q
               if (here < ilst) go to 10
            else
               here = ifst
-20            continue
+              20 continue
               ! swap with next one below.
               if (nbf == 1 .or. nbf == 2) then
                  ! current block either 1-by-1 or 2-by-2.
@@ -77866,7 +77866,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: idifjb = 3
-           
+
            ! Local Scalars
            logical(lk) :: lquery,pair,swap,wantd,wantd1,wantd2,wantp
            integer(ilp) :: i,ierr,ijb,k,kase,kk,ks,liwmin,lwmin,mn2,n1,n2
@@ -78067,9 +78067,9 @@ module stdlib_linalg_lapack_q
                  ijb = 0
                  mn2 = 2*n1*n2
                  ! 1-norm-based estimate of difu.
-40   continue
+                 40 continue
                  call stdlib_qlacn2(mn2,work(mn2 + 1),work,iwork,dif(1),kase,isave)
-                           
+
                  if (kase /= 0) then
                     if (kase == 1) then
                        ! solve generalized sylvester equation.
@@ -78086,9 +78086,9 @@ module stdlib_linalg_lapack_q
                  end if
                  dif(1) = dscale/dif(1)
                  ! 1-norm-based estimate of difl.
-50   continue
+                 50 continue
                  call stdlib_qlacn2(mn2,work(mn2 + 1),work,iwork,dif(2),kase,isave)
-                           
+
                  if (kase /= 0) then
                     if (kase == 1) then
                        ! solve generalized sylvester equation.
@@ -78106,7 +78106,7 @@ module stdlib_linalg_lapack_q
                  dif(2) = dscale/dif(2)
               end if
            end if
-60         continue
+           60 continue
            ! compute generalized eigenvalues of reordered pair (a, b) and
            ! normalize the generalized schur form.
            pair = .false.
@@ -78231,7 +78231,7 @@ module stdlib_linalg_lapack_q
            ! Parameters
            integer(ilp),parameter :: maxit = 40
            real(qp),parameter :: hugenum = huge(zero)
-           
+
            ! Local Scalars
            logical(lk) :: initq,initu,initv,upper,wantq,wantu,wantv
            integer(ilp) :: i,j,kcycle
@@ -78309,7 +78309,7 @@ module stdlib_linalg_lapack_q
                     ! update (n-l+i)-th and (n-l+j)-th columns of matrices
                     ! a and b: a*q and b*q
                     call stdlib_qrot(min(k + l,m),a(1,n - l + j),1,a(1,n - l + i),1,csq,snq)
-                              
+
                     call stdlib_qrot(l,b(1,n - l + j),1,b(1,n - l + i),1,csq,snq)
                     if (upper) then
                        if (k + i <= m) a(k + i,n - l + j) = zero
@@ -78323,7 +78323,7 @@ module stdlib_linalg_lapack_q
                               csu,snu)
                     if (wantv) call stdlib_qrot(p,v(1,j),1,v(1,i),1,csv,snv)
                     if (wantq) call stdlib_qrot(n,q(1,n - l + j),1,q(1,n - l + i),1,csq,snq)
-                              
+
                  end do loop_10
               end do loop_20
               if (.not. upper) then
@@ -78345,7 +78345,7 @@ module stdlib_linalg_lapack_q
            ! the algorithm has not converged after maxit cycles.
            info = 1
            go to 100
-50         continue
+           50 continue
            ! if error <= min(tola,tolb), then the algorithm has converged.
            ! compute the generalized singular value pairs (alpha, beta), and
            ! set the triangular matrix r to array a.
@@ -78387,7 +78387,7 @@ module stdlib_linalg_lapack_q
                  beta(i) = zero
               end do
            end if
-100        continue
+           100 continue
            ncycle = kcycle
            return
      end subroutine stdlib_qtgsja
@@ -78418,7 +78418,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: difdri = 3
-           
+
            ! Local Scalars
            logical(lk) :: lquery,pair,somcon,wantbh,wantdf,wants
            integer(ilp) :: i,ierr,ifst,ilst,iz,k,ks,lwmin,n1,n2
@@ -78530,21 +78530,21 @@ module stdlib_linalg_lapack_q
                     lnrm = stdlib_qlapy2(stdlib_qnrm2(n,vl(1,ks),1),stdlib_qnrm2(n,vl( &
                               1,ks + 1),1))
                     call stdlib_qgemv('N',n,n,one,a,lda,vr(1,ks),1,zero,work,1)
-                              
+
                     tmprr = stdlib_qdot(n,work,1,vl(1,ks),1)
                     tmpri = stdlib_qdot(n,work,1,vl(1,ks + 1),1)
                     call stdlib_qgemv('N',n,n,one,a,lda,vr(1,ks + 1),1,zero,work,1)
-                              
+
                     tmpii = stdlib_qdot(n,work,1,vl(1,ks + 1),1)
                     tmpir = stdlib_qdot(n,work,1,vl(1,ks),1)
                     uhav = tmprr + tmpii
                     uhavi = tmpir - tmpri
                     call stdlib_qgemv('N',n,n,one,b,ldb,vr(1,ks),1,zero,work,1)
-                              
+
                     tmprr = stdlib_qdot(n,work,1,vl(1,ks),1)
                     tmpri = stdlib_qdot(n,work,1,vl(1,ks + 1),1)
                     call stdlib_qgemv('N',n,n,one,b,ldb,vr(1,ks + 1),1,zero,work,1)
-                              
+
                     tmpii = stdlib_qdot(n,work,1,vl(1,ks + 1),1)
                     tmpir = stdlib_qdot(n,work,1,vl(1,ks),1)
                     uhbv = tmprr + tmpii
@@ -78559,10 +78559,10 @@ module stdlib_linalg_lapack_q
                     rnrm = stdlib_qnrm2(n,vr(1,ks),1)
                     lnrm = stdlib_qnrm2(n,vl(1,ks),1)
                     call stdlib_qgemv('N',n,n,one,a,lda,vr(1,ks),1,zero,work,1)
-                              
+
                     uhav = stdlib_qdot(n,work,1,vl(1,ks),1)
                     call stdlib_qgemv('N',n,n,one,b,ldb,vr(1,ks),1,zero,work,1)
-                              
+
                     uhbv = stdlib_qdot(n,work,1,vl(1,ks),1)
                     cond = stdlib_qlapy2(uhav,uhbv)
                     if (cond == zero) then
@@ -78688,7 +78688,7 @@ module stdlib_linalg_lapack_q
         ! sven hammarling, 27/5/02.
            ! Parameters
            integer(ilp),parameter :: ldz = 8
-           
+
            ! Local Scalars
            logical(lk) :: notran
            integer(ilp) :: i,ie,ierr,ii,is,isp1,j,je,jj,js,jsp1,k,mb,nb,p,q, &
@@ -78738,7 +78738,7 @@ module stdlib_linalg_lapack_q
            pq = 0
            p = 0
            i = 1
-10         continue
+           10 continue
            if (i > m) go to 20
            p = p + 1
            iwork(p) = i
@@ -78749,12 +78749,12 @@ module stdlib_linalg_lapack_q
               i = i + 1
            end if
            go to 10
-20         continue
+           20 continue
            iwork(p + 1) = m + 1
            ! determine block structure of b
            q = p + 1
            j = 1
-30         continue
+           30 continue
            if (j > n) go to 40
            q = q + 1
            iwork(q) = j
@@ -78765,7 +78765,7 @@ module stdlib_linalg_lapack_q
               j = j + 1
            end if
            go to 30
-40         continue
+           40 continue
            iwork(q + 1) = n + 1
            pq = p*(q - p - 1)
            if (notran) then
@@ -78809,7 +78809,7 @@ module stdlib_linalg_lapack_q
                           end if
                        else
                           call stdlib_qlatdf(ijob,zdim,z,ldz,rhs,rdsum,rdscal,ipiv,jpiv)
-                                    
+
                        end if
                        ! unpack solution vector(s)
                        c(is,js) = rhs(1)
@@ -78864,7 +78864,7 @@ module stdlib_linalg_lapack_q
                           end if
                        else
                           call stdlib_qlatdf(ijob,zdim,z,ldz,rhs,rdsum,rdscal,ipiv,jpiv)
-                                    
+
                        end if
                        ! unpack solution vector(s)
                        c(is,js) = rhs(1)
@@ -78926,7 +78926,7 @@ module stdlib_linalg_lapack_q
                           end if
                        else
                           call stdlib_qlatdf(ijob,zdim,z,ldz,rhs,rdsum,rdscal,ipiv,jpiv)
-                                    
+
                        end if
                        ! unpack solution vector(s)
                        c(is,js) = rhs(1)
@@ -79001,7 +79001,7 @@ module stdlib_linalg_lapack_q
                           end if
                        else
                           call stdlib_qlatdf(ijob,zdim,z,ldz,rhs,rdsum,rdscal,ipiv,jpiv)
-                                    
+
                        end if
                        ! unpack solution vector(s)
                        k = 1
@@ -79082,10 +79082,10 @@ module stdlib_linalg_lapack_q
                        if (i < p) then
                           alpha = -rhs(1)
                           call stdlib_qaxpy(m - ie,alpha,a(is,ie + 1),lda,c(ie + 1,js),1)
-                                    
+
                           alpha = -rhs(2)
                           call stdlib_qaxpy(m - ie,alpha,d(is,ie + 1),ldd,c(ie + 1,js),1)
-                                    
+
                        end if
                     else if ((mb == 1) .and. (nb == 2)) then
                        ! build a 4-by-4 system z**t * x = rhs
@@ -79130,13 +79130,13 @@ module stdlib_linalg_lapack_q
                        ! equation.
                        if (j > p + 2) then
                           call stdlib_qaxpy(js - 1,rhs(1),b(1,js),1,f(is,1),ldf)
-                                    
+
                           call stdlib_qaxpy(js - 1,rhs(2),b(1,jsp1),1,f(is,1),ldf)
-                                    
+
                           call stdlib_qaxpy(js - 1,rhs(3),e(1,js),1,f(is,1),ldf)
-                                    
+
                           call stdlib_qaxpy(js - 1,rhs(4),e(1,jsp1),1,f(is,1),ldf)
-                                    
+
                        end if
                        if (i < p) then
                           call stdlib_qger(m - ie,nb,-one,a(is,ie + 1),lda,rhs(1),1,c(ie + &
@@ -79325,7 +79325,7 @@ module stdlib_linalg_lapack_q
         ! =====================================================================
         ! replaced various illegal calls to stdlib_qcopy by calls to stdlib_qlaset.
         ! sven hammarling, 1/5/02.
-           
+
            ! Local Scalars
            logical(lk) :: lquery,notran
            integer(ilp) :: i,ie,ifunc,iround,is,isolve,j,je,js,k,linfo,lwmin,mb,nb, &
@@ -79444,7 +79444,7 @@ module stdlib_linalg_lapack_q
            ! determine block structure of a
            p = 0
            i = 1
-40         continue
+           40 continue
            if (i > m) go to 50
            p = p + 1
            iwork(p) = i
@@ -79452,13 +79452,13 @@ module stdlib_linalg_lapack_q
            if (i >= m) go to 50
            if (a(i,i - 1) /= zero) i = i + 1
            go to 40
-50         continue
+           50 continue
            iwork(p + 1) = m + 1
            if (iwork(p) == iwork(p + 1)) p = p - 1
            ! determine block structure of b
            q = p + 1
            j = 1
-60         continue
+           60 continue
            if (j > n) go to 70
            q = q + 1
            iwork(q) = j
@@ -79466,7 +79466,7 @@ module stdlib_linalg_lapack_q
            if (j >= n) go to 70
            if (b(j,j - 1) /= zero) j = j + 1
            go to 60
-70         continue
+           70 continue
            iwork(q + 1) = n + 1
            if (iwork(q) == iwork(q + 1)) q = q - 1
            if (notran) then
@@ -79628,7 +79628,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: ap(*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,onenrm,upper
            character :: normin
@@ -79677,7 +79677,7 @@ module stdlib_linalg_lapack_q
                  kase1 = 2
               end if
               kase = 0
-10            continue
+              10 continue
               call stdlib_qlacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
               if (kase /= 0) then
                  if (kase == kase1) then
@@ -79702,7 +79702,7 @@ module stdlib_linalg_lapack_q
               ! compute the estimate of the reciprocal condition number.
               if (ainvnm /= zero) rcond = (one/anorm)/ainvnm
            end if
-20         continue
+           20 continue
            return
      end subroutine stdlib_qtpcon
 
@@ -79758,7 +79758,7 @@ module stdlib_linalg_lapack_q
                  lb = nb - n + l - i + 1
               end if
               call stdlib_qtplqt2(ib,nb,lb,a(i,i),lda,b(i,1),ldb,t(1,i),ldt,iinfo)
-                        
+
            ! update by applying h**t to b(i+ib:m,:) from the right
               if (i + ib <= m) then
                  call stdlib_qtprfb('R','N','F','R',m - i - ib + 1,nb,ib,lb,b(i,1),ldb,t( &
@@ -79783,7 +79783,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*),b(ldb,*)
            real(qp),intent(out) :: t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,p,mp,np
            real(qp) :: alpha
@@ -80155,7 +80155,7 @@ module stdlib_linalg_lapack_q
                  lb = mb - m + l - i + 1
               end if
               call stdlib_qtpqrt2(mb,ib,lb,a(i,i),lda,b(1,i),ldb,t(1,i),ldt,iinfo)
-                        
+
            ! update by applying h**t to b(:,i+ib:n) from the left
               if (i + ib <= n) then
                  call stdlib_qtprfb('L','T','F','C',mb,n - i - ib + 1,ib,lb,b(1,i),ldb,t( &
@@ -80180,7 +80180,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*),b(ldb,*)
            real(qp),intent(out) :: t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,p,mp,np
            real(qp) :: alpha
@@ -80225,7 +80225,7 @@ module stdlib_linalg_lapack_q
                     a(i,i + j) = a(i,i + j) + alpha*(t(j,n))
                  end do
                  call stdlib_qger(p,n - i,alpha,b(1,i),1,t(1,n),1,b(1,i + 1),ldb)
-                           
+
               end if
            end do
            do i = 2,n
@@ -80247,7 +80247,7 @@ module stdlib_linalg_lapack_q
                         np,i),1)
               ! b1
               call stdlib_qgemv('T',m - l,i - 1,alpha,b,ldb,b(1,i),1,one,t(1,i),1)
-                        
+
               ! t(1:i-1,i) := t(1:i-1,1:i-1) * t(1:i-1,i)
               call stdlib_qtrmv('U','N','N',i - 1,t,ldt,t(1,i),1)
               ! t(i,i) = tau(i)
@@ -80273,7 +80273,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: t(ldt,*),v(ldv,*)
            real(qp),intent(out) :: work(ldwork,*)
         ! ==========================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,mp,np,kp
            logical(lk) :: left,forward,column,right,backward,row
@@ -80329,9 +80329,9 @@ module stdlib_linalg_lapack_q
                  end do
               end do
               call stdlib_qtrmm('L','U','T','N',l,n,one,v(mp,1),ldv,work,ldwork)
-                        
+
               call stdlib_qgemm('T','N',l,n,m - l,one,v,ldv,b,ldb,one,work,ldwork)
-                        
+
               call stdlib_qgemm('T','N',k - l,n,m,one,v(1,kp),ldv,b,ldb,zero,work(kp, &
                          1),ldwork)
               do j = 1,n
@@ -80346,11 +80346,11 @@ module stdlib_linalg_lapack_q
                  end do
               end do
               call stdlib_qgemm('N','N',m - l,n,k,-one,v,ldv,work,ldwork,one,b,ldb)
-                        
+
               call stdlib_qgemm('N','N',l,n,k - l,-one,v(mp,kp),ldv,work(kp,1), &
                         ldwork,one,b(mp,1),ldb)
               call stdlib_qtrmm('L','U','N','N',l,n,one,v(mp,1),ldv,work,ldwork)
-                        
+
               do j = 1,n
                  do i = 1,l
                     b(m - l + i,j) = b(m - l + i,j) - work(i,j)
@@ -80374,9 +80374,9 @@ module stdlib_linalg_lapack_q
                  end do
               end do
               call stdlib_qtrmm('R','U','N','N',m,l,one,v(np,1),ldv,work,ldwork)
-                        
+
               call stdlib_qgemm('N','N',m,l,n - l,one,b,ldb,v,ldv,one,work,ldwork)
-                        
+
               call stdlib_qgemm('N','N',m,k - l,n,one,b,ldb,v(1,kp),ldv,zero,work(1, &
                         kp),ldwork)
               do j = 1,k
@@ -80391,11 +80391,11 @@ module stdlib_linalg_lapack_q
                  end do
               end do
               call stdlib_qgemm('N','T',m,n - l,k,-one,work,ldwork,v,ldv,one,b,ldb)
-                        
+
               call stdlib_qgemm('N','T',m,l,k - l,-one,work(1,kp),ldwork,v(np,kp), &
                         ldv,one,b(1,np),ldb)
               call stdlib_qtrmm('R','U','T','N',m,l,one,v(np,1),ldv,work,ldwork)
-                        
+
               do j = 1,l
                  do i = 1,m
                     b(i,n - l + j) = b(i,n - l + j) - work(i,j)
@@ -80424,7 +80424,7 @@ module stdlib_linalg_lapack_q
               call stdlib_qgemm('T','N',l,n,m - l,one,v(mp,kp),ldv,b(mp,1),ldb,one, &
                         work(kp,1),ldwork)
               call stdlib_qgemm('T','N',k - l,n,m,one,v,ldv,b,ldb,zero,work,ldwork)
-                        
+
               do j = 1,n
                  do i = 1,k
                     work(i,j) = work(i,j) + a(i,j)
@@ -80439,7 +80439,7 @@ module stdlib_linalg_lapack_q
               call stdlib_qgemm('N','N',m - l,n,k,-one,v(mp,1),ldv,work,ldwork,one,b( &
                         mp,1),ldb)
               call stdlib_qgemm('N','N',l,n,k - l,-one,v,ldv,work,ldwork,one,b,ldb)
-                        
+
               call stdlib_qtrmm('L','L','N','N',l,n,one,v(1,kp),ldv,work(kp,1), &
                         ldwork)
               do j = 1,n
@@ -80469,7 +80469,7 @@ module stdlib_linalg_lapack_q
               call stdlib_qgemm('N','N',m,l,n - l,one,b(1,np),ldb,v(np,kp),ldv,one, &
                         work(1,kp),ldwork)
               call stdlib_qgemm('N','N',m,k - l,n,one,b,ldb,v,ldv,zero,work,ldwork)
-                        
+
               do j = 1,k
                  do i = 1,m
                     work(i,j) = work(i,j) + a(i,j)
@@ -80484,7 +80484,7 @@ module stdlib_linalg_lapack_q
               call stdlib_qgemm('N','T',m,n - l,k,-one,work,ldwork,v(np,1),ldv,one,b( &
                         1,np),ldb)
               call stdlib_qgemm('N','T',m,l,k - l,-one,work,ldwork,v,ldv,one,b,ldb)
-                        
+
               call stdlib_qtrmm('R','L','T','N',m,l,one,v(1,kp),ldv,work(1,kp), &
                         ldwork)
               do j = 1,l
@@ -80510,9 +80510,9 @@ module stdlib_linalg_lapack_q
                  end do
               end do
               call stdlib_qtrmm('L','L','N','N',l,n,one,v(1,mp),ldv,work,ldb)
-                        
+
               call stdlib_qgemm('N','N',l,n,m - l,one,v,ldv,b,ldb,one,work,ldwork)
-                        
+
               call stdlib_qgemm('N','N',k - l,n,m,one,v(kp,1),ldv,b,ldb,zero,work(kp, &
                          1),ldwork)
               do j = 1,n
@@ -80527,11 +80527,11 @@ module stdlib_linalg_lapack_q
                  end do
               end do
               call stdlib_qgemm('T','N',m - l,n,k,-one,v,ldv,work,ldwork,one,b,ldb)
-                        
+
               call stdlib_qgemm('T','N',l,n,k - l,-one,v(kp,mp),ldv,work(kp,1), &
                         ldwork,one,b(mp,1),ldb)
               call stdlib_qtrmm('L','L','T','N',l,n,one,v(1,mp),ldv,work,ldwork)
-                        
+
               do j = 1,n
                  do i = 1,l
                     b(m - l + i,j) = b(m - l + i,j) - work(i,j)
@@ -80554,9 +80554,9 @@ module stdlib_linalg_lapack_q
                  end do
               end do
               call stdlib_qtrmm('R','L','T','N',m,l,one,v(1,np),ldv,work,ldwork)
-                        
+
               call stdlib_qgemm('N','T',m,l,n - l,one,b,ldb,v,ldv,one,work,ldwork)
-                        
+
               call stdlib_qgemm('N','T',m,k - l,n,one,b,ldb,v(kp,1),ldv,zero,work(1, &
                         kp),ldwork)
               do j = 1,k
@@ -80571,11 +80571,11 @@ module stdlib_linalg_lapack_q
                  end do
               end do
               call stdlib_qgemm('N','N',m,n - l,k,-one,work,ldwork,v,ldv,one,b,ldb)
-                        
+
               call stdlib_qgemm('N','N',m,l,k - l,-one,work(1,kp),ldwork,v(kp,np), &
                         ldv,one,b(1,np),ldb)
               call stdlib_qtrmm('R','L','N','N',m,l,one,v(1,np),ldv,work,ldwork)
-                        
+
               do j = 1,l
                  do i = 1,m
                     b(i,n - l + j) = b(i,n - l + j) - work(i,j)
@@ -80603,7 +80603,7 @@ module stdlib_linalg_lapack_q
               call stdlib_qgemm('N','N',l,n,m - l,one,v(kp,mp),ldv,b(mp,1),ldb,one, &
                         work(kp,1),ldwork)
               call stdlib_qgemm('N','N',k - l,n,m,one,v,ldv,b,ldb,zero,work,ldwork)
-                        
+
               do j = 1,n
                  do i = 1,k
                     work(i,j) = work(i,j) + a(i,j)
@@ -80618,7 +80618,7 @@ module stdlib_linalg_lapack_q
               call stdlib_qgemm('T','N',m - l,n,k,-one,v(1,mp),ldv,work,ldwork,one,b( &
                         mp,1),ldb)
               call stdlib_qgemm('T','N',l,n,k - l,-one,v,ldv,work,ldwork,one,b,ldb)
-                        
+
               call stdlib_qtrmm('L','U','T','N',l,n,one,v(kp,1),ldv,work(kp,1), &
                         ldwork)
               do j = 1,n
@@ -80647,7 +80647,7 @@ module stdlib_linalg_lapack_q
               call stdlib_qgemm('N','T',m,l,n - l,one,b(1,np),ldb,v(kp,np),ldv,one, &
                         work(1,kp),ldwork)
               call stdlib_qgemm('N','T',m,k - l,n,one,b,ldb,v,ldv,zero,work,ldwork)
-                        
+
               do j = 1,k
                  do i = 1,m
                     work(i,j) = work(i,j) + a(i,j)
@@ -80662,7 +80662,7 @@ module stdlib_linalg_lapack_q
               call stdlib_qgemm('N','N',m,n - l,k,-one,work,ldwork,v(1,np),ldv,one,b( &
                         1,np),ldb)
               call stdlib_qgemm('N','N',m,l,k - l,-one,work,ldwork,v,ldv,one,b,ldb)
-                        
+
               call stdlib_qtrmm('R','U','N','N',m,l,one,v(kp,1),ldv,work(1,kp), &
                         ldwork)
               do j = 1,l
@@ -80695,7 +80695,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: ap(*),b(ldb,*),x(ldx,*)
            real(qp),intent(out) :: berr(*),ferr(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            character :: transt
@@ -80889,9 +80889,9 @@ module stdlib_linalg_lapack_q
                  end if
               end do
               kase = 0
-210           continue
+              210 continue
               call stdlib_qlacn2(n,work(2*n + 1),work(n + 1),iwork,ferr(j),kase,isave)
-                        
+
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(op(a)**t).
@@ -80932,7 +80932,7 @@ module stdlib_linalg_lapack_q
            ! Array Arguments
            real(qp),intent(inout) :: ap(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,upper
            integer(ilp) :: j,jc,jclast,jj
@@ -81026,7 +81026,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: ap(*)
            real(qp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,upper
            integer(ilp) :: j,jc
@@ -81398,7 +81398,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: a(lda,*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,onenrm,upper
            character :: normin
@@ -81449,7 +81449,7 @@ module stdlib_linalg_lapack_q
                  kase1 = 2
               end if
               kase = 0
-10            continue
+              10 continue
               call stdlib_qlacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
               if (kase /= 0) then
                  if (kase == kase1) then
@@ -81474,7 +81474,7 @@ module stdlib_linalg_lapack_q
               ! compute the estimate of the reciprocal condition number.
               if (ainvnm /= zero) rcond = (one/anorm)/ainvnm
            end if
-20         continue
+           20 continue
            return
      end subroutine stdlib_qtrcon
 
@@ -81509,7 +81509,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: vl(ldvl,*),vr(ldvr,*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: allv,bothv,leftv,over,pair,rightv,somev
            integer(ilp) :: i,ierr,ii,ip,is,j,j1,j2,jnxt,k,ki,n2
@@ -81610,7 +81610,7 @@ module stdlib_linalg_lapack_q
                  if (ki == 1) go to 40
                  if (t(ki,ki - 1) == zero) go to 40
                  ip = -1
-40               continue
+                 40 continue
                  if (somev) then
                     if (ip == 0) then
                        if (.not. select(ki)) go to 130
@@ -81661,7 +81661,7 @@ module stdlib_linalg_lapack_q
                           work(j + n) = x(1,1)
                           ! update right-hand side
                           call stdlib_qaxpy(j - 1,-x(1,1),t(1,j),1,work(1 + n),1)
-                                    
+
                        else
                           ! 2-by-2 diagonal block
                           call stdlib_qlaln2(.false.,2,1,smin,one,t(j - 1,j - 1),ldt,one, &
@@ -81682,9 +81682,9 @@ module stdlib_linalg_lapack_q
                           work(j + n) = x(2,1)
                           ! update right-hand side
                           call stdlib_qaxpy(j - 2,-x(1,1),t(1,j - 1),1,work(1 + n),1)
-                                    
+
                           call stdlib_qaxpy(j - 2,-x(2,1),t(1,j),1,work(1 + n),1)
-                                    
+
                        end if
                     end do loop_60
                     ! copy the vector x or q*x to vr and normalize.
@@ -81758,9 +81758,9 @@ module stdlib_linalg_lapack_q
                           work(j + n2) = x(1,2)
                           ! update the right-hand side
                           call stdlib_qaxpy(j - 1,-x(1,1),t(1,j),1,work(1 + n),1)
-                                    
+
                           call stdlib_qaxpy(j - 1,-x(1,2),t(1,j),1,work(1 + n2),1)
-                                    
+
                        else
                           ! 2-by-2 diagonal block
                           call stdlib_qlaln2(.false.,2,2,smin,one,t(j - 1,j - 1),ldt,one, &
@@ -81789,13 +81789,13 @@ module stdlib_linalg_lapack_q
                           work(j + n2) = x(2,2)
                           ! update the right-hand side
                           call stdlib_qaxpy(j - 2,-x(1,1),t(1,j - 1),1,work(1 + n),1)
-                                    
+
                           call stdlib_qaxpy(j - 2,-x(2,1),t(1,j),1,work(1 + n),1)
-                                    
+
                           call stdlib_qaxpy(j - 2,-x(1,2),t(1,j - 1),1,work(1 + n2),1)
-                                    
+
                           call stdlib_qaxpy(j - 2,-x(2,2),t(1,j),1,work(1 + n2),1)
-                                    
+
                        end if
                     end do loop_90
                     ! copy the vector x or q*x to vr and normalize.
@@ -81834,7 +81834,7 @@ module stdlib_linalg_lapack_q
                  end if
                  is = is - 1
                  if (ip /= 0) is = is - 1
-130              continue
+                 130 continue
                  if (ip == 1) ip = 0
                  if (ip == -1) ip = 1
               end do loop_140
@@ -81848,7 +81848,7 @@ module stdlib_linalg_lapack_q
                  if (ki == n) go to 150
                  if (t(ki + 1,ki) == zero) go to 150
                  ip = 1
-150              continue
+                 150 continue
                  if (somev) then
                     if (.not. select(ki)) go to 250
                  end if
@@ -81897,7 +81897,7 @@ module stdlib_linalg_lapack_q
                                     work(j + n),n,wr,zero,x,2,scale,xnorm,ierr)
                           ! scale if necessary
                           if (scale /= one) call stdlib_qscal(n - ki + 1,scale,work(ki + n),1)
-                                    
+
                           work(j + n) = x(1,1)
                           vmax = max(abs(work(j + n)),vmax)
                           vcrit = bignum/vmax
@@ -81923,7 +81923,7 @@ module stdlib_linalg_lapack_q
                                     work(j + n),n,wr,zero,x,2,scale,xnorm,ierr)
                           ! scale if necessary
                           if (scale /= one) call stdlib_qscal(n - ki + 1,scale,work(ki + n),1)
-                                    
+
                           work(j + n) = x(1,1)
                           work(j + 1 + n) = x(2,1)
                           vmax = max(abs(work(j + n)),abs(work(j + 1 + n)),vmax)
@@ -82083,7 +82083,7 @@ module stdlib_linalg_lapack_q
                  end if
                  is = is + 1
                  if (ip /= 0) is = is + 1
-250              continue
+                 250 continue
                  if (ip == -1) ip = 0
                  if (ip == 1) ip = -1
               end do loop_260
@@ -82126,7 +82126,7 @@ module stdlib_linalg_lapack_q
            ! Parameters
            integer(ilp),parameter :: nbmin = 8
            integer(ilp),parameter :: nbmax = 128
-           
+
            ! Local Scalars
            logical(lk) :: allv,bothv,leftv,lquery,over,pair,rightv,somev
            integer(ilp) :: i,ierr,ii,ip,is,j,j1,j2,jnxt,k,ki,iv,maxwrk,nb, &
@@ -82315,11 +82315,11 @@ module stdlib_linalg_lapack_q
                           end if
                           ! scale if necessary
                           if (scale /= one) call stdlib_qscal(ki,scale,work(1 + iv*n),1)
-                                    
+
                           work(j + iv*n) = x(1,1)
                           ! update right-hand side
                           call stdlib_qaxpy(j - 1,-x(1,1),t(1,j),1,work(1 + iv*n),1)
-                                    
+
                        else
                           ! 2-by-2 diagonal block
                           call stdlib_qlaln2(.false.,2,1,smin,one,t(j - 1,j - 1),ldt,one, &
@@ -82336,14 +82336,14 @@ module stdlib_linalg_lapack_q
                           end if
                           ! scale if necessary
                           if (scale /= one) call stdlib_qscal(ki,scale,work(1 + iv*n),1)
-                                    
+
                           work(j - 1 + iv*n) = x(1,1)
                           work(j + iv*n) = x(2,1)
                           ! update right-hand side
                           call stdlib_qaxpy(j - 2,-x(1,1),t(1,j - 1),1,work(1 + iv*n),1)
-                                    
+
                           call stdlib_qaxpy(j - 2,-x(2,1),t(1,j),1,work(1 + iv*n),1)
-                                    
+
                        end if
                     end do loop_60
                     ! copy the vector x or q*x to vr and normalize.
@@ -82431,9 +82431,9 @@ module stdlib_linalg_lapack_q
                           work(j + (iv)*n) = x(1,2)
                           ! update the right-hand side
                           call stdlib_qaxpy(j - 1,-x(1,1),t(1,j),1,work(1 + (iv - 1)*n),1)
-                                    
+
                           call stdlib_qaxpy(j - 1,-x(1,2),t(1,j),1,work(1 + (iv)*n),1)
-                                    
+
                        else
                           ! 2-by-2 diagonal block
                           call stdlib_qlaln2(.false.,2,2,smin,one,t(j - 1,j - 1),ldt,one, &
@@ -82468,7 +82468,7 @@ module stdlib_linalg_lapack_q
                           call stdlib_qaxpy(j - 2,-x(1,2),t(1,j - 1),1,work(1 + (iv)*n), &
                                     1)
                           call stdlib_qaxpy(j - 2,-x(2,2),t(1,j),1,work(1 + (iv)*n),1)
-                                    
+
                        end if
                     end do loop_90
                     ! copy the vector x or q*x to vr and normalize.
@@ -82643,7 +82643,7 @@ module stdlib_linalg_lapack_q
                                     work(j + iv*n),n,wr,zero,x,2,scale,xnorm,ierr)
                           ! scale if necessary
                           if (scale /= one) call stdlib_qscal(n - ki + 1,scale,work(ki + iv*n),1)
-                                    
+
                           work(j + iv*n) = x(1,1)
                           vmax = max(abs(work(j + iv*n)),vmax)
                           vcrit = bignum/vmax
@@ -82669,11 +82669,11 @@ module stdlib_linalg_lapack_q
                                     work(j + iv*n),n,wr,zero,x,2,scale,xnorm,ierr)
                           ! scale if necessary
                           if (scale /= one) call stdlib_qscal(n - ki + 1,scale,work(ki + iv*n),1)
-                                    
+
                           work(j + iv*n) = x(1,1)
                           work(j + 1 + iv*n) = x(2,1)
                           vmax = max(abs(work(j + iv*n)),abs(work(j + 1 + iv*n)),vmax)
-                                    
+
                           vcrit = bignum/vmax
                        end if
                     end do loop_170
@@ -82769,7 +82769,7 @@ module stdlib_linalg_lapack_q
                           work(j + (iv)*n) = x(1,1)
                           work(j + (iv + 1)*n) = x(1,2)
                           vmax = max(abs(work(j + (iv)*n)),abs(work(j + (iv + 1)*n)),vmax)
-                                    
+
                           vcrit = bignum/vmax
                        else
                           ! 2-by-2 diagonal block
@@ -82815,9 +82815,9 @@ module stdlib_linalg_lapack_q
                        ! ------------------------------
                        ! no back-transform: copy x to vl and normalize.
                        call stdlib_qcopy(n - ki + 1,work(ki + (iv)*n),1,vl(ki,is),1)
-                                 
+
                        call stdlib_qcopy(n - ki + 1,work(ki + (iv + 1)*n),1,vl(ki,is + 1),1)
-                                 
+
                        emax = zero
                        do k = ki,n
                           emax = max(emax,abs(vl(k,is)) + abs(vl(k,is + 1)))
@@ -82936,7 +82936,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: q(ldq,*),t(ldt,*)
            real(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: wantq
            integer(ilp) :: here,nbf,nbl,nbnext
@@ -82989,7 +82989,7 @@ module stdlib_linalg_lapack_q
               if (nbf == 2 .and. nbl == 1) ilst = ilst - 1
               if (nbf == 1 .and. nbl == 2) ilst = ilst + 1
               here = ifst
-10            continue
+              10 continue
               ! swap block with next one below
               if (nbf == 1 .or. nbf == 2) then
                  ! current block either 1 by 1 or 2 by 2
@@ -82998,7 +82998,7 @@ module stdlib_linalg_lapack_q
                     if (t(here + nbf + 1,here + nbf) /= zero) nbnext = 2
                  end if
                  call stdlib_qlaexc(wantq,n,t,ldt,q,ldq,here,nbf,nbnext,work,info)
-                           
+
                  if (info /= 0) then
                     ilst = here
                     return
@@ -83016,7 +83016,7 @@ module stdlib_linalg_lapack_q
                     if (t(here + 3,here + 2) /= zero) nbnext = 2
                  end if
                  call stdlib_qlaexc(wantq,n,t,ldt,q,ldq,here + 1,1,nbnext,work,info)
-                           
+
                  if (info /= 0) then
                     ilst = here
                     return
@@ -83024,7 +83024,7 @@ module stdlib_linalg_lapack_q
                  if (nbnext == 1) then
                     ! swap two 1 by 1 blocks, no problems possible
                     call stdlib_qlaexc(wantq,n,t,ldt,q,ldq,here,1,nbnext,work,info)
-                              
+
                     here = here + 1
                  else
                     ! recompute nbnext in case 2 by 2 split
@@ -83032,7 +83032,7 @@ module stdlib_linalg_lapack_q
                     if (nbnext == 2) then
                        ! 2 by 2 block did not split
                        call stdlib_qlaexc(wantq,n,t,ldt,q,ldq,here,1,nbnext,work,info)
-                                 
+
                        if (info /= 0) then
                           ilst = here
                           return
@@ -83041,9 +83041,9 @@ module stdlib_linalg_lapack_q
                     else
                        ! 2 by 2 block did split
                        call stdlib_qlaexc(wantq,n,t,ldt,q,ldq,here,1,1,work,info)
-                                 
+
                        call stdlib_qlaexc(wantq,n,t,ldt,q,ldq,here + 1,1,1,work,info)
-                                 
+
                        here = here + 2
                     end if
                  end if
@@ -83051,7 +83051,7 @@ module stdlib_linalg_lapack_q
               if (here < ilst) go to 10
            else
               here = ifst
-20            continue
+              20 continue
               ! swap block with next one above
               if (nbf == 1 .or. nbf == 2) then
                  ! current block either 1 by 1 or 2 by 2
@@ -83078,7 +83078,7 @@ module stdlib_linalg_lapack_q
                     if (t(here - 1,here - 2) /= zero) nbnext = 2
                  end if
                  call stdlib_qlaexc(wantq,n,t,ldt,q,ldq,here - nbnext,nbnext,1,work,info)
-                           
+
                  if (info /= 0) then
                     ilst = here
                     return
@@ -83086,7 +83086,7 @@ module stdlib_linalg_lapack_q
                  if (nbnext == 1) then
                     ! swap two 1 by 1 blocks, no problems possible
                     call stdlib_qlaexc(wantq,n,t,ldt,q,ldq,here,nbnext,1,work,info)
-                              
+
                     here = here - 1
                  else
                     ! recompute nbnext in case 2 by 2 split
@@ -83094,7 +83094,7 @@ module stdlib_linalg_lapack_q
                     if (nbnext == 2) then
                        ! 2 by 2 block did not split
                        call stdlib_qlaexc(wantq,n,t,ldt,q,ldq,here - 1,2,1,work,info)
-                                 
+
                        if (info /= 0) then
                           ilst = here
                           return
@@ -83103,9 +83103,9 @@ module stdlib_linalg_lapack_q
                     else
                        ! 2 by 2 block did split
                        call stdlib_qlaexc(wantq,n,t,ldt,q,ldq,here,1,1,work,info)
-                                 
+
                        call stdlib_qlaexc(wantq,n,t,ldt,q,ldq,here - 1,1,1,work,info)
-                                 
+
                        here = here - 2
                     end if
                  end if
@@ -83137,7 +83137,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: a(lda,*),b(ldb,*),x(ldx,*)
            real(qp),intent(out) :: berr(*),ferr(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            character :: transt
@@ -83321,9 +83321,9 @@ module stdlib_linalg_lapack_q
                  end if
               end do
               kase = 0
-210           continue
+              210 continue
               call stdlib_qlacn2(n,work(2*n + 1),work(n + 1),iwork,ferr(j),kase,isave)
-                        
+
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(op(a)**t).
@@ -83378,7 +83378,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: q(ldq,*),t(ldt,*)
            real(qp),intent(out) :: wi(*),work(*),wr(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,pair,swap,wantbh,wantq,wants,wantsp
            integer(ilp) :: ierr,k,kase,kk,ks,liwmin,lwmin,n1,n2,nn
@@ -83481,7 +83481,7 @@ module stdlib_linalg_lapack_q
                     ierr = 0
                     kk = k
                     if (k /= ks) call stdlib_qtrexc(compq,n,t,ldt,q,ldq,kk,ks,work,ierr)
-                              
+
                     if (ierr == 1 .or. ierr == 2) then
                        ! blocks too close to swap: exit.
                        info = 1
@@ -83512,7 +83512,7 @@ module stdlib_linalg_lapack_q
               ! estimate sep(t11,t22).
               est = zero
               kase = 0
-30            continue
+              30 continue
               call stdlib_qlacn2(nn,work(nn + 1),work,iwork,est,kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -83528,7 +83528,7 @@ module stdlib_linalg_lapack_q
               end if
               sep = scale/est
            end if
-40         continue
+           40 continue
            ! store the output eigenvalues in wr and wi.
            do k = 1,n
               wr(k) = t(k,k)
@@ -83569,7 +83569,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(out) :: s(*),sep(*),work(ldwork,*)
            real(qp),intent(in) :: t(ldt,*),vl(ldvl,*),vr(ldvr,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: pair,somcon,wantbh,wants,wantsp
            integer(ilp) :: i,ierr,ifst,ilst,j,k,kase,ks,n2,nn
@@ -83752,7 +83752,7 @@ module stdlib_linalg_lapack_q
                     ! estimate norm(inv(c**t))
                     est = zero
                     kase = 0
-50                  continue
+                    50 continue
                     call stdlib_qlacn2(nn,work(1,n + 2),work(1,n + 4),iwork,est,kase, &
                               isave)
                     if (kase /= 0) then
@@ -83803,7 +83803,7 @@ module stdlib_linalg_lapack_q
      !> off-diagonal elements of opposite sign.
 
      subroutine stdlib_qtrsyl(trana,tranb,isgn,m,n,a,lda,b,ldb,c,ldc,scale,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -83816,7 +83816,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: a(lda,*),b(ldb,*)
            real(qp),intent(inout) :: c(ldc,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notrna,notrnb
            integer(ilp) :: ierr,j,k,k1,k2,knext,l,l1,l2,lnext
@@ -84466,7 +84466,7 @@ module stdlib_linalg_lapack_q
            ! Array Arguments
            real(qp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,upper
            integer(ilp) :: j
@@ -84502,7 +84502,7 @@ module stdlib_linalg_lapack_q
                  end if
                  ! compute elements 1:j-1 of j-th column.
                  call stdlib_qtrmv('UPPER','NO TRANSPOSE',diag,j - 1,a,lda,a(1,j),1)
-                           
+
                  call stdlib_qscal(j - 1,ajj,a(1,j),1)
               end do
            else
@@ -84540,7 +84540,7 @@ module stdlib_linalg_lapack_q
            ! Array Arguments
            real(qp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,upper
            integer(ilp) :: j,jb,nb,nn
@@ -84629,7 +84629,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(in) :: a(lda,*)
            real(qp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit
            ! Intrinsic Functions
@@ -84972,7 +84972,7 @@ module stdlib_linalg_lapack_q
            real(qp),intent(inout) :: a(lda,*)
            real(qp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,iws,ki,kk,ldwork,lwkmin,lwkopt,m1,mu,nb,nbmin, &
@@ -85057,7 +85057,7 @@ module stdlib_linalg_lapack_q
                     ! apply h to a(1:i-1,i:n) from the right
                     call stdlib_qlarzb('RIGHT','NO TRANSPOSE','BACKWARD','ROWWISE',i - 1,n - i + 1, &
                      ib,n - m,a(i,m1),lda,work,ldwork,a(1,i),lda,work(ib + 1),ldwork)
-                               
+
                  end if
               end do
               mu = i + nb - 1
@@ -85103,7 +85103,7 @@ module stdlib_linalg_lapack_q
            stdlib_qzsum1 = stemp
            return
            ! code for increment equal to 1
-20   continue
+           20 continue
            do i = 1,n
               ! next line modified.
               stemp = stemp + abs(cx(i))

--- a/src/stdlib_linalg_lapack_s.f90
+++ b/src/stdlib_linalg_lapack_s.f90
@@ -544,7 +544,7 @@ module stdlib_linalg_lapack_s
            stdlib_scsum1 = stemp
            return
            ! code for increment equal to 1
-20   continue
+           20 continue
            do i = 1,n
               ! next line modified.
               stemp = stemp + abs(cx(i))
@@ -568,7 +568,7 @@ module stdlib_linalg_lapack_s
            integer(ilp),intent(out) :: ipiv(*)
            real(sp),intent(inout) :: ab(ldab,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,jp,ju,km,kv
            ! Intrinsic Functions
@@ -657,7 +657,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: ab(ldab,*)
            real(sp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lnoti,notran
            integer(ilp) :: i,j,kd,l,lm
@@ -749,7 +749,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: v(ldv,*)
            real(sp),intent(in) :: scale(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: leftv,rightv
            integer(ilp) :: i,ii,k
@@ -804,7 +804,7 @@ module stdlib_linalg_lapack_s
            ! backward permutation
            ! for  i = ilo-1 step -1 until 1,
                     ! ihi+1 step 1 until n do --
-30   continue
+                    30 continue
            if (stdlib_lsame(job,'P') .or. stdlib_lsame(job,'B')) then
               if (rightv) then
                  loop_40: do ii = 1,n
@@ -836,7 +836,7 @@ module stdlib_linalg_lapack_s
      !> SGGBAL.
 
      pure subroutine stdlib_sggbak(job,side,n,ilo,ihi,lscale,rscale,m,v,ldv,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -903,7 +903,7 @@ module stdlib_linalg_lapack_s
               end if
            end if
            ! backward permutation
-30   continue
+           30 continue
            if (stdlib_lsame(job,'P') .or. stdlib_lsame(job,'B')) then
               ! backward permutation on right eigenvectors
               if (rightv) then
@@ -913,7 +913,7 @@ module stdlib_linalg_lapack_s
                     if (k == i) cycle loop_40
                     call stdlib_sswap(m,v(i,1),ldv,v(k,1),ldv)
                  end do loop_40
-50               continue
+                 50 continue
                  if (ihi == n) go to 70
                  loop_60: do i = ihi + 1,n
                     k = rscale(i)
@@ -922,7 +922,7 @@ module stdlib_linalg_lapack_s
                  end do loop_60
               end if
               ! backward permutation on left eigenvectors
-70   continue
+              70 continue
               if (leftv) then
                  if (ilo == 1) go to 90
                  loop_80: do i = ilo - 1,1,-1
@@ -930,7 +930,7 @@ module stdlib_linalg_lapack_s
                     if (k == i) cycle loop_80
                     call stdlib_sswap(m,v(i,1),ldv,v(k,1),ldv)
                  end do loop_80
-90               continue
+                 90 continue
                  if (ihi == n) go to 110
                  loop_100: do i = ihi + 1,n
                     k = lscale(i)
@@ -939,7 +939,7 @@ module stdlib_linalg_lapack_s
                  end do loop_100
               end if
            end if
-110        continue
+           110 continue
            return
      end subroutine stdlib_sggbak
 
@@ -960,7 +960,7 @@ module stdlib_linalg_lapack_s
            ! Array Arguments
            real(sp),intent(inout) :: b(ldb,*),d(*),dl(*),du(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(sp) :: fact,temp
@@ -1098,12 +1098,12 @@ module stdlib_linalg_lapack_s
            ! back solve with the matrix u from the factorization.
            if (nrhs <= 2) then
               j = 1
-70            continue
+              70 continue
               b(n,j) = b(n,j)/d(n)
               if (n > 1) b(n - 1,j) = (b(n - 1,j) - du(n - 1)*b(n,j))/d(n - 1)
               do i = n - 2,1,-1
                  b(i,j) = (b(i,j) - du(i)*b(i + 1,j) - dl(i)*b(i + 2,j))/d(i)
-                           
+
               end do
               if (j < nrhs) then
                  j = j + 1
@@ -1115,7 +1115,7 @@ module stdlib_linalg_lapack_s
                  if (n > 1) b(n - 1,j) = (b(n - 1,j) - du(n - 1)*b(n,j))/d(n - 1)
                  do i = n - 2,1,-1
                     b(i,j) = (b(i,j) - du(i)*b(i + 1,j) - dl(i)*b(i + 2,j))/d(i)
-                              
+
                  end do
               end do
            end if
@@ -1142,7 +1142,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: d(*),dl(*),du(*)
            real(sp),intent(out) :: du2(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(sp) :: fact,temp
@@ -1210,7 +1210,7 @@ module stdlib_linalg_lapack_s
                  go to 50
               end if
            end do
-50         continue
+           50 continue
            return
      end subroutine stdlib_sgttrf
 
@@ -1241,7 +1241,7 @@ module stdlib_linalg_lapack_s
               ! overwriting each right hand side vector with its solution.
               if (nrhs <= 1) then
                  j = 1
-10               continue
+                 10 continue
                  ! solve l*x = b.
                  do i = 1,n - 1
                     ip = ipiv(i)
@@ -1254,7 +1254,7 @@ module stdlib_linalg_lapack_s
                  if (n > 1) b(n - 1,j) = (b(n - 1,j) - du(n - 1)*b(n,j))/d(n - 1)
                  do i = n - 2,1,-1
                     b(i,j) = (b(i,j) - du(i)*b(i + 1,j) - du2(i)*b(i + 2,j))/d(i)
-                              
+
                  end do
                  if (j < nrhs) then
                     j = j + 1
@@ -1277,7 +1277,7 @@ module stdlib_linalg_lapack_s
                     if (n > 1) b(n - 1,j) = (b(n - 1,j) - du(n - 1)*b(n,j))/d(n - 1)
                     do i = n - 2,1,-1
                        b(i,j) = (b(i,j) - du(i)*b(i + 1,j) - du2(i)*b(i + 2,j))/d(i)
-                                 
+
                     end do
                  end do
               end if
@@ -1286,7 +1286,7 @@ module stdlib_linalg_lapack_s
               if (nrhs <= 1) then
                  ! solve u**t*x = b.
                  j = 1
-70               continue
+                 70 continue
                  b(1,j) = b(1,j)/d(1)
                  if (n > 1) b(2,j) = (b(2,j) - du(1)*b(1,j))/d(2)
                  do i = 3,n
@@ -1429,7 +1429,7 @@ module stdlib_linalg_lapack_s
              s = (s + s) - s
              y(i) = ((x(i) - s) + w(i)) + y(i)
              x(i) = s
-10           continue
+             10 continue
            return
      end subroutine stdlib_sla_wwaddw
 
@@ -1480,7 +1480,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            integer(ilp) :: i,jlast
            real(sp) :: altsgn,estold,temp,xs
@@ -1498,7 +1498,7 @@ module stdlib_linalg_lapack_s
            go to(20,40,70,110,140) isave(1)
            ! ................ entry   (isave( 1 ) = 1)
            ! first iteration.  x has been overwritten by a*x.
-20   continue
+           20 continue
            if (n == 1) then
               v(1) = x(1)
               est = abs(v(1))
@@ -1519,11 +1519,11 @@ module stdlib_linalg_lapack_s
            return
            ! ................ entry   (isave( 1 ) = 2)
            ! first iteration.  x has been overwritten by transpose(a)*x.
-40   continue
+           40 continue
            isave(2) = stdlib_isamax(n,x,1)
            isave(3) = 2
            ! main loop - iterations 2,3,...,itmax.
-50   continue
+           50 continue
            do i = 1,n
               x(i) = zero
            end do
@@ -1533,7 +1533,7 @@ module stdlib_linalg_lapack_s
            return
            ! ................ entry   (isave( 1 ) = 3)
            ! x has been overwritten by a*x.
-70   continue
+           70 continue
            call stdlib_scopy(n,x,1,v,1)
            estold = est
            est = stdlib_sasum(n,v,1)
@@ -1547,7 +1547,7 @@ module stdlib_linalg_lapack_s
            end do
            ! repeated sign vector detected, hence algorithm has converged.
            go to 120
-90         continue
+           90 continue
            ! test for cycling.
            if (est <= estold) go to 120
            do i = 1,n
@@ -1563,7 +1563,7 @@ module stdlib_linalg_lapack_s
            return
            ! ................ entry   (isave( 1 ) = 4)
            ! x has been overwritten by transpose(a)*x.
-110  continue
+           110 continue
            jlast = isave(2)
            isave(2) = stdlib_isamax(n,x,1)
            if ((x(jlast) /= abs(x(isave(2)))) .and. (isave(3) < itmax)) then
@@ -1571,7 +1571,7 @@ module stdlib_linalg_lapack_s
               go to 50
            end if
            ! iteration complete.  final stage.
-120  continue
+           120 continue
            altsgn = one
            do i = 1,n
               x(i) = altsgn*(one + real(i - 1,KIND=sp)/real(n - 1,KIND=sp))
@@ -1582,13 +1582,13 @@ module stdlib_linalg_lapack_s
            return
            ! ................ entry   (isave( 1 ) = 5)
            ! x has been overwritten by a*x.
-140  continue
+           140 continue
            temp = two*(stdlib_sasum(n,x,1)/real(3*n,KIND=sp))
            if (temp > est) then
               call stdlib_scopy(n,x,1,v,1)
               est = temp
            end if
-150        continue
+           150 continue
            kase = 0
            return
      end subroutine stdlib_slacn2
@@ -1611,7 +1611,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            integer(ilp) :: i,iter,j,jlast,jump
            real(sp) :: altsgn,estold,temp
@@ -1631,7 +1631,7 @@ module stdlib_linalg_lapack_s
            go to(20,40,70,110,140) jump
            ! ................ entry   (jump = 1)
            ! first iteration.  x has been overwritten by a*x.
-20   continue
+           20 continue
            if (n == 1) then
               v(1) = x(1)
               est = abs(v(1))
@@ -1648,11 +1648,11 @@ module stdlib_linalg_lapack_s
            return
            ! ................ entry   (jump = 2)
            ! first iteration.  x has been overwritten by transpose(a)*x.
-40   continue
+           40 continue
            j = stdlib_isamax(n,x,1)
            iter = 2
            ! main loop - iterations 2,3,...,itmax.
-50   continue
+           50 continue
            do i = 1,n
               x(i) = zero
            end do
@@ -1662,7 +1662,7 @@ module stdlib_linalg_lapack_s
            return
            ! ................ entry   (jump = 3)
            ! x has been overwritten by a*x.
-70   continue
+           70 continue
            call stdlib_scopy(n,x,1,v,1)
            estold = est
            est = stdlib_sasum(n,v,1)
@@ -1671,7 +1671,7 @@ module stdlib_linalg_lapack_s
            end do
            ! repeated sign vector detected, hence algorithm has converged.
            go to 120
-90         continue
+           90 continue
            ! test for cycling.
            if (est <= estold) go to 120
            do i = 1,n
@@ -1683,7 +1683,7 @@ module stdlib_linalg_lapack_s
            return
            ! ................ entry   (jump = 4)
            ! x has been overwritten by transpose(a)*x.
-110  continue
+           110 continue
            jlast = j
            j = stdlib_isamax(n,x,1)
            if ((x(jlast) /= abs(x(j))) .and. (iter < itmax)) then
@@ -1691,7 +1691,7 @@ module stdlib_linalg_lapack_s
               go to 50
            end if
            ! iteration complete.  final stage.
-120  continue
+           120 continue
            altsgn = one
            do i = 1,n
               x(i) = altsgn*(one + real(i - 1,KIND=sp)/real(n - 1,KIND=sp))
@@ -1702,13 +1702,13 @@ module stdlib_linalg_lapack_s
            return
            ! ................ entry   (jump = 5)
            ! x has been overwritten by a*x.
-140  continue
+           140 continue
            temp = two*(stdlib_sasum(n,x,1)/real(3*n,KIND=sp))
            if (temp > est) then
               call stdlib_scopy(n,x,1,v,1)
               est = temp
            end if
-150        continue
+           150 continue
            kase = 0
            return
      end subroutine stdlib_slacon
@@ -1761,7 +1761,7 @@ module stdlib_linalg_lapack_s
            ! Scalar Arguments
            real(sp),intent(in) :: a,b,c,d,r,t
         ! =====================================================================
-           
+
            ! Local Scalars
            real(sp) :: br
            ! Executable Statements
@@ -1792,7 +1792,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: a,b,c
            real(sp),intent(out) :: rt1,rt2
        ! =====================================================================
-           
+
            ! Local Scalars
            real(sp) :: ab,acmn,acmx,adf,df,rt,sm,tb
            ! Intrinsic Functions
@@ -1887,7 +1887,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: d(*),e(*),e2(*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: itmp1,itmp2,j,ji,jit,jp,kf,kfnew,kl,klnew
            real(sp) :: tmp1,tmp2
@@ -2104,7 +2104,7 @@ module stdlib_linalg_lapack_s
               if (kf > kl) go to 140
            end do loop_130
            ! converged
-140  continue
+           140 continue
            info = max(kl + 1 - kf,0)
            mout = kl
            return
@@ -2130,7 +2130,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: d(2),z(2)
            real(sp),intent(out) :: delta(2)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(sp) :: b,c,del,tau,temp,w
            ! Intrinsic Functions
@@ -2198,7 +2198,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: givnum(2,*),q(*)
            real(sp),intent(out) :: z(*),ztemp(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: bsiz1,bsiz2,curr,i,k,mid,psiz1,psiz2,ptr,zptr1
            ! Intrinsic Functions
@@ -2227,7 +2227,7 @@ module stdlib_linalg_lapack_s
            ! roots.
            bsiz1 = int(half + sqrt(real(qptr(curr + 1) - qptr(curr),KIND=sp)),KIND=ilp)
            bsiz2 = int(half + sqrt(real(qptr(curr + 2) - qptr(curr + 1),KIND=sp)),KIND=ilp)
-                     
+
            do k = 1,mid - bsiz1 - 1
               z(k) = zero
            end do
@@ -2267,9 +2267,9 @@ module stdlib_linalg_lapack_s
               ! the sqrt in case the machine underestimates one of these
               ! square roots.
               bsiz1 = int(half + sqrt(real(qptr(curr + 1) - qptr(curr),KIND=sp)),KIND=ilp)
-                        
+
               bsiz2 = int(half + sqrt(real(qptr(curr + 2) - qptr(curr + 1),KIND=sp)),KIND=ilp)
-                        
+
               if (bsiz1 > 0) then
                  call stdlib_sgemv('T',bsiz1,bsiz1,one,q(qptr(curr)),bsiz1,ztemp(1), &
                            1,zero,z(zptr1),1)
@@ -2280,7 +2280,7 @@ module stdlib_linalg_lapack_s
                            psiz1 + 1),1,zero,z(mid),1)
               end if
               call stdlib_scopy(psiz2 - bsiz2,ztemp(psiz1 + bsiz2 + 1),1,z(mid + bsiz2),1)
-                        
+
               ptr = ptr + 2**(tlvls - k)
            end do loop_70
            return
@@ -2303,7 +2303,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: a,b,c
            real(sp),intent(out) :: cs1,rt1,rt2,sn1
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: sgn1,sgn2
            real(sp) :: ab,acmn,acmx,acs,adf,cs,ct,df,rt,sm,tb,tn
@@ -2402,7 +2402,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: fuzzy1 = one + 1.0e-5_sp
-           
+
            ! Local Scalars
            real(sp) :: a11,a12,a21,a22,abi22,anorm,as11,as12,as22,ascale,b11,b12,b22, &
            binv11,binv22,bmin,bnorm,bscale,bsize,c1,c2,c3,c4,c5,diff,discr,pp,qq,r, &
@@ -2527,7 +2527,7 @@ module stdlib_linalg_lapack_s
            ! scale first eigenvalue
            wabs = abs(wr1) + abs(wi)
            wsize = max(safmin,c1,fuzzy1*(wabs*c2 + c3),min(c4,half*max(wabs,c5)))
-                     
+
            if (wsize /= one) then
               wscale = one/wsize
               if (wsize > one) then
@@ -2601,7 +2601,7 @@ module stdlib_linalg_lapack_s
      !> 0., 1., or -1.
 
      pure subroutine stdlib_slagtm(trans,n,nrhs,alpha,dl,d,du,x,ldx,beta,b,ldb)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -2613,7 +2613,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: b(ldb,*)
            real(sp),intent(in) :: d(*),dl(*),du(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            ! Executable Statements
@@ -2729,7 +2729,7 @@ module stdlib_linalg_lapack_s
            ! Scalar Arguments
            character,intent(in) :: cmach
        ! =====================================================================
-           
+
            ! Local Scalars
            real(sp) :: rnd,eps,sfmin,small,rmach
            ! Intrinsic Functions
@@ -2818,7 +2818,7 @@ module stdlib_linalg_lapack_s
            end if
            i = 1
            ! while ( (n1sv > 0)
-10   continue
+           10 continue
            if (n1sv > 0 .and. n2sv > 0) then
               if (a(ind1) <= a(ind2)) then
                  index(i) = ind1
@@ -2911,7 +2911,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: d(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(sp) :: sfmin
            integer(ilp) :: i,iinfo,n1,n2
@@ -2966,17 +2966,17 @@ module stdlib_linalg_lapack_s
               call stdlib_slaorhr_col_getrfnp2(n1,n1,a,lda,d,iinfo)
               ! solve for b21
               call stdlib_strsm('R','U','N','N',m - n1,n1,one,a,lda,a(n1 + 1,1),lda)
-                        
+
               ! solve for b12
               call stdlib_strsm('L','L','N','U',n1,n2,one,a,lda,a(1,n1 + 1),lda)
-                        
+
               ! update b22, i.e. compute the schur complement
               ! b22 := b22 - b21*b12
               call stdlib_sgemm('N','N',m - n1,n2,n1,-one,a(n1 + 1,1),lda,a(1,n1 + 1), &
                         lda,one,a(n1 + 1,n1 + 1),lda)
               ! factor b22, recursive call
               call stdlib_slaorhr_col_getrfnp2(m - n1,n2,a(n1 + 1,n1 + 1),lda,d(n1 + 1),iinfo)
-                        
+
            end if
            return
      end subroutine stdlib_slaorhr_col_getrfnp2
@@ -3014,7 +3014,7 @@ module stdlib_linalg_lapack_s
                  j = i
                  k(j) = -k(j)
                  in = k(j)
-20               continue
+                 20 continue
                  if (k(in) > 0) go to 40
                  do jj = 1,n
                     temp = x(j,jj)
@@ -3025,7 +3025,7 @@ module stdlib_linalg_lapack_s
                  j = in
                  in = k(in)
                  go to 20
-40               continue
+                 40 continue
               end do
            else
               ! backward permutation
@@ -3033,7 +3033,7 @@ module stdlib_linalg_lapack_s
                  if (k(i) > 0) go to 80
                  k(i) = -k(i)
                  j = k(i)
-60               continue
+                 60 continue
                  if (j == i) go to 80
                  do jj = 1,n
                     temp = x(i,jj)
@@ -3043,7 +3043,7 @@ module stdlib_linalg_lapack_s
                  k(j) = -k(j)
                  j = k(j)
                  go to 60
-80               continue
+                 80 continue
               end do
            end if
            return
@@ -3082,7 +3082,7 @@ module stdlib_linalg_lapack_s
                  j = i
                  k(j) = -k(j)
                  in = k(j)
-20               continue
+                 20 continue
                  if (k(in) > 0) go to 40
                  do ii = 1,m
                     temp = x(ii,j)
@@ -3093,7 +3093,7 @@ module stdlib_linalg_lapack_s
                  j = in
                  in = k(in)
                  go to 20
-40               continue
+                 40 continue
               end do
            else
               ! backward permutation
@@ -3101,7 +3101,7 @@ module stdlib_linalg_lapack_s
                  if (k(i) > 0) go to 100
                  k(i) = -k(i)
                  j = k(i)
-80               continue
+                 80 continue
                  if (j == i) go to 100
                  do ii = 1,m
                     temp = x(ii,i)
@@ -3111,7 +3111,7 @@ module stdlib_linalg_lapack_s
                  k(j) = -k(j)
                  j = k(j)
                  go to 80
-100              continue
+                 100 continue
               end do
            end if
            return
@@ -3127,7 +3127,7 @@ module stdlib_linalg_lapack_s
            ! Scalar Arguments
            real(sp),intent(in) :: x,y,z
         ! =====================================================================
-           
+
            ! Local Scalars
            real(sp) :: w,xabs,yabs,zabs,hugeval
            ! Intrinsic Functions
@@ -3154,7 +3154,7 @@ module stdlib_linalg_lapack_s
      !> in the vectors R and C.
 
      pure subroutine stdlib_slaqgb(m,n,kl,ku,ab,ldab,r,c,rowcnd,colcnd,amax,equed)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -3168,7 +3168,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: thresh = 0.1e+0_sp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(sp) :: cj,large,small
@@ -3236,7 +3236,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: thresh = 0.1e+0_sp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(sp) :: cj,large,small
@@ -3307,7 +3307,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: h(ldh,*)
            real(sp),intent(out) :: v(*)
         ! ================================================================
-           
+
            ! Local Scalars
            real(sp) :: h21s,h31s,s
            ! Intrinsic Functions
@@ -3363,7 +3363,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: thresh = 0.1e+0_sp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(sp) :: cj,large,small
@@ -3423,7 +3423,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: thresh = 0.1e+0_sp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,jc
            real(sp) :: cj,large,small
@@ -3485,7 +3485,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: thresh = 0.1e+0_sp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(sp) :: cj,large,small
@@ -3587,7 +3587,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: v(*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: applyleft
            integer(ilp) :: i,lastv,lastc
@@ -3661,7 +3661,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: t(ldt,*),v(ldv,*)
            real(sp),intent(out) :: work(ldwork,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            character :: transt
            integer(ilp) :: i,j
@@ -3976,7 +3976,7 @@ module stdlib_linalg_lapack_s
      !> arrays A, B and T. See Further Details section.
 
      pure subroutine stdlib_slarfb_gett(ident,m,n,k,t,ldt,a,lda,b,ldb,work,ldwork)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -3988,7 +3988,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: t(ldt,*)
            real(sp),intent(out) :: work(ldwork,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lnotident
            integer(ilp) :: i,j
@@ -4126,7 +4126,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(out) :: t(ldt,*)
            real(sp),intent(in) :: tau(*),v(ldv,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,prevlastv,lastv
            ! Executable Statements
@@ -4252,7 +4252,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: v(*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j
            real(sp) :: sum,t1,t10,t2,t3,t4,t5,t6,t7,t8,t9,v1,v10,v2,v3,v4,v5,v6, &
@@ -4265,14 +4265,14 @@ module stdlib_linalg_lapack_s
               ! code for general m
               call stdlib_slarf(side,m,n,v,1,tau,c,ldc,work)
               go to 410
-10            continue
+              10 continue
               ! special code for 1 x 1 householder
               t1 = one - tau*v(1)*v(1)
               do j = 1,n
                  c(1,j) = t1*c(1,j)
               end do
               go to 410
-30            continue
+              30 continue
               ! special code for 2 x 2 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4284,7 +4284,7 @@ module stdlib_linalg_lapack_s
                  c(2,j) = c(2,j) - sum*t2
               end do
               go to 410
-50            continue
+              50 continue
               ! special code for 3 x 3 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4299,7 +4299,7 @@ module stdlib_linalg_lapack_s
                  c(3,j) = c(3,j) - sum*t3
               end do
               go to 410
-70            continue
+              70 continue
               ! special code for 4 x 4 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4317,7 +4317,7 @@ module stdlib_linalg_lapack_s
                  c(4,j) = c(4,j) - sum*t4
               end do
               go to 410
-90            continue
+              90 continue
               ! special code for 5 x 5 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4331,7 +4331,7 @@ module stdlib_linalg_lapack_s
               t5 = tau*v5
               do j = 1,n
                  sum = v1*c(1,j) + v2*c(2,j) + v3*c(3,j) + v4*c(4,j) + v5*c(5,j)
-                           
+
                  c(1,j) = c(1,j) - sum*t1
                  c(2,j) = c(2,j) - sum*t2
                  c(3,j) = c(3,j) - sum*t3
@@ -4339,7 +4339,7 @@ module stdlib_linalg_lapack_s
                  c(5,j) = c(5,j) - sum*t5
               end do
               go to 410
-110           continue
+              110 continue
               ! special code for 6 x 6 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4364,7 +4364,7 @@ module stdlib_linalg_lapack_s
                  c(6,j) = c(6,j) - sum*t6
               end do
               go to 410
-130           continue
+              130 continue
               ! special code for 7 x 7 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4392,7 +4392,7 @@ module stdlib_linalg_lapack_s
                  c(7,j) = c(7,j) - sum*t7
               end do
               go to 410
-150           continue
+              150 continue
               ! special code for 8 x 8 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4423,7 +4423,7 @@ module stdlib_linalg_lapack_s
                  c(8,j) = c(8,j) - sum*t8
               end do
               go to 410
-170           continue
+              170 continue
               ! special code for 9 x 9 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4457,7 +4457,7 @@ module stdlib_linalg_lapack_s
                  c(9,j) = c(9,j) - sum*t9
               end do
               go to 410
-190           continue
+              190 continue
               ! special code for 10 x 10 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4500,14 +4500,14 @@ module stdlib_linalg_lapack_s
               ! code for general n
               call stdlib_slarf(side,m,n,v,1,tau,c,ldc,work)
               go to 410
-210           continue
+              210 continue
               ! special code for 1 x 1 householder
               t1 = one - tau*v(1)*v(1)
               do j = 1,m
                  c(j,1) = t1*c(j,1)
               end do
               go to 410
-230           continue
+              230 continue
               ! special code for 2 x 2 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4519,7 +4519,7 @@ module stdlib_linalg_lapack_s
                  c(j,2) = c(j,2) - sum*t2
               end do
               go to 410
-250           continue
+              250 continue
               ! special code for 3 x 3 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4534,7 +4534,7 @@ module stdlib_linalg_lapack_s
                  c(j,3) = c(j,3) - sum*t3
               end do
               go to 410
-270           continue
+              270 continue
               ! special code for 4 x 4 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4552,7 +4552,7 @@ module stdlib_linalg_lapack_s
                  c(j,4) = c(j,4) - sum*t4
               end do
               go to 410
-290           continue
+              290 continue
               ! special code for 5 x 5 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4566,7 +4566,7 @@ module stdlib_linalg_lapack_s
               t5 = tau*v5
               do j = 1,m
                  sum = v1*c(j,1) + v2*c(j,2) + v3*c(j,3) + v4*c(j,4) + v5*c(j,5)
-                           
+
                  c(j,1) = c(j,1) - sum*t1
                  c(j,2) = c(j,2) - sum*t2
                  c(j,3) = c(j,3) - sum*t3
@@ -4574,7 +4574,7 @@ module stdlib_linalg_lapack_s
                  c(j,5) = c(j,5) - sum*t5
               end do
               go to 410
-310           continue
+              310 continue
               ! special code for 6 x 6 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4599,7 +4599,7 @@ module stdlib_linalg_lapack_s
                  c(j,6) = c(j,6) - sum*t6
               end do
               go to 410
-330           continue
+              330 continue
               ! special code for 7 x 7 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4627,7 +4627,7 @@ module stdlib_linalg_lapack_s
                  c(j,7) = c(j,7) - sum*t7
               end do
               go to 410
-350           continue
+              350 continue
               ! special code for 8 x 8 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4658,7 +4658,7 @@ module stdlib_linalg_lapack_s
                  c(j,8) = c(j,8) - sum*t8
               end do
               go to 410
-370           continue
+              370 continue
               ! special code for 9 x 9 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4692,7 +4692,7 @@ module stdlib_linalg_lapack_s
                  c(j,9) = c(j,9) - sum*t9
               end do
               go to 410
-390           continue
+              390 continue
               ! special code for 10 x 10 householder
               v1 = v(1)
               t1 = tau*v1
@@ -4753,7 +4753,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: v(*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(sp) :: alpha
            ! Executable Statements
@@ -4782,7 +4782,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(out) :: c(*)
            real(sp),intent(inout) :: x(*),y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,ic,ix,iy
            real(sp) :: f,g,t,tt
@@ -4837,7 +4837,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: d(*)
            real(sp),intent(inout) :: e(*),e2(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(sp) :: eabs,tmp1
@@ -4884,7 +4884,7 @@ module stdlib_linalg_lapack_s
      !> if JOBT = 'L'.
 
      pure subroutine stdlib_slarrc(jobt,n,vl,vu,d,e,pivmin,eigcnt,lcnt,rcnt,info)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -4896,7 +4896,7 @@ module stdlib_linalg_lapack_s
            ! Array Arguments
            real(sp),intent(in) :: d(*),e(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            logical(lk) :: matt
@@ -5007,7 +5007,7 @@ module stdlib_linalg_lapack_s
            integer(ilp),parameter :: allrng = 1
            integer(ilp),parameter :: valrng = 2
            integer(ilp),parameter :: indrng = 3
-           
+
            ! Local Scalars
            logical(lk) :: ncnvrg,toofew
            integer(ilp) :: i,ib,ibegin,idiscl,idiscu,ie,iend,iinfo,im,in,ioff,iout, &
@@ -5465,7 +5465,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: w(*),werr(*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            integer(ilp) :: maxitr
            ! Local Scalars
            integer(ilp) :: cnt,i,i1,i2,ii,iter,j,k,next,nint,olnint,p,prev, &
@@ -5516,7 +5516,7 @@ module stdlib_linalg_lapack_s
                  ! make sure that [left,right] contains the desired eigenvalue
                  ! do while( cnt(left)>i-1 )
                  fac = one
-20               continue
+                 20 continue
                  cnt = 0
                  s = left
                  dplus = d(1) - s
@@ -5532,7 +5532,7 @@ module stdlib_linalg_lapack_s
                  end if
                  ! do while( cnt(right)<i )
                  fac = one
-50               continue
+                 50 continue
                  cnt = 0
                  s = right
                  dplus = d(1) - s
@@ -5557,7 +5557,7 @@ module stdlib_linalg_lapack_s
            ! do while( nint>0 ), i.e. there are still unconverged intervals
            ! and while (iter<maxitr)
            iter = 0
-80         continue
+           80 continue
            prev = i1 - 1
            i = i1
            olnint = nint
@@ -5644,7 +5644,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: fudge = two
-           
+
            ! Local Scalars
            integer(ilp) :: i,it,itmax,negcnt
            real(sp) :: atoli,eps,left,mid,right,rtoli,tmp1,tmp2,tnorm
@@ -5666,7 +5666,7 @@ module stdlib_linalg_lapack_s
            left = gl - fudge*tnorm*eps*n - fudge*two*pivmin
            right = gu + fudge*tnorm*eps*n + fudge*two*pivmin
            it = 0
-10         continue
+           10 continue
            ! check if interval converged or maximum number of iterations reached
            tmp1 = abs(right - left)
            tmp2 = max(abs(right),abs(left))
@@ -5693,7 +5693,7 @@ module stdlib_linalg_lapack_s
               left = mid
            end if
            goto 10
-30         continue
+           30 continue
            ! converged or maximum number of iterations reached
            w = half*(left + right)
            werr = half*abs(right - left)
@@ -5717,7 +5717,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: relcond = 0.999_sp
-           
+
            ! Local Scalars
            integer(ilp) :: i
            logical(lk) :: yesrel
@@ -5765,7 +5765,7 @@ module stdlib_linalg_lapack_s
               tmp = tmp2
               offdig = offdig2
            end do
-11         continue
+           11 continue
            if (yesrel) then
               info = 0
               return
@@ -5869,7 +5869,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(out) :: cs,r,sn
            real(sp),intent(in) :: f,g
         ! =====================================================================
-           
+
            ! Local Scalars
            ! logical            first
            integer(ilp) :: count,i
@@ -5903,7 +5903,7 @@ module stdlib_linalg_lapack_s
               scale = max(abs(f1),abs(g1))
               if (scale >= safmx2) then
                  count = 0
-10               continue
+                 10 continue
                  count = count + 1
                  f1 = f1*safmn2
                  g1 = g1*safmn2
@@ -5917,7 +5917,7 @@ module stdlib_linalg_lapack_s
                  end do
               else if (scale <= safmn2) then
                  count = 0
-30               continue
+                 30 continue
                  count = count + 1
                  f1 = f1*safmx2
                  g1 = g1*safmx2
@@ -5960,7 +5960,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(out) :: cs,sn
            real(sp),intent(in) :: sigma,x,y
         ! ===================================================================
-           
+
            ! Local Scalars
            real(sp) :: r,s,thresh,w,z
            thresh = stdlib_slamch('E')
@@ -6051,7 +6051,7 @@ module stdlib_linalg_lapack_s
            integer(ilp),parameter :: lv = 128
            integer(ilp),parameter :: ipw2 = 4096
            real(sp),parameter :: r = one/ipw2
-           
+
            ! Local Scalars
            integer(ilp) :: i,i1,i2,i3,i4,it1,it2,it3,it4,j
            ! Local Arrays
@@ -6193,7 +6193,7 @@ module stdlib_linalg_lapack_s
            i3 = iseed(3)
            i4 = iseed(4)
            loop_10: do i = 1,min(n,lv)
-20         continue
+           20 continue
               ! multiply the seed by i-th power of the multiplier modulo 2**48
               it4 = i4*mm(i,4)
               it3 = it4/ipw2
@@ -6255,7 +6255,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: v(*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Executable Statements
            if (stdlib_lsame(side,'L')) then
               ! form  h * c
@@ -6305,7 +6305,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: c(ldc,*),t(ldt,*),v(ldv,*)
            real(sp),intent(out) :: work(ldwork,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            character :: transt
            integer(ilp) :: i,info,j
@@ -6403,7 +6403,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: tau(*)
            real(sp),intent(inout) :: v(ldv,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,info,j
            ! Executable Statements
@@ -6454,7 +6454,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: f,g,h
            real(sp),intent(out) :: ssmax,ssmin
         ! ====================================================================
-           
+
            ! Local Scalars
            real(sp) :: as,at,au,c,fa,fhmn,fhmx,ga,ha
            ! Intrinsic Functions
@@ -6471,7 +6471,7 @@ module stdlib_linalg_lapack_s
                  ssmax = ga
               else
                  ssmax = max(fhmx,ga)*sqrt(one + (min(fhmx,ga)/max(fhmx,ga))**2)
-                           
+
               end if
            else
               if (ga < fhmx) then
@@ -6523,7 +6523,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: d(2),z(2)
            real(sp),intent(out) :: delta(2),work(2)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(sp) :: b,c,del,delsq,tau,w
            ! Intrinsic Functions
@@ -6610,7 +6610,7 @@ module stdlib_linalg_lapack_s
            ! Array Arguments
            integer(ilp),intent(out) :: inode(*),ndiml(*),ndimr(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,il,ir,llst,maxn,ncrnt,nlvl
            real(sp) :: temp
@@ -6722,7 +6722,7 @@ module stdlib_linalg_lapack_s
            real(sp),parameter :: qurtr = 0.250_sp
            real(sp),parameter :: third = 0.3330_sp
            real(sp),parameter :: hundrd = 100.0_sp
-           
+
            ! Local Scalars
            integer(ilp) :: i4,nn,np
            real(sp) :: a2,b1,b2,gam,gap1,gap2,s
@@ -6790,7 +6790,7 @@ module stdlib_linalg_lapack_s
                        a2 = a2 + b2
                        if (hundrd*max(b2,b1) < a2 .or. cnst1 < a2) go to 20
                     end do
-20                  continue
+                    20 continue
                     a2 = cnst3*a2
                     ! rayleigh quotient residual bound.
                     if (a2 < cnst1) s = gam*(one - sqrt(a2))/(one + a2)
@@ -6818,7 +6818,7 @@ module stdlib_linalg_lapack_s
                        a2 = a2 + b2
                        if (hundrd*max(b2,b1) < a2 .or. cnst1 < a2) go to 40
                     end do
-40                  continue
+                    40 continue
                     a2 = cnst3*a2
                  end if
                  if (a2 < cnst1) s = gam*(one - sqrt(a2))/(one + a2)
@@ -6851,7 +6851,7 @@ module stdlib_linalg_lapack_s
                     b2 = b2 + b1
                     if (hundrd*max(b1,a2) < b2) go to 60
                  end do
-60               continue
+                 60 continue
                  b2 = sqrt(cnst3*b2)
                  a2 = dmin1/(one + b2**2)
                  gap2 = half*dmin2 - a2
@@ -6883,7 +6883,7 @@ module stdlib_linalg_lapack_s
                     b2 = b2 + b1
                     if (hundrd*b1 < b2) go to 80
                  end do
-80               continue
+                 80 continue
                  b2 = sqrt(cnst3*b2)
                  a2 = dmin2/(one + b2**2)
                  gap2 = z(nn - 7) + z(nn - 9) - sqrt(z(nn - 11))*sqrt(z(nn - 9)) - a2
@@ -6922,7 +6922,7 @@ module stdlib_linalg_lapack_s
            ! Array Arguments
            real(sp),intent(inout) :: z(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j4,j4p2
            real(sp) :: d,emin,temp,dthresh
@@ -7146,7 +7146,7 @@ module stdlib_linalg_lapack_s
            ! Array Arguments
            real(sp),intent(inout) :: z(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j4,j4p2
            real(sp) :: d,emin,safmin,temp
@@ -7306,7 +7306,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(in) :: c(*),s(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,info,j
            real(sp) :: ctemp,stemp,temp
@@ -7520,7 +7520,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: select = 20
-           
+
            ! Local Scalars
            integer(ilp) :: dir,endd,i,j,start,stkpnt
            real(sp) :: d1,d2,d3,dmnmx,tmp
@@ -7549,7 +7549,7 @@ module stdlib_linalg_lapack_s
            stkpnt = 1
            stack(1,1) = 1
            stack(2,1) = n
-10         continue
+           10 continue
            start = stack(1,stkpnt)
            endd = stack(2,stkpnt)
            stkpnt = stkpnt - 1
@@ -7610,11 +7610,11 @@ module stdlib_linalg_lapack_s
                  ! sort into decreasing order
                  i = start - 1
                  j = endd + 1
-60               continue
-70               continue
+                 60 continue
+                 70 continue
                  j = j - 1
                  if (d(j) < dmnmx) go to 70
-80               continue
+                 80 continue
                  i = i + 1
                  if (d(i) > dmnmx) go to 80
                  if (i < j) then
@@ -7642,11 +7642,11 @@ module stdlib_linalg_lapack_s
                  ! sort into increasing order
                  i = start - 1
                  j = endd + 1
-90               continue
-100              continue
+                 90 continue
+                 100 continue
                  j = j - 1
                  if (d(j) > dmnmx) go to 100
-110              continue
+                 110 continue
                  i = i + 1
                  if (d(i) < dmnmx) go to 110
                  if (i < j) then
@@ -7811,7 +7811,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(out) :: csl,csr,snl,snr,ssmax,ssmin
            real(sp),intent(in) :: f,g,h
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: gasmal,swap
            integer(ilp) :: pmax
@@ -8020,7 +8020,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: b(ldb,*),tl(ldtl,*),tr(ldtr,*)
            real(sp),intent(out) :: x(ldx,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: bswap,xswap
            integer(ilp) :: i,ip,ipiv,ipsv,j,jp,jpsv,k
@@ -8050,7 +8050,7 @@ module stdlib_linalg_lapack_s
            k = n1 + n1 + n2 - 2
            go to(10,20,30,50) k
            ! 1 by 1: tl11*x + sgn*x*tr11 = b11
-10   continue
+           10 continue
            tau1 = tl(1,1) + sgn*tr(1,1)
            bet = abs(tau1)
            if (bet <= smlnum) then
@@ -8067,7 +8067,7 @@ module stdlib_linalg_lapack_s
            ! 1 by 2:
            ! tl11*[x11 x12] + isgn*[x11 x12]*op[tr11 tr12]  = [b11 b12]
                                              ! [tr21 tr22]
-20   continue
+                                             20 continue
            smin = max(eps*max(abs(tl(1,1)),abs(tr(1,1)),abs(tr(1,2)),abs(tr( &
                      2,1)),abs(tr(2,2))),smlnum)
            tmp(1) = tl(1,1) + sgn*tr(1,1)
@@ -8085,7 +8085,7 @@ module stdlib_linalg_lapack_s
            ! 2 by 1:
                 ! op[tl11 tl12]*[x11] + isgn* [x11]*tr11  = [b11]
                   ! [tl21 tl22] [x21]         [x21]         [b21]
-30   continue
+                  30 continue
            smin = max(eps*max(abs(tr(1,1)),abs(tl(1,1)),abs(tl(1,2)),abs(tl( &
                      2,1)),abs(tl(2,2))),smlnum)
            tmp(1) = tl(1,1) + sgn*tr(1,1)
@@ -8099,7 +8099,7 @@ module stdlib_linalg_lapack_s
            end if
            btmp(1) = b(1,1)
            btmp(2) = b(2,1)
-40         continue
+           40 continue
            ! solve 2 by 2 system using complete pivoting.
            ! set pivots less than smin to smin.
            ipiv = stdlib_isamax(4,tmp,1)
@@ -8152,9 +8152,9 @@ module stdlib_linalg_lapack_s
              ! [tl21 tl22] [x21 x22]        [x21 x22]   [tr21 tr22]   [b21 b22]
            ! solve equivalent 4 by 4 system using complete pivoting.
            ! set pivots less than smin to smin.
-50   continue
+           50 continue
            smin = max(abs(tr(1,1)),abs(tr(1,2)),abs(tr(2,1)),abs(tr(2,2)))
-                     
+
            smin = max(smin,abs(tl(1,1)),abs(tl(1,2)),abs(tl(2,1)),abs(tl(2, &
                      2)))
            smin = max(eps*smin,smlnum)
@@ -8288,7 +8288,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: sevten = 17.0e+0_sp
-           
+
            ! Local Scalars
            integer(ilp) :: imax,j,jb,jj,jmax,jp,k,kk,kkw,kp,kstep,kw
            real(sp) :: absakk,alpha,colmax,d11,d21,d22,r1,rowmax,t
@@ -8305,7 +8305,7 @@ module stdlib_linalg_lapack_s
               ! k is the main loop index, decreasing from n in steps of 1 or 2
               ! kw is the column of w which corresponds to column k of a
               k = n
-10            continue
+              10 continue
               kw = nb + k - n
               ! exit from loop
               if ((k <= n - nb + 1 .and. nb < n) .or. k < 1) go to 30
@@ -8338,7 +8338,7 @@ module stdlib_linalg_lapack_s
                     ! copy column imax to column kw-1 of w and update it
                     call stdlib_scopy(imax,a(1,imax),1,w(1,kw - 1),1)
                     call stdlib_scopy(k - imax,a(imax,imax + 1),lda,w(imax + 1,kw - 1),1)
-                              
+
                     if (k < n) call stdlib_sgemv('NO TRANSPOSE',k,n - k,-one,a(1,k + 1),lda,w( &
                               imax,kw + 1),ldw,one,w(1,kw - 1),1)
                     ! jmax is the column-index of the largest off-diagonal
@@ -8459,7 +8459,7 @@ module stdlib_linalg_lapack_s
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-30            continue
+              30 continue
               ! update the upper triangle of a11 (= a(1:k,1:k)) as
               ! a11 := a11 - u12*d*u12**t = a11 - u12*w**t
               ! computing blocks of nb columns at a time
@@ -8477,7 +8477,7 @@ module stdlib_linalg_lapack_s
               ! put u12 in standard form by partially undoing the interchanges
               ! in columns k+1:n looping backwards from k+1 to n
               j = k + 1
-60            continue
+              60 continue
                  ! undo the interchanges (if any) of rows jj and jp at each
                  ! step j
                  ! (here, j is a diagonal index)
@@ -8502,7 +8502,7 @@ module stdlib_linalg_lapack_s
               ! for use in updating a22
               ! k is the main loop index, increasing from 1 in steps of 1 or 2
               k = 1
-70            continue
+              70 continue
               ! exit from loop
               if ((k >= nb .and. nb < n) .or. k > n) go to 90
               ! copy column k of a to column k of w and update it
@@ -8573,7 +8573,7 @@ module stdlib_linalg_lapack_s
                     a(kp,kp) = a(kk,kk)
                     call stdlib_scopy(kp - kk - 1,a(kk + 1,kk),1,a(kp,kk + 1),lda)
                     if (kp < n) call stdlib_scopy(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     ! interchange rows kk and kp in first k-1 columns of a
                     ! (columns k (or k and k+1 for 2-by-2 pivot) of a will be
                     ! later overwritten). interchange rows kk and kp
@@ -8655,7 +8655,7 @@ module stdlib_linalg_lapack_s
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 70
-90            continue
+              90 continue
               ! update the lower triangle of a22 (= a(k:n,k:n)) as
               ! a22 := a22 - l21*d*l21**t = a22 - l21*w**t
               ! computing blocks of nb columns at a time
@@ -8673,7 +8673,7 @@ module stdlib_linalg_lapack_s
               ! put l21 in standard form by partially undoing the interchanges
               ! of rows in columns 1:k-1 looping backwards from k-1 to 1
               j = k - 1
-120           continue
+              120 continue
                  ! undo the interchanges (if any) of rows jj and jp at each
                  ! step j
                  ! (here, j is a diagonal index)
@@ -8688,7 +8688,7 @@ module stdlib_linalg_lapack_s
                  ! of the rows to swap back doesn't include diagonal element)
                  j = j - 1
                  if (jp /= jj .and. j >= 1) call stdlib_sswap(j,a(jp,1),lda,a(jj,1),lda)
-                           
+
               if (j > 1) go to 120
               ! set kb to the number of columns factorized
               kb = k - 1
@@ -8724,7 +8724,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: sevten = 17.0e+0_sp
-           
+
            ! Local Scalars
            logical(lk) :: done
            integer(ilp) :: imax,itemp,j,jb,jj,jmax,k,kk,kw,kkw,kp,kstep,p,ii
@@ -8747,7 +8747,7 @@ module stdlib_linalg_lapack_s
               e(1) = zero
               ! k is the main loop index, decreasing from n in steps of 1 or 2
               k = n
-10            continue
+              10 continue
               ! kw is the column of w which corresponds to column k of a
               kw = nb + k - n
               ! exit from loop
@@ -8788,12 +8788,12 @@ module stdlib_linalg_lapack_s
                  else
                     done = .false.
                     ! loop until pivot found
-12   continue
+                    12 continue
                        ! begin pivot search loop body
                        ! copy column imax to column kw-1 of w and update it
                        call stdlib_scopy(imax,a(1,imax),1,w(1,kw - 1),1)
                        call stdlib_scopy(k - imax,a(imax,imax + 1),lda,w(imax + 1,kw - 1),1)
-                                 
+
                        if (k < n) call stdlib_sgemv('NO TRANSPOSE',k,n - k,-one,a(1,k + 1),lda, &
                                  w(imax,kw + 1),ldw,one,w(1,kw - 1),1)
                        ! jmax is the column-index of the largest off-diagonal
@@ -8922,7 +8922,7 @@ module stdlib_linalg_lapack_s
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-30            continue
+              30 continue
               ! update the upper triangle of a11 (= a(1:k,1:k)) as
               ! a11 := a11 - u12*d*u12**t = a11 - u12*w**t
               ! computing blocks of nb columns at a time
@@ -8947,7 +8947,7 @@ module stdlib_linalg_lapack_s
               e(n) = zero
               ! k is the main loop index, increasing from 1 in steps of 1 or 2
               k = 1
-70            continue
+              70 continue
               ! exit from loop
               if ((k >= nb .and. nb < n) .or. k > n) go to 90
               kstep = 1
@@ -8986,7 +8986,7 @@ module stdlib_linalg_lapack_s
                  else
                     done = .false.
                     ! loop until pivot found
-72   continue
+                    72 continue
                        ! begin pivot search loop body
                        ! copy column imax to column k+1 of w and update it
                        call stdlib_scopy(imax - k,a(imax,k),lda,w(k,k + 1),1)
@@ -9115,7 +9115,7 @@ module stdlib_linalg_lapack_s
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 70
-90            continue
+              90 continue
               ! update the lower triangle of a22 (= a(k:n,k:n)) as
               ! a22 := a22 - l21*d*l21**t = a22 - l21*w**t
               ! computing blocks of nb columns at a time
@@ -9164,7 +9164,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: sevten = 17.0e+0_sp
-           
+
            ! Local Scalars
            logical(lk) :: done
            integer(ilp) :: imax,itemp,j,jb,jj,jmax,jp1,jp2,k,kk,kw,kkw,kp,kstep,p, &
@@ -9185,7 +9185,7 @@ module stdlib_linalg_lapack_s
               ! for use in updating a11
               ! k is the main loop index, decreasing from n in steps of 1 or 2
               k = n
-10            continue
+              10 continue
               ! kw is the column of w which corresponds to column k of a
               kw = nb + k - n
               ! exit from loop
@@ -9224,12 +9224,12 @@ module stdlib_linalg_lapack_s
                  else
                     done = .false.
                     ! loop until pivot found
-12   continue
+                    12 continue
                        ! begin pivot search loop body
                        ! copy column imax to column kw-1 of w and update it
                        call stdlib_scopy(imax,a(1,imax),1,w(1,kw - 1),1)
                        call stdlib_scopy(k - imax,a(imax,imax + 1),lda,w(imax + 1,kw - 1),1)
-                                 
+
                        if (k < n) call stdlib_sgemv('NO TRANSPOSE',k,n - k,-one,a(1,k + 1),lda, &
                                  w(imax,kw + 1),ldw,one,w(1,kw - 1),1)
                        ! jmax is the column-index of the largest off-diagonal
@@ -9351,7 +9351,7 @@ module stdlib_linalg_lapack_s
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-30            continue
+              30 continue
               ! update the upper triangle of a11 (= a(1:k,1:k)) as
               ! a11 := a11 - u12*d*u12**t = a11 - u12*w**t
               ! computing blocks of nb columns at a time
@@ -9369,7 +9369,7 @@ module stdlib_linalg_lapack_s
               ! put u12 in standard form by partially undoing the interchanges
               ! in columns k+1:n
               j = k + 1
-60            continue
+              60 continue
                  kstep = 1
                  jp1 = 1
                  jj = j
@@ -9395,7 +9395,7 @@ module stdlib_linalg_lapack_s
               ! for use in updating a22
               ! k is the main loop index, increasing from 1 in steps of 1 or 2
               k = 1
-70            continue
+              70 continue
               ! exit from loop
               if ((k >= nb .and. nb < n) .or. k > n) go to 90
               kstep = 1
@@ -9432,7 +9432,7 @@ module stdlib_linalg_lapack_s
                  else
                     done = .false.
                     ! loop until pivot found
-72   continue
+                    72 continue
                        ! begin pivot search loop body
                        ! copy column imax to column k+1 of w and update it
                        call stdlib_scopy(imax - k,a(imax,k),lda,w(k,k + 1),1)
@@ -9554,7 +9554,7 @@ module stdlib_linalg_lapack_s
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 70
-90            continue
+              90 continue
               ! update the lower triangle of a22 (= a(k:n,k:n)) as
               ! a22 := a22 - l21*d*l21**t = a22 - l21*w**t
               ! computing blocks of nb columns at a time
@@ -9572,7 +9572,7 @@ module stdlib_linalg_lapack_s
               ! put l21 in standard form by partially undoing the interchanges
               ! in columns 1:k-1
               j = k - 1
-120           continue
+              120 continue
                  kstep = 1
                  jp1 = 1
                  jj = j
@@ -9585,7 +9585,7 @@ module stdlib_linalg_lapack_s
                  end if
                  j = j - 1
                  if (jp2 /= jj .and. j >= 1) call stdlib_sswap(j,a(jp2,1),lda,a(jj,1),lda)
-                           
+
                  jj = j + 1
                  if (jp1 /= jj .and. kstep == 2) call stdlib_sswap(j,a(jp1,1),lda,a(jj,1), &
                            lda)
@@ -9621,7 +9621,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: ab(ldab,*)
            real(sp),intent(inout) :: cnorm(*),x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            integer(ilp) :: i,imax,j,jfirst,jinc,jlast,jlen,maind
@@ -9746,7 +9746,7 @@ module stdlib_linalg_lapack_s
                     grow = grow*(one/(one + cnorm(j)))
                  end do
               end if
-50            continue
+              50 continue
            else
               ! compute the growth in a**t * x = b.
               if (upper) then
@@ -9793,7 +9793,7 @@ module stdlib_linalg_lapack_s
                     grow = grow/xj
                  end do
               end if
-80            continue
+              80 continue
            end if
            if ((grow*tscal) > smlnum) then
               ! use the level 2 blas solve if the reciprocal of the bound on
@@ -9861,7 +9861,7 @@ module stdlib_linalg_lapack_s
                           scale = zero
                           xmax = zero
                        end if
-95                     continue
+                       95 continue
                     ! scale x if necessary to avoid overflow when adding a
                     ! multiple of column j of a.
                     if (xj > one) then
@@ -9937,7 +9937,7 @@ module stdlib_linalg_lapack_s
                        else
                           jlen = min(kd,n - j)
                           if (jlen > 0) sumj = stdlib_sdot(jlen,ab(2,j),1,x(j + 1),1)
-                                    
+
                        end if
                     else
                        ! otherwise, use in-line code for the dot product.
@@ -9998,7 +9998,7 @@ module stdlib_linalg_lapack_s
                              scale = zero
                              xmax = zero
                           end if
-135                       continue
+                          135 continue
                     else
                        ! compute x(j) := x(j) / a(j,j) - sumj if the dot
                        ! product has already been divided by 1/a(j,j).
@@ -10028,7 +10028,7 @@ module stdlib_linalg_lapack_s
      !> then s is set to 0 and a non-trivial solution to A*x = 0 is returned.
 
      pure subroutine stdlib_slatps(uplo,trans,diag,normin,n,ap,x,scale,cnorm,info)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -10041,7 +10041,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: ap(*)
            real(sp),intent(inout) :: cnorm(*),x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            integer(ilp) :: i,imax,ip,j,jfirst,jinc,jlast,jlen
@@ -10163,7 +10163,7 @@ module stdlib_linalg_lapack_s
                     grow = grow*(one/(one + cnorm(j)))
                  end do
               end if
-50            continue
+              50 continue
            else
               ! compute the growth in a**t * x = b.
               if (upper) then
@@ -10212,7 +10212,7 @@ module stdlib_linalg_lapack_s
                     grow = grow/xj
                  end do
               end if
-80            continue
+              80 continue
            end if
            if ((grow*tscal) > smlnum) then
               ! use the level 2 blas solve if the reciprocal of the bound on
@@ -10281,7 +10281,7 @@ module stdlib_linalg_lapack_s
                           scale = zero
                           xmax = zero
                        end if
-95                     continue
+                       95 continue
                     ! scale x if necessary to avoid overflow when adding a
                     ! multiple of column j of a.
                     if (xj > one) then
@@ -10311,7 +10311,7 @@ module stdlib_linalg_lapack_s
                           ! compute the update
                              ! x(j+1:n) := x(j+1:n) - x(j) * a(j+1:n,j)
                           call stdlib_saxpy(n - j,-x(j)*tscal,ap(ip + 1),1,x(j + 1),1)
-                                    
+
                           i = j + stdlib_isamax(n - j,x(j + 1),1)
                           xmax = abs(x(i))
                        end if
@@ -10414,7 +10414,7 @@ module stdlib_linalg_lapack_s
                              scale = zero
                              xmax = zero
                           end if
-135                       continue
+                          135 continue
                     else
                        ! compute x(j) := x(j) / a(j,j)  - sumj if the dot
                        ! product has already been divided by 1/a(j,j).
@@ -10446,7 +10446,7 @@ module stdlib_linalg_lapack_s
      !> non-trivial solution to A*x = 0 is returned.
 
      pure subroutine stdlib_slatrs(uplo,trans,diag,normin,n,a,lda,x,scale,cnorm,info)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -10459,7 +10459,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: a(lda,*)
            real(sp),intent(inout) :: cnorm(*),x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            integer(ilp) :: i,imax,j,jfirst,jinc,jlast
@@ -10575,7 +10575,7 @@ module stdlib_linalg_lapack_s
                     grow = grow*(one/(one + cnorm(j)))
                  end do
               end if
-50            continue
+              50 continue
            else
               ! compute the growth in a**t * x = b.
               if (upper) then
@@ -10620,7 +10620,7 @@ module stdlib_linalg_lapack_s
                     grow = grow/xj
                  end do
               end if
-80            continue
+              80 continue
            end if
            if ((grow*tscal) > smlnum) then
               ! use the level 2 blas solve if the reciprocal of the bound on
@@ -10688,7 +10688,7 @@ module stdlib_linalg_lapack_s
                           scale = zero
                           xmax = zero
                        end if
-95                     continue
+                       95 continue
                     ! scale x if necessary to avoid overflow when adding a
                     ! multiple of column j of a.
                     if (xj > one) then
@@ -10717,7 +10717,7 @@ module stdlib_linalg_lapack_s
                           ! compute the update
                              ! x(j+1:n) := x(j+1:n) - x(j) * a(j+1:n,j)
                           call stdlib_saxpy(n - j,-x(j)*tscal,a(j + 1,j),1,x(j + 1),1)
-                                    
+
                           i = j + stdlib_isamax(n - j,x(j + 1),1)
                           xmax = abs(x(i))
                        end if
@@ -10817,7 +10817,7 @@ module stdlib_linalg_lapack_s
                              scale = zero
                              xmax = zero
                           end if
-135                       continue
+                          135 continue
                     else
                        ! compute x(j) := x(j) / a(j,j)  - sumj if the dot
                        ! product has already been divided by 1/a(j,j).
@@ -10855,7 +10855,7 @@ module stdlib_linalg_lapack_s
            ! Array Arguments
            real(sp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i
@@ -10927,7 +10927,7 @@ module stdlib_linalg_lapack_s
            ! Array Arguments
            real(sp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,ib,nb
@@ -11017,7 +11017,7 @@ module stdlib_linalg_lapack_s
            real(sp),parameter :: alphasq = 0.01_sp
            real(sp),parameter :: realone = 1.0_sp
            real(sp),parameter :: realzero = 0.0_sp
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(sp) :: normsq1,normsq2,scl1,scl2,ssq1,ssq2
@@ -11135,7 +11135,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: tau(*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,ii,j,l
            ! Intrinsic Functions
@@ -11170,7 +11170,7 @@ module stdlib_linalg_lapack_s
               ! apply h(i) to a(1:m-k+i,1:n-k+i) from the left
               a(m - n + ii,ii) = one
               call stdlib_slarf('LEFT',m - n + ii,ii - 1,a(1,ii),1,tau(i),a,lda,work)
-                        
+
               call stdlib_sscal(m - n + ii - 1,-tau(i),a(1,ii),1)
               a(m - n + ii,ii) = one - tau(i)
               ! set a(m-k+i+1:m,n-k+i) to zero
@@ -11199,7 +11199,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: tau(*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,l
            ! Intrinsic Functions
@@ -11264,7 +11264,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: tau(*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,l
            ! Intrinsic Functions
@@ -11333,7 +11333,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: tau(*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,iinfo,iws,j,ki,kk,l,ldwork,lwkopt,nb,nbmin,nx
@@ -11415,7 +11415,7 @@ module stdlib_linalg_lapack_s
                     ! apply h**t to a(i+ib:m,i:n) from the right
                     call stdlib_slarfb('RIGHT','TRANSPOSE','FORWARD','ROWWISE',m - i - ib + 1,n - i + &
                     1,ib,a(i,i),lda,work,ldwork,a(i + ib,i),lda,work(ib + 1),ldwork)
-                              
+
                  end if
                  ! apply h**t to columns i:n of current block
                  call stdlib_sorgl2(ib,n - i + 1,ib,a(i,i),lda,tau(i),work,iinfo)
@@ -11449,7 +11449,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: tau(*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,iinfo,iws,j,kk,l,ldwork,lwkopt,nb,nbmin,nx
@@ -11535,7 +11535,7 @@ module stdlib_linalg_lapack_s
                     ! apply h to a(1:m-k+i+ib-1,1:n-k+i-1) from the left
                     call stdlib_slarfb('LEFT','NO TRANSPOSE','BACKWARD','COLUMNWISE',m - k + i + ib - &
                     1,n - k + i - 1,ib,a(1,n - k + i),lda,work,ldwork,a,lda,work(ib + 1),ldwork)
-                              
+
                  end if
                  ! apply h to rows 1:m-k+i+ib-1 of current block
                  call stdlib_sorg2l(m - k + i + ib - 1,ib,ib,a(1,n - k + i),lda,tau(i),work,iinfo &
@@ -11570,7 +11570,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: tau(*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,iinfo,iws,j,ki,kk,l,ldwork,lwkopt,nb,nbmin,nx
@@ -11686,7 +11686,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: tau(*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,ii,j,l
            ! Intrinsic Functions
@@ -11723,7 +11723,7 @@ module stdlib_linalg_lapack_s
               ! apply h(i) to a(1:m-k+i,1:n-k+i) from the right
               a(ii,n - m + ii) = one
               call stdlib_slarf('RIGHT',ii - 1,n - m + ii,a(ii,1),lda,tau(i),a,lda,work)
-                        
+
               call stdlib_sscal(n - m + ii - 1,-tau(i),a(ii,1),lda)
               a(ii,n - m + ii) = one - tau(i)
               ! set a(m-k+i,n-k+i+1:n) to zero
@@ -11752,7 +11752,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: tau(*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,ii,iinfo,iws,j,kk,l,ldwork,lwkopt,nb,nbmin,nx
@@ -11842,7 +11842,7 @@ module stdlib_linalg_lapack_s
                  end if
                  ! apply h**t to columns 1:n-k+i+ib-1 of current block
                  call stdlib_sorgr2(ib,n - k + i + ib - 1,ib,a(ii,1),lda,tau(i),work,iinfo)
-                           
+
                  ! set columns n-k+i+ib:n of current block to zero
                  do l = n - k + i + ib,n
                     do j = ii,ii + ib - 1
@@ -11883,7 +11883,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: t(ldt,*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: nblocal,mb2,m_plus_one,itmp,ib_bottom,lworkopt, &
@@ -11999,7 +11999,7 @@ module stdlib_linalg_lapack_s
      end subroutine stdlib_sorgtsqr_row
 
      pure subroutine stdlib_sorm22(side,trans,m,n,n1,n2,q,ldq,c,ldc,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -12012,7 +12012,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: c(ldc,*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            integer(ilp) :: i,ldwork,len,lwkopt,nb,nq,nw
@@ -12071,12 +12071,12 @@ module stdlib_linalg_lapack_s
            ! degenerate cases (n1 = 0 or n2 = 0) are handled using stdlib_strmm.
            if (n1 == 0) then
               call stdlib_strmm(side,'UPPER',trans,'NON-UNIT',m,n,one,q,ldq,c,ldc)
-                        
+
               work(1) = one
               return
            else if (n2 == 0) then
               call stdlib_strmm(side,'LOWER',trans,'NON-UNIT',m,n,one,q,ldq,c,ldc)
-                        
+
               work(1) = one
               return
            end if
@@ -12096,7 +12096,7 @@ module stdlib_linalg_lapack_s
                                1,i),ldc,one,work,ldwork)
                     ! multiply top part of c by q21.
                     call stdlib_slacpy('ALL',n2,len,c(1,i),ldc,work(n1 + 1),ldwork)
-                              
+
                     call stdlib_strmm('LEFT','UPPER','NO TRANSPOSE','NON-UNIT',n2,len,one, &
                               q(n1 + 1,1),ldq,work(n1 + 1),ldwork)
                     ! multiply bottom part of c by q22.
@@ -12118,7 +12118,7 @@ module stdlib_linalg_lapack_s
                                i),ldc,one,work,ldwork)
                     ! multiply top part of c by q12**t.
                     call stdlib_slacpy('ALL',n1,len,c(1,i),ldc,work(n2 + 1),ldwork)
-                              
+
                     call stdlib_strmm('LEFT','LOWER','TRANSPOSE','NON-UNIT',n1,len,one,q( &
                               1,n2 + 1),ldq,work(n2 + 1),ldwork)
                     ! multiply bottom part of c by q22**t.
@@ -12203,7 +12203,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: tau(*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: left,notran
            integer(ilp) :: i,i1,i2,i3,mi,ni,nq
@@ -12297,7 +12297,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: tau(*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: left,notran
            integer(ilp) :: i,i1,i2,i3,ic,jc,mi,ni,nq
@@ -12366,7 +12366,7 @@ module stdlib_linalg_lapack_s
               aii = a(i,i)
               a(i,i) = one
               call stdlib_slarf(side,mi,ni,a(i,i),1,tau(i),c(ic,jc),ldc,work)
-                        
+
               a(i,i) = aii
            end do
            return
@@ -12396,7 +12396,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: tau(*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: left,notran
            integer(ilp) :: i,i1,i2,i3,ic,jc,mi,ni,nq
@@ -12465,7 +12465,7 @@ module stdlib_linalg_lapack_s
               aii = a(i,i)
               a(i,i) = one
               call stdlib_slarf(side,mi,ni,a(i,i),lda,tau(i),c(ic,jc),ldc,work)
-                        
+
               a(i,i) = aii
            end do
            return
@@ -12482,7 +12482,7 @@ module stdlib_linalg_lapack_s
      !> if SIDE = 'R'.
 
      pure subroutine stdlib_sormlq(side,trans,m,n,k,a,lda,tau,c,ldc,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -12499,7 +12499,7 @@ module stdlib_linalg_lapack_s
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            character :: transt
@@ -12625,7 +12625,7 @@ module stdlib_linalg_lapack_s
      !> if SIDE = 'R'.
 
      pure subroutine stdlib_sormql(side,trans,m,n,k,a,lda,tau,c,ldc,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -12642,7 +12642,7 @@ module stdlib_linalg_lapack_s
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            integer(ilp) :: i,i1,i2,i3,ib,iinfo,iwt,ldwork,lwkopt,mi,nb,nbmin,ni,nq, &
@@ -12686,7 +12686,7 @@ module stdlib_linalg_lapack_s
                  lwkopt = 1
               else
                  nb = min(nbmax,stdlib_ilaenv(1,'SORMQL',side//trans,m,n,k,-1))
-                           
+
                  lwkopt = nw*nb + tsize
               end if
               work(1) = lwkopt
@@ -12762,7 +12762,7 @@ module stdlib_linalg_lapack_s
      !> if SIDE = 'R'.
 
      pure subroutine stdlib_sormqr(side,trans,m,n,k,a,lda,tau,c,ldc,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -12779,7 +12779,7 @@ module stdlib_linalg_lapack_s
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            integer(ilp) :: i,i1,i2,i3,ib,ic,iinfo,iwt,jc,ldwork,lwkopt,mi,nb,nbmin, &
@@ -12912,7 +12912,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: tau(*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: left,notran
            integer(ilp) :: i,i1,i2,i3,mi,ni,nq
@@ -12994,7 +12994,7 @@ module stdlib_linalg_lapack_s
      !> if SIDE = 'R'.
 
      pure subroutine stdlib_sormr3(side,trans,m,n,k,l,a,lda,tau,c,ldc,work,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -13092,7 +13092,7 @@ module stdlib_linalg_lapack_s
      !> if SIDE = 'R'.
 
      pure subroutine stdlib_sormrq(side,trans,m,n,k,a,lda,tau,c,ldc,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -13109,7 +13109,7 @@ module stdlib_linalg_lapack_s
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            character :: transt
@@ -13154,7 +13154,7 @@ module stdlib_linalg_lapack_s
                  lwkopt = 1
               else
                  nb = min(nbmax,stdlib_ilaenv(1,'SORMRQ',side//trans,m,n,k,-1))
-                           
+
                  lwkopt = nw*nb + tsize
               end if
               work(1) = lwkopt
@@ -13252,7 +13252,7 @@ module stdlib_linalg_lapack_s
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            character :: transt
@@ -13299,7 +13299,7 @@ module stdlib_linalg_lapack_s
                  lwkopt = 1
               else
                  nb = min(nbmax,stdlib_ilaenv(1,'SORMRQ',side//trans,m,n,k,-1))
-                           
+
                  lwkopt = nw*nb + tsize
               end if
               work(1) = lwkopt
@@ -13325,7 +13325,7 @@ module stdlib_linalg_lapack_s
            if (nb < nbmin .or. nb >= k) then
               ! use unblocked code
               call stdlib_sormr3(side,trans,m,n,k,l,a,lda,tau,c,ldc,work,iinfo)
-                        
+
            else
               ! use blocked code
               iwt = 1 + nw*nb
@@ -13398,7 +13398,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: ab(ldab,*)
            real(sp),intent(out) :: s(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,j
@@ -13484,7 +13484,7 @@ module stdlib_linalg_lapack_s
            ! Array Arguments
            real(sp),intent(inout) :: ab(ldab,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,kld,km,m
@@ -13526,7 +13526,7 @@ module stdlib_linalg_lapack_s
                  ! the leading submatrix within the band.
                  call stdlib_sscal(km,one/ajj,ab(kd + 1 - km,j),1)
                  call stdlib_ssyr('UPPER',km,-one,ab(kd + 1 - km,j),1,ab(kd + 1,j - km),kld)
-                           
+
               end do
               ! factorize the updated submatrix a(1:m,1:m) as u**t*u.
               do j = 1,m
@@ -13541,7 +13541,7 @@ module stdlib_linalg_lapack_s
                  if (km > 0) then
                     call stdlib_sscal(km,one/ajj,ab(kd,j + 1),kld)
                     call stdlib_ssyr('UPPER',km,-one,ab(kd,j + 1),kld,ab(kd + 1,j + 1),kld)
-                              
+
                  end if
               end do
            else
@@ -13557,7 +13557,7 @@ module stdlib_linalg_lapack_s
                  ! trailing submatrix within the band.
                  call stdlib_sscal(km,one/ajj,ab(km + 1,j - km),kld)
                  call stdlib_ssyr('LOWER',km,-one,ab(km + 1,j - km),kld,ab(1,j - km),kld)
-                           
+
               end do
               ! factorize the updated submatrix a(1:m,1:m) as u**t*u.
               do j = 1,m
@@ -13576,7 +13576,7 @@ module stdlib_linalg_lapack_s
               end do
            end if
            return
-50         continue
+           50 continue
            info = j
            return
      end subroutine stdlib_spbstf
@@ -13601,7 +13601,7 @@ module stdlib_linalg_lapack_s
            ! Array Arguments
            real(sp),intent(inout) :: ab(ldab,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,kld,kn
@@ -13642,7 +13642,7 @@ module stdlib_linalg_lapack_s
                  if (kn > 0) then
                     call stdlib_sscal(kn,one/ajj,ab(kd,j + 1),kld)
                     call stdlib_ssyr('UPPER',kn,-one,ab(kd,j + 1),kld,ab(kd + 1,j + 1),kld)
-                              
+
                  end if
               end do
            else
@@ -13663,7 +13663,7 @@ module stdlib_linalg_lapack_s
               end do
            end if
            return
-30         continue
+           30 continue
            info = j
            return
      end subroutine stdlib_spbtf2
@@ -13757,7 +13757,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: a(lda,*)
            real(sp),intent(out) :: s(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(sp) :: smin
@@ -13836,7 +13836,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: a(lda,*)
            real(sp),intent(out) :: s(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(sp) :: smin,base,tmp
@@ -13908,7 +13908,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: a(lda,*)
            real(sp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            ! Intrinsic Functions
@@ -13976,7 +13976,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: ap(*)
            real(sp),intent(out) :: s(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,jj
@@ -14065,7 +14065,7 @@ module stdlib_linalg_lapack_s
            ! Array Arguments
            real(sp),intent(inout) :: ap(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,jc,jj
@@ -14126,9 +14126,9 @@ module stdlib_linalg_lapack_s
               end do
            end if
            go to 40
-30         continue
+           30 continue
            info = j
-40         continue
+           40 continue
            return
      end subroutine stdlib_spptrf
 
@@ -14179,14 +14179,14 @@ module stdlib_linalg_lapack_s
                  call stdlib_stpsv('UPPER','TRANSPOSE','NON-UNIT',n,ap,b(1,i),1)
                  ! solve u*x = b, overwriting b with x.
                  call stdlib_stpsv('UPPER','NO TRANSPOSE','NON-UNIT',n,ap,b(1,i),1)
-                           
+
               end do
            else
               ! solve a*x = b where a = l * l**t.
               do i = 1,nrhs
                  ! solve l*y = b, overwriting b with x.
                  call stdlib_stpsv('LOWER','NO TRANSPOSE','NON-UNIT',n,ap,b(1,i),1)
-                           
+
                  ! solve l**t *x = y, overwriting b with x.
                  call stdlib_stpsv('LOWER','TRANSPOSE','NON-UNIT',n,ap,b(1,i),1)
               end do
@@ -14215,7 +14215,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: d(*),e(*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,ix
            real(sp) :: ainvnm
@@ -14281,7 +14281,7 @@ module stdlib_linalg_lapack_s
            ! Array Arguments
            real(sp),intent(inout) :: d(*),e(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,i4
            real(sp) :: ei
@@ -14346,7 +14346,7 @@ module stdlib_linalg_lapack_s
            end do loop_20
            ! check d(n) for positive definiteness.
            if (d(n) <= zero) info = n
-30         continue
+           30 continue
            return
      end subroutine stdlib_spttrf
 
@@ -14405,7 +14405,7 @@ module stdlib_linalg_lapack_s
            ! Array Arguments
            real(sp),intent(inout) :: sx(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: done
            real(sp) :: bignum,cden,cden1,cnum,cnum1,mul,smlnum
@@ -14421,7 +14421,7 @@ module stdlib_linalg_lapack_s
            ! initialize the denominator to sa and the numerator to 1.
            cden = sa
            cnum = one
-10         continue
+           10 continue
            cden1 = cden*smlnum
            cnum1 = cnum/bignum
            if (abs(cden1) > abs(cnum) .and. cnum /= zero) then
@@ -14454,7 +14454,7 @@ module stdlib_linalg_lapack_s
      !> bandwidth of A.
 
      pure subroutine stdlib_ssbgst(vect,uplo,n,ka,kb,ab,ldab,bb,ldbb,x,ldx,work,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -14467,7 +14467,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: bb(ldbb,*)
            real(sp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: update,upper,wantx
            integer(ilp) :: i,i0,i1,i2,inca,j,j1,j1t,j2,j2t,k,ka1,kb1,kbt,l,m,nr, &
@@ -14559,7 +14559,7 @@ module stdlib_linalg_lapack_s
            ! to avoid duplicating code, the two loops are merged.
            update = .true.
            i = n + 1
-10         continue
+           10 continue
            if (update) then
               i = i - 1
               kbt = min(kb,i - 1)
@@ -14596,13 +14596,13 @@ module stdlib_linalg_lapack_s
                     end do
                     do j = max(1,i - ka),i - kbt - 1
                        ab(j - k + ka1,k) = ab(j - k + ka1,k) - bb(k - i + kb1,i)*ab(j - i + ka1,i)
-                                 
+
                     end do
                  end do
                  do j = i,i1
                     do k = max(j - ka,i - kbt),i - 1
                        ab(k - j + ka1,j) = ab(k - j + ka1,j) - bb(k - i + kb1,i)*ab(i - j + ka1,j)
-                                 
+
                     end do
                  end do
                  if (wantx) then
@@ -14629,9 +14629,9 @@ module stdlib_linalg_lapack_s
                        ! band and store it in work(i-k)
                        t = -bb(kb1 - k,i)*ra1
                        work(i - k) = work(n + i - k + ka - m)*t - work(i - k + ka - m)*ab(1,i - k + ka)
-                                 
+
                        ab(1,i - k + ka) = work(i - k + ka - m)*t + work(n + i - k + ka - m)*ab(1,i - k + ka)
-                                 
+
                        ra1 = ra
                     end if
                  end if
@@ -14722,7 +14722,7 @@ module stdlib_linalg_lapack_s
                     ! generate rotations in 2nd set to annihilate elements
                     ! which have been created outside the band
                     call stdlib_slargv(nr,ab(1,j2),inca,work(j2),ka1,work(n + j2),ka1)
-                              
+
                     ! apply rotations in 2nd set from the right
                     do l = 1,ka - 1
                        call stdlib_slartv(nr,ab(ka1 - l,j2),inca,ab(ka - l,j2 + 1),inca,work( &
@@ -14812,7 +14812,7 @@ module stdlib_linalg_lapack_s
                        t = -bb(k + 1,i - k)*ra1
                        work(i - k) = work(n + i - k + ka - m)*t - work(i - k + ka - m)*ab(ka1,i - k)
                        ab(ka1,i - k) = work(i - k + ka - m)*t + work(n + i - k + ka - m)*ab(ka1,i - k)
-                                 
+
                        ra1 = ra
                     end if
                  end if
@@ -14945,7 +14945,7 @@ module stdlib_linalg_lapack_s
               end if
            end if
            go to 10
-480        continue
+           480 continue
            ! **************************** phase 2 *****************************
            ! the logical structure of this phase is:
            ! update = .true.
@@ -14960,7 +14960,7 @@ module stdlib_linalg_lapack_s
            ! to avoid duplicating code, the two loops are merged.
            update = .true.
            i = 0
-490        continue
+           490 continue
            if (update) then
               i = i + 1
               kbt = min(kb,m - i)
@@ -15002,13 +15002,13 @@ module stdlib_linalg_lapack_s
                     end do
                     do j = i + kbt + 1,min(n,i + ka)
                        ab(k - j + ka1,j) = ab(k - j + ka1,j) - bb(i - k + kb1,k)*ab(i - j + ka1,j)
-                                 
+
                     end do
                  end do
                  do j = i1,i
                     do k = i + 1,min(j + ka,i + kbt)
                        ab(j - k + ka1,k) = ab(j - k + ka1,k) - bb(i - k + kb1,k)*ab(j - i + ka1,i)
-                                 
+
                     end do
                  end do
                  if (wantx) then
@@ -15079,7 +15079,7 @@ module stdlib_linalg_lapack_s
                     ! post-multiply x by product of rotations in 1st set
                     do j = j1,j2,ka1
                        call stdlib_srot(nx,x(1,j),1,x(1,j - 1),1,work(n + j),work(j))
-                                 
+
                     end do
                  end if
               end do loop_610
@@ -15217,9 +15217,9 @@ module stdlib_linalg_lapack_s
                        ! band and store it in work(m-kb+i+k)
                        t = -bb(k + 1,i)*ra1
                        work(m - kb + i + k) = work(n + i + k - ka)*t - work(i + k - ka)*ab(ka1,i + k - ka)
-                                 
+
                        ab(ka1,i + k - ka) = work(i + k - ka)*t + work(n + i + k - ka)*ab(ka1,i + k - ka)
-                                 
+
                        ra1 = ra
                     end if
                  end if
@@ -15264,7 +15264,7 @@ module stdlib_linalg_lapack_s
                     ! post-multiply x by product of rotations in 1st set
                     do j = j1,j2,ka1
                        call stdlib_srot(nx,x(1,j),1,x(1,j - 1),1,work(n + j),work(j))
-                                 
+
                     end do
                  end if
               end do loop_840
@@ -15374,7 +15374,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: ab(ldab,*),q(ldq,*)
            real(sp),intent(out) :: d(*),e(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: initq,upper,wantq
            integer(ilp) :: i,i2,ibl,inca,incx,iqaend,iqb,iqend,j,j1,j1end,j1inc,j2, &
@@ -15710,7 +15710,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: a(lda,*)
            real(sp),intent(inout) :: c(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,normaltransr,nisodd,notrans
            integer(ilp) :: info,nrowa,j,nk,n1,n2
@@ -15780,7 +15780,7 @@ module stdlib_linalg_lapack_s
                     if (notrans) then
                        ! n is odd, transr = 'n', uplo = 'l', and trans = 'n'
                        call stdlib_ssyrk('L','N',n1,k,alpha,a(1,1),lda,beta,c(1),n)
-                                 
+
                        call stdlib_ssyrk('U','N',n2,k,alpha,a(n1 + 1,1),lda,beta,c(n + 1) &
                                  ,n)
                        call stdlib_sgemm('N','T',n2,n1,k,alpha,a(n1 + 1,1),lda,a(1,1), &
@@ -15788,7 +15788,7 @@ module stdlib_linalg_lapack_s
                     else
                        ! n is odd, transr = 'n', uplo = 'l', and trans = 't'
                        call stdlib_ssyrk('L','T',n1,k,alpha,a(1,1),lda,beta,c(1),n)
-                                 
+
                        call stdlib_ssyrk('U','T',n2,k,alpha,a(1,n1 + 1),lda,beta,c(n + 1) &
                                  ,n)
                        call stdlib_sgemm('T','N',n2,n1,k,alpha,a(1,n1 + 1),lda,a(1,1), &
@@ -15965,7 +15965,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: ap(*)
            real(sp),intent(in) :: bp(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,j1,j1j1,jj,k,k1,k1k1,kk
@@ -16037,7 +16037,7 @@ module stdlib_linalg_lapack_s
                     akk = ap(kk)
                     bkk = bp(kk)
                     call stdlib_stpmv(uplo,'NO TRANSPOSE','NON-UNIT',k - 1,bp,ap(k1),1)
-                              
+
                     ct = half*akk
                     call stdlib_saxpy(k - 1,ct,bp(k1),1,ap(k1),1)
                     call stdlib_sspr2(uplo,k - 1,one,ap(k1),1,bp(k1),1,ap)
@@ -16088,7 +16088,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: sevten = 17.0e+0_sp
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,imax,j,jmax,k,kc,kk,knc,kp,kpc,kstep,kx,npp
@@ -16117,7 +16117,7 @@ module stdlib_linalg_lapack_s
               ! 1 or 2
               k = n
               kc = (n - 1)*n/2 + 1
-10            continue
+              10 continue
               knc = kc
               ! if k < 1, exit from loop
               if (k < 1) go to 110
@@ -16220,9 +16220,9 @@ module stdlib_linalg_lapack_s
                        d12 = t/d12
                        do j = k - 2,1,-1
                           wkm1 = d12*(d11*ap(j + (k - 2)*(k - 1)/2) - ap(j + (k - 1)*k/2))
-                                    
+
                           wk = d12*(d22*ap(j + (k - 1)*k/2) - ap(j + (k - 2)*(k - 1)/2))
-                                    
+
                           do i = j,1,-1
                              ap(i + (j - 1)*j/2) = ap(i + (j - 1)*j/2) - ap(i + (k - 1)*k/2) &
                                        *wk - ap(i + (k - 2)*(k - 1)/2)*wkm1
@@ -16251,7 +16251,7 @@ module stdlib_linalg_lapack_s
               k = 1
               kc = 1
               npp = n*(n + 1)/2
-60            continue
+              60 continue
               knc = kc
               ! if k > n, exit from loop
               if (k > n) go to 110
@@ -16312,7 +16312,7 @@ module stdlib_linalg_lapack_s
                     ! interchange rows and columns kk and kp in the trailing
                     ! submatrix a(k:n,k:n)
                     if (kp < n) call stdlib_sswap(n - kp,ap(knc + kp - kk + 1),1,ap(kpc + 1),1)
-                              
+
                     kx = knc + kp - kk
                     do j = kk + 1,kp - 1
                        kx = kx + n - j + 1
@@ -16360,7 +16360,7 @@ module stdlib_linalg_lapack_s
                        d21 = t/d21
                        do j = k + 2,n
                           wk = d21*(d11*ap(j + (k - 1)*(2*n - k)/2) - ap(j + k*(2*n - k - 1)/2))
-                                    
+
                           wkp1 = d21*(d22*ap(j + k*(2*n - k - 1)/2) - ap(j + (k - 1)*(2*n - k)/2) &
                                      )
                           do i = j,n
@@ -16385,7 +16385,7 @@ module stdlib_linalg_lapack_s
               kc = knc + n - k + 2
               go to 60
            end if
-110        continue
+           110 continue
            return
      end subroutine stdlib_ssptrf
 
@@ -16406,7 +16406,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: ap(*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kc,kcnext,kp,kpc,kstep,kx,npp
@@ -16451,7 +16451,7 @@ module stdlib_linalg_lapack_s
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
               kc = 1
-30            continue
+              30 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               kcnext = kc + k
@@ -16486,9 +16486,9 @@ module stdlib_linalg_lapack_s
                               kcnext),1)
                     call stdlib_scopy(k - 1,ap(kcnext),1,work,1)
                     call stdlib_sspmv(uplo,k - 1,-one,ap,work,1,zero,ap(kcnext),1)
-                              
+
                     ap(kcnext + k) = ap(kcnext + k) - stdlib_sdot(k - 1,work,1,ap(kcnext),1)
-                              
+
                  end if
                  kstep = 2
                  kcnext = kcnext + k + 1
@@ -16518,7 +16518,7 @@ module stdlib_linalg_lapack_s
               k = k + kstep
               kc = kcnext
               go to 30
-50            continue
+              50 continue
            else
               ! compute inv(a) from the factorization a = l*d*l**t.
               ! k is the main loop index, increasing from 1 to n in steps of
@@ -16526,7 +16526,7 @@ module stdlib_linalg_lapack_s
               npp = n*(n + 1)/2
               k = n
               kc = npp
-60            continue
+              60 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 80
               kcnext = kc - (n - k + 2)
@@ -16565,7 +16565,7 @@ module stdlib_linalg_lapack_s
                     call stdlib_sspmv(uplo,n - k,-one,ap(kc + (n - k + 1)),work,1,zero,ap( &
                               kcnext + 2),1)
                     ap(kcnext) = ap(kcnext) - stdlib_sdot(n - k,work,1,ap(kcnext + 2),1)
-                              
+
                  end if
                  kstep = 2
                  kcnext = kcnext - (n - k + 3)
@@ -16595,7 +16595,7 @@ module stdlib_linalg_lapack_s
               k = k - kstep
               kc = kcnext
               go to 60
-80            continue
+              80 continue
            end if
            return
      end subroutine stdlib_ssptri
@@ -16617,7 +16617,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: ap(*)
            real(sp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kc,kp
@@ -16649,7 +16649,7 @@ module stdlib_linalg_lapack_s
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
               kc = n*(n + 1)/2 + 1
-10            continue
+              10 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 30
               kc = kc - k
@@ -16661,7 +16661,7 @@ module stdlib_linalg_lapack_s
                  ! multiply by inv(u(k)), where u(k) is the transformation
                  ! stored in column k of a.
                  call stdlib_sger(k - 1,nrhs,-one,ap(kc),1,b(k,1),ldb,b(1,1),ldb)
-                           
+
                  ! multiply by the inverse of the diagonal block.
                  call stdlib_sscal(nrhs,one/ap(kc + k - 1),b(k,1),ldb)
                  k = k - 1
@@ -16673,7 +16673,7 @@ module stdlib_linalg_lapack_s
                  ! multiply by inv(u(k)), where u(k) is the transformation
                  ! stored in columns k-1 and k of a.
                  call stdlib_sger(k - 2,nrhs,-one,ap(kc),1,b(k,1),ldb,b(1,1),ldb)
-                           
+
                  call stdlib_sger(k - 2,nrhs,-one,ap(kc - (k - 1)),1,b(k - 1,1),ldb,b(1,1 &
                            ),ldb)
                  ! multiply by the inverse of the diagonal block.
@@ -16691,13 +16691,13 @@ module stdlib_linalg_lapack_s
                  k = k - 2
               end if
               go to 10
-30            continue
+              30 continue
               ! next solve u**t*x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
               kc = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               if (ipiv(k) > 0) then
@@ -16726,7 +16726,7 @@ module stdlib_linalg_lapack_s
                  k = k + 2
               end if
               go to 40
-50            continue
+              50 continue
            else
               ! solve a*x = b, where a = l*d*l**t.
               ! first solve l*d*x = b, overwriting b with x.
@@ -16734,7 +16734,7 @@ module stdlib_linalg_lapack_s
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
               kc = 1
-60            continue
+              60 continue
               ! if k > n, exit from loop.
               if (k > n) go to 80
               if (ipiv(k) > 0) then
@@ -16778,13 +16778,13 @@ module stdlib_linalg_lapack_s
                  k = k + 2
               end if
               go to 60
-80            continue
+              80 continue
               ! next solve l**t*x = b, overwriting b with x.
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
               kc = n*(n + 1)/2 + 1
-90            continue
+              90 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 100
               kc = kc - (n - k + 1)
@@ -16815,7 +16815,7 @@ module stdlib_linalg_lapack_s
                  k = k - 2
               end if
               go to 90
-100           continue
+              100 continue
            end if
            return
      end subroutine stdlib_ssptrs
@@ -16849,7 +16849,7 @@ module stdlib_linalg_lapack_s
            ! Parameters
            real(sp),parameter :: fudge = 2.1_sp
            real(sp),parameter :: relfac = 2.0_sp
-           
+
            ! Local Scalars
            logical(lk) :: ncnvrg,toofew
            integer(ilp) :: ib,ibegin,idiscl,idiscu,ie,iend,iinfo,im,in,ioff,iorder, &
@@ -17229,7 +17229,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: e(*)
         ! =====================================================================
-           
+
            ! External Subroutines
            logical(lk) :: upper,convert
            integer(ilp) :: i,ip,j
@@ -17445,7 +17445,7 @@ module stdlib_linalg_lapack_s
            integer(ilp),intent(inout) :: ipiv(*)
            real(sp),intent(inout) :: a(lda,*),e(*)
         ! =====================================================================
-           
+
            ! External Subroutines
            logical(lk) :: upper,convert
            integer(ilp) :: i,ip
@@ -17509,7 +17509,7 @@ module stdlib_linalg_lapack_s
                        if (i < n) then
                           if (ip /= (i - 1)) then
                              call stdlib_sswap(n - i,a(i - 1,i + 1),lda,a(ip,i + 1),lda)
-                                       
+
                           end if
                        end if
                        ! convert ipiv
@@ -17545,7 +17545,7 @@ module stdlib_linalg_lapack_s
                        if (i < n) then
                           if (ip /= (i - 1)) then
                              call stdlib_sswap(n - i,a(ip,i + 1),lda,a(i - 1,i + 1),lda)
-                                       
+
                           end if
                        end if
                        ! convert ipiv
@@ -17698,7 +17698,7 @@ module stdlib_linalg_lapack_s
            integer(ilp),intent(in) :: ipiv(*)
            real(sp),intent(inout) :: a(lda,*),e(*)
         ! =====================================================================
-           
+
            ! External Subroutines
            logical(lk) :: upper,convert
            integer(ilp) :: i,ip,ip2
@@ -17767,7 +17767,7 @@ module stdlib_linalg_lapack_s
                           end if
                           if (ip2 /= (i - 1)) then
                              call stdlib_sswap(n - i,a(i - 1,i + 1),lda,a(ip2,i + 1),lda)
-                                       
+
                           end if
                        end if
                        i = i - 1
@@ -17800,7 +17800,7 @@ module stdlib_linalg_lapack_s
                        if (i < n) then
                           if (ip2 /= (i - 1)) then
                              call stdlib_sswap(n - i,a(ip2,i + 1),lda,a(i - 1,i + 1),lda)
-                                       
+
                           end if
                           if (ip /= i) then
                              call stdlib_sswap(n - i,a(ip,i + 1),lda,a(i,i + 1),lda)
@@ -17948,7 +17948,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: max_iter = 100
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,iter
            real(sp) :: avg,std,tol,c0,c1,c2,t,u,si,d,base,smin,smax,smlnum,bignum, &
@@ -18084,7 +18084,7 @@ module stdlib_linalg_lapack_s
                  s(i) = si
               end do
            end do
-999        continue
+           999 continue
            smlnum = stdlib_slamch('SAFEMIN')
            bignum = one/smlnum
            smin = bignum
@@ -18120,7 +18120,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(in) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: k
@@ -18209,11 +18209,11 @@ module stdlib_linalg_lapack_s
                     akk = a(k,k)
                     bkk = b(k,k)
                     call stdlib_strmv(uplo,'TRANSPOSE','NON-UNIT',k - 1,b,ldb,a(k,1),lda)
-                              
+
                     ct = half*akk
                     call stdlib_saxpy(k - 1,ct,b(k,1),ldb,a(k,1),lda)
                     call stdlib_ssyr2(uplo,k - 1,one,a(k,1),lda,b(k,1),ldb,a,lda)
-                              
+
                     call stdlib_saxpy(k - 1,ct,b(k,1),ldb,a(k,1),lda)
                     call stdlib_sscal(k - 1,bkk,a(k,1),lda)
                     a(k,k) = akk*bkk**2
@@ -18243,7 +18243,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(in) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: k,kb,nb
@@ -18284,7 +18284,7 @@ module stdlib_linalg_lapack_s
                        kb = min(n - k + 1,nb)
                        ! update the upper triangle of a(k:n,k:n)
                        call stdlib_ssygs2(itype,uplo,kb,a(k,k),lda,b(k,k),ldb,info)
-                                 
+
                        if (k + kb <= n) then
                           call stdlib_strsm('LEFT',uplo,'TRANSPOSE','NON-UNIT',kb,n - k - kb + 1, &
                                     one,b(k,k),ldb,a(k,k + kb),lda)
@@ -18304,7 +18304,7 @@ module stdlib_linalg_lapack_s
                        kb = min(n - k + 1,nb)
                        ! update the lower triangle of a(k:n,k:n)
                        call stdlib_ssygs2(itype,uplo,kb,a(k,k),lda,b(k,k),ldb,info)
-                                 
+
                        if (k + kb <= n) then
                           call stdlib_strsm('RIGHT',uplo,'TRANSPOSE','NON-UNIT',n - k - kb + 1,kb, &
                                     one,b(k,k),ldb,a(k + kb,k),lda)
@@ -18336,7 +18336,7 @@ module stdlib_linalg_lapack_s
                        call stdlib_strmm('RIGHT',uplo,'TRANSPOSE','NON-UNIT',k - 1,kb,one,b( &
                                  k,k),ldb,a(1,k),lda)
                        call stdlib_ssygs2(itype,uplo,kb,a(k,k),lda,b(k,k),ldb,info)
-                                 
+
                     end do
                  else
                     ! compute l**t*a*l
@@ -18354,7 +18354,7 @@ module stdlib_linalg_lapack_s
                        call stdlib_strmm('LEFT',uplo,'TRANSPOSE','NON-UNIT',kb,k - 1,one,b( &
                                  k,k),ldb,a(k,1),lda)
                        call stdlib_ssygs2(itype,uplo,kb,a(k,k),lda,b(k,k),ldb,info)
-                                 
+
                     end do
                  end if
               end if
@@ -18455,7 +18455,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: sevten = 17.0e+0_sp
-           
+
            ! Local Scalars
            logical(lk) :: upper,done
            integer(ilp) :: i,imax,j,jmax,itemp,k,kk,kp,kstep,p,ii
@@ -18490,7 +18490,7 @@ module stdlib_linalg_lapack_s
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 34
               kstep = 1
@@ -18524,7 +18524,7 @@ module stdlib_linalg_lapack_s
                  else
                     done = .false.
                     ! loop until pivot found
-12   continue
+                    12 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -18574,7 +18574,7 @@ module stdlib_linalg_lapack_s
                     ! submatrix a(1:k,1:k) if we have a 2-by-2 pivot
                     if (p > 1) call stdlib_sswap(p - 1,a(1,k),1,a(1,p),1)
                     if (p < (k - 1)) call stdlib_sswap(k - p - 1,a(p + 1,k),1,a(p,p + 1),lda)
-                              
+
                     t = a(k,k)
                     a(k,k) = a(p,p)
                     a(p,p) = t
@@ -18677,7 +18677,7 @@ module stdlib_linalg_lapack_s
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-34            continue
+              34 continue
            else
               ! factorize a as l*d*l**t using the lower triangle of a
               ! initialize the unused last entry of the subdiagonal array e.
@@ -18685,7 +18685,7 @@ module stdlib_linalg_lapack_s
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop
               if (k > n) go to 64
               kstep = 1
@@ -18718,7 +18718,7 @@ module stdlib_linalg_lapack_s
                  else
                     done = .false.
                     ! loop until pivot found
-42   continue
+                    42 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -18768,7 +18768,7 @@ module stdlib_linalg_lapack_s
                     ! submatrix a(k:n,k:n) if we have a 2-by-2 pivot
                     if (p < n) call stdlib_sswap(n - p,a(p + 1,k),1,a(p + 1,p),1)
                     if (p > (k + 1)) call stdlib_sswap(p - k - 1,a(k + 1,k),1,a(p,k + 1),lda)
-                              
+
                     t = a(k,k)
                     a(k,k) = a(p,p)
                     a(p,p) = t
@@ -18782,7 +18782,7 @@ module stdlib_linalg_lapack_s
                     ! interchange rows and columns kk and kp in the trailing
                     ! submatrix a(k:n,k:n)
                     if (kp < n) call stdlib_sswap(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     if ((kk < n) .and. (kp > (kk + 1))) call stdlib_sswap(kp - kk - 1,a(kk + 1,kk), &
                               1,a(kp,kk + 1),lda)
                     t = a(kk,kk)
@@ -18811,7 +18811,7 @@ module stdlib_linalg_lapack_s
                              ! = a - w(k)*(1/d(k))*w(k)**t
                           d11 = one/a(k,k)
                           call stdlib_ssyr(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                           ! store l(k) in column k
                           call stdlib_sscal(n - k,d11,a(k + 1,k),1)
                        else
@@ -18825,7 +18825,7 @@ module stdlib_linalg_lapack_s
                              ! = a - w(k)*(1/d(k))*w(k)**t
                              ! = a - (w(k)/d(k))*(d(k))*(w(k)/d(k))**t
                           call stdlib_ssyr(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                        end if
                        ! store the subdiagonal element of d in array e
                        e(k) = zero
@@ -18876,7 +18876,7 @@ module stdlib_linalg_lapack_s
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 40
-64            continue
+              64 continue
            end if
            return
      end subroutine stdlib_ssytf2_rk
@@ -18903,7 +18903,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: sevten = 17.0e+0_sp
-           
+
            ! Local Scalars
            logical(lk) :: upper,done
            integer(ilp) :: i,imax,j,jmax,itemp,k,kk,kp,kstep,p,ii
@@ -18935,7 +18935,7 @@ module stdlib_linalg_lapack_s
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 70
               kstep = 1
@@ -18967,7 +18967,7 @@ module stdlib_linalg_lapack_s
                  else
                     done = .false.
                     ! loop until pivot found
-12   continue
+                    12 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -19017,7 +19017,7 @@ module stdlib_linalg_lapack_s
                     ! submatrix a(1:k,1:k) if we have a 2-by-2 pivot
                     if (p > 1) call stdlib_sswap(p - 1,a(1,k),1,a(1,p),1)
                     if (p < (k - 1)) call stdlib_sswap(k - p - 1,a(p + 1,k),1,a(p,p + 1),lda)
-                              
+
                     t = a(k,k)
                     a(k,k) = a(p,p)
                     a(p,p) = t
@@ -19111,7 +19111,7 @@ module stdlib_linalg_lapack_s
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop
               if (k > n) go to 70
               kstep = 1
@@ -19142,7 +19142,7 @@ module stdlib_linalg_lapack_s
                  else
                     done = .false.
                     ! loop until pivot found
-42   continue
+                    42 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -19192,7 +19192,7 @@ module stdlib_linalg_lapack_s
                     ! submatrix a(k:n,k:n) if we have a 2-by-2 pivot
                     if (p < n) call stdlib_sswap(n - p,a(p + 1,k),1,a(p + 1,p),1)
                     if (p > (k + 1)) call stdlib_sswap(p - k - 1,a(k + 1,k),1,a(p,k + 1),lda)
-                              
+
                     t = a(k,k)
                     a(k,k) = a(p,p)
                     a(p,p) = t
@@ -19203,7 +19203,7 @@ module stdlib_linalg_lapack_s
                     ! interchange rows and columns kk and kp in the trailing
                     ! submatrix a(k:n,k:n)
                     if (kp < n) call stdlib_sswap(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     if ((kk < n) .and. (kp > (kk + 1))) call stdlib_sswap(kp - kk - 1,a(kk + 1,kk), &
                               1,a(kp,kk + 1),lda)
                     t = a(kk,kk)
@@ -19229,7 +19229,7 @@ module stdlib_linalg_lapack_s
                              ! = a - w(k)*(1/d(k))*w(k)**t
                           d11 = one/a(k,k)
                           call stdlib_ssyr(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                           ! store l(k) in column k
                           call stdlib_sscal(n - k,d11,a(k + 1,k),1)
                        else
@@ -19243,7 +19243,7 @@ module stdlib_linalg_lapack_s
                              ! = a - w(k)*(1/d(k))*w(k)**t
                              ! = a - (w(k)/d(k))*(d(k))*(w(k)/d(k))**t
                           call stdlib_ssyr(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                        end if
                     end if
                  else
@@ -19287,7 +19287,7 @@ module stdlib_linalg_lapack_s
               k = k + kstep
               go to 40
            end if
-70         continue
+           70 continue
            return
      end subroutine stdlib_ssytf2_rook
 
@@ -19363,14 +19363,14 @@ module stdlib_linalg_lapack_s
               ! kb, where kb is the number of columns factorized by stdlib_slasyf_rk;
               ! kb is either nb or nb-1, or k for the last block
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 15
               if (k > nb) then
                  ! factorize columns k-kb+1:k of a and use blocked code to
                  ! update columns 1:k-kb
                  call stdlib_slasyf_rk(uplo,k,nb,kb,a,lda,e,ipiv,work,ldwork,iinfo)
-                           
+
               else
                  ! use unblocked code to factorize columns 1:k of a
                  call stdlib_ssytf2_rk(uplo,k,a,lda,e,ipiv,iinfo)
@@ -19399,14 +19399,14 @@ module stdlib_linalg_lapack_s
               go to 10
               ! this label is the exit from main loop over k decreasing
               ! from n to 1 in steps of kb
-15   continue
+              15 continue
            else
               ! factorize a as l*d*l**t using the lower triangle of a
               ! k is the main loop index, increasing from 1 to n in steps of
               ! kb, where kb is the number of columns factorized by stdlib_slasyf_rk;
               ! kb is either nb or nb-1, or n-k+1 for the last block
               k = 1
-20            continue
+              20 continue
               ! if k > n, exit from loop
               if (k > n) go to 35
               if (k <= n - nb) then
@@ -19417,7 +19417,7 @@ module stdlib_linalg_lapack_s
               else
                  ! use unblocked code to factorize columns k:n of a
                  call stdlib_ssytf2_rk(uplo,n - k + 1,a(k,k),lda,e(k),ipiv(k),iinfo)
-                           
+
                  kb = n - k + 1
               end if
               ! set info on the first occurrence of a zero pivot
@@ -19450,7 +19450,7 @@ module stdlib_linalg_lapack_s
               go to 20
               ! this label is the exit from main loop over k increasing
               ! from 1 to n in steps of kb
-35   continue
+              35 continue
            ! end lower
            end if
            work(1) = lwkopt
@@ -19528,14 +19528,14 @@ module stdlib_linalg_lapack_s
               ! kb, where kb is the number of columns factorized by stdlib_slasyf_rook;
               ! kb is either nb or nb-1, or k for the last block
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 40
               if (k > nb) then
                  ! factorize columns k-kb+1:k of a and use blocked code to
                  ! update columns 1:k-kb
                  call stdlib_slasyf_rook(uplo,k,nb,kb,a,lda,ipiv,work,ldwork,iinfo)
-                           
+
               else
                  ! use unblocked code to factorize columns 1:k of a
                  call stdlib_ssytf2_rook(uplo,k,a,lda,ipiv,iinfo)
@@ -19553,7 +19553,7 @@ module stdlib_linalg_lapack_s
               ! kb, where kb is the number of columns factorized by stdlib_slasyf_rook;
               ! kb is either nb or nb-1, or n-k+1 for the last block
               k = 1
-20            continue
+              20 continue
               ! if k > n, exit from loop
               if (k > n) go to 40
               if (k <= n - nb) then
@@ -19580,7 +19580,7 @@ module stdlib_linalg_lapack_s
               k = k + kb
               go to 20
            end if
-40         continue
+           40 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_ssytrf_rook
@@ -19602,7 +19602,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: k,kp,kstep
@@ -19644,7 +19644,7 @@ module stdlib_linalg_lapack_s
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-30            continue
+              30 continue
               ! if k > n, exit from loop.
               if (k > n) go to 40
               if (ipiv(k) > 0) then
@@ -19655,7 +19655,7 @@ module stdlib_linalg_lapack_s
                  if (k > 1) then
                     call stdlib_scopy(k - 1,a(1,k),1,work,1)
                     call stdlib_ssymv(uplo,k - 1,-one,a,lda,work,1,zero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - stdlib_sdot(k - 1,work,1,a(1,k),1)
                  end if
                  kstep = 1
@@ -19674,15 +19674,15 @@ module stdlib_linalg_lapack_s
                  if (k > 1) then
                     call stdlib_scopy(k - 1,a(1,k),1,work,1)
                     call stdlib_ssymv(uplo,k - 1,-one,a,lda,work,1,zero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - stdlib_sdot(k - 1,work,1,a(1,k),1)
                     a(k,k + 1) = a(k,k + 1) - stdlib_sdot(k - 1,a(1,k),1,a(1,k + 1),1)
-                              
+
                     call stdlib_scopy(k - 1,a(1,k + 1),1,work,1)
                     call stdlib_ssymv(uplo,k - 1,-one,a,lda,work,1,zero,a(1,k + 1),1)
-                              
+
                     a(k + 1,k + 1) = a(k + 1,k + 1) - stdlib_sdot(k - 1,work,1,a(1,k + 1),1)
-                              
+
                  end if
                  kstep = 2
               end if
@@ -19703,13 +19703,13 @@ module stdlib_linalg_lapack_s
               end if
               k = k + kstep
               go to 30
-40            continue
+              40 continue
            else
               ! compute inv(a) from the factorization a = l*d*l**t.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-50            continue
+              50 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 60
               if (ipiv(k) > 0) then
@@ -19742,12 +19742,12 @@ module stdlib_linalg_lapack_s
                               k),1)
                     a(k,k) = a(k,k) - stdlib_sdot(n - k,work,1,a(k + 1,k),1)
                     a(k,k - 1) = a(k,k - 1) - stdlib_sdot(n - k,a(k + 1,k),1,a(k + 1,k - 1),1)
-                              
+
                     call stdlib_scopy(n - k,a(k + 1,k - 1),1,work,1)
                     call stdlib_ssymv(uplo,n - k,-one,a(k + 1,k + 1),lda,work,1,zero,a(k + 1, &
                               k - 1),1)
                     a(k - 1,k - 1) = a(k - 1,k - 1) - stdlib_sdot(n - k,work,1,a(k + 1,k - 1),1)
-                              
+
                  end if
                  kstep = 2
               end if
@@ -19768,7 +19768,7 @@ module stdlib_linalg_lapack_s
               end if
               k = k - kstep
               go to 50
-60            continue
+              60 continue
            end if
            return
      end subroutine stdlib_ssytri
@@ -19790,7 +19790,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: k,kp,kstep
@@ -19832,7 +19832,7 @@ module stdlib_linalg_lapack_s
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-30            continue
+              30 continue
               ! if k > n, exit from loop.
               if (k > n) go to 40
               if (ipiv(k) > 0) then
@@ -19843,7 +19843,7 @@ module stdlib_linalg_lapack_s
                  if (k > 1) then
                     call stdlib_scopy(k - 1,a(1,k),1,work,1)
                     call stdlib_ssymv(uplo,k - 1,-one,a,lda,work,1,zero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - stdlib_sdot(k - 1,work,1,a(1,k),1)
                  end if
                  kstep = 1
@@ -19862,15 +19862,15 @@ module stdlib_linalg_lapack_s
                  if (k > 1) then
                     call stdlib_scopy(k - 1,a(1,k),1,work,1)
                     call stdlib_ssymv(uplo,k - 1,-one,a,lda,work,1,zero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - stdlib_sdot(k - 1,work,1,a(1,k),1)
                     a(k,k + 1) = a(k,k + 1) - stdlib_sdot(k - 1,a(1,k),1,a(1,k + 1),1)
-                              
+
                     call stdlib_scopy(k - 1,a(1,k + 1),1,work,1)
                     call stdlib_ssymv(uplo,k - 1,-one,a,lda,work,1,zero,a(1,k + 1),1)
-                              
+
                     a(k + 1,k + 1) = a(k + 1,k + 1) - stdlib_sdot(k - 1,work,1,a(1,k + 1),1)
-                              
+
                  end if
                  kstep = 2
               end if
@@ -19911,13 +19911,13 @@ module stdlib_linalg_lapack_s
               end if
               k = k + 1
               go to 30
-40            continue
+              40 continue
            else
               ! compute inv(a) from the factorization a = l*d*l**t.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-50            continue
+              50 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 60
               if (ipiv(k) > 0) then
@@ -19950,12 +19950,12 @@ module stdlib_linalg_lapack_s
                               k),1)
                     a(k,k) = a(k,k) - stdlib_sdot(n - k,work,1,a(k + 1,k),1)
                     a(k,k - 1) = a(k,k - 1) - stdlib_sdot(n - k,a(k + 1,k),1,a(k + 1,k - 1),1)
-                              
+
                     call stdlib_scopy(n - k,a(k + 1,k - 1),1,work,1)
                     call stdlib_ssymv(uplo,n - k,-one,a(k + 1,k + 1),lda,work,1,zero,a(k + 1, &
                               k - 1),1)
                     a(k - 1,k - 1) = a(k - 1,k - 1) - stdlib_sdot(n - k,work,1,a(k + 1,k - 1),1)
-                              
+
                  end if
                  kstep = 2
               end if
@@ -19996,7 +19996,7 @@ module stdlib_linalg_lapack_s
               end if
               k = k - 1
               go to 50
-60            continue
+              60 continue
            end if
            return
      end subroutine stdlib_ssytri_rook
@@ -20018,7 +20018,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: a(lda,*)
            real(sp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kp
@@ -20051,7 +20051,7 @@ module stdlib_linalg_lapack_s
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 30
               if (ipiv(k) > 0) then
@@ -20062,7 +20062,7 @@ module stdlib_linalg_lapack_s
                  ! multiply by inv(u(k)), where u(k) is the transformation
                  ! stored in column k of a.
                  call stdlib_sger(k - 1,nrhs,-one,a(1,k),1,b(k,1),ldb,b(1,1),ldb)
-                           
+
                  ! multiply by the inverse of the diagonal block.
                  call stdlib_sscal(nrhs,one/a(k,k),b(k,1),ldb)
                  k = k - 1
@@ -20074,7 +20074,7 @@ module stdlib_linalg_lapack_s
                  ! multiply by inv(u(k)), where u(k) is the transformation
                  ! stored in columns k-1 and k of a.
                  call stdlib_sger(k - 2,nrhs,-one,a(1,k),1,b(k,1),ldb,b(1,1),ldb)
-                           
+
                  call stdlib_sger(k - 2,nrhs,-one,a(1,k - 1),1,b(k - 1,1),ldb,b(1,1), &
                            ldb)
                  ! multiply by the inverse of the diagonal block.
@@ -20091,12 +20091,12 @@ module stdlib_linalg_lapack_s
                  k = k - 2
               end if
               go to 10
-30            continue
+              30 continue
               ! next solve u**t *x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               if (ipiv(k) > 0) then
@@ -20123,14 +20123,14 @@ module stdlib_linalg_lapack_s
                  k = k + 2
               end if
               go to 40
-50            continue
+              50 continue
            else
               ! solve a*x = b, where a = l*d*l**t.
               ! first solve l*d*x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-60            continue
+              60 continue
               ! if k > n, exit from loop.
               if (k > n) go to 80
               if (ipiv(k) > 0) then
@@ -20172,12 +20172,12 @@ module stdlib_linalg_lapack_s
                  k = k + 2
               end if
               go to 60
-80            continue
+              80 continue
               ! next solve l**t *x = b, overwriting b with x.
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-90            continue
+              90 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 100
               if (ipiv(k) > 0) then
@@ -20206,7 +20206,7 @@ module stdlib_linalg_lapack_s
                  k = k - 2
               end if
               go to 90
-100           continue
+              100 continue
            end if
            return
      end subroutine stdlib_ssytrs
@@ -20228,7 +20228,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*),b(ldb,*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,iinfo,j,k,kp
@@ -20337,7 +20337,7 @@ module stdlib_linalg_lapack_s
                  ! interchange rows k and -ipiv(k+1).
                  kp = -ipiv(k + 1)
                  if (kp == -ipiv(k)) call stdlib_sswap(nrhs,b(k + 1,1),ldb,b(kp,1),ldb)
-                           
+
                  k = k + 2
               end if
              end do
@@ -20412,7 +20412,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: a(lda,*),e(*)
            real(sp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,j,k,kp
@@ -20551,7 +20551,7 @@ module stdlib_linalg_lapack_s
      !> A = L*T*L**T computed by SSYTRF_AA.
 
      pure subroutine stdlib_ssytrs_aa(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -20565,7 +20565,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: b(ldb,*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            logical(lk) :: lquery,upper
            integer(ilp) :: k,kp,lwkopt
            ! Intrinsic Functions
@@ -20690,7 +20690,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: a(lda,*)
            real(sp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kp
@@ -20723,7 +20723,7 @@ module stdlib_linalg_lapack_s
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 30
               if (ipiv(k) > 0) then
@@ -20734,7 +20734,7 @@ module stdlib_linalg_lapack_s
                  ! multiply by inv(u(k)), where u(k) is the transformation
                  ! stored in column k of a.
                  call stdlib_sger(k - 1,nrhs,-one,a(1,k),1,b(k,1),ldb,b(1,1),ldb)
-                           
+
                  ! multiply by the inverse of the diagonal block.
                  call stdlib_sscal(nrhs,one/a(k,k),b(k,1),ldb)
                  k = k - 1
@@ -20767,12 +20767,12 @@ module stdlib_linalg_lapack_s
                  k = k - 2
               end if
               go to 10
-30            continue
+              30 continue
               ! next solve u**t *x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               if (ipiv(k) > 0) then
@@ -20803,14 +20803,14 @@ module stdlib_linalg_lapack_s
                  k = k + 2
               end if
               go to 40
-50            continue
+              50 continue
            else
               ! solve a*x = b, where a = l*d*l**t.
               ! first solve l*d*x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-60            continue
+              60 continue
               ! if k > n, exit from loop.
               if (k > n) go to 80
               if (ipiv(k) > 0) then
@@ -20854,12 +20854,12 @@ module stdlib_linalg_lapack_s
                  k = k + 2
               end if
               go to 60
-80            continue
+              80 continue
               ! next solve l**t *x = b, overwriting b with x.
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-90            continue
+              90 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 100
               if (ipiv(k) > 0) then
@@ -20890,7 +20890,7 @@ module stdlib_linalg_lapack_s
                  k = k - 2
               end if
               go to 90
-100           continue
+              100 continue
            end if
            return
      end subroutine stdlib_ssytrs_rook
@@ -20916,7 +20916,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: ab(ldab,*),b(ldb,*),x(ldx,*)
            real(sp),intent(out) :: berr(*),ferr(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            character :: transt
@@ -21102,14 +21102,14 @@ module stdlib_linalg_lapack_s
                  end if
               end do
               kase = 0
-210           continue
+              210 continue
               call stdlib_slacn2(n,work(2*n + 1),work(n + 1),iwork,ferr(j),kase,isave)
-                        
+
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(op(a)**t).
                     call stdlib_stbsv(uplo,transt,diag,n,kd,ab,ldab,work(n + 1),1)
-                              
+
                     do i = 1,n
                        work(n + i) = work(i)*work(n + i)
                     end do
@@ -21138,7 +21138,7 @@ module stdlib_linalg_lapack_s
      !> N-by NRHS matrix.  A check is made to verify that A is nonsingular.
 
      pure subroutine stdlib_stbtrs(uplo,trans,diag,n,kd,nrhs,ab,ldab,b,ldb,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -21150,7 +21150,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: ab(ldab,*)
            real(sp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,upper
            integer(ilp) :: j
@@ -21215,7 +21215,7 @@ module stdlib_linalg_lapack_s
      !> The matrix X is overwritten on B.
 
      pure subroutine stdlib_stfsm(transr,side,uplo,trans,diag,m,n,alpha,a,b,ldb)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -21227,7 +21227,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: a(0:*)
            real(sp),intent(inout) :: b(0:ldb - 1,0:*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,lside,misodd,nisodd,normaltransr,notrans
            integer(ilp) :: m1,m2,n1,n2,k,info,i,j
@@ -21302,7 +21302,7 @@ module stdlib_linalg_lapack_s
                           ! trans = 'n'
                           if (m == 1) then
                              call stdlib_strsm('L','L','N',diag,m1,n,alpha,a,m,b,ldb)
-                                       
+
                           else
                              call stdlib_strsm('L','L','N',diag,m1,n,alpha,a(0),m,b, &
                                        ldb)
@@ -21345,7 +21345,7 @@ module stdlib_linalg_lapack_s
                           call stdlib_sgemm('N','N',m1,n,m2,-one,a(0),m,b(m1,0),ldb, &
                                      alpha,b,ldb)
                           call stdlib_strsm('L','L','T',diag,m1,n,one,a(m2),m,b,ldb)
-                                    
+
                        end if
                     end if
                  else
@@ -21427,7 +21427,7 @@ module stdlib_linalg_lapack_s
                           call stdlib_sgemm('T','N',k,n,k,-one,a(k + 1),m + 1,b(k,0), &
                                     ldb,alpha,b,ldb)
                           call stdlib_strsm('L','L','T',diag,k,n,one,a(1),m + 1,b,ldb)
-                                    
+
                        end if
                     else
                        ! side  ='l', n is even, transr = 'n', and uplo = 'u'
@@ -21459,7 +21459,7 @@ module stdlib_linalg_lapack_s
                           ! side  ='l', n is even, transr = 't', uplo = 'l',
                           ! and trans = 'n'
                           call stdlib_strsm('L','U','T',diag,k,n,alpha,a(k),k,b,ldb)
-                                    
+
                           call stdlib_sgemm('T','N',k,n,k,-one,a(k*(k + 1)),k,b,ldb, &
                                     alpha,b(k,0),ldb)
                           call stdlib_strsm('L','L','N',diag,k,n,one,a(0),k,b(k,0), &
@@ -21472,7 +21472,7 @@ module stdlib_linalg_lapack_s
                           call stdlib_sgemm('N','N',k,n,k,-one,a(k*(k + 1)),k,b(k,0), &
                                      ldb,alpha,b,ldb)
                           call stdlib_strsm('L','U','N',diag,k,n,one,a(k),k,b,ldb)
-                                    
+
                        end if
                     else
                        ! side  ='l', n is even, transr = 't', and uplo = 'u'
@@ -22209,7 +22209,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: t(ldt,*),v(ldv,*)
            real(sp),intent(out) :: work(ldwork,*)
         ! ==========================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,mp,np,kp
            logical(lk) :: left,forward,column,right,backward,row
@@ -22265,9 +22265,9 @@ module stdlib_linalg_lapack_s
                  end do
               end do
               call stdlib_strmm('L','U','T','N',l,n,one,v(mp,1),ldv,work,ldwork)
-                        
+
               call stdlib_sgemm('T','N',l,n,m - l,one,v,ldv,b,ldb,one,work,ldwork)
-                        
+
               call stdlib_sgemm('T','N',k - l,n,m,one,v(1,kp),ldv,b,ldb,zero,work(kp, &
                          1),ldwork)
               do j = 1,n
@@ -22282,11 +22282,11 @@ module stdlib_linalg_lapack_s
                  end do
               end do
               call stdlib_sgemm('N','N',m - l,n,k,-one,v,ldv,work,ldwork,one,b,ldb)
-                        
+
               call stdlib_sgemm('N','N',l,n,k - l,-one,v(mp,kp),ldv,work(kp,1), &
                         ldwork,one,b(mp,1),ldb)
               call stdlib_strmm('L','U','N','N',l,n,one,v(mp,1),ldv,work,ldwork)
-                        
+
               do j = 1,n
                  do i = 1,l
                     b(m - l + i,j) = b(m - l + i,j) - work(i,j)
@@ -22310,9 +22310,9 @@ module stdlib_linalg_lapack_s
                  end do
               end do
               call stdlib_strmm('R','U','N','N',m,l,one,v(np,1),ldv,work,ldwork)
-                        
+
               call stdlib_sgemm('N','N',m,l,n - l,one,b,ldb,v,ldv,one,work,ldwork)
-                        
+
               call stdlib_sgemm('N','N',m,k - l,n,one,b,ldb,v(1,kp),ldv,zero,work(1, &
                         kp),ldwork)
               do j = 1,k
@@ -22327,11 +22327,11 @@ module stdlib_linalg_lapack_s
                  end do
               end do
               call stdlib_sgemm('N','T',m,n - l,k,-one,work,ldwork,v,ldv,one,b,ldb)
-                        
+
               call stdlib_sgemm('N','T',m,l,k - l,-one,work(1,kp),ldwork,v(np,kp), &
                         ldv,one,b(1,np),ldb)
               call stdlib_strmm('R','U','T','N',m,l,one,v(np,1),ldv,work,ldwork)
-                        
+
               do j = 1,l
                  do i = 1,m
                     b(i,n - l + j) = b(i,n - l + j) - work(i,j)
@@ -22360,7 +22360,7 @@ module stdlib_linalg_lapack_s
               call stdlib_sgemm('T','N',l,n,m - l,one,v(mp,kp),ldv,b(mp,1),ldb,one, &
                         work(kp,1),ldwork)
               call stdlib_sgemm('T','N',k - l,n,m,one,v,ldv,b,ldb,zero,work,ldwork)
-                        
+
               do j = 1,n
                  do i = 1,k
                     work(i,j) = work(i,j) + a(i,j)
@@ -22375,7 +22375,7 @@ module stdlib_linalg_lapack_s
               call stdlib_sgemm('N','N',m - l,n,k,-one,v(mp,1),ldv,work,ldwork,one,b( &
                         mp,1),ldb)
               call stdlib_sgemm('N','N',l,n,k - l,-one,v,ldv,work,ldwork,one,b,ldb)
-                        
+
               call stdlib_strmm('L','L','N','N',l,n,one,v(1,kp),ldv,work(kp,1), &
                         ldwork)
               do j = 1,n
@@ -22405,7 +22405,7 @@ module stdlib_linalg_lapack_s
               call stdlib_sgemm('N','N',m,l,n - l,one,b(1,np),ldb,v(np,kp),ldv,one, &
                         work(1,kp),ldwork)
               call stdlib_sgemm('N','N',m,k - l,n,one,b,ldb,v,ldv,zero,work,ldwork)
-                        
+
               do j = 1,k
                  do i = 1,m
                     work(i,j) = work(i,j) + a(i,j)
@@ -22420,7 +22420,7 @@ module stdlib_linalg_lapack_s
               call stdlib_sgemm('N','T',m,n - l,k,-one,work,ldwork,v(np,1),ldv,one,b( &
                         1,np),ldb)
               call stdlib_sgemm('N','T',m,l,k - l,-one,work,ldwork,v,ldv,one,b,ldb)
-                        
+
               call stdlib_strmm('R','L','T','N',m,l,one,v(1,kp),ldv,work(1,kp), &
                         ldwork)
               do j = 1,l
@@ -22446,9 +22446,9 @@ module stdlib_linalg_lapack_s
                  end do
               end do
               call stdlib_strmm('L','L','N','N',l,n,one,v(1,mp),ldv,work,ldb)
-                        
+
               call stdlib_sgemm('N','N',l,n,m - l,one,v,ldv,b,ldb,one,work,ldwork)
-                        
+
               call stdlib_sgemm('N','N',k - l,n,m,one,v(kp,1),ldv,b,ldb,zero,work(kp, &
                          1),ldwork)
               do j = 1,n
@@ -22463,11 +22463,11 @@ module stdlib_linalg_lapack_s
                  end do
               end do
               call stdlib_sgemm('T','N',m - l,n,k,-one,v,ldv,work,ldwork,one,b,ldb)
-                        
+
               call stdlib_sgemm('T','N',l,n,k - l,-one,v(kp,mp),ldv,work(kp,1), &
                         ldwork,one,b(mp,1),ldb)
               call stdlib_strmm('L','L','T','N',l,n,one,v(1,mp),ldv,work,ldwork)
-                        
+
               do j = 1,n
                  do i = 1,l
                     b(m - l + i,j) = b(m - l + i,j) - work(i,j)
@@ -22490,9 +22490,9 @@ module stdlib_linalg_lapack_s
                  end do
               end do
               call stdlib_strmm('R','L','T','N',m,l,one,v(1,np),ldv,work,ldwork)
-                        
+
               call stdlib_sgemm('N','T',m,l,n - l,one,b,ldb,v,ldv,one,work,ldwork)
-                        
+
               call stdlib_sgemm('N','T',m,k - l,n,one,b,ldb,v(kp,1),ldv,zero,work(1, &
                         kp),ldwork)
               do j = 1,k
@@ -22507,11 +22507,11 @@ module stdlib_linalg_lapack_s
                  end do
               end do
               call stdlib_sgemm('N','N',m,n - l,k,-one,work,ldwork,v,ldv,one,b,ldb)
-                        
+
               call stdlib_sgemm('N','N',m,l,k - l,-one,work(1,kp),ldwork,v(kp,np), &
                         ldv,one,b(1,np),ldb)
               call stdlib_strmm('R','L','N','N',m,l,one,v(1,np),ldv,work,ldwork)
-                        
+
               do j = 1,l
                  do i = 1,m
                     b(i,n - l + j) = b(i,n - l + j) - work(i,j)
@@ -22539,7 +22539,7 @@ module stdlib_linalg_lapack_s
               call stdlib_sgemm('N','N',l,n,m - l,one,v(kp,mp),ldv,b(mp,1),ldb,one, &
                         work(kp,1),ldwork)
               call stdlib_sgemm('N','N',k - l,n,m,one,v,ldv,b,ldb,zero,work,ldwork)
-                        
+
               do j = 1,n
                  do i = 1,k
                     work(i,j) = work(i,j) + a(i,j)
@@ -22554,7 +22554,7 @@ module stdlib_linalg_lapack_s
               call stdlib_sgemm('T','N',m - l,n,k,-one,v(1,mp),ldv,work,ldwork,one,b( &
                         mp,1),ldb)
               call stdlib_sgemm('T','N',l,n,k - l,-one,v,ldv,work,ldwork,one,b,ldb)
-                        
+
               call stdlib_strmm('L','U','T','N',l,n,one,v(kp,1),ldv,work(kp,1), &
                         ldwork)
               do j = 1,n
@@ -22583,7 +22583,7 @@ module stdlib_linalg_lapack_s
               call stdlib_sgemm('N','T',m,l,n - l,one,b(1,np),ldb,v(kp,np),ldv,one, &
                         work(1,kp),ldwork)
               call stdlib_sgemm('N','T',m,k - l,n,one,b,ldb,v,ldv,zero,work,ldwork)
-                        
+
               do j = 1,k
                  do i = 1,m
                     work(i,j) = work(i,j) + a(i,j)
@@ -22598,7 +22598,7 @@ module stdlib_linalg_lapack_s
               call stdlib_sgemm('N','N',m,n - l,k,-one,work,ldwork,v(1,np),ldv,one,b( &
                         1,np),ldb)
               call stdlib_sgemm('N','N',m,l,k - l,-one,work,ldwork,v,ldv,one,b,ldb)
-                        
+
               call stdlib_strmm('R','U','N','N',m,l,one,v(kp,1),ldv,work(1,kp), &
                         ldwork)
               do j = 1,l
@@ -22631,7 +22631,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: ap(*),b(ldb,*),x(ldx,*)
            real(sp),intent(out) :: berr(*),ferr(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            character :: transt
@@ -22825,9 +22825,9 @@ module stdlib_linalg_lapack_s
                  end if
               end do
               kase = 0
-210           continue
+              210 continue
               call stdlib_slacn2(n,work(2*n + 1),work(n + 1),iwork,ferr(j),kase,isave)
-                        
+
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(op(a)**t).
@@ -22868,7 +22868,7 @@ module stdlib_linalg_lapack_s
            ! Array Arguments
            real(sp),intent(inout) :: ap(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,upper
            integer(ilp) :: j,jc,jclast,jj
@@ -22962,7 +22962,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: ap(*)
            real(sp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,upper
            integer(ilp) :: j,jc
@@ -23334,7 +23334,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: a(lda,*),b(ldb,*),x(ldx,*)
            real(sp),intent(out) :: berr(*),ferr(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            character :: transt
@@ -23518,9 +23518,9 @@ module stdlib_linalg_lapack_s
                  end if
               end do
               kase = 0
-210           continue
+              210 continue
               call stdlib_slacn2(n,work(2*n + 1),work(n + 1),iwork,ferr(j),kase,isave)
-                        
+
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(op(a)**t).
@@ -23562,7 +23562,7 @@ module stdlib_linalg_lapack_s
            ! Array Arguments
            real(sp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,upper
            integer(ilp) :: j
@@ -23598,7 +23598,7 @@ module stdlib_linalg_lapack_s
                  end if
                  ! compute elements 1:j-1 of j-th column.
                  call stdlib_strmv('UPPER','NO TRANSPOSE',diag,j - 1,a,lda,a(1,j),1)
-                           
+
                  call stdlib_sscal(j - 1,ajj,a(1,j),1)
               end do
            else
@@ -23636,7 +23636,7 @@ module stdlib_linalg_lapack_s
            ! Array Arguments
            real(sp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,upper
            integer(ilp) :: j,jb,nb,nn
@@ -23725,7 +23725,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: a(lda,*)
            real(sp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit
            ! Intrinsic Functions
@@ -24093,7 +24093,7 @@ module stdlib_linalg_lapack_s
            real(sp),parameter :: hundred = 100.0_sp
            real(sp),parameter :: meighth = -0.125_sp
            real(sp),parameter :: piover2 = 1.57079632679489661923132169163975144210_sp
-           
+
            ! Local Scalars
            logical(lk) :: colmajor,lquery,restart11,restart12,restart21,restart22,wantu1, &
                      wantu2,wantv1t,wantv2t
@@ -24243,9 +24243,9 @@ module stdlib_linalg_lapack_s
               else
                  ! compute shifts for b11 and b21 and use the lesser
                  call stdlib_slas2(b11d(imax - 1),b11e(imax - 1),b11d(imax),sigma11,dummy)
-                           
+
                  call stdlib_slas2(b21d(imax - 1),b21e(imax - 1),b21d(imax),sigma21,dummy)
-                           
+
                  if (sigma11 <= sigma21) then
                     mu = sigma11
                     nu = sqrt(one - mu**2)
@@ -24308,7 +24308,7 @@ module stdlib_linalg_lapack_s
               work(iu2sn + imin - 1) = -work(iu2sn + imin - 1)
               temp = work(iu1cs + imin - 1)*b11e(imin) + work(iu1sn + imin - 1)*b11d(imin + 1)
               b11d(imin + 1) = work(iu1cs + imin - 1)*b11d(imin + 1) - work(iu1sn + imin - 1)*b11e(imin)
-                        
+
               b11e(imin) = temp
               if (imax > imin + 1) then
                  b11bulge = work(iu1sn + imin - 1)*b11e(imin + 1)
@@ -24321,7 +24321,7 @@ module stdlib_linalg_lapack_s
               b12d(imin + 1) = work(iu1cs + imin - 1)*b12d(imin + 1)
               temp = work(iu2cs + imin - 1)*b21e(imin) + work(iu2sn + imin - 1)*b21d(imin + 1)
               b21d(imin + 1) = work(iu2cs + imin - 1)*b21d(imin + 1) - work(iu2sn + imin - 1)*b21e(imin)
-                        
+
               b21e(imin) = temp
               if (imax > imin + 1) then
                  b21bulge = work(iu2sn + imin - 1)*b21e(imin + 1)
@@ -24361,16 +24361,16 @@ module stdlib_linalg_lapack_s
                               r)
                  else if (mu <= nu) then
                     call stdlib_slartgs(b11d(i),b11e(i),mu,work(iv1tcs + i - 1),work(iv1tsn + i - 1))
-                              
+
                  else
                     call stdlib_slartgs(b21d(i),b21e(i),nu,work(iv1tcs + i - 1),work(iv1tsn + i - 1))
-                              
+
                  end if
                  work(iv1tcs + i - 1) = -work(iv1tcs + i - 1)
                  work(iv1tsn + i - 1) = -work(iv1tsn + i - 1)
                  if (.not. restart12 .and. .not. restart22) then
                     call stdlib_slartgp(y2,y1,work(iv2tsn + i - 1 - 1),work(iv2tcs + i - 1 - 1),r)
-                              
+
                  else if (.not. restart12 .and. restart22) then
                     call stdlib_slartgp(b12bulge,b12d(i - 1),work(iv2tsn + i - 1 - 1),work(iv2tcs + i - 1 - &
                               1),r)
@@ -24423,31 +24423,31 @@ module stdlib_linalg_lapack_s
                     call stdlib_slartgp(x2,x1,work(iu1sn + i - 1),work(iu1cs + i - 1),r)
                  else if (.not. restart11 .and. restart12) then
                     call stdlib_slartgp(b11bulge,b11d(i),work(iu1sn + i - 1),work(iu1cs + i - 1),r)
-                              
+
                  else if (restart11 .and. .not. restart12) then
                     call stdlib_slartgp(b12bulge,b12e(i - 1),work(iu1sn + i - 1),work(iu1cs + i - 1),r)
-                              
+
                  else if (mu <= nu) then
                     call stdlib_slartgs(b11e(i),b11d(i + 1),mu,work(iu1cs + i - 1),work(iu1sn + i - 1))
-                              
+
                  else
                     call stdlib_slartgs(b12d(i),b12e(i),nu,work(iu1cs + i - 1),work(iu1sn + i - 1))
-                              
+
                  end if
                  if (.not. restart21 .and. .not. restart22) then
                     call stdlib_slartgp(y2,y1,work(iu2sn + i - 1),work(iu2cs + i - 1),r)
                  else if (.not. restart21 .and. restart22) then
                     call stdlib_slartgp(b21bulge,b21d(i),work(iu2sn + i - 1),work(iu2cs + i - 1),r)
-                              
+
                  else if (restart21 .and. .not. restart22) then
                     call stdlib_slartgp(b22bulge,b22e(i - 1),work(iu2sn + i - 1),work(iu2cs + i - 1),r)
-                              
+
                  else if (nu < mu) then
                     call stdlib_slartgs(b21e(i),b21e(i + 1),nu,work(iu2cs + i - 1),work(iu2sn + i - 1))
-                              
+
                  else
                     call stdlib_slartgs(b22d(i),b22e(i),mu,work(iu2cs + i - 1),work(iu2sn + i - 1))
-                              
+
                  end if
                  work(iu2cs + i - 1) = -work(iu2cs + i - 1)
                  work(iu2sn + i - 1) = -work(iu2sn + i - 1)
@@ -24486,7 +24486,7 @@ module stdlib_linalg_lapack_s
               restart22 = b22d(imax - 1)**2 + b22bulge**2 <= thresh**2
               if (.not. restart12 .and. .not. restart22) then
                  call stdlib_slartgp(y2,y1,work(iv2tsn + imax - 1 - 1),work(iv2tcs + imax - 1 - 1),r)
-                           
+
               else if (.not. restart12 .and. restart22) then
                  call stdlib_slartgp(b12bulge,b12d(imax - 1),work(iv2tsn + imax - 1 - 1),work(iv2tcs + &
                            imax - 1 - 1),r)
@@ -24502,11 +24502,11 @@ module stdlib_linalg_lapack_s
               end if
               temp = work(iv2tcs + imax - 1 - 1)*b12e(imax - 1) + work(iv2tsn + imax - 1 - 1)*b12d(imax)
               b12d(imax) = work(iv2tcs + imax - 1 - 1)*b12d(imax) - work(iv2tsn + imax - 1 - 1)*b12e(imax - 1)
-                        
+
               b12e(imax - 1) = temp
               temp = work(iv2tcs + imax - 1 - 1)*b22e(imax - 1) + work(iv2tsn + imax - 1 - 1)*b22d(imax)
               b22d(imax) = work(iv2tcs + imax - 1 - 1)*b22d(imax) - work(iv2tsn + imax - 1 - 1)*b22e(imax - 1)
-                        
+
               b22e(imax - 1) = temp
               ! update singular vectors
               if (wantu1) then
@@ -24641,9 +24641,9 @@ module stdlib_linalg_lapack_s
                     if (wantu1) call stdlib_sswap(p,u1(1,i),1,u1(1,mini),1)
                     if (wantu2) call stdlib_sswap(m - p,u2(1,i),1,u2(1,mini),1)
                     if (wantv1t) call stdlib_sswap(q,v1t(i,1),ldv1t,v1t(mini,1),ldv1t)
-                              
+
                     if (wantv2t) call stdlib_sswap(m - q,v2t(i,1),ldv2t,v2t(mini,1),ldv2t)
-                              
+
                  else
                     if (wantu1) call stdlib_sswap(p,u1(i,1),ldu1,u1(mini,1),ldu1)
                     if (wantu2) call stdlib_sswap(m - p,u2(i,1),ldu2,u2(mini,1),ldu2)
@@ -24681,7 +24681,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: d(*)
            real(sp),intent(out) :: sep(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: decr,eigen,incr,left,right,sing
            integer(ilp) :: i,k
@@ -24778,7 +24778,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: ab(ldab,*),c(ldc,*)
            real(sp),intent(out) :: d(*),e(*),pt(ldpt,*),q(ldq,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: wantb,wantc,wantpt,wantq
            integer(ilp) :: i,inca,j,j1,j2,kb,kb1,kk,klm,klu1,kun,l,minmn,ml,ml0,mn, &
@@ -24975,7 +24975,7 @@ module stdlib_linalg_lapack_s
                  end if
                  if (wantq) call stdlib_srot(m,q(1,i),1,q(1,i + 1),1,rc,rs)
                  if (wantc) call stdlib_srot(ncc,c(i,1),ldc,c(i + 1,1),ldc,rc,rs)
-                           
+
               end do
               if (m <= n) d(m) = ab(1,m)
            else if (ku > 0) then
@@ -24993,7 +24993,7 @@ module stdlib_linalg_lapack_s
                        e(i - 1) = rc*ab(ku,i)
                     end if
                     if (wantpt) call stdlib_srot(n,pt(i,1),ldpt,pt(m + 1,1),ldpt,rc,rs)
-                              
+
                  end do
               else
                  ! copy off-diagonal elements to e and diagonal elements to d
@@ -25041,7 +25041,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: ab(ldab,*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lnoti,onenrm
            character :: normin
@@ -25092,7 +25092,7 @@ module stdlib_linalg_lapack_s
            kd = kl + ku + 1
            lnoti = kl > 0
            kase = 0
-10         continue
+           10 continue
            call stdlib_slacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == kase1) then
@@ -25121,7 +25121,7 @@ module stdlib_linalg_lapack_s
                     do j = n - 1,1,-1
                        lm = min(kl,n - j)
                        work(j) = work(j) - stdlib_sdot(lm,ab(kd + 1,j),1,work(j + 1),1)
-                                 
+
                        jp = ipiv(j)
                        if (jp /= j) then
                           t = work(jp)
@@ -25142,7 +25142,7 @@ module stdlib_linalg_lapack_s
            end if
            ! compute the estimate of the reciprocal condition number.
            if (ainvnm /= zero) rcond = (one/ainvnm)/anorm
-40         continue
+           40 continue
            return
      end subroutine stdlib_sgbcon
 
@@ -25157,7 +25157,7 @@ module stdlib_linalg_lapack_s
      !> works well in practice.
 
      pure subroutine stdlib_sgbequ(m,n,kl,ku,ab,ldab,r,c,rowcnd,colcnd,amax,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -25169,7 +25169,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: ab(ldab,*)
            real(sp),intent(out) :: c(*),r(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,kd
            real(sp) :: bignum,rcmax,rcmin,smlnum
@@ -25293,7 +25293,7 @@ module stdlib_linalg_lapack_s
      !> between sqrt(radix) and 1/sqrt(radix).
 
      pure subroutine stdlib_sgbequb(m,n,kl,ku,ab,ldab,r,c,rowcnd,colcnd,amax,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -25305,7 +25305,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: ab(ldab,*)
            real(sp),intent(out) :: c(*),r(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,kd
            real(sp) :: bignum,rcmax,rcmin,smlnum,radix,logrdx
@@ -25443,7 +25443,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: notran
            character :: transt
@@ -25504,7 +25504,7 @@ module stdlib_linalg_lapack_s
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - op(a) * x,
               ! where op(a) = a, a**t, or a**h, depending on trans.
@@ -25556,7 +25556,7 @@ module stdlib_linalg_lapack_s
               if (berr(j) > eps .and. two*berr(j) <= lstres .and. count <= itmax) then
                  ! update solution and try again.
                  call stdlib_sgbtrs(trans,n,kl,ku,1,afb,ldafb,ipiv,work(n + 1),n,info)
-                           
+
                  call stdlib_saxpy(n,one,work(n + 1),1,x(1,j),1)
                  lstres = berr(j)
                  count = count + 1
@@ -25587,9 +25587,9 @@ module stdlib_linalg_lapack_s
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_slacn2(n,work(2*n + 1),work(n + 1),iwork,ferr(j),kase,isave)
-                        
+
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(op(a)**t).
@@ -25636,7 +25636,7 @@ module stdlib_linalg_lapack_s
            ! Parameters
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldwork = nbmax + 1
-           
+
            ! Local Scalars
            integer(ilp) :: i,i2,i3,ii,ip,j,j2,j3,jb,jj,jm,jp,ju,k2,km,kv,nb, &
                      nw
@@ -25768,7 +25768,7 @@ module stdlib_linalg_lapack_s
                     ! use stdlib_slaswp to apply the row interchanges to a12, a22, and
                     ! a32.
                     call stdlib_slaswp(j2,ab(kv + 1 - jb,j + jb),ldab - 1,1,jb,ipiv(j),1)
-                              
+
                     ! adjust the pivot indices.
                     do i = j,j + jb - 1
                        ipiv(i) = ipiv(i) + j - 1
@@ -25820,7 +25820,7 @@ module stdlib_linalg_lapack_s
                           ! update a23
                           call stdlib_sgemm('NO TRANSPOSE','NO TRANSPOSE',i2,j3,jb,-one,ab( &
                           kv + 1 + jb,j),ldab - 1,work13,ldwork,one,ab(1 + jb,j + kv),ldab - 1)
-                                    
+
                        end if
                        if (i3 > 0) then
                           ! update a33
@@ -25889,7 +25889,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: onenrm
            character :: normin
@@ -25934,7 +25934,7 @@ module stdlib_linalg_lapack_s
               kase1 = 2
            end if
            kase = 0
-10         continue
+           10 continue
            call stdlib_slacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == kase1) then
@@ -25964,7 +25964,7 @@ module stdlib_linalg_lapack_s
            end if
            ! compute the estimate of the reciprocal condition number.
            if (ainvnm /= zero) rcond = (one/ainvnm)/anorm
-20         continue
+           20 continue
            return
      end subroutine stdlib_sgecon
 
@@ -25990,7 +25990,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: a(lda,*)
            real(sp),intent(out) :: c(*),r(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(sp) :: bignum,rcmax,rcmin,smlnum
@@ -26119,7 +26119,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: a(lda,*)
            real(sp),intent(out) :: c(*),r(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(sp) :: bignum,rcmax,rcmin,smlnum,radix,logrdx
@@ -26241,7 +26241,7 @@ module stdlib_linalg_lapack_s
      !> Q is of order M if SIDE = 'L' and of order N  if SIDE = 'R'.
 
      pure subroutine stdlib_sgemlqt(side,trans,m,n,k,mb,v,ldv,t,ldt,c,ldc,work,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -26339,7 +26339,7 @@ module stdlib_linalg_lapack_s
      !> Q is of order M if SIDE = 'L' and of order N  if SIDE = 'R'.
 
      pure subroutine stdlib_sgemqrt(side,trans,m,n,k,nb,v,ldv,t,ldt,c,ldc,work,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -26443,7 +26443,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: a(lda,*)
            real(sp),intent(inout) :: rhs(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(sp) :: bignum,eps,smlnum,temp
@@ -26501,7 +26501,7 @@ module stdlib_linalg_lapack_s
            integer(ilp),intent(out) :: ipiv(*),jpiv(*)
            real(sp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,ip,ipv,j,jp,jpv
            real(sp) :: bignum,eps,smin,smlnum,xmax
@@ -26588,7 +26588,7 @@ module stdlib_linalg_lapack_s
            integer(ilp),intent(out) :: ipiv(*)
            real(sp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(sp) :: sfmin
            integer(ilp) :: i,j,jp
@@ -26672,7 +26672,7 @@ module stdlib_linalg_lapack_s
            integer(ilp),intent(out) :: ipiv(*)
            real(sp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(sp) :: sfmin,temp
            integer(ilp) :: i,iinfo,n1,n2
@@ -26739,7 +26739,7 @@ module stdlib_linalg_lapack_s
               call stdlib_slaswp(n2,a(1,n1 + 1),lda,1,n1,ipiv,1)
               ! solve a12
               call stdlib_strsm('L','L','N','U',n1,n2,one,a,lda,a(1,n1 + 1),lda)
-                        
+
               ! update a22
               call stdlib_sgemm('N','N',m - n1,n2,n1,-one,a(n1 + 1,1),lda,a(1,n1 + 1), &
                         lda,one,a(n1 + 1,n1 + 1),lda)
@@ -26773,7 +26773,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,iws,j,jb,jj,jp,ldwork,lwkopt,nb,nbmin,nn
@@ -26876,7 +26876,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: a(lda,*)
            real(sp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran
            ! Intrinsic Functions
@@ -26938,7 +26938,7 @@ module stdlib_linalg_lapack_s
      !> generalized eigenvalue problem A*x = lambda*B*x.
 
      pure subroutine stdlib_sggbal(job,n,a,lda,b,ldb,ilo,ihi,lscale,rscale,work,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -26952,7 +26952,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: sclfac = 1.0e+1_sp
-           
+
            ! Local Scalars
            integer(ilp) :: i,icab,iflow,ip1,ir,irab,it,j,jc,jp1,k,kount,l,lcab,lm1, &
                      lrab,lsfmax,lsfmin,m,nr,nrp2
@@ -27005,13 +27005,13 @@ module stdlib_linalg_lapack_s
            go to 30
            ! permute the matrices a and b to isolate the eigenvalues.
            ! find row with one nonzero in columns 1 through l
-20   continue
+           20 continue
            l = lm1
            if (l /= 1) go to 30
            rscale(1) = one
            lscale(1) = one
            go to 190
-30         continue
+           30 continue
            lm1 = l - 1
            loop_80: do i = l,1,-1
               do j = 1,lm1
@@ -27020,21 +27020,21 @@ module stdlib_linalg_lapack_s
               end do
               j = l
               go to 70
-50            continue
+              50 continue
               do j = jp1,l
                  if (a(i,j) /= zero .or. b(i,j) /= zero) cycle loop_80
               end do
               j = jp1 - 1
-70            continue
+              70 continue
               m = l
               iflow = 1
               go to 160
            end do loop_80
            go to 100
            ! find column with one nonzero in rows k through n
-90   continue
+           90 continue
            k = k + 1
-100        continue
+           100 continue
            loop_150: do j = k,l
               do i = k,lm1
                  ip1 = i + 1
@@ -27042,32 +27042,32 @@ module stdlib_linalg_lapack_s
               end do
               i = l
               go to 140
-120           continue
+              120 continue
               do i = ip1,l
                  if (a(i,j) /= zero .or. b(i,j) /= zero) cycle loop_150
               end do
               i = ip1 - 1
-140           continue
+              140 continue
               m = k
               iflow = 2
               go to 160
            end do loop_150
            go to 190
            ! permute rows m and i
-160  continue
+           160 continue
            lscale(m) = i
            if (i == m) go to 170
            call stdlib_sswap(n - k + 1,a(i,k),lda,a(m,k),lda)
            call stdlib_sswap(n - k + 1,b(i,k),ldb,b(m,k),ldb)
            ! permute columns m and j
-170  continue
+           170 continue
            rscale(m) = j
            if (j == m) go to 180
            call stdlib_sswap(l,a(1,j),1,a(1,m),1)
            call stdlib_sswap(l,b(1,j),1,b(1,m),1)
-180        continue
+           180 continue
            go to(20,90) iflow
-190        continue
+           190 continue
            ilo = k
            ihi = l
            if (stdlib_lsame(job,'P')) then
@@ -27098,10 +27098,10 @@ module stdlib_linalg_lapack_s
                  ta = a(i,j)
                  if (ta == zero) go to 210
                  ta = log10(abs(ta))/basl
-210              continue
+                 210 continue
                  if (tb == zero) go to 220
                  tb = log10(abs(tb))/basl
-220              continue
+                 220 continue
                  work(i + 4*n) = work(i + 4*n) - ta - tb
                  work(j + 5*n) = work(j + 5*n) - ta - tb
               end do
@@ -27113,7 +27113,7 @@ module stdlib_linalg_lapack_s
            beta = zero
            it = 1
            ! start generalized conjugate gradient iteration
-250  continue
+           250 continue
            gamma = stdlib_sdot(nr,work(ilo + 4*n),1,work(ilo + 4*n),1) + stdlib_sdot(nr, &
                      work(ilo + 5*n),1,work(ilo + 5*n),1)
            ew = zero
@@ -27143,7 +27143,7 @@ module stdlib_linalg_lapack_s
                  if (a(i,j) == zero) go to 280
                  kount = kount + 1
                  sum = sum + work(j)
-280              continue
+                 280 continue
                  if (b(i,j) == zero) cycle loop_290
                  kount = kount + 1
                  sum = sum + work(j)
@@ -27157,7 +27157,7 @@ module stdlib_linalg_lapack_s
                  if (a(i,j) == zero) go to 310
                  kount = kount + 1
                  sum = sum + work(i + n)
-310              continue
+                 310 continue
                  if (b(i,j) == zero) cycle loop_320
                  kount = kount + 1
                  sum = sum + work(i + n)
@@ -27184,7 +27184,7 @@ module stdlib_linalg_lapack_s
            it = it + 1
            if (it <= nrp2) go to 250
            ! end generalized conjugate gradient iteration
-350  continue
+           350 continue
            sfmin = stdlib_slamch('S')
            sfmax = one/sfmin
            lsfmin = int(log10(sfmin)/basl + one,KIND=ilp)
@@ -27256,7 +27256,7 @@ module stdlib_linalg_lapack_s
            ! Array Arguments
            real(sp),intent(inout) :: a(lda,*),b(ldb,*),q(ldq,*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: ilq,ilz
            integer(ilp) :: icompq,icompz,jcol,jrow
@@ -27334,7 +27334,7 @@ module stdlib_linalg_lapack_s
                  call stdlib_slartg(temp,a(jrow,jcol),c,s,a(jrow - 1,jcol))
                  a(jrow,jcol) = zero
                  call stdlib_srot(n - jcol,a(jrow - 1,jcol + 1),lda,a(jrow,jcol + 1),lda,c,s)
-                           
+
                  call stdlib_srot(n + 2 - jrow,b(jrow - 1,jrow - 1),ldb,b(jrow,jrow - 1),ldb,c, &
                            s)
                  if (ilq) call stdlib_srot(n,q(1,jrow - 1),1,q(1,jrow),1,c,s)
@@ -27445,7 +27445,7 @@ module stdlib_linalg_lapack_s
      !> in computing that entry have at least one zero multiplicand.
 
      subroutine stdlib_sla_gbamv(trans,m,n,kl,ku,alpha,ab,ldab,x,incx,beta,y,incy)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -27456,7 +27456,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: ab(ldab,*),x(*)
            real(sp),intent(inout) :: y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: symb_zero
            real(sp) :: temp,safe1
@@ -27719,7 +27719,7 @@ module stdlib_linalg_lapack_s
            ! estimate the norm of inv(op(a)).
            ainvnm = zero
            kase = 0
-10         continue
+           10 continue
            call stdlib_slacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == 2) then
@@ -27799,7 +27799,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: a(lda,*),x(*)
            real(sp),intent(inout) :: y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: symb_zero
            real(sp) :: temp,safe1
@@ -28050,7 +28050,7 @@ module stdlib_linalg_lapack_s
            ! estimate the norm of inv(op(a)).
            ainvnm = zero
            kase = 0
-10         continue
+           10 continue
            call stdlib_slacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == 2) then
@@ -28060,7 +28060,7 @@ module stdlib_linalg_lapack_s
                  end do
                  if (notrans) then
                     call stdlib_sgetrs('NO TRANSPOSE',n,1,af,ldaf,ipiv,work,n,info)
-                              
+
                  else
                     call stdlib_sgetrs('TRANSPOSE',n,1,af,ldaf,ipiv,work,n,info)
                  end if
@@ -28089,7 +28089,7 @@ module stdlib_linalg_lapack_s
                     call stdlib_sgetrs('TRANSPOSE',n,1,af,ldaf,ipiv,work,n,info)
                  else
                     call stdlib_sgetrs('NO TRANSPOSE',n,1,af,ldaf,ipiv,work,n,info)
-                              
+
                  end if
                  ! multiply by r.
                  do i = 1,n
@@ -28155,7 +28155,7 @@ module stdlib_linalg_lapack_s
      !> infinity-norm condition number.
 
      real(sp) function stdlib_sla_porcond(uplo,n,a,lda,af,ldaf,cmode,c,info,work,iwork)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -28252,7 +28252,7 @@ module stdlib_linalg_lapack_s
            ! estimate the norm of inv(op(a)).
            ainvnm = zero
            kase = 0
-10         continue
+           10 continue
            call stdlib_slacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == 2) then
@@ -28327,7 +28327,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: a(lda,*),x(*)
            real(sp),intent(inout) :: y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: symb_zero
            real(sp) :: temp,safe1
@@ -28608,7 +28608,7 @@ module stdlib_linalg_lapack_s
            ainvnm = zero
            normin = 'N'
            kase = 0
-10         continue
+           10 continue
            call stdlib_slacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == 2) then
@@ -28852,7 +28852,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: b,c,d
            real(sp),intent(out) :: p,q
         ! =====================================================================
-           
+
            ! Local Scalars
            real(sp) :: r,t
            ! Executable Statements
@@ -28891,7 +28891,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: maxit = 40
-           
+
            ! Local Arrays
            real(sp) :: dscale(3),zscale(3)
            ! Local Scalars
@@ -28961,7 +28961,7 @@ module stdlib_linalg_lapack_s
            eps = stdlib_slamch('EPSILON')
            base = stdlib_slamch('BASE')
            small1 = base**(int(log(stdlib_slamch('SAFMIN'))/log(base)/three,KIND=ilp))
-                     
+
            sminv1 = one/small1
            small2 = small1*small1
            sminv2 = sminv1*sminv1
@@ -29083,7 +29083,7 @@ module stdlib_linalg_lapack_s
               end if
            end do loop_50
            info = 1
-60         continue
+           60 continue
            ! undo scaling
            if (scale) tau = tau*sclinv
            return
@@ -29108,7 +29108,7 @@ module stdlib_linalg_lapack_s
      !> Z**T denotes the transpose of Z.
 
      pure subroutine stdlib_slags2(upper,a1,a2,a3,b1,b2,b3,csu,snu,csv,snv,csq,snq)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -29117,7 +29117,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: a1,a2,a3,b1,b2,b3
            real(sp),intent(out) :: csq,csu,csv,snq,snu,snv
         ! =====================================================================
-           
+
            ! Local Scalars
            real(sp) :: a,aua11,aua12,aua21,aua22,avb11,avb12,avb21,avb22,csl,csr,d,s1, &
             s2,snl,snr,ua11r,ua22r,vb11r,vb22r,b,c,r,ua11,ua12,ua21,ua22,vb11,vb12, &
@@ -29275,7 +29275,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(*),b(*),c(*)
            real(sp),intent(out) :: d(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: k
            real(sp) :: eps,mult,piv1,piv2,scale1,scale2,temp,tl
@@ -29363,7 +29363,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: a(*),b(*),c(*),d(*)
            real(sp),intent(inout) :: y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: k
            real(sp) :: absak,ak,bignum,eps,pert,sfmin,temp
@@ -29443,7 +29443,7 @@ module stdlib_linalg_lapack_s
                     end if
                     ak = a(k)
                     pert = sign(tol,ak)
-40                  continue
+                    40 continue
                     absak = abs(ak)
                     if (absak < one) then
                        if (absak < sfmin) then
@@ -29504,7 +29504,7 @@ module stdlib_linalg_lapack_s
                     end if
                     ak = a(k)
                     pert = sign(tol,ak)
-70                  continue
+                    70 continue
                     absak = abs(ak)
                     if (absak < one) then
                        if (absak < sfmin) then
@@ -29569,7 +29569,7 @@ module stdlib_linalg_lapack_s
            ! Array Arguments
            real(sp),intent(in) :: w(j),x(j)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(sp) :: absalp,absest,absgam,alpha,b,cosine,eps,norma,s1,s2,sine,t, &
                      test,tmp,zeta1,zeta2
@@ -29715,7 +29715,7 @@ module stdlib_linalg_lapack_s
                  zeta1 = alpha/absest
                  zeta2 = gamma/absest
                  norma = max(one + zeta1*zeta1 + abs(zeta1*zeta2),abs(zeta1*zeta2) + zeta2*zeta2)
-                           
+
                  ! see if root is closer to zero or to one
                  test = one + two*(zeta1 - zeta2)*(zeta1 + zeta2)
                  if (test >= zero) then
@@ -29776,13 +29776,13 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: blklen = 128
-           
+
            ! some architectures propagate infinities and nans very slowly, so
            ! the code computes counts in blklen chunks.  then a nan can
            ! propagate at most blklen columns before being detected.  this is
            ! not a general tuning parameter; it needs only to be just large
            ! enough that the overhead is tiny in common cases.
-           
+
            ! Local Scalars
            integer(ilp) :: bj,j,neg1,neg2,negcnt
            real(sp) :: bsav,dminus,dplus,gamma,p,t,tmp
@@ -29868,7 +29868,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: ab(ldab,*)
            real(sp),intent(out) :: work(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,k,l
            real(sp) :: scale,sum,value,temp
@@ -29943,7 +29943,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: a(lda,*)
            real(sp),intent(out) :: work(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(sp) :: scale,sum,value,temp
@@ -30014,7 +30014,7 @@ module stdlib_linalg_lapack_s
            ! Array Arguments
            real(sp),intent(in) :: d(*),dl(*),du(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(sp) :: anorm,scale,sum,temp
@@ -30028,11 +30028,11 @@ module stdlib_linalg_lapack_s
               anorm = abs(d(n))
               do i = 1,n - 1
                  if (anorm < abs(dl(i)) .or. stdlib_sisnan(abs(dl(i)))) anorm = abs(dl(i))
-                           
+
                  if (anorm < abs(d(i)) .or. stdlib_sisnan(abs(d(i)))) anorm = abs(d(i))
-                           
+
                  if (anorm < abs(du(i)) .or. stdlib_sisnan(abs(du(i)))) anorm = abs(du(i))
-                           
+
               end do
            else if (stdlib_lsame(norm,'O') .or. norm == '1') then
               ! find norm1(a).
@@ -30091,7 +30091,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: a(lda,*)
            real(sp),intent(out) :: work(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(sp) :: scale,sum,value
@@ -30163,7 +30163,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: ab(ldab,*)
            real(sp),intent(out) :: work(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,l
            real(sp) :: absa,scale,sum,value
@@ -30233,7 +30233,7 @@ module stdlib_linalg_lapack_s
                  if (stdlib_lsame(uplo,'U')) then
                     do j = 2,n
                        call stdlib_slassq(min(j - 1,k),ab(max(k + 2 - j,1),j),1,scale,sum)
-                                 
+
                     end do
                     l = k + 1
                  else
@@ -30268,7 +30268,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: a(0:*)
            real(sp),intent(out) :: work(0:*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,ifm,ilu,noe,n1,k,l,lda
            real(sp) :: scale,s,value,aa,temp
@@ -30385,7 +30385,7 @@ module stdlib_linalg_lapack_s
                           end do
                           work(j) = work(j) + s
                        end do
-10                     continue
+                       10 continue
                        value = work(0)
                        do i = 1,n - 1
                           temp = work(i)
@@ -30972,7 +30972,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: ap(*)
            real(sp),intent(out) :: work(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,k
            real(sp) :: absa,scale,sum,value
@@ -31095,7 +31095,7 @@ module stdlib_linalg_lapack_s
            ! Array Arguments
            real(sp),intent(in) :: d(*),e(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(sp) :: anorm,scale,sum
@@ -31158,7 +31158,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: a(lda,*)
            real(sp),intent(out) :: work(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(sp) :: absa,scale,sum,value
@@ -31254,7 +31254,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: ab(ldab,*)
            real(sp),intent(out) :: work(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: udiag
            integer(ilp) :: i,j,l
@@ -31406,7 +31406,7 @@ module stdlib_linalg_lapack_s
                     sum = one
                     do j = 1,n
                        call stdlib_slassq(min(j,k + 1),ab(max(k + 2 - j,1),j),1,scale,sum)
-                                 
+
                     end do
                  end if
               else
@@ -31447,7 +31447,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: ap(*)
            real(sp),intent(out) :: work(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: udiag
            integer(ilp) :: i,j,k
@@ -31653,7 +31653,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: a(lda,*)
            real(sp),intent(out) :: work(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: udiag
            integer(ilp) :: i,j
@@ -31869,7 +31869,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: d(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: iinfo,j,jb,nb
            ! Intrinsic Functions
@@ -31901,7 +31901,7 @@ module stdlib_linalg_lapack_s
                  jb = min(min(m,n) - j + 1,nb)
                  ! factor diagonal and subdiagonal blocks.
                  call stdlib_slaorhr_col_getrfnp2(m - j + 1,jb,a(j,j),lda,d(j),iinfo)
-                           
+
                  if (j + jb <= n) then
                     ! compute block row of u.
                     call stdlib_strsm('LEFT','LOWER','NO TRANSPOSE','UNIT',jb,n - j - jb + 1,one, &
@@ -31910,7 +31910,7 @@ module stdlib_linalg_lapack_s
                        ! update trailing submatrix.
                        call stdlib_sgemm('NO TRANSPOSE','NO TRANSPOSE',m - j - jb + 1,n - j - jb + 1,jb,- &
                        one,a(j + jb,j),lda,a(j,j + jb),lda,one,a(j + jb,j + jb),lda)
-                                 
+
                     end if
                  end if
               end do
@@ -31928,7 +31928,7 @@ module stdlib_linalg_lapack_s
            ! Scalar Arguments
            real(sp),intent(in) :: x,y
         ! =====================================================================
-           
+
            ! Local Scalars
            real(sp) :: w,xabs,yabs,z,hugeval
            logical(lk) :: x_is_nan,y_is_nan
@@ -31969,7 +31969,7 @@ module stdlib_linalg_lapack_s
            integer(ilp),intent(in) :: lda,ldb
            real(sp),intent(in) :: a(lda,*),b(ldb,*),sr1,sr2,si,beta1,beta2
            real(sp),intent(out) :: v(*)
-           
+
            ! local scalars
            real(sp) :: w(2),safmin,safmax,scale1,scale2
            safmin = stdlib_slamch('SAFE MINIMUM')
@@ -32018,7 +32018,7 @@ module stdlib_linalg_lapack_s
            integer(ilp),intent(in) :: k,lda,ldb,ldq,ldz,istartm,istopm,nq,nz,qstart, &
                      zstart,ihi
            real(sp),intent(inout) :: a(lda,*),b(ldb,*),q(ldq,*),z(ldz,*)
-           
+
            ! local variables
            real(sp) :: h(2,3),c1,s1,c2,s2,temp
            if (k + 2 == ihi) then
@@ -32063,7 +32063,7 @@ module stdlib_linalg_lapack_s
               b(ihi,ihi) = temp
               b(ihi,ihi - 1) = zero
               call stdlib_srot(ihi - istartm,b(istartm,ihi),1,b(istartm,ihi - 1),1,c1,s1)
-                        
+
               call stdlib_srot(ihi - istartm + 1,a(istartm,ihi),1,a(istartm,ihi - 1),1,c1, &
                         s1)
               if (ilz) then
@@ -32084,18 +32084,18 @@ module stdlib_linalg_lapack_s
               call stdlib_slartg(h(1,2),h(1,1),c2,s2,temp)
               ! apply transformations from the right
               call stdlib_srot(k + 3 - istartm + 1,a(istartm,k + 2),1,a(istartm,k + 1),1,c1,s1)
-                        
+
               call stdlib_srot(k + 3 - istartm + 1,a(istartm,k + 1),1,a(istartm,k),1,c2,s2)
-                        
+
               call stdlib_srot(k + 2 - istartm + 1,b(istartm,k + 2),1,b(istartm,k + 1),1,c1,s1)
-                        
+
               call stdlib_srot(k + 2 - istartm + 1,b(istartm,k + 1),1,b(istartm,k),1,c2,s2)
-                        
+
               if (ilz) then
                  call stdlib_srot(nz,z(1,k + 2 - zstart + 1),1,z(1,k + 1 - zstart + 1),1,c1,s1)
-                           
+
                  call stdlib_srot(nz,z(1,k + 1 - zstart + 1),1,z(1,k - zstart + 1),1,c2,s2)
-                           
+
               end if
               b(k + 1,k) = zero
               b(k + 2,k) = zero
@@ -32113,9 +32113,9 @@ module stdlib_linalg_lapack_s
               call stdlib_srot(istopm - k,b(k + 1,k + 1),ldb,b(k + 2,k + 1),ldb,c2,s2)
               if (ilq) then
                  call stdlib_srot(nq,q(1,k + 2 - qstart + 1),1,q(1,k + 3 - qstart + 1),1,c1,s1)
-                           
+
                  call stdlib_srot(nq,q(1,k + 1 - qstart + 1),1,q(1,k + 2 - qstart + 1),1,c2,s2)
-                           
+
               end if
            end if
      end subroutine stdlib_slaqz2
@@ -32131,7 +32131,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*),b(ldb,*),q(ldq,*),z(ldz,*),qc( &
                      ldqc,*),zc(ldzc,*),work(*),sr(*),si(*),ss(*)
            integer(ilp),intent(out) :: info
-           
+
            ! local scalars
            integer(ilp) :: i,j,ns,istartm,istopm,sheight,swidth,k,np,istartb,istopb, &
                      ishift,nblock,npos
@@ -32225,11 +32225,11 @@ module stdlib_linalg_lapack_s
               call stdlib_sgemm('T','N',sheight,swidth,sheight,one,qc,ldqc,a(ilo,ilo + ns &
                         ),lda,zero,work,sheight)
               call stdlib_slacpy('ALL',sheight,swidth,work,sheight,a(ilo,ilo + ns),lda)
-                        
+
               call stdlib_sgemm('T','N',sheight,swidth,sheight,one,qc,ldqc,b(ilo,ilo + ns &
                         ),ldb,zero,work,sheight)
               call stdlib_slacpy('ALL',sheight,swidth,work,sheight,b(ilo,ilo + ns),ldb)
-                        
+
            end if
            if (ilq) then
               call stdlib_sgemm('N','N',n,sheight,sheight,one,q(1,ilo),ldq,qc,ldqc, &
@@ -32244,11 +32244,11 @@ module stdlib_linalg_lapack_s
               call stdlib_sgemm('N','N',sheight,swidth,swidth,one,a(istartm,ilo),lda, &
                         zc,ldzc,zero,work,sheight)
               call stdlib_slacpy('ALL',sheight,swidth,work,sheight,a(istartm,ilo),lda)
-                        
+
               call stdlib_sgemm('N','N',sheight,swidth,swidth,one,b(istartm,ilo),ldb, &
                         zc,ldzc,zero,work,sheight)
               call stdlib_slacpy('ALL',sheight,swidth,work,sheight,b(istartm,ilo),ldb)
-                        
+
            end if
            if (ilz) then
               call stdlib_sgemm('N','N',n,swidth,swidth,one,z(1,ilo),ldz,zc,ldzc, &
@@ -32308,11 +32308,11 @@ module stdlib_linalg_lapack_s
                  call stdlib_sgemm('N','N',sheight,swidth,swidth,one,a(istartm,k),lda, &
                            zc,ldzc,zero,work,sheight)
                  call stdlib_slacpy('ALL',sheight,swidth,work,sheight,a(istartm,k),lda)
-                           
+
                  call stdlib_sgemm('N','N',sheight,swidth,swidth,one,b(istartm,k),ldb, &
                            zc,ldzc,zero,work,sheight)
                  call stdlib_slacpy('ALL',sheight,swidth,work,sheight,b(istartm,k),ldb)
-                           
+
               end if
               if (ilz) then
                  call stdlib_sgemm('N','N',n,nblock,nblock,one,z(1,k),ldz,zc,ldzc, &
@@ -32411,7 +32411,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(out) :: work(*)
            real(sp),intent(inout) :: z(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: sawnan1,sawnan2
            integer(ilp) :: i,indlpl,indp,inds,indumn,neg1,neg2,r1,r2
@@ -32459,7 +32459,7 @@ module stdlib_linalg_lapack_s
               s = work(inds + i) - lambda
            end do
            sawnan1 = stdlib_sisnan(s)
-60         continue
+           60 continue
            if (sawnan1) then
               ! runs a slower version of the above loop if a nan is detected
               neg1 = 0
@@ -32544,7 +32544,7 @@ module stdlib_linalg_lapack_s
                  end if
                  ztz = ztz + z(i)*z(i)
               end do
-220           continue
+              220 continue
            else
               ! run slower loop if nan occurred.
               do i = r - 1,b1,-1
@@ -32560,7 +32560,7 @@ module stdlib_linalg_lapack_s
                  end if
                  ztz = ztz + z(i)*z(i)
               end do
-240           continue
+              240 continue
            end if
            ! compute the fp vector downwards from r in blocks of size blksiz
            if (.not. sawnan1 .and. .not. sawnan2) then
@@ -32573,7 +32573,7 @@ module stdlib_linalg_lapack_s
                  end if
                  ztz = ztz + z(i + 1)*z(i + 1)
               end do
-260           continue
+              260 continue
            else
               ! run slower loop if nan occurred.
               do i = r,bn - 1
@@ -32589,7 +32589,7 @@ module stdlib_linalg_lapack_s
                  end if
                  ztz = ztz + z(i + 1)*z(i + 1)
               end do
-280           continue
+              280 continue
            end if
            ! compute quantities for convergence test
            tmp = one/ztz
@@ -32624,7 +32624,7 @@ module stdlib_linalg_lapack_s
            ! Array Arguments
            real(sp),intent(inout) :: x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j,knt
            real(sp) :: beta,rsafmn,safmin,xnorm
@@ -32647,7 +32647,7 @@ module stdlib_linalg_lapack_s
               if (abs(beta) < safmin) then
                  ! xnorm, beta may be inaccurate; scale x and recompute them
                  rsafmn = one/safmin
-10               continue
+                 10 continue
                  knt = knt + 1
                  call stdlib_sscal(n - 1,rsafmn,x,incx)
                  beta = beta*rsafmn
@@ -32692,7 +32692,7 @@ module stdlib_linalg_lapack_s
            ! Array Arguments
            real(sp),intent(inout) :: x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j,knt
            real(sp) :: beta,bignum,savealpha,smlnum,xnorm
@@ -32728,7 +32728,7 @@ module stdlib_linalg_lapack_s
               if (abs(beta) < smlnum) then
                  ! xnorm, beta may be inaccurate; scale x and recompute them
                  bignum = one/smlnum
-10               continue
+                 10 continue
                  knt = knt + 1
                  call stdlib_sscal(n - 1,bignum,x,incx)
                  beta = beta*bignum
@@ -32792,7 +32792,7 @@ module stdlib_linalg_lapack_s
            ! Parameters
            integer(ilp),parameter :: lv = 128
            real(sp),parameter :: twopi = 6.28318530717958647692528676655900576839e+0_sp
-           
+
            ! Local Scalars
            integer(ilp) :: i,il,il2,iv
            ! Local Arrays
@@ -32826,7 +32826,7 @@ module stdlib_linalg_lapack_s
                     x(iv + i - 1) = sqrt(-two*log(u(2*i - 1)))*cos(twopi*u(2*i))
                  end do
               end if
-40            continue
+              40 continue
            return
      end subroutine stdlib_slarnv
 
@@ -32854,7 +32854,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: w(*),werr(*),wgap(*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            integer(ilp) :: maxitr
            ! Local Scalars
            integer(ilp) :: i,i1,ii,ip,iter,k,negcnt,next,nint,olnint,prev,r
@@ -32895,7 +32895,7 @@ module stdlib_linalg_lapack_s
               ! compute negcount from dstqds facto l+d+l+^t = l d l^t - left
               ! do while( negcnt(left)>i-1 )
               back = werr(ii)
-20            continue
+              20 continue
               negcnt = stdlib_slaneg(n,d,lld,left,pivmin,r)
               if (negcnt > i - 1) then
                  left = left - back
@@ -32905,7 +32905,7 @@ module stdlib_linalg_lapack_s
               ! do while( negcnt(right)<i )
               ! compute negcount from dstqds facto l+d+l+^t = l d l^t - right
               back = werr(ii)
-50            continue
+              50 continue
               negcnt = stdlib_slaneg(n,d,lld,right,pivmin,r)
                if (negcnt < i) then
                   right = right + back
@@ -32937,7 +32937,7 @@ module stdlib_linalg_lapack_s
            ! do while( nint>0 ), i.e. there are still unconverged intervals
            ! and while (iter<maxitr)
            iter = 0
-80         continue
+           80 continue
            prev = i1 - 1
            i = i1
            olnint = nint
@@ -33031,7 +33031,7 @@ module stdlib_linalg_lapack_s
            integer(ilp),parameter :: ktrymax = 1
            integer(ilp),parameter :: sleft = 1
            integer(ilp),parameter :: sright = 2
-           
+
            ! Local Scalars
            logical(lk) :: dorrr1,forcer,nofail,sawnan1,sawnan2,tryrrr1
            integer(ilp) :: i,indx,ktry,shift
@@ -33087,7 +33087,7 @@ module stdlib_linalg_lapack_s
            ! while (ktry <= ktrymax)
            ktry = 0
            growthbound = maxgrowth1*spdiam
-5          continue
+           5 continue
            sawnan1 = .false.
            sawnan2 = .false.
            ! ensure that we do not back off too much of the initial shifts
@@ -33229,7 +33229,7 @@ module stdlib_linalg_lapack_s
               end if
            end if
            end if
-50         continue
+           50 continue
            if (ktry < ktrymax) then
               ! if we are here, both shifts failed also the rrr test.
               ! back off to the outside
@@ -33252,7 +33252,7 @@ module stdlib_linalg_lapack_s
                  return
               end if
            end if
-100        continue
+           100 continue
            if (shift == sleft) then
            elseif (shift == sright) then
               ! store new l and d back into dplus, lplus
@@ -33286,7 +33286,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: maxitr = 10
-           
+
            ! Local Scalars
            logical(lk) :: eskip,needbs,stp2ii,tryrqc,usedbs,usedrq
            integer(ilp) :: done,i,ibegin,idone,iend,ii,iindc1,iindc2,iindr,iindwk,iinfo, &
@@ -33365,7 +33365,7 @@ module stdlib_linalg_lapack_s
               ! find the eigenvectors of the submatrix indexed ibegin
               ! through iend.
               wend = wbegin - 1
-15            continue
+              15 continue
               if (wend < m) then
                  if (iblock(wend + 1) == jblk) then
                     wend = wend + 1
@@ -33433,7 +33433,7 @@ module stdlib_linalg_lapack_s
               ! loop while( idone<im )
               ! generate the representation tree for the current block and
               ! compute the eigenvectors
-40   continue
+              40 continue
               if (idone < im) then
                  ! this is a crude protection against infinitely deep trees
                  if (ndepth > m) then
@@ -33521,7 +33521,7 @@ module stdlib_linalg_lapack_s
                        if (oldfst > 1) then
                           wgap(wbegin + oldfst - 2) = max(wgap(wbegin + oldfst - 2),w(wbegin + oldfst - 1) - &
                           werr(wbegin + oldfst - 1) - w(wbegin + oldfst - 2) - werr(wbegin + oldfst - 2))
-                                    
+
                        end if
                        if (wbegin + oldlst - 1 < wend) then
                           wgap(wbegin + oldlst - 1) = max(wgap(wbegin + oldlst - 1),w(wbegin + oldlst) - &
@@ -33722,7 +33722,7 @@ module stdlib_linalg_lapack_s
                           usedrq = .false.
                           ! bisection is initially turned off unless it is forced
                           needbs = .not. tryrqc
-120                       continue
+                          120 continue
                           ! check if bisection should be used to refine eigenvalue
                           if (needbs) then
                              ! take the bisection as new iterate
@@ -33856,7 +33856,7 @@ module stdlib_linalg_lapack_s
                              end do
                           end if
                           call stdlib_sscal(zto - zfrom + 1,nrminv,z(zfrom,windex),1)
-125                       continue
+                          125 continue
                           ! update w
                           w(windex) = lambda + sigma
                           ! recompute the gaps on the left and right
@@ -33878,7 +33878,7 @@ module stdlib_linalg_lapack_s
                           idone = idone + 1
                        end if
                        ! here ends the code for the current child
-139  continue
+                       139 continue
                        ! proceed to any remaining child nodes
                        newfst = j + 1
                     end do loop_140
@@ -33910,7 +33910,7 @@ module stdlib_linalg_lapack_s
            ! Array Arguments
            real(sp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: done
            integer(ilp) :: i,itype,j,k1,k2,k3,k4
@@ -33971,7 +33971,7 @@ module stdlib_linalg_lapack_s
            bignum = one/smlnum
            cfromc = cfrom
            ctoc = cto
-10         continue
+           10 continue
            cfrom1 = cfromc*smlnum
            if (cfrom1 == cfromc) then
               ! cfromc is an inf.  multiply by a correctly signed zero for
@@ -34089,7 +34089,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: maxit = 400
-           
+
            ! Local Scalars
            logical(lk) :: orgati,swtch,swtch3,geomavg
            integer(ilp) :: ii,iim1,iip1,ip1,iter,j,niter
@@ -34785,7 +34785,7 @@ module stdlib_linalg_lapack_s
               ! return with info = 1, niter = maxit and not converged
               info = 1
            end if
-240        continue
+           240 continue
            return
      end subroutine stdlib_slasd4
 
@@ -34799,7 +34799,7 @@ module stdlib_linalg_lapack_s
 
      pure subroutine stdlib_slasd7(icompq,nl,nr,sqre,k,d,z,zw,vf,vfw,vl,vlw,alpha, &
      beta,dsigma,idx,idxp,idxq,perm,givptr,givcol,ldgcol,givnum,ldgnum,c,s,info)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -34813,9 +34813,9 @@ module stdlib_linalg_lapack_s
            integer(ilp),intent(inout) :: idxq(*)
            real(sp),intent(inout) :: d(*),vf(*),vl(*)
            real(sp),intent(out) :: dsigma(*),givnum(ldgnum,*),vfw(*),vlw(*),z(*),zw(*)
-                     
+
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,idxi,idxj,idxjp,j,jp,jprev,k2,m,n,nlp1,nlp2
            real(sp) :: eps,hlftol,tau,tol,z1
@@ -34917,9 +34917,9 @@ module stdlib_linalg_lapack_s
                  go to 70
               end if
            end do
-70         continue
+           70 continue
            j = jprev
-80         continue
+           80 continue
            j = j + 1
            if (j > n) go to 90
            if (abs(z(j)) <= tol) then
@@ -34969,13 +34969,13 @@ module stdlib_linalg_lapack_s
               end if
            end if
            go to 80
-90         continue
+           90 continue
            ! record the last singular value.
            k = k + 1
            zw(k) = z(jprev)
            dsigma(k) = d(jprev)
            idxp(k) = jprev
-100        continue
+           100 continue
            ! sort the singular values into dsigma. the singular values which
            ! were not deflated go into the first k slots of dsigma, except
            ! that dsigma(1) is treated separately.
@@ -35048,7 +35048,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(out) :: d(*),difl(*),difr(lddifr,*),work(*)
            real(sp),intent(inout) :: dsigma(*),vf(*),vl(*),z(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,iwk1,iwk2,iwk2i,iwk3,iwk3i,j
            real(sp) :: diflj,difrj,dj,dsigj,dsigjp,rho,temp
@@ -35113,7 +35113,7 @@ module stdlib_linalg_lapack_s
            ! and the updated z.
            do j = 1,k
               call stdlib_slasd4(k,j,dsigma,z,work(iwk1),rho,d(j),work(iwk2),info)
-                        
+
               ! if the root finder fails, report the convergence failure.
               if (info /= 0) then
                  return
@@ -35186,7 +35186,7 @@ module stdlib_linalg_lapack_s
            real(sp),parameter :: cbias = 1.50_sp
            real(sp),parameter :: qurtr = 0.250_sp
            real(sp),parameter :: hundrd = 100.0_sp
-           
+
            ! Local Scalars
            integer(ilp) :: ipn4,j4,n0in,nn
            integer(ilp),intent(inout) :: ttype
@@ -35199,7 +35199,7 @@ module stdlib_linalg_lapack_s
            tol = eps*hundrd
            tol2 = tol**2
            ! check for deflation.
-10   continue
+           10 continue
            if (n0 < i0) return
            if (n0 == i0) go to 20
            nn = 4*n0 + pp
@@ -35207,14 +35207,14 @@ module stdlib_linalg_lapack_s
            ! check whether e(n0-1) is negligible, 1 eigenvalue.
            if (z(nn - 5) > tol2*(sigma + z(nn - 3)) .and. z(nn - 2*pp - 4) > tol2*z(nn - 7)) go to &
                      30
-20         continue
+                     20 continue
            z(4*n0 - 3) = z(4*n0 + pp - 3) + sigma
            n0 = n0 - 1
            go to 10
            ! check  whether e(n0-2) is negligible, 2 eigenvalues.
-30   continue
+           30 continue
            if (z(nn - 9) > tol2*sigma .and. z(nn - 2*pp - 8) > tol2*z(nn - 11)) go to 50
-40         continue
+           40 continue
            if (z(nn - 3) > z(nn - 7)) then
               s = z(nn - 3)
               z(nn - 3) = z(nn - 7)
@@ -35236,7 +35236,7 @@ module stdlib_linalg_lapack_s
            z(4*n0 - 3) = z(nn - 3) + sigma
            n0 = n0 - 2
            go to 10
-50         continue
+           50 continue
            if (pp == 2) pp = 0
            ! reverse the qd-array, if warranted.
            if (dmin <= zero .or. n0 < n0in) then
@@ -35271,7 +35271,7 @@ module stdlib_linalg_lapack_s
            call stdlib_slasq4(i0,n0,z,pp,n0in,dmin,dmin1,dmin2,dn,dn1,dn2,tau,ttype, &
                      g)
            ! call dqds until dmin > 0.
-70   continue
+           70 continue
            call stdlib_slasq5(i0,n0,z,pp,tau,sigma,dmin,dmin1,dmin2,dn,dn1,dn2,ieee, &
                      eps)
            ndiv = ndiv + (n0 - i0 + 2)
@@ -35315,12 +35315,12 @@ module stdlib_linalg_lapack_s
               go to 80
            end if
            ! risk of underflow.
-80   continue
+           80 continue
            call stdlib_slasq6(i0,n0,z,pp,dmin,dmin1,dmin2,dn,dn1,dn2)
            ndiv = ndiv + (n0 - i0 + 2)
            iter = iter + 1
            tau = zero
-90         continue
+           90 continue
            if (tau < sigma) then
               desig = desig + tau
               t = sigma + desig
@@ -35355,7 +35355,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: maxdim = 8
-           
+
            ! Local Scalars
            integer(ilp) :: i,info,j,k
            real(sp) :: bm,bp,pmone,sminu,splus,temp
@@ -35463,7 +35463,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: e(*),tau(*),w(ldw,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,iw
            real(sp) :: alpha
@@ -35504,7 +35504,7 @@ module stdlib_linalg_lapack_s
                     end if
                     call stdlib_sscal(i - 1,tau(i - 1),w(1,iw),1)
                     alpha = -half*tau(i - 1)*stdlib_sdot(i - 1,w(1,iw),1,a(1,i),1)
-                              
+
                     call stdlib_saxpy(i - 1,alpha,a(1,i),1,w(1,iw),1)
                  end if
               end do loop_10
@@ -35520,7 +35520,7 @@ module stdlib_linalg_lapack_s
                     ! generate elementary reflector h(i) to annihilate
                     ! a(i+2:n,i)
                     call stdlib_slarfg(n - i,a(i + 1,i),a(min(i + 2,n),i),1,tau(i))
-                              
+
                     e(i) = a(i + 1,i)
                     a(i + 1,i) = one
                     ! compute w(i+1:n,i)
@@ -35536,7 +35536,7 @@ module stdlib_linalg_lapack_s
                                1,one,w(i + 1,i),1)
                     call stdlib_sscal(n - i,tau(i),w(i + 1,i),1)
                     alpha = -half*tau(i)*stdlib_sdot(n - i,w(i + 1,i),1,a(i + 1,i),1)
-                              
+
                     call stdlib_saxpy(n - i,alpha,a(i + 1,i),1,w(i + 1,i),1)
                  end if
               end do
@@ -35559,7 +35559,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            ! Executable Statements
@@ -35614,11 +35614,11 @@ module stdlib_linalg_lapack_s
            real(sp),intent(out) :: phi(*),theta(*)
            real(sp),intent(out) :: taup1(*),taup2(*),tauq1(*),tauq2(*),work(*)
            real(sp),intent(inout) :: x11(ldx11,*),x12(ldx12,*),x21(ldx21,*),x22(ldx22,*)
-                     
+
         ! ====================================================================
            ! Parameters
            real(sp),parameter :: realone = 1.0_sp
-           
+
            ! Local Scalars
            logical(lk) :: colmajor,lquery
            integer(ilp) :: i,lworkmin,lworkopt
@@ -35688,7 +35688,7 @@ module stdlib_linalg_lapack_s
                  else
                     call stdlib_sscal(p - i + 1,z1*cos(phi(i - 1)),x11(i,i),1)
                     call stdlib_saxpy(p - i + 1,-z1*z3*z4*sin(phi(i - 1)),x12(i,i - 1),1,x11(i,i),1)
-                              
+
                  end if
                  if (i == 1) then
                     call stdlib_sscal(m - p - i + 1,z2,x21(i,i),1)
@@ -35750,7 +35750,7 @@ module stdlib_linalg_lapack_s
                        call stdlib_slarfgp(m - q - i + 1,x12(i,i),x12(i,i),ldx12,tauq2(i))
                     else
                        call stdlib_slarfgp(m - q - i + 1,x12(i,i),x12(i,i + 1),ldx12,tauq2(i))
-                                 
+
                     end if
                  end if
                  x12(i,i) = one
@@ -35790,7 +35790,7 @@ module stdlib_linalg_lapack_s
                  call stdlib_sscal(m - p - q - i + 1,z2*z4,x22(q + i,p + i),ldx22)
                  if (i == m - p - q) then
                     call stdlib_slarfgp(m - p - q - i + 1,x22(q + i,p + i),x22(q + i,p + i),ldx22,tauq2(p + i))
-                              
+
                  else
                     call stdlib_slarfgp(m - p - q - i + 1,x22(q + i,p + i),x22(q + i,p + i + 1),ldx22,tauq2(p + i) &
                                )
@@ -35847,11 +35847,11 @@ module stdlib_linalg_lapack_s
                  if (i < q) then
                     call stdlib_sscal(q - i,-z1*z3*sin(theta(i)),x11(i + 1,i),1)
                     call stdlib_saxpy(q - i,z2*z3*cos(theta(i)),x21(i + 1,i),1,x11(i + 1,i),1)
-                              
+
                  end if
                  call stdlib_sscal(m - q - i + 1,-z1*z4*sin(theta(i)),x12(i,i),1)
                  call stdlib_saxpy(m - q - i + 1,z2*z4*cos(theta(i)),x22(i,i),1,x12(i,i),1)
-                           
+
                  if (i < q) phi(i) = atan2(stdlib_snrm2(q - i,x11(i + 1,i),1),stdlib_snrm2(m - q - &
                            i + 1,x12(i,i),1))
                  if (i < q) then
@@ -35898,11 +35898,11 @@ module stdlib_linalg_lapack_s
                  call stdlib_sscal(m - p - q - i + 1,z2*z4,x22(p + i,q + i),1)
                  if (m - p - q == i) then
                     call stdlib_slarfgp(m - p - q - i + 1,x22(p + i,q + i),x22(p + i,q + i),1,tauq2(p + i))
-                              
+
                     x22(p + i,q + i) = one
                  else
                     call stdlib_slarfgp(m - p - q - i + 1,x22(p + i,q + i),x22(p + i + 1,q + i),1,tauq2(p + i))
-                              
+
                     x22(p + i,q + i) = one
                     call stdlib_slarf('L',m - p - q - i + 1,m - p - q - i,x22(p + i,q + i),1,tauq2(p + i),x22(p + &
                               i,q + i + 1),ldx22,work)
@@ -35937,7 +35937,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(out) :: work(*)
            real(sp),intent(inout) :: x1(*),x2(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: childinfo,i,j
            ! Intrinsic Function
@@ -36040,11 +36040,11 @@ module stdlib_linalg_lapack_s
            integer(ilp),intent(out) :: iwork(*)
            real(sp),intent(out) :: theta(*)
            real(sp),intent(out) :: u1(ldu1,*),u2(ldu2,*),v1t(ldv1t,*),v2t(ldv2t,*),work(*)
-                     
+
            real(sp),intent(inout) :: x11(ldx11,*),x12(ldx12,*),x21(ldx21,*),x22(ldx22,*)
-                     
+
         ! ===================================================================
-           
+
            ! Local Arrays
            real(sp) :: dummy(1)
            ! Local Scalars
@@ -36137,12 +36137,12 @@ module stdlib_linalg_lapack_s
               itauq2 = itauq1 + max(1,q)
               iorgqr = itauq2 + max(1,m - q)
               call stdlib_sorgqr(m - q,m - q,m - q,dummy,max(1,m - q),dummy,work,-1,childinfo)
-                        
+
               lorgqrworkopt = int(work(1),KIND=ilp)
               lorgqrworkmin = max(1,m - q)
               iorglq = itauq2 + max(1,m - q)
               call stdlib_sorglq(m - q,m - q,m - q,dummy,max(1,m - q),dummy,work,-1,childinfo)
-                        
+
               lorglqworkopt = int(work(1),KIND=ilp)
               lorglqworkmin = max(1,m - q)
               iorbdb = itauq2 + max(1,m - q)
@@ -36214,7 +36214,7 @@ module stdlib_linalg_lapack_s
               if (wantv2t .and. m - q > 0) then
                  call stdlib_slacpy('U',p,m - q,x12,ldx12,v2t,ldv2t)
                  call stdlib_slacpy('U',m - p - q,m - p - q,x22(q + 1,p + 1),ldx22,v2t(p + 1,p + 1),ldv2t)
-                           
+
                  call stdlib_sorglq(m - q,m - q,m - q,v2t,ldv2t,work(itauq2),work(iorglq), &
                            lorglqwork,info)
               end if
@@ -36242,7 +36242,7 @@ module stdlib_linalg_lapack_s
               if (wantv2t .and. m - q > 0) then
                  call stdlib_slacpy('L',m - q,p,x12,ldx12,v2t,ldv2t)
                  call stdlib_slacpy('L',m - p - q,m - p - q,x22(p + 1,q + 1),ldx22,v2t(p + 1,p + 1),ldv2t)
-                           
+
                  call stdlib_sorgqr(m - q,m - q,m - q,v2t,ldv2t,work(itauq2),work(iorgqr), &
                            lorgqrwork,info)
               end if
@@ -36303,7 +36303,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: tau(*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,iinfo,j,lwkopt,nb,nh
@@ -36397,7 +36397,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: d(*),t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,iinfo,j,jb,jbtemp1,jbtemp2,jnb,nplusone
            ! Intrinsic Functions
@@ -36437,7 +36437,7 @@ module stdlib_linalg_lapack_s
            ! (1-2) solve for v2.
            if (m > n) then
               call stdlib_strsm('R','U','N','N',m - n,n,one,a,lda,a(n + 1,1),lda)
-                        
+
            end if
            ! (2) reconstruct the block reflector t stored in t(1:nb, 1:n)
            ! as a sequence of upper-triangular blocks with nb-size column
@@ -36619,7 +36619,7 @@ module stdlib_linalg_lapack_s
      !> condition number is computed as RCOND = 1 / (ANORM * norm(inv(A))).
 
      pure subroutine stdlib_spbcon(uplo,n,kd,ab,ldab,anorm,rcond,work,iwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -36634,7 +36634,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: ab(ldab,*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            character :: normin
@@ -36675,7 +36675,7 @@ module stdlib_linalg_lapack_s
            ! estimate the 1-norm of the inverse.
            kase = 0
            normin = 'N'
-10         continue
+           10 continue
            call stdlib_slacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               if (upper) then
@@ -36706,7 +36706,7 @@ module stdlib_linalg_lapack_s
            end if
            ! compute the estimate of the reciprocal condition number.
            if (ainvnm /= zero) rcond = (one/ainvnm)/anorm
-20         continue
+           20 continue
            return
      end subroutine stdlib_spbcon
 
@@ -36732,7 +36732,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,j,k,kase,l,nz
@@ -36784,12 +36784,12 @@ module stdlib_linalg_lapack_s
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_scopy(n,b(1,j),1,work(n + 1),1)
               call stdlib_ssbmv(uplo,n,kd,-one,ab,ldab,x(1,j),1,one,work(n + 1),1)
-                        
+
               ! compute componentwise relative backward error from formula
               ! max(i) ( abs(r(i)) / ( abs(a)*abs(x) + abs(b) )(i) )
               ! where abs(z) is the componentwise absolute value of the matrix
@@ -36871,9 +36871,9 @@ module stdlib_linalg_lapack_s
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_slacn2(n,work(2*n + 1),work(n + 1),iwork,ferr(j),kase,isave)
-                        
+
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(a**t).
@@ -36916,7 +36916,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: a(0:*)
            real(sp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,normaltransr
            ! Intrinsic Functions
@@ -36975,7 +36975,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            character :: normin
@@ -37014,7 +37014,7 @@ module stdlib_linalg_lapack_s
            ! estimate the 1-norm of inv(a).
            kase = 0
            normin = 'N'
-10         continue
+           10 continue
            call stdlib_slacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               if (upper) then
@@ -37045,7 +37045,7 @@ module stdlib_linalg_lapack_s
            end if
            ! compute the estimate of the reciprocal condition number.
            if (ainvnm /= zero) rcond = (one/ainvnm)/anorm
-20         continue
+           20 continue
            return
      end subroutine stdlib_spocon
 
@@ -37071,7 +37071,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,j,k,kase,nz
@@ -37121,7 +37121,7 @@ module stdlib_linalg_lapack_s
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_scopy(n,b(1,j),1,work(n + 1),1)
@@ -37205,9 +37205,9 @@ module stdlib_linalg_lapack_s
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_slacn2(n,work(2*n + 1),work(n + 1),iwork,ferr(j),kase,isave)
-                        
+
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(a**t).
@@ -37253,7 +37253,7 @@ module stdlib_linalg_lapack_s
            ! Array Arguments
            real(sp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j
@@ -37315,9 +37315,9 @@ module stdlib_linalg_lapack_s
               end do
            end if
            go to 40
-30         continue
+           30 continue
            info = j
-40         continue
+           40 continue
            return
      end subroutine stdlib_spotf2
 
@@ -37346,7 +37346,7 @@ module stdlib_linalg_lapack_s
            ! Array Arguments
            real(sp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: n1,n2,iinfo
@@ -37482,7 +37482,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: ap(*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            character :: normin
@@ -37519,7 +37519,7 @@ module stdlib_linalg_lapack_s
            ! estimate the 1-norm of the inverse.
            kase = 0
            normin = 'N'
-10         continue
+           10 continue
            call stdlib_slacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               if (upper) then
@@ -37550,7 +37550,7 @@ module stdlib_linalg_lapack_s
            end if
            ! compute the estimate of the reciprocal condition number.
            if (ainvnm /= zero) rcond = (one/ainvnm)/anorm
-20         continue
+           20 continue
            return
      end subroutine stdlib_sppcon
 
@@ -37576,7 +37576,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,ik,j,k,kase,kk,nz
@@ -37622,7 +37622,7 @@ module stdlib_linalg_lapack_s
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_scopy(n,b(1,j),1,work(n + 1),1)
@@ -37713,9 +37713,9 @@ module stdlib_linalg_lapack_s
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_slacn2(n,work(2*n + 1),work(n + 1),iwork,ferr(j),kase,isave)
-                        
+
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(a**t).
@@ -37815,7 +37815,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: afp(*),ap(*),b(ldb,*),s(*)
            real(sp),intent(out) :: berr(*),ferr(*),work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: equil,nofact,rcequ
            integer(ilp) :: i,infequ,j
@@ -37945,7 +37945,7 @@ module stdlib_linalg_lapack_s
            ! Array Arguments
            real(sp),intent(inout) :: ap(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,jc,jj,jjn
@@ -38016,7 +38016,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(out) :: work(2*n)
            integer(ilp),intent(out) :: piv(n)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(sp) :: ajj,sstop,stemp
            integer(ilp) :: i,itemp,j,pvt
@@ -38094,7 +38094,7 @@ module stdlib_linalg_lapack_s
                     a(pvt,pvt) = a(j,j)
                     call stdlib_sswap(j - 1,a(1,j),1,a(1,pvt),1)
                     if (pvt < n) call stdlib_sswap(n - pvt,a(j,pvt + 1),lda,a(pvt,pvt + 1),lda)
-                              
+
                     call stdlib_sswap(pvt - j - 1,a(j,j + 1),lda,a(j + 1,pvt),1)
                     ! swap dot products and piv
                     stemp = work(j)
@@ -38139,7 +38139,7 @@ module stdlib_linalg_lapack_s
                     a(pvt,pvt) = a(j,j)
                     call stdlib_sswap(j - 1,a(j,1),lda,a(pvt,1),lda)
                     if (pvt < n) call stdlib_sswap(n - pvt,a(pvt + 1,j),1,a(pvt + 1,pvt),1)
-                              
+
                     call stdlib_sswap(pvt - j - 1,a(j + 1,j),1,a(pvt,j + 1),lda)
                     ! swap dot products and piv
                     stemp = work(j)
@@ -38162,12 +38162,12 @@ module stdlib_linalg_lapack_s
            ! ran to completion, a has full rank
            rank = n
            go to 170
-160        continue
+           160 continue
            ! rank is number of steps completed.  set info = 1 to signal
            ! that the factorization cannot be used to solve a system.
            rank = j - 1
            info = 1
-170        continue
+           170 continue
            return
      end subroutine stdlib_spstf2
 
@@ -38195,7 +38195,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(out) :: work(2*n)
            integer(ilp),intent(out) :: piv(n)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(sp) :: ajj,sstop,stemp
            integer(ilp) :: i,itemp,j,jb,k,nb,pvt
@@ -38373,12 +38373,12 @@ module stdlib_linalg_lapack_s
            ! ran to completion, a has full rank
            rank = n
            go to 200
-190        continue
+           190 continue
            ! rank is the number of steps completed.  set info = 1 to signal
            ! that the factorization cannot be used to solve a system.
            rank = j - 1
            info = 1
-200        continue
+           200 continue
            return
      end subroutine stdlib_spstrf
 
@@ -38453,7 +38453,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: v(*),tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,j1,j2,lm,ln,vpos,taupos,dpos,ofdpos,ajeter
@@ -38542,7 +38542,7 @@ module stdlib_linalg_lapack_s
                        a(ofdpos + i,st - 1) = zero
                    end do
                    call stdlib_slarfg(lm,a(ofdpos,st - 1),v(vpos + 1),1,tau(taupos))
-                             
+
                    lm = ed - st + 1
                    call stdlib_slarfy(uplo,lm,v(vpos),1, (tau(taupos)),a(dpos,st), &
                              lda - 1,work)
@@ -38573,7 +38573,7 @@ module stdlib_linalg_lapack_s
                            a(dpos + nb + i,st) = zero
                        end do
                        call stdlib_slarfg(lm,a(dpos + nb,st),v(vpos + 1),1,tau(taupos))
-                                 
+
                        call stdlib_slarfx('LEFT',lm,ln - 1,v(vpos), (tau(taupos)),a(dpos + &
                                  nb - 1,st + 1),lda - 1,work)
                    end if
@@ -38604,7 +38604,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: ap(*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,ip,kase
@@ -38652,7 +38652,7 @@ module stdlib_linalg_lapack_s
            end if
            ! estimate the 1-norm of the inverse.
            kase = 0
-30         continue
+           30 continue
            call stdlib_slacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               ! multiply by inv(l*d*l**t) or inv(u*d*u**t).
@@ -38687,7 +38687,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,ik,j,k,kase,kk,nz
@@ -38733,7 +38733,7 @@ module stdlib_linalg_lapack_s
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_scopy(n,b(1,j),1,work(n + 1),1)
@@ -38824,9 +38824,9 @@ module stdlib_linalg_lapack_s
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_slacn2(n,work(2*n + 1),work(n + 1),iwork,ferr(j),kase,isave)
-                        
+
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(a**t).
@@ -38928,7 +38928,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: ap(*),b(ldb,*)
            real(sp),intent(out) :: berr(*),ferr(*),work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nofact
            real(sp) :: anorm
@@ -38998,7 +38998,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: ap(*)
            real(sp),intent(out) :: d(*),e(*),tau(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,i1,i1i1,ii
@@ -39067,7 +39067,7 @@ module stdlib_linalg_lapack_s
                     ! apply the transformation as a rank-2 update:
                        ! a := a - v * w**t - w * v**t
                     call stdlib_sspr2(uplo,n - i,-one,ap(ii + 1),1,tau(i),1,ap(i1i1))
-                              
+
                     ap(ii + 1) = e(i)
                  end if
                  d(i) = ap(ii)
@@ -39104,7 +39104,7 @@ module stdlib_linalg_lapack_s
            real(sp),parameter :: odm1 = 1.0e-1_sp
            integer(ilp),parameter :: maxits = 5
            integer(ilp),parameter :: extra = 2
-           
+
            ! Local Scalars
            integer(ilp) :: b1,blksiz,bn,gpind,i,iinfo,indrv1,indrv2,indrv3,indrv4, &
                      indrv5,its,j,j1,jblk,jmax,nblk,nrmchk
@@ -39137,7 +39137,7 @@ module stdlib_linalg_lapack_s
                     go to 30
                  end if
               end do
-30            continue
+              30 continue
            end if
            if (info /= 0) then
               call stdlib_xerbla('SSTEIN',-info)
@@ -39184,7 +39184,7 @@ module stdlib_linalg_lapack_s
               ortol = odm3*onenrm
               stpcrt = sqrt(odm1/blksiz)
               ! loop through eigenvalues of block nblk.
-60   continue
+              60 continue
               jblk = 0
               loop_150: do j = j1,m
                  if (iblock(j) /= nblk) then
@@ -39219,7 +39219,7 @@ module stdlib_linalg_lapack_s
                  call stdlib_slagtf(blksiz,work(indrv4 + 1),xj,work(indrv2 + 2),work(indrv3 + &
                            1),tol,work(indrv5 + 1),iwork,iinfo)
                  ! update iteration count.
-70   continue
+                 70 continue
                  its = its + 1
                  if (its > maxits) go to 100
                  ! normalize and scale the righthand side vector pb.
@@ -39241,7 +39241,7 @@ module stdlib_linalg_lapack_s
                     end do
                  end if
                  ! check the infinity norm of the iterate.
-90   continue
+                 90 continue
                  jmax = stdlib_isamax(blksiz,work(indrv1 + 1),1)
                  nrm = abs(work(indrv1 + jmax))
                  ! continue for additional iterations after norm reaches
@@ -39252,16 +39252,16 @@ module stdlib_linalg_lapack_s
                  go to 110
                  ! if stopping criterion was not satisfied, update info and
                  ! store eigenvector number in array ifail.
-100  continue
+                 100 continue
                  info = info + 1
                  ifail(info) = j
                  ! accept iterate as jth eigenvector.
-110  continue
+                 110 continue
                  scl = one/stdlib_snrm2(blksiz,work(indrv1 + 1),1)
                  jmax = stdlib_isamax(blksiz,work(indrv1 + 1),1)
                  if (work(indrv1 + jmax) < zero) scl = -scl
                  call stdlib_sscal(blksiz,scl,work(indrv1 + 1),1)
-120              continue
+                 120 continue
                  do i = 1,n
                     z(i,j) = zero
                  end do
@@ -39296,7 +39296,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: maxit = 30
-           
+
            ! Local Scalars
            integer(ilp) :: i,icompz,ii,iscale,j,jtot,k,l,l1,lend,lendm1,lendp1,lendsv, &
                       lm1,lsv,m,mm,mm1,nm1,nmaxit
@@ -39350,7 +39350,7 @@ module stdlib_linalg_lapack_s
            ! element is smaller.
            l1 = 1
            nm1 = n - 1
-10         continue
+           10 continue
            if (l1 > n) go to 160
            if (l1 > 1) e(l1 - 1) = zero
            if (l1 <= nm1) then
@@ -39364,7 +39364,7 @@ module stdlib_linalg_lapack_s
               end do
            end if
            m = n
-30         continue
+           30 continue
            l = l1
            lsv = l
            lend = m
@@ -39392,7 +39392,7 @@ module stdlib_linalg_lapack_s
            if (lend > l) then
               ! ql iteration
               ! look for small subdiagonal element.
-40   continue
+              40 continue
               if (l /= lend) then
                  lendm1 = lend - 1
                  do m = l,lendm1
@@ -39401,7 +39401,7 @@ module stdlib_linalg_lapack_s
                  end do
               end if
               m = lend
-60            continue
+              60 continue
               if (m < lend) e(m) = zero
               p = d(l)
               if (m == l) go to 80
@@ -39461,7 +39461,7 @@ module stdlib_linalg_lapack_s
               e(l) = g
               go to 40
               ! eigenvalue found.
-80   continue
+              80 continue
               d(l) = p
               l = l + 1
               if (l <= lend) go to 40
@@ -39469,7 +39469,7 @@ module stdlib_linalg_lapack_s
            else
               ! qr iteration
               ! look for small superdiagonal element.
-90   continue
+              90 continue
               if (l /= lend) then
                  lendp1 = lend + 1
                  do m = l,lendp1,-1
@@ -39478,7 +39478,7 @@ module stdlib_linalg_lapack_s
                  end do
               end if
               m = lend
-110           continue
+              110 continue
               if (m > lend) e(m - 1) = zero
               p = d(l)
               if (m == l) go to 130
@@ -39538,24 +39538,24 @@ module stdlib_linalg_lapack_s
               e(lm1) = g
               go to 90
               ! eigenvalue found.
-130  continue
+              130 continue
               d(l) = p
               l = l - 1
               if (l >= lend) go to 90
               go to 140
            end if
            ! undo scaling if necessary
-140  continue
+           140 continue
            if (iscale == 1) then
               call stdlib_slascl('G',0,0,ssfmax,anorm,lendsv - lsv + 1,1,d(lsv),n,info)
-                        
+
               call stdlib_slascl('G',0,0,ssfmax,anorm,lendsv - lsv,1,e(lsv),n,info)
-                        
+
            else if (iscale == 2) then
               call stdlib_slascl('G',0,0,ssfmin,anorm,lendsv - lsv + 1,1,d(lsv),n,info)
-                        
+
               call stdlib_slascl('G',0,0,ssfmin,anorm,lendsv - lsv,1,e(lsv),n,info)
-                        
+
            end if
            ! check for no convergence to an eigenvalue after a total
            ! of n*maxit iterations.
@@ -39565,7 +39565,7 @@ module stdlib_linalg_lapack_s
            end do
            go to 190
            ! order eigenvalues and eigenvectors.
-160  continue
+           160 continue
            if (icompz == 0) then
               ! use quick sort
               call stdlib_slasrt('I',n,d,info)
@@ -39588,7 +39588,7 @@ module stdlib_linalg_lapack_s
                  end if
               end do
            end if
-190        continue
+           190 continue
            return
      end subroutine stdlib_ssteqr
 
@@ -39607,7 +39607,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: maxit = 30
-           
+
            ! Local Scalars
            integer(ilp) :: i,iscale,jtot,l,l1,lend,lendsv,lsv,m,nmaxit
            real(sp) :: alpha,anorm,bb,c,eps,eps2,gamma,oldc,oldgam,p,r,rt1,rt2,rte, &
@@ -39639,7 +39639,7 @@ module stdlib_linalg_lapack_s
            ! for each block, according to whether top or bottom diagonal
            ! element is smaller.
            l1 = 1
-10         continue
+           10 continue
            if (l1 > n) go to 170
            if (l1 > 1) e(l1 - 1) = zero
            do m = l1,n - 1
@@ -39650,7 +39650,7 @@ module stdlib_linalg_lapack_s
               end if
            end do
            m = n
-30         continue
+           30 continue
            l = l1
            lsv = l
            lend = m
@@ -39681,14 +39681,14 @@ module stdlib_linalg_lapack_s
            if (lend >= l) then
               ! ql iteration
               ! look for small subdiagonal element.
-50   continue
+              50 continue
               if (l /= lend) then
                  do m = l,lend - 1
                     if (abs(e(m)) <= eps2*abs(d(m)*d(m + 1))) go to 70
                  end do
               end if
               m = lend
-70            continue
+              70 continue
               if (m < lend) e(m) = zero
               p = d(l)
               if (m == l) go to 90
@@ -39737,7 +39737,7 @@ module stdlib_linalg_lapack_s
               d(l) = sigma + gamma
               go to 50
               ! eigenvalue found.
-90   continue
+              90 continue
               d(l) = p
               l = l + 1
               if (l <= lend) go to 50
@@ -39745,12 +39745,12 @@ module stdlib_linalg_lapack_s
            else
               ! qr iteration
               ! look for small superdiagonal element.
-100  continue
+              100 continue
               do m = l,lend + 1,-1
                  if (abs(e(m - 1)) <= eps2*abs(d(m)*d(m - 1))) go to 120
               end do
               m = lend
-120           continue
+              120 continue
               if (m > lend) e(m - 1) = zero
               p = d(l)
               if (m == l) go to 140
@@ -39799,14 +39799,14 @@ module stdlib_linalg_lapack_s
               d(l) = sigma + gamma
               go to 100
               ! eigenvalue found.
-140  continue
+              140 continue
               d(l) = p
               l = l - 1
               if (l >= lend) go to 100
               go to 150
            end if
            ! undo scaling if necessary
-150  continue
+           150 continue
            if (iscale == 1) call stdlib_slascl('G',0,0,ssfmax,anorm,lendsv - lsv + 1,1,d(lsv), &
                      n,info)
            if (iscale == 2) call stdlib_slascl('G',0,0,ssfmin,anorm,lendsv - lsv + 1,1,d(lsv), &
@@ -39819,9 +39819,9 @@ module stdlib_linalg_lapack_s
            end do
            go to 180
            ! sort eigenvalues in increasing order.
-170  continue
+           170 continue
            call stdlib_slasrt('I',n,d,info)
-180        continue
+           180 continue
            return
      end subroutine stdlib_ssterf
 
@@ -39840,7 +39840,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: d(*),e(*)
            real(sp),intent(out) :: work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: wantz
            integer(ilp) :: imax,iscale
@@ -39928,7 +39928,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: d(*),e(*)
            real(sp),intent(out) :: w(*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,test,valeig,wantz
            character :: order
@@ -40063,7 +40063,7 @@ module stdlib_linalg_lapack_s
                         indwrk),iwork(indiwo),ifail,info)
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
-20   continue
+           20 continue
            if (iscale == 1) then
               if (info == 0) then
                  imax = m
@@ -40109,7 +40109,7 @@ module stdlib_linalg_lapack_s
      !> condition number is computed as RCOND = 1 / (ANORM * norm(inv(A))).
 
      pure subroutine stdlib_ssycon(uplo,n,a,lda,ipiv,anorm,rcond,work,iwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -40125,7 +40125,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: a(lda,*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,kase
@@ -40173,7 +40173,7 @@ module stdlib_linalg_lapack_s
            end if
            ! estimate the 1-norm of the inverse.
            kase = 0
-30         continue
+           30 continue
            call stdlib_slacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               ! multiply by inv(l*d*l**t) or inv(u*d*u**t).
@@ -40192,7 +40192,7 @@ module stdlib_linalg_lapack_s
      !> condition number is computed as RCOND = 1 / (ANORM * norm(inv(A))).
 
      pure subroutine stdlib_ssycon_rook(uplo,n,a,lda,ipiv,anorm,rcond,work,iwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -40208,7 +40208,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: a(lda,*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,kase
@@ -40256,7 +40256,7 @@ module stdlib_linalg_lapack_s
            end if
            ! estimate the 1-norm of the inverse.
            kase = 0
-30         continue
+           30 continue
            call stdlib_slacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               ! multiply by inv(l*d*l**t) or inv(u*d*u**t).
@@ -40290,7 +40290,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,j,k,kase,nz
@@ -40340,7 +40340,7 @@ module stdlib_linalg_lapack_s
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_scopy(n,b(1,j),1,work(n + 1),1)
@@ -40424,9 +40424,9 @@ module stdlib_linalg_lapack_s
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_slacn2(n,work(2*n + 1),work(n + 1),iwork,ferr(j),kase,isave)
-                        
+
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(a**t).
@@ -40469,7 +40469,7 @@ module stdlib_linalg_lapack_s
      !> the system of equations A * X = B by calling BLAS3 routine SSYTRS_3.
 
      pure subroutine stdlib_ssysv_rk(uplo,n,nrhs,a,lda,e,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -40548,7 +40548,7 @@ module stdlib_linalg_lapack_s
      !> of equations A * X = B by calling SSYTRS_ROOK.
 
      pure subroutine stdlib_ssysv_rook(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -40624,7 +40624,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: d(*),e(*),tau(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i
@@ -40660,7 +40660,7 @@ module stdlib_linalg_lapack_s
                     a(i,i + 1) = one
                     ! compute  x := tau * a * v  storing x in tau(1:i)
                     call stdlib_ssymv(uplo,i,taui,a,lda,a(1,i + 1),1,zero,tau,1)
-                              
+
                     ! compute  w := x - 1/2 * tau * (x**t * v) * v
                     alpha = -half*taui*stdlib_sdot(i,tau,1,a(1,i + 1),1)
                     call stdlib_saxpy(i,alpha,a(1,i + 1),1,tau,1)
@@ -40725,7 +40725,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: sevten = 17.0e+0_sp
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,imax,j,jmax,k,kk,kp,kstep
@@ -40755,7 +40755,7 @@ module stdlib_linalg_lapack_s
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 70
               kstep = 1
@@ -40870,7 +40870,7 @@ module stdlib_linalg_lapack_s
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop
               if (k > n) go to 70
               kstep = 1
@@ -40923,7 +40923,7 @@ module stdlib_linalg_lapack_s
                     ! interchange rows and columns kk and kp in the trailing
                     ! submatrix a(k:n,k:n)
                     if (kp < n) call stdlib_sswap(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     call stdlib_sswap(kp - kk - 1,a(kk + 1,kk),1,a(kp,kk + 1),lda)
                     t = a(kk,kk)
                     a(kk,kk) = a(kp,kp)
@@ -40944,7 +40944,7 @@ module stdlib_linalg_lapack_s
                        ! a := a - l(k)*d(k)*l(k)**t = a - w(k)*(1/d(k))*w(k)**t
                        d11 = one/a(k,k)
                        call stdlib_ssyr(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                 
+
                        ! store l(k) in column k
                        call stdlib_sscal(n - k,d11,a(k + 1,k),1)
                     end if
@@ -40983,7 +40983,7 @@ module stdlib_linalg_lapack_s
               k = k + kstep
               go to 40
            end if
-70         continue
+           70 continue
            return
      end subroutine stdlib_ssytf2
 
@@ -41003,7 +41003,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: d(*),e(*),tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper
            integer(ilp) :: i,iinfo,iws,j,kk,ldwork,lwkopt,nb,nbmin,nx
@@ -41107,7 +41107,7 @@ module stdlib_linalg_lapack_s
               end do
               ! use unblocked code to reduce the last or only block
               call stdlib_ssytd2(uplo,n - i + 1,a(i,i),lda,d(i),e(i),tau(i),iinfo)
-                        
+
            end if
            work(1) = lwkopt
            return
@@ -41135,7 +41135,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: rzero = 0.0e+0_sp
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wantq,upper,afters1
            integer(ilp) :: i,m,k,ib,sweepid,myid,shift,stt,st,ed,stind,edind, &
@@ -41441,7 +41441,7 @@ module stdlib_linalg_lapack_s
               ! kb, where kb is the number of columns factorized by stdlib_slasyf;
               ! kb is either nb or nb-1, or k for the last block
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 40
               if (k > nb) then
@@ -41464,7 +41464,7 @@ module stdlib_linalg_lapack_s
               ! kb, where kb is the number of columns factorized by stdlib_slasyf;
               ! kb is either nb or nb-1, or n-k+1 for the last block
               k = 1
-20            continue
+              20 continue
               ! if k > n, exit from loop
               if (k > n) go to 40
               if (k <= n - nb) then
@@ -41491,7 +41491,7 @@ module stdlib_linalg_lapack_s
               k = k + kb
               go to 20
            end if
-40         continue
+           40 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_ssytrf
@@ -41504,7 +41504,7 @@ module stdlib_linalg_lapack_s
      !> RCOND = 1 / ( norm(A) * norm(inv(A)) ).
 
      subroutine stdlib_stbcon(norm,uplo,diag,n,kd,ab,ldab,rcond,work,iwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -41518,7 +41518,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: ab(ldab,*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,onenrm,upper
            character :: normin
@@ -41571,7 +41571,7 @@ module stdlib_linalg_lapack_s
                  kase1 = 2
               end if
               kase = 0
-10            continue
+              10 continue
               call stdlib_slacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
               if (kase /= 0) then
                  if (kase == kase1) then
@@ -41596,7 +41596,7 @@ module stdlib_linalg_lapack_s
               ! compute the estimate of the reciprocal condition number.
               if (ainvnm /= zero) rcond = (one/anorm)/ainvnm
            end if
-20         continue
+           20 continue
            return
      end subroutine stdlib_stbcon
 
@@ -41615,7 +41615,7 @@ module stdlib_linalg_lapack_s
            ! Array Arguments
            real(sp),intent(inout) :: a(0:*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,nisodd,normaltransr
            integer(ilp) :: n1,n2,k
@@ -41670,12 +41670,12 @@ module stdlib_linalg_lapack_s
                     call stdlib_strtri('L',diag,n1,a(0),n,info)
                     if (info > 0) return
                     call stdlib_strmm('R','L','N',diag,n2,n1,-one,a(0),n,a(n1),n)
-                              
+
                     call stdlib_strtri('U',diag,n2,a(n),n,info)
                     if (info > 0) info = info + n1
                     if (info > 0) return
                     call stdlib_strmm('L','U','T',diag,n2,n1,one,a(n),n,a(n1),n)
-                              
+
                  else
                    ! srpa for upper, normal and n is odd ( a(0:n-1,0:n2-1)
                    ! t1 -> a(n1+1,0), t2 -> a(n1,0), s -> a(0,0)
@@ -41683,12 +41683,12 @@ module stdlib_linalg_lapack_s
                     call stdlib_strtri('L',diag,n1,a(n2),n,info)
                     if (info > 0) return
                     call stdlib_strmm('L','L','T',diag,n1,n2,-one,a(n2),n,a(0),n)
-                              
+
                     call stdlib_strtri('U',diag,n2,a(n1),n,info)
                     if (info > 0) info = info + n1
                     if (info > 0) return
                     call stdlib_strmm('R','U','N',diag,n1,n2,one,a(n1),n,a(0),n)
-                              
+
                  end if
               else
                  ! n is odd and transr = 't'
@@ -41734,7 +41734,7 @@ module stdlib_linalg_lapack_s
                     if (info > 0) info = info + k
                     if (info > 0) return
                     call stdlib_strmm('L','U','T',diag,k,k,one,a(0),n + 1,a(k + 1),n + 1)
-                              
+
                  else
                     ! srpa for upper, normal, and n is even ( a(0:n,0:k-1) )
                     ! t1 -> a(k+1,0) ,  t2 -> a(k,0),   s -> a(0,0)
@@ -41747,7 +41747,7 @@ module stdlib_linalg_lapack_s
                     if (info > 0) info = info + k
                     if (info > 0) return
                     call stdlib_strmm('R','U','N',diag,k,k,one,a(k),n + 1,a(0),n + 1)
-                              
+
                  end if
               else
                  ! n is even and transr = 't'
@@ -41776,7 +41776,7 @@ module stdlib_linalg_lapack_s
                     if (info > 0) info = info + k
                     if (info > 0) return
                     call stdlib_strmm('L','L','N',diag,k,k,one,a(k*k),k,a(0),k)
-                              
+
                  end if
               end if
            end if
@@ -41832,7 +41832,7 @@ module stdlib_linalg_lapack_s
         ! sven hammarling, 27/5/02.
            ! Parameters
            integer(ilp),parameter :: ldz = 8
-           
+
            ! Local Scalars
            logical(lk) :: notran
            integer(ilp) :: i,ie,ierr,ii,is,isp1,j,je,jj,js,jsp1,k,mb,nb,p,q, &
@@ -41882,7 +41882,7 @@ module stdlib_linalg_lapack_s
            pq = 0
            p = 0
            i = 1
-10         continue
+           10 continue
            if (i > m) go to 20
            p = p + 1
            iwork(p) = i
@@ -41893,12 +41893,12 @@ module stdlib_linalg_lapack_s
               i = i + 1
            end if
            go to 10
-20         continue
+           20 continue
            iwork(p + 1) = m + 1
            ! determine block structure of b
            q = p + 1
            j = 1
-30         continue
+           30 continue
            if (j > n) go to 40
            q = q + 1
            iwork(q) = j
@@ -41909,7 +41909,7 @@ module stdlib_linalg_lapack_s
               j = j + 1
            end if
            go to 30
-40         continue
+           40 continue
            iwork(q + 1) = n + 1
            pq = p*(q - p - 1)
            if (notran) then
@@ -41953,7 +41953,7 @@ module stdlib_linalg_lapack_s
                           end if
                        else
                           call stdlib_slatdf(ijob,zdim,z,ldz,rhs,rdsum,rdscal,ipiv,jpiv)
-                                    
+
                        end if
                        ! unpack solution vector(s)
                        c(is,js) = rhs(1)
@@ -42008,7 +42008,7 @@ module stdlib_linalg_lapack_s
                           end if
                        else
                           call stdlib_slatdf(ijob,zdim,z,ldz,rhs,rdsum,rdscal,ipiv,jpiv)
-                                    
+
                        end if
                        ! unpack solution vector(s)
                        c(is,js) = rhs(1)
@@ -42070,7 +42070,7 @@ module stdlib_linalg_lapack_s
                           end if
                        else
                           call stdlib_slatdf(ijob,zdim,z,ldz,rhs,rdsum,rdscal,ipiv,jpiv)
-                                    
+
                        end if
                        ! unpack solution vector(s)
                        c(is,js) = rhs(1)
@@ -42145,7 +42145,7 @@ module stdlib_linalg_lapack_s
                           end if
                        else
                           call stdlib_slatdf(ijob,zdim,z,ldz,rhs,rdsum,rdscal,ipiv,jpiv)
-                                    
+
                        end if
                        ! unpack solution vector(s)
                        k = 1
@@ -42226,10 +42226,10 @@ module stdlib_linalg_lapack_s
                        if (i < p) then
                           alpha = -rhs(1)
                           call stdlib_saxpy(m - ie,alpha,a(is,ie + 1),lda,c(ie + 1,js),1)
-                                    
+
                           alpha = -rhs(2)
                           call stdlib_saxpy(m - ie,alpha,d(is,ie + 1),ldd,c(ie + 1,js),1)
-                                    
+
                        end if
                     else if ((mb == 1) .and. (nb == 2)) then
                        ! build a 4-by-4 system z**t * x = rhs
@@ -42274,13 +42274,13 @@ module stdlib_linalg_lapack_s
                        ! equation.
                        if (j > p + 2) then
                           call stdlib_saxpy(js - 1,rhs(1),b(1,js),1,f(is,1),ldf)
-                                    
+
                           call stdlib_saxpy(js - 1,rhs(2),b(1,jsp1),1,f(is,1),ldf)
-                                    
+
                           call stdlib_saxpy(js - 1,rhs(3),e(1,js),1,f(is,1),ldf)
-                                    
+
                           call stdlib_saxpy(js - 1,rhs(4),e(1,jsp1),1,f(is,1),ldf)
-                                    
+
                        end if
                        if (i < p) then
                           call stdlib_sger(m - ie,nb,-one,a(is,ie + 1),lda,rhs(1),1,c(ie + &
@@ -42469,7 +42469,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
         ! replaced various illegal calls to stdlib_scopy by calls to stdlib_slaset.
         ! sven hammarling, 1/5/02.
-           
+
            ! Local Scalars
            logical(lk) :: lquery,notran
            integer(ilp) :: i,ie,ifunc,iround,is,isolve,j,je,js,k,linfo,lwmin,mb,nb, &
@@ -42588,7 +42588,7 @@ module stdlib_linalg_lapack_s
            ! determine block structure of a
            p = 0
            i = 1
-40         continue
+           40 continue
            if (i > m) go to 50
            p = p + 1
            iwork(p) = i
@@ -42596,13 +42596,13 @@ module stdlib_linalg_lapack_s
            if (i >= m) go to 50
            if (a(i,i - 1) /= zero) i = i + 1
            go to 40
-50         continue
+           50 continue
            iwork(p + 1) = m + 1
            if (iwork(p) == iwork(p + 1)) p = p - 1
            ! determine block structure of b
            q = p + 1
            j = 1
-60         continue
+           60 continue
            if (j > n) go to 70
            q = q + 1
            iwork(q) = j
@@ -42610,7 +42610,7 @@ module stdlib_linalg_lapack_s
            if (j >= n) go to 70
            if (b(j,j - 1) /= zero) j = j + 1
            go to 60
-70         continue
+           70 continue
            iwork(q + 1) = n + 1
            if (iwork(q) == iwork(q + 1)) q = q - 1
            if (notran) then
@@ -42772,7 +42772,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: ap(*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,onenrm,upper
            character :: normin
@@ -42821,7 +42821,7 @@ module stdlib_linalg_lapack_s
                  kase1 = 2
               end if
               kase = 0
-10            continue
+              10 continue
               call stdlib_slacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
               if (kase /= 0) then
                  if (kase == kase1) then
@@ -42846,7 +42846,7 @@ module stdlib_linalg_lapack_s
               ! compute the estimate of the reciprocal condition number.
               if (ainvnm /= zero) rcond = (one/anorm)/ainvnm
            end if
-20         continue
+           20 continue
            return
      end subroutine stdlib_stpcon
 
@@ -42865,7 +42865,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*),b(ldb,*)
            real(sp),intent(out) :: t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,p,mp,np
            real(sp) :: alpha
@@ -43200,7 +43200,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*),b(ldb,*)
            real(sp),intent(out) :: t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,p,mp,np
            real(sp) :: alpha
@@ -43245,7 +43245,7 @@ module stdlib_linalg_lapack_s
                     a(i,i + j) = a(i,i + j) + alpha*(t(j,n))
                  end do
                  call stdlib_sger(p,n - i,alpha,b(1,i),1,t(1,n),1,b(1,i + 1),ldb)
-                           
+
               end if
            end do
            do i = 2,n
@@ -43267,7 +43267,7 @@ module stdlib_linalg_lapack_s
                         np,i),1)
               ! b1
               call stdlib_sgemv('T',m - l,i - 1,alpha,b,ldb,b(1,i),1,one,t(1,i),1)
-                        
+
               ! t(1:i-1,i) := t(1:i-1,1:i-1) * t(1:i-1,i)
               call stdlib_strmv('U','N','N',i - 1,t,ldt,t(1,i),1)
               ! t(i,i) = tau(i)
@@ -43297,7 +43297,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: a(lda,*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,onenrm,upper
            character :: normin
@@ -43348,7 +43348,7 @@ module stdlib_linalg_lapack_s
                  kase1 = 2
               end if
               kase = 0
-10            continue
+              10 continue
               call stdlib_slacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
               if (kase /= 0) then
                  if (kase == kase1) then
@@ -43373,7 +43373,7 @@ module stdlib_linalg_lapack_s
               ! compute the estimate of the reciprocal condition number.
               if (ainvnm /= zero) rcond = (one/anorm)/ainvnm
            end if
-20         continue
+           20 continue
            return
      end subroutine stdlib_strcon
 
@@ -43395,7 +43395,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,iws,ki,kk,ldwork,lwkmin,lwkopt,m1,mu,nb,nbmin, &
@@ -43480,7 +43480,7 @@ module stdlib_linalg_lapack_s
                     ! apply h to a(1:i-1,i:n) from the right
                     call stdlib_slarzb('RIGHT','NO TRANSPOSE','BACKWARD','ROWWISE',i - 1,n - i + 1, &
                      ib,n - m,a(i,m1),lda,work,ldwork,a(1,i),lda,work(ib + 1),ldwork)
-                               
+
                  end if
               end do
               mu = i + nb - 1
@@ -43540,7 +43540,7 @@ module stdlib_linalg_lapack_s
            if (info == 0) then
               ! solve the system a*x = b, overwriting b with x.
               call stdlib_sgbtrs('NO TRANSPOSE',n,kl,ku,nrhs,ab,ldab,ipiv,b,ldb,info)
-                        
+
            end if
            return
      end subroutine stdlib_sgbsv
@@ -43572,7 +43572,7 @@ module stdlib_linalg_lapack_s
         ! moved setting of info = n+1 so info does not subsequently get
         ! overwritten.  sven, 17 mar 05.
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: colequ,equil,nofact,notran,rowequ
            character :: norm
@@ -43662,11 +43662,11 @@ module stdlib_linalg_lapack_s
            if (equil) then
               ! compute row and column scalings to equilibrate the matrix a.
               call stdlib_sgbequ(n,n,kl,ku,ab,ldab,r,c,rowcnd,colcnd,amax,infequ)
-                        
+
               if (infequ == 0) then
                  ! equilibrate the matrix.
                  call stdlib_slaqgb(n,n,kl,ku,ab,ldab,r,c,rowcnd,colcnd,amax,equed)
-                           
+
                  rowequ = stdlib_lsame(equed,'R') .or. stdlib_lsame(equed,'B')
                  colequ = stdlib_lsame(equed,'C') .or. stdlib_lsame(equed,'B')
               end if
@@ -43693,7 +43693,7 @@ module stdlib_linalg_lapack_s
                  j1 = max(j - ku,1)
                  j2 = min(j + kl,n)
                  call stdlib_scopy(j2 - j1 + 1,ab(ku + 1 - j + j1,j),1,afb(kl + ku + 1 - j + j1,j),1)
-                           
+
               end do
               call stdlib_sgbtrf(n,n,kl,ku,afb,ldafb,ipiv,info)
               ! return if info is non-zero.
@@ -43734,7 +43734,7 @@ module stdlib_linalg_lapack_s
            end if
            ! compute the reciprocal of the condition number of a.
            call stdlib_sgbcon(norm,n,kl,ku,afb,ldafb,ipiv,anorm,rcond,work,iwork,info)
-                     
+
            ! compute the solution matrix x.
            call stdlib_slacpy('FULL',n,nrhs,b,ldb,x,ldx)
            call stdlib_sgbtrs(trans,n,kl,ku,nrhs,afb,ldafb,ipiv,x,ldx,info)
@@ -43795,7 +43795,7 @@ module stdlib_linalg_lapack_s
            ! Parameters
            real(sp),parameter :: sclfac = 2.0e+0_sp
            real(sp),parameter :: factor = 0.95e+0_sp
-           
+
            ! Local Scalars
            logical(lk) :: noconv
            integer(ilp) :: i,ica,iexc,ira,j,k,l,m
@@ -43829,18 +43829,18 @@ module stdlib_linalg_lapack_s
            ! permutation to isolate eigenvalues if possible
            go to 50
            ! row and column exchange.
-20   continue
+           20 continue
            scale(m) = j
            if (j == m) go to 30
            call stdlib_sswap(l,a(1,j),1,a(1,m),1)
            call stdlib_sswap(n - k + 1,a(j,k),lda,a(m,k),lda)
-30         continue
+           30 continue
            go to(40,80) iexc
            ! search for rows isolating an eigenvalue and push them down.
-40   continue
+           40 continue
            if (l == 1) go to 210
            l = l - 1
-50         continue
+           50 continue
            loop_70: do j = l,1,-1
               loop_60: do i = 1,l
                  if (i == j) cycle loop_60
@@ -43852,9 +43852,9 @@ module stdlib_linalg_lapack_s
            end do loop_70
            go to 90
            ! search for columns isolating an eigenvalue and push them left.
-80   continue
+           80 continue
            k = k + 1
-90         continue
+           90 continue
            loop_110: do j = k,l
               loop_100: do i = k,l
                  if (i == j) cycle loop_100
@@ -43864,7 +43864,7 @@ module stdlib_linalg_lapack_s
               iexc = 2
               go to 20
            end do loop_110
-120        continue
+           120 continue
            do i = k,l
               scale(i) = one
            end do
@@ -43875,7 +43875,7 @@ module stdlib_linalg_lapack_s
            sfmax1 = one/sfmin1
            sfmin2 = sfmin1*sclfac
            sfmax2 = one/sfmin2
-140        continue
+           140 continue
            noconv = .false.
            loop_200: do i = k,l
               c = stdlib_snrm2(l - k + 1,a(k,i),1)
@@ -43889,7 +43889,7 @@ module stdlib_linalg_lapack_s
               g = r/sclfac
               f = one
               s = c + r
-160           continue
+              160 continue
               if (c >= g .or. max(f,c,ca) >= sfmax2 .or. min(r,g,ra) <= sfmin2) go to 170
               f = f*sclfac
               c = c*sclfac
@@ -43898,9 +43898,9 @@ module stdlib_linalg_lapack_s
               g = g/sclfac
               ra = ra/sclfac
               go to 160
-170           continue
+              170 continue
               g = c/sclfac
-180           continue
+              180 continue
               if (g < r .or. max(r,ra) >= sfmax2 .or. min(f,c,g,ca) <= sfmin2) go to 190
                  if (stdlib_sisnan(c + f + ca + r + g + ra)) then
                  ! exit if nan to avoid infinite loop
@@ -43916,7 +43916,7 @@ module stdlib_linalg_lapack_s
               ra = ra*sclfac
               go to 180
               ! now balance.
-190  continue
+              190 continue
               if ((c + r) >= factor*s) cycle loop_200
               if (f < one .and. scale(i) < one) then
                  if (f*scale(i) <= sfmin1) cycle loop_200
@@ -43931,7 +43931,7 @@ module stdlib_linalg_lapack_s
               call stdlib_sscal(l,f,a(1,i),1)
            end do loop_200
            if (noconv) go to 140
-210        continue
+           210 continue
            ilo = k
            ihi = l
            return
@@ -43952,7 +43952,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: d(*),e(*),taup(*),tauq(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            ! Intrinsic Functions
@@ -43976,7 +43976,7 @@ module stdlib_linalg_lapack_s
               do i = 1,n
                  ! generate elementary reflector h(i) to annihilate a(i+1:m,i)
                  call stdlib_slarfg(m - i + 1,a(i,i),a(min(i + 1,m),i),1,tauq(i))
-                           
+
                  d(i) = a(i,i)
                  a(i,i) = one
                  ! apply h(i) to a(i:m,i+1:n) from the left
@@ -43987,7 +43987,7 @@ module stdlib_linalg_lapack_s
                     ! generate elementary reflector g(i) to annihilate
                     ! a(i,i+2:n)
                     call stdlib_slarfg(n - i,a(i,i + 1),a(i,min(i + 2,n)),lda,taup(i))
-                              
+
                     e(i) = a(i,i + 1)
                     a(i,i + 1) = one
                     ! apply g(i) to a(i+1:m,i+1:n) from the right
@@ -44003,7 +44003,7 @@ module stdlib_linalg_lapack_s
               do i = 1,m
                  ! generate elementary reflector g(i) to annihilate a(i,i+1:n)
                  call stdlib_slarfg(n - i + 1,a(i,i),a(i,min(i + 1,n)),lda,taup(i))
-                           
+
                  d(i) = a(i,i)
                  a(i,i) = one
                  ! apply g(i) to a(i+1:m,i:n) from the right
@@ -44014,7 +44014,7 @@ module stdlib_linalg_lapack_s
                     ! generate elementary reflector h(i) to annihilate
                     ! a(i+2:m,i)
                     call stdlib_slarfg(m - i,a(i + 1,i),a(min(i + 2,m),i),1,tauq(i))
-                              
+
                     e(i) = a(i + 1,i)
                     a(i + 1,i) = one
                     ! apply h(i) to a(i+1:m,i+1:n) from the left
@@ -44043,7 +44043,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(sp) :: aii
@@ -44099,7 +44099,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            real(sp) :: aii
@@ -44219,7 +44219,7 @@ module stdlib_linalg_lapack_s
                     ! apply h to a(i+ib:m,i:n) from the right
                     call stdlib_slarfb('RIGHT','NO TRANSPOSE','FORWARD','ROWWISE',m - i - ib + 1,n - &
                     i + 1,ib,a(i,i),lda,work,ldwork,a(i + ib,i),lda,work(ib + 1),ldwork)
-                              
+
                  end if
               end do
            else
@@ -44227,7 +44227,7 @@ module stdlib_linalg_lapack_s
            end if
            ! use unblocked code to factor the last or only block.
            if (i <= k) call stdlib_sgelq2(m - i + 1,n - i + 1,a(i,i),lda,tau(i),work,iinfo)
-                     
+
            work(1) = iws
            return
      end subroutine stdlib_sgelqf
@@ -44248,7 +44248,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,i1,j,j1,m1,m2,iinfo
            ! Executable Statements
@@ -44290,7 +44290,7 @@ module stdlib_linalg_lapack_s
               call stdlib_sgemm('N','N',m2,n - m1,m1,-one,t(i1,1),ldt,a(1,i1),lda, &
                         one,a(i1,i1),lda)
               call stdlib_strmm('R','U','N','U',m2,m1,one,a,lda,t(i1,1),ldt)
-                        
+
               do i = 1,m2
                  do j = 1,m1
                     a(i + m1,j) = a(i + m1,j) - t(i + m1,j)
@@ -44310,7 +44310,7 @@ module stdlib_linalg_lapack_s
               call stdlib_sgemm('N','T',m1,m2,n - m,one,a(1,j1),lda,a(i1,j1),lda, &
                         one,t(1,i1),ldt)
               call stdlib_strmm('L','U','N','N',m1,m2,-one,t,ldt,t(1,i1),ldt)
-                        
+
               call stdlib_strmm('R','U','N','N',m1,m2,one,t(i1,i1),ldt,t(1,i1), &
                         ldt)
               ! y = (y1,y2); l = [ l1            0  ];  t = [t1 t3]
@@ -44333,7 +44333,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            real(sp) :: aii
@@ -44362,7 +44362,7 @@ module stdlib_linalg_lapack_s
               aii = a(m - k + i,n - k + i)
               a(m - k + i,n - k + i) = one
               call stdlib_slarf('LEFT',m - k + i,n - k + i - 1,a(1,n - k + i),1,tau(i),a,lda,work)
-                        
+
               a(m - k + i,n - k + i) = aii
            end do
            return
@@ -44450,7 +44450,7 @@ module stdlib_linalg_lapack_s
                  ! compute the ql factorization of the current block
                  ! a(1:m-k+i+ib-1,n-k+i:n-k+i+ib-1)
                  call stdlib_sgeql2(m - k + i + ib - 1,ib,a(1,n - k + i),lda,tau(i),work,iinfo)
-                           
+
                  if (n - k + i > 1) then
                     ! form the triangular factor of the block reflector
                     ! h = h(i+ib-1) . . . h(i+1) h(i)
@@ -44459,7 +44459,7 @@ module stdlib_linalg_lapack_s
                     ! apply h**t to a(1:m-k+i+ib-1,1:n-k+i-1) from the left
                     call stdlib_slarfb('LEFT','TRANSPOSE','BACKWARD','COLUMNWISE',m - k + i + ib - 1, &
                     n - k + i - 1,ib,a(1,n - k + i),lda,work,ldwork,a,lda,work(ib + 1),ldwork)
-                              
+
                  end if
               end do
               mu = m - k + i + nb - 1
@@ -44493,7 +44493,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            real(sp) :: aii
@@ -44549,7 +44549,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            real(sp) :: aii
@@ -44682,7 +44682,7 @@ module stdlib_linalg_lapack_s
            end if
            ! use unblocked code to factor the last or only block.
            if (i <= k) call stdlib_sgeqr2(m - i + 1,n - i + 1,a(i,i),lda,tau(i),work,iinfo)
-                     
+
            work(1) = iws
            return
      end subroutine stdlib_sgeqrf
@@ -44781,7 +44781,7 @@ module stdlib_linalg_lapack_s
            end if
            ! use unblocked code to factor the last or only block.
            if (i <= k) call stdlib_sgeqr2p(m - i + 1,n - i + 1,a(i,i),lda,tau(i),work,iinfo)
-                     
+
            work(1) = iws
            return
      end subroutine stdlib_sgeqrfp
@@ -44800,7 +44800,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            real(sp) :: aii,alpha
@@ -44870,7 +44870,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,i1,j,j1,n1,n2,iinfo
            ! Executable Statements
@@ -44930,7 +44930,7 @@ module stdlib_linalg_lapack_s
               call stdlib_sgemm('T','N',n1,n2,m - n,one,a(i1,1),lda,a(i1,j1),lda, &
                         one,t(1,j1),ldt)
               call stdlib_strmm('L','U','N','N',n1,n2,-one,t,ldt,t(1,j1),ldt)
-                        
+
               call stdlib_strmm('R','U','N','N',n1,n2,one,t(j1,j1),ldt,t(1,j1), &
                         ldt)
               ! y = (y1,y2); r = [ r1  a(1:n1,j1:n) ];  t = [t1 t3]
@@ -44961,7 +44961,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: notran
            character :: transt
@@ -45018,13 +45018,13 @@ module stdlib_linalg_lapack_s
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - op(a) * x,
               ! where op(a) = a, a**t, or a**h, depending on trans.
               call stdlib_scopy(n,b(1,j),1,work(n + 1),1)
               call stdlib_sgemv(trans,n,n,-one,a,lda,x(1,j),1,one,work(n + 1),1)
-                        
+
               ! compute componentwise relative backward error from formula
               ! max(i) ( abs(r(i)) / ( abs(op(a))*abs(x) + abs(b) )(i) )
               ! where abs(z) is the componentwise absolute value of the matrix
@@ -45098,14 +45098,14 @@ module stdlib_linalg_lapack_s
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_slacn2(n,work(2*n + 1),work(n + 1),iwork,ferr(j),kase,isave)
-                        
+
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(op(a)**t).
                     call stdlib_sgetrs(transt,n,1,af,ldaf,ipiv,work(n + 1),n,info)
-                              
+
                     do i = 1,n
                        work(n + i) = work(i)*work(n + i)
                     end do
@@ -45142,7 +45142,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            real(sp) :: aii
@@ -45259,7 +45259,7 @@ module stdlib_linalg_lapack_s
                  ! compute the rq factorization of the current block
                  ! a(m-k+i:m-k+i+ib-1,1:n-k+i+ib-1)
                  call stdlib_sgerq2(ib,n - k + i + ib - 1,a(m - k + i,1),lda,tau(i),work,iinfo)
-                           
+
                  if (m - k + i > 1) then
                     ! form the triangular factor of the block reflector
                     ! h = h(i+ib-1) . . . h(i+1) h(i)
@@ -45268,7 +45268,7 @@ module stdlib_linalg_lapack_s
                     ! apply h to a(1:m-k+i-1,1:n-k+i+ib-1) from the right
                     call stdlib_slarfb('RIGHT','NO TRANSPOSE','BACKWARD','ROWWISE',m - k + i - 1,n - &
                     k + i + ib - 1,ib,a(m - k + i,1),lda,work,ldwork,a,lda,work(ib + 1),ldwork)
-                              
+
                  end if
               end do
               mu = m - k + i + nb - 1
@@ -45303,7 +45303,7 @@ module stdlib_linalg_lapack_s
            integer(ilp),intent(out) :: ipiv(*)
            real(sp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,iinfo,j,jb,nb
            ! Intrinsic Functions
@@ -45353,7 +45353,7 @@ module stdlib_linalg_lapack_s
                        ! update trailing submatrix.
                        call stdlib_sgemm('NO TRANSPOSE','NO TRANSPOSE',m - j - jb + 1,n - j - jb + 1,jb,- &
                        one,a(j + jb,j),lda,a(j,j + jb),lda,one,a(j + jb,j + jb),lda)
-                                 
+
                     end if
                  end if
               end do
@@ -45400,7 +45400,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*),b(ldb,*),q(ldq,*),z(ldz,*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: blk22,initq,initz,lquery,wantq,wantz
            character :: compq2,compz2
@@ -45567,7 +45567,7 @@ module stdlib_linalg_lapack_s
                           call stdlib_slartg(temp,b(jj + 1,jj),c,s,b(jj + 1,jj + 1))
                           b(jj + 1,jj) = zero
                           call stdlib_srot(jj - top,b(top + 1,jj + 1),1,b(top + 1,jj),1,c,s)
-                                    
+
                           a(jj + 1,j) = c
                           b(jj + 1,j) = -s
                        end if
@@ -45627,7 +45627,7 @@ module stdlib_linalg_lapack_s
                                  len*nblst + 1),nblst,work(pw + len),1)
                        call stdlib_sgemv('TRANSPOSE',len,nblst - len,one,work((len + 1)*nblst - &
                        len + 1),nblst,a(jrow + nblst - len,j + 1),1,one,work(pw + len),1)
-                                 
+
                        ppw = pw
                        do i = jrow,jrow + nblst - 1
                           a(i,j + 1) = work(ppw)
@@ -45679,7 +45679,7 @@ module stdlib_linalg_lapack_s
                  call stdlib_sgemm('TRANSPOSE','NO TRANSPOSE',nblst,cola,nblst,one,work, &
                            nblst,a(j,jcol + nnb),lda,zero,work(pw),nblst)
                  call stdlib_slacpy('ALL',nblst,cola,work(pw),nblst,a(j,jcol + nnb),lda)
-                           
+
                  ppwo = nblst*nblst + 1
                  j0 = j - nnb
                  do j = j0,jcol + 1,-nnb
@@ -45714,7 +45714,7 @@ module stdlib_linalg_lapack_s
                     call stdlib_sgemm('NO TRANSPOSE','NO TRANSPOSE',nh,nblst,nblst,one,q( &
                               topq,j),ldq,work,nblst,zero,work(pw),nh)
                     call stdlib_slacpy('ALL',nh,nblst,work(pw),nh,q(topq,j),ldq)
-                              
+
                     ppwo = nblst*nblst + 1
                     j0 = j - nnb
                     do j = j0,jcol + 1,-nnb
@@ -45731,7 +45731,7 @@ module stdlib_linalg_lapack_s
                           call stdlib_sgemm('NO TRANSPOSE','NO TRANSPOSE',nh,2*nnb,2*nnb,one, &
                                      q(topq,j),ldq,work(ppwo),2*nnb,zero,work(pw),nh)
                           call stdlib_slacpy('ALL',nh,2*nnb,work(pw),nh,q(topq,j),ldq)
-                                    
+
                        end if
                        ppwo = ppwo + 4*nnb*nnb
                     end do
@@ -45744,7 +45744,7 @@ module stdlib_linalg_lapack_s
                     pw = nblst*nblst + 1
                     do i = 1,n2nb
                        call stdlib_slaset('ALL',2*nnb,2*nnb,zero,one,work(pw),2*nnb)
-                                 
+
                        pw = pw + 4*nnb*nnb
                     end do
                     ! accumulate givens rotations into workspace array.
@@ -45798,7 +45798,7 @@ module stdlib_linalg_lapack_s
                     call stdlib_sgemm('NO TRANSPOSE','NO TRANSPOSE',top,nblst,nblst,one,a( &
                               1,j),lda,work,nblst,zero,work(pw),top)
                     call stdlib_slacpy('ALL',top,nblst,work(pw),top,a(1,j),lda)
-                              
+
                     ppwo = nblst*nblst + 1
                     j0 = j - nnb
                     do j = j0,jcol + 1,-nnb
@@ -45811,7 +45811,7 @@ module stdlib_linalg_lapack_s
                           call stdlib_sgemm('NO TRANSPOSE','NO TRANSPOSE',top,2*nnb,2*nnb, &
                                     one,a(1,j),lda,work(ppwo),2*nnb,zero,work(pw),top)
                           call stdlib_slacpy('ALL',top,2*nnb,work(pw),top,a(1,j),lda)
-                                    
+
                        end if
                        ppwo = ppwo + 4*nnb*nnb
                     end do
@@ -45819,7 +45819,7 @@ module stdlib_linalg_lapack_s
                     call stdlib_sgemm('NO TRANSPOSE','NO TRANSPOSE',top,nblst,nblst,one,b( &
                               1,j),ldb,work,nblst,zero,work(pw),top)
                     call stdlib_slacpy('ALL',top,nblst,work(pw),top,b(1,j),ldb)
-                              
+
                     ppwo = nblst*nblst + 1
                     j0 = j - nnb
                     do j = j0,jcol + 1,-nnb
@@ -45832,7 +45832,7 @@ module stdlib_linalg_lapack_s
                           call stdlib_sgemm('NO TRANSPOSE','NO TRANSPOSE',top,2*nnb,2*nnb, &
                                     one,b(1,j),ldb,work(ppwo),2*nnb,zero,work(pw),top)
                           call stdlib_slacpy('ALL',top,2*nnb,work(pw),top,b(1,j),ldb)
-                                    
+
                        end if
                        ppwo = ppwo + 4*nnb*nnb
                     end do
@@ -45850,7 +45850,7 @@ module stdlib_linalg_lapack_s
                     call stdlib_sgemm('NO TRANSPOSE','NO TRANSPOSE',nh,nblst,nblst,one,z( &
                               topq,j),ldz,work,nblst,zero,work(pw),nh)
                     call stdlib_slacpy('ALL',nh,nblst,work(pw),nh,z(topq,j),ldz)
-                              
+
                     ppwo = nblst*nblst + 1
                     j0 = j - nnb
                     do j = j0,jcol + 1,-nnb
@@ -45867,7 +45867,7 @@ module stdlib_linalg_lapack_s
                           call stdlib_sgemm('NO TRANSPOSE','NO TRANSPOSE',nh,2*nnb,2*nnb,one, &
                                      z(topq,j),ldz,work(ppwo),2*nnb,zero,work(pw),nh)
                           call stdlib_slacpy('ALL',nh,2*nnb,work(pw),nh,z(topq,j),ldz)
-                                    
+
                        end if
                        ppwo = ppwo + 4*nnb*nnb
                     end do
@@ -45908,7 +45908,7 @@ module stdlib_linalg_lapack_s
      !> transpose of the matrix Z.
 
      pure subroutine stdlib_sggqrf(n,m,p,a,lda,taua,b,ldb,taub,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -45986,7 +45986,7 @@ module stdlib_linalg_lapack_s
      !> transpose of the matrix Z.
 
      pure subroutine stdlib_sggrqf(m,p,n,a,lda,taua,b,ldb,taub,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -46067,7 +46067,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: d(*),dl(*),du(*),du2(*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: onenrm
            integer(ilp) :: i,kase,kase1
@@ -46108,17 +46108,17 @@ module stdlib_linalg_lapack_s
               kase1 = 2
            end if
            kase = 0
-20         continue
+           20 continue
            call stdlib_slacn2(n,work(n + 1),work,iwork,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == kase1) then
                  ! multiply by inv(u)*inv(l).
                  call stdlib_sgttrs('NO TRANSPOSE',n,1,dl,d,du,du2,ipiv,work,n,info)
-                           
+
               else
                  ! multiply by inv(l**t)*inv(u**t).
                  call stdlib_sgttrs('TRANSPOSE',n,1,dl,d,du,du2,ipiv,work,n,info)
-                           
+
               end if
               go to 20
            end if
@@ -46144,13 +46144,13 @@ module stdlib_linalg_lapack_s
            integer(ilp),intent(in) :: ipiv(*)
            integer(ilp),intent(out) :: iwork(*)
            real(sp),intent(in) :: b(ldb,*),d(*),df(*),dl(*),dlf(*),du(*),du2(*),duf(*)
-                     
+
            real(sp),intent(out) :: berr(*),ferr(*),work(*)
            real(sp),intent(inout) :: x(ldx,*)
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: notran
            character :: transn,transt
@@ -46205,7 +46205,7 @@ module stdlib_linalg_lapack_s
            loop_110: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - op(a) * x,
               ! where op(a) = a, a**t, or a**h, depending on trans.
@@ -46264,7 +46264,7 @@ module stdlib_linalg_lapack_s
               if (berr(j) > eps .and. two*berr(j) <= lstres .and. count <= itmax) then
                  ! update solution and try again.
                  call stdlib_sgttrs(trans,n,1,dlf,df,duf,du2,ipiv,work(n + 1),n,info)
-                           
+
                  call stdlib_saxpy(n,one,work(n + 1),1,x(1,j),1)
                  lstres = berr(j)
                  count = count + 1
@@ -46295,9 +46295,9 @@ module stdlib_linalg_lapack_s
                  end if
               end do
               kase = 0
-70            continue
+              70 continue
               call stdlib_slacn2(n,work(2*n + 1),work(n + 1),iwork,ferr(j),kase,isave)
-                        
+
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(op(a)**t).
@@ -46350,7 +46350,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(out) :: berr(*),ferr(*),work(*),x(ldx,*)
            real(sp),intent(inout) :: df(*),dlf(*),du2(*),duf(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nofact,notran
            character :: norm
@@ -46402,7 +46402,7 @@ module stdlib_linalg_lapack_s
            anorm = stdlib_slangt(norm,n,dl,d,du)
            ! compute the reciprocal of the condition number of a.
            call stdlib_sgtcon(norm,n,dlf,df,duf,du2,ipiv,anorm,rcond,work,iwork,info)
-                     
+
            ! compute the solution vectors x.
            call stdlib_slacpy('FULL',n,nrhs,b,ldb,x,ldx)
            call stdlib_sgttrs(trans,n,nrhs,dlf,df,duf,du2,ipiv,x,ldx,info)
@@ -46475,7 +46475,7 @@ module stdlib_linalg_lapack_s
            ! Parameters
            real(sp),parameter :: safety = 1.0e+2_sp
           ! $                     safety = one )
-           
+
            ! Local Scalars
            logical(lk) :: ilazr2,ilazro,ilpivt,ilq,ilschr,ilz,lquery
            integer(ilp) :: icompq,icompz,ifirst,ifrstm,iiter,ilast,ilastm,in,ischur, &
@@ -46690,7 +46690,7 @@ module stdlib_linalg_lapack_s
                           call stdlib_srot(ilastm - jch,t(jch,jch + 1),ldt,t(jch + 1,jch + 1), &
                                     ldt,c,s)
                           if (ilq) call stdlib_srot(n,q(1,jch),1,q(1,jch + 1),1,c,s)
-                                    
+
                           if (ilazr2) h(jch,jch - 1) = h(jch,jch - 1)*c
                           ilazr2 = .false.
                           if (abs(t(jch + 1,jch + 1)) >= btol) then
@@ -46710,24 +46710,24 @@ module stdlib_linalg_lapack_s
                        do jch = j,ilast - 1
                           temp = t(jch,jch + 1)
                           call stdlib_slartg(temp,t(jch + 1,jch + 1),c,s,t(jch,jch + 1))
-                                    
+
                           t(jch + 1,jch + 1) = zero
                           if (jch < ilastm - 1) call stdlib_srot(ilastm - jch - 1,t(jch,jch + 2),ldt, &
                                     t(jch + 1,jch + 2),ldt,c,s)
                           call stdlib_srot(ilastm - jch + 2,h(jch,jch - 1),ldh,h(jch + 1,jch - 1), &
                                     ldh,c,s)
                           if (ilq) call stdlib_srot(n,q(1,jch),1,q(1,jch + 1),1,c,s)
-                                    
+
                           temp = h(jch + 1,jch)
                           call stdlib_slartg(temp,h(jch + 1,jch - 1),c,s,h(jch + 1,jch))
-                                    
+
                           h(jch + 1,jch - 1) = zero
                           call stdlib_srot(jch + 1 - ifrstm,h(ifrstm,jch),1,h(ifrstm,jch - 1), &
                                     1,c,s)
                           call stdlib_srot(jch - ifrstm,t(ifrstm,jch),1,t(ifrstm,jch - 1),1, &
                                      c,s)
                           if (ilz) call stdlib_srot(n,z(1,jch),1,z(1,jch - 1),1,c,s)
-                                    
+
                        end do
                        go to 70
                     end if
@@ -46743,7 +46743,7 @@ module stdlib_linalg_lapack_s
               go to 420
               ! t(ilast,ilast)=0 -- clear h(ilast,ilast-1) to split off a
               ! 1x1 block.
-70   continue
+              70 continue
               temp = h(ilast,ilast)
               call stdlib_slartg(temp,h(ilast,ilast - 1),c,s,h(ilast,ilast))
               h(ilast,ilast - 1) = zero
@@ -46754,7 +46754,7 @@ module stdlib_linalg_lapack_s
               if (ilz) call stdlib_srot(n,z(1,ilast),1,z(1,ilast - 1),1,c,s)
               ! h(ilast,ilast-1)=0 -- standardize b, set alphar, alphai,
                                     ! and beta
-80   continue
+                                    80 continue
               if (t(ilast,ilast) < zero) then
                  if (ilschr) then
                     do j = ifrstm,ilast
@@ -46788,7 +46788,7 @@ module stdlib_linalg_lapack_s
               ! qz step
               ! this iteration only involves rows/columns ifirst:ilast. we
               ! assume ifirst < ilast, and that the diagonal of b is non-zero.
-110  continue
+              110 continue
               iiter = iiter + 1
               if (.not. ilschr) then
                  ifrstm = ifirst
@@ -46850,7 +46850,7 @@ module stdlib_linalg_lapack_s
                  if (abs((ascale*h(j + 1,j))*temp) <= (ascale*atol)*temp2) go to 130
               end do
               istart = ifirst
-130           continue
+              130 continue
               ! do an implicit single-shift qz sweep.
               ! initial q
               temp = s1*h(istart,istart) - wr*t(istart,istart)
@@ -46905,7 +46905,7 @@ module stdlib_linalg_lapack_s
                     ! but only if the block is at least 3x3.
                     ! this code may break if this point is reached with
                     ! a 2x2 block with real eigenvalues.
-200  continue
+                    200 continue
               if (ifirst + 1 == ilast) then
                  ! special case -- 2x2 block with complex eigenvectors
                  ! step 1: standardize, that is, rotate so that
@@ -46929,9 +46929,9 @@ module stdlib_linalg_lapack_s
                  if (ifrstm < ilast - 1) call stdlib_srot(ifirst - ifrstm,t(ifrstm,ilast - 1),1,t( &
                            ifrstm,ilast),1,cr,sr)
                  if (ilq) call stdlib_srot(n,q(1,ilast - 1),1,q(1,ilast),1,cl,sl)
-                           
+
                  if (ilz) call stdlib_srot(n,z(1,ilast - 1),1,z(1,ilast),1,cr,sr)
-                           
+
                  t(ilast - 1,ilast - 1) = b11
                  t(ilast - 1,ilast) = zero
                  t(ilast,ilast - 1) = zero
@@ -47070,11 +47070,11 @@ module stdlib_linalg_lapack_s
                  ad11l = (ascale*h(ifirst,ifirst))/(bscale*t(ifirst,ifirst))
                  ad21l = (ascale*h(ifirst + 1,ifirst))/(bscale*t(ifirst,ifirst))
                  ad12l = (ascale*h(ifirst,ifirst + 1))/(bscale*t(ifirst + 1,ifirst + 1))
-                           
+
                  ad22l = (ascale*h(ifirst + 1,ifirst + 1))/(bscale*t(ifirst + 1,ifirst + 1))
-                           
+
                  ad32l = (ascale*h(ifirst + 2,ifirst + 1))/(bscale*t(ifirst + 1,ifirst + 1))
-                           
+
                  u12l = t(ifirst,ifirst + 1)/t(ifirst + 1,ifirst + 1)
                  v(1) = (ad11 - ad11l)*(ad22 - ad11l) - ad12*ad21 + ad21*u12*ad11l + (ad12l - &
                            ad11l*u12l)*ad21l
@@ -47110,7 +47110,7 @@ module stdlib_linalg_lapack_s
                     if (ilq) then
                        do jr = 1,n
                           temp = tau*(q(jr,j) + v(2)*q(jr,j + 1) + v(3)*q(jr,j + 2))
-                                    
+
                           q(jr,j) = q(jr,j) - temp
                           q(jr,j + 1) = q(jr,j + 1) - temp*v(2)
                           q(jr,j + 2) = q(jr,j + 2) - temp*v(3)
@@ -47169,7 +47169,7 @@ module stdlib_linalg_lapack_s
                     ! solve
                     u2 = (scale*u2)/w22
                     u1 = (scale*u1 - w12*u2)/w11
-250                 continue
+                    250 continue
                     if (ilpivt) then
                        temp = u2
                        u2 = u1
@@ -47198,7 +47198,7 @@ module stdlib_linalg_lapack_s
                     if (ilz) then
                        do jr = 1,n
                           temp = tau*(z(jr,j) + v(2)*z(jr,j + 1) + v(3)*z(jr,j + 2))
-                                    
+
                           z(jr,j) = z(jr,j) - temp
                           z(jr,j + 1) = z(jr,j + 1) - temp*v(2)
                           z(jr,j + 2) = z(jr,j + 2) - temp*v(3)
@@ -47253,13 +47253,13 @@ module stdlib_linalg_lapack_s
               end if
               go to 350
               ! end of iteration loop
-350  continue
+              350 continue
            end do loop_360
            ! drop-through = non-convergence
            info = ilast
            go to 420
            ! successful completion of all qz steps
-380  continue
+           380 continue
            ! set eigenvalues 1:ilo-1
            do j = 1,ilo - 1
               if (t(j,j) < zero) then
@@ -47285,7 +47285,7 @@ module stdlib_linalg_lapack_s
            ! normal termination
            info = 0
            ! exit (other than argument error) -- return optimal workspace size
-420  continue
+           420 continue
            work(1) = real(n,KIND=sp)
            return
      end subroutine stdlib_shgeqz
@@ -47308,7 +47308,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: d(*),e(*),taup(*),tauq(*),x(ldx,*),y(ldy,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            ! Intrinsic Functions
@@ -47326,7 +47326,7 @@ module stdlib_linalg_lapack_s
                             one,a(i,i),1)
                  ! generate reflection q(i) to annihilate a(i+1:m,i)
                  call stdlib_slarfg(m - i + 1,a(i,i),a(min(i + 1,m),i),1,tauq(i))
-                           
+
                  d(i) = a(i,i)
                  if (i < n) then
                     a(i,i) = one
@@ -47349,7 +47349,7 @@ module stdlib_linalg_lapack_s
                               ldx,one,a(i,i + 1),lda)
                     ! generate reflection p(i) to annihilate a(i,i+2:n)
                     call stdlib_slarfg(n - i,a(i,i + 1),a(i,min(i + 2,n)),lda,taup(i))
-                              
+
                     e(i) = a(i,i + 1)
                     a(i,i + 1) = one
                     ! compute x(i+1:m,i)
@@ -47376,7 +47376,7 @@ module stdlib_linalg_lapack_s
                            one,a(i,i),lda)
                  ! generate reflection p(i) to annihilate a(i,i+1:n)
                  call stdlib_slarfg(n - i + 1,a(i,i),a(i,min(i + 1,n)),lda,taup(i))
-                           
+
                  d(i) = a(i,i)
                  if (i < m) then
                     a(i,i) = one
@@ -47399,7 +47399,7 @@ module stdlib_linalg_lapack_s
                               1,one,a(i + 1,i),1)
                     ! generate reflection q(i) to annihilate a(i+2:m,i)
                     call stdlib_slarfg(m - i,a(i + 1,i),a(min(i + 2,m),i),1,tauq(i))
-                              
+
                     e(i) = a(i + 1,i)
                     a(i + 1,i) = one
                     ! compute y(i+1:n,i)
@@ -47438,7 +47438,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: bs = 2.0_sp
-           
+
            ! Local Scalars
            real(sp) :: aa,bb,cc,dd,ab,cd,s,ov,un,be,eps
            ! Intrinsic Functions
@@ -47512,7 +47512,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: maxit = 30
-           
+
            ! Local Scalars
            logical(lk) :: orgati,swtch,swtch3
            integer(ilp) :: ii,iim1,iip1,ip1,iter,j,niter
@@ -47609,7 +47609,7 @@ module stdlib_linalg_lapack_s
               phi = z(n)*temp
               dphi = temp*temp
               erretm = eight*(-phi - psi) + erretm - phi + rhoinv + abs(tau)*(dpsi + dphi)
-                        
+
               w = rhoinv + phi + psi
               ! test for convergence
               if (abs(w) <= eps*erretm) then
@@ -47670,7 +47670,7 @@ module stdlib_linalg_lapack_s
               phi = z(n)*temp
               dphi = temp*temp
               erretm = eight*(-phi - psi) + erretm - phi + rhoinv + abs(tau)*(dpsi + dphi)
-                        
+
               w = rhoinv + phi + psi
               ! main loop to update the values of the array   delta
               iter = niter + 1
@@ -47728,7 +47728,7 @@ module stdlib_linalg_lapack_s
                  phi = z(n)*temp
                  dphi = temp*temp
                  erretm = eight*(-phi - psi) + erretm - phi + rhoinv + abs(tau)*(dpsi + dphi)
-                           
+
                  w = rhoinv + phi + psi
               end do loop_90
               ! return with info = 1, niter = maxit and not converged
@@ -47989,7 +47989,7 @@ module stdlib_linalg_lapack_s
                           if (.not. swtch) then
                              if (orgati) then
                                 a = z(i)*z(i) + delta(ip1)*delta(ip1)*(dpsi + dphi)
-                                          
+
                              else
                                 a = z(ip1)*z(ip1) + delta(i)*delta(i)*(dpsi + dphi)
                              end if
@@ -48086,7 +48086,7 @@ module stdlib_linalg_lapack_s
                  dlam = d(ip1) + tau
               end if
            end if
-250        continue
+           250 continue
            return
      end subroutine stdlib_slaed4
 
@@ -48114,7 +48114,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: mone = -1.0_sp
-           
+
            ! Local Scalars
            integer(ilp) :: i,imax,j,jlam,jmax,jp,k2,n1,n1p1,n2
            real(sp) :: c,eps,s,t,tau,tol
@@ -48216,7 +48216,7 @@ module stdlib_linalg_lapack_s
                  go to 80
               end if
            end do
-80         continue
+           80 continue
            j = j + 1
            if (j > n) go to 100
            if (rho*abs(z(j)) <= tol) then
@@ -48252,7 +48252,7 @@ module stdlib_linalg_lapack_s
                  d(jlam) = t
                  k2 = k2 - 1
                  i = 1
-90               continue
+                 90 continue
                  if (k2 + i <= n) then
                     if (d(jlam) < d(indxp(k2 + i))) then
                        indxp(k2 + i - 1) = indxp(k2 + i)
@@ -48275,13 +48275,13 @@ module stdlib_linalg_lapack_s
               end if
            end if
            go to 80
-100        continue
+           100 continue
            ! record the last eigenvalue.
            k = k + 1
            w(k) = z(jlam)
            dlamda(k) = d(jlam)
            indxp(k) = jlam
-110        continue
+           110 continue
            ! sort the eigenvalues and corresponding eigenvectors into dlamda
            ! and q2 respectively.  the eigenvalues/vectors which were not
            ! deflated go into the first k slots of dlamda and q2 respectively,
@@ -48319,7 +48319,7 @@ module stdlib_linalg_lapack_s
      !> eigenvectors for use in calculating the next level of Z vectors.
 
      pure subroutine stdlib_slaed9(k,kstart,kstop,n,d,q,ldq,rho,dlamda,w,s,lds,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -48415,7 +48415,7 @@ module stdlib_linalg_lapack_s
                  s(i,j) = q(i,j)/temp
               end do
            end do
-120        continue
+           120 continue
            return
      end subroutine stdlib_slaed9
 
@@ -48440,7 +48440,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: tenth = 1.0e-1_sp
-           
+
            ! Local Scalars
            character :: normin,trans
            integer(ilp) :: i,i1,i2,i3,ierr,its,j
@@ -48551,7 +48551,7 @@ module stdlib_linalg_lapack_s
               end do
               ! failure to find eigenvector in n iterations.
               info = 1
-120           continue
+              120 continue
               ! normalize eigenvector.
               i = stdlib_isamax(n,vr,1)
               call stdlib_sscal(n,one/abs(vr(i)),vr,1)
@@ -48566,7 +48566,7 @@ module stdlib_linalg_lapack_s
               else
                  ! scale supplied initial vector.
                  norm = stdlib_slapy2(stdlib_snrm2(n,vr,1),stdlib_snrm2(n,vi,1))
-                           
+
                  rec = (eps3*rootn)/max(norm,nrmsml)
                  call stdlib_sscal(n,rec,vr,1)
                  call stdlib_sscal(n,rec,vi,1)
@@ -48723,7 +48723,7 @@ module stdlib_linalg_lapack_s
                        end if
                        ! divide by diagonal element of b.
                        call stdlib_sladiv(xr,xi,b(i,i),b(i + 1,i),vr(i),vi(i))
-                                 
+
                        vmax = max(abs(vr(i)) + abs(vi(i)),vmax)
                        vcrit = bignum/vmax
                     else
@@ -48753,7 +48753,7 @@ module stdlib_linalg_lapack_s
               end do loop_270
               ! failure to find eigenvector in n iterations
               info = 1
-280           continue
+              280 continue
               ! normalize eigenvector.
               vnorm = zero
               do i = 1,n
@@ -48784,7 +48784,7 @@ module stdlib_linalg_lapack_s
      !> where b11 >= b22 > 0.
 
      pure subroutine stdlib_slagv2(a,lda,b,ldb,alphar,alphai,beta,csl,snl,csr,snr)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -48795,7 +48795,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*),b(ldb,*)
            real(sp),intent(out) :: alphai(2),alphar(2),beta(2)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(sp) :: anorm,ascale,bnorm,bscale,h1,h2,h3,qq,r,rr,safmin,scale1, &
                      scale2,t,ulp,wi,wr1,wr2
@@ -48873,9 +48873,9 @@ module stdlib_linalg_lapack_s
                  call stdlib_srot(2,b(1,1),1,b(1,2),1,csr,snr)
                  ! compute inf norms of a and b
                  h1 = max(abs(a(1,1)) + abs(a(1,2)),abs(a(2,1)) + abs(a(2,2)))
-                           
+
                  h2 = max(abs(b(1,1)) + abs(b(1,2)),abs(b(2,1)) + abs(b(2,2)))
-                           
+
                  if ((scale1*h1) >= abs(wr1)*h2) then
                     ! find left rotation matrix q to zero out b(2,1)
                     call stdlib_slartg(b(1,1),b(2,1),csl,snl,r)
@@ -48891,7 +48891,7 @@ module stdlib_linalg_lapack_s
                  ! a pair of complex conjugate eigenvalues
                  ! first compute the svd of the matrix b
                  call stdlib_slasv2(b(1,1),b(1,2),b(2,2),r,t,snr,csr,snl,csl)
-                           
+
                  ! form (a,b) := q(a,b)z**t where q is left rotation matrix and
                  ! z is right rotation matrix computed from stdlib_slasv2
                  call stdlib_srot(2,a(1,1),lda,a(2,1),lda,csl,snl)
@@ -48946,7 +48946,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: t(ldt,nb),tau(nb),y(ldy,nb)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(sp) :: ei
@@ -48975,7 +48975,7 @@ module stdlib_linalg_lapack_s
                            1,one,t(1,nb),1)
                  ! w := t**t * w
                  call stdlib_strmv('UPPER','TRANSPOSE','NON-UNIT',i - 1,t,ldt,t(1,nb),1)
-                           
+
                  ! b2 := b2 - v2*w
                  call stdlib_sgemv('NO TRANSPOSE',n - k - i + 1,i - 1,-one,a(k + i,1),lda,t(1,nb) &
                            ,1,one,a(k + i,i),1)
@@ -48988,7 +48988,7 @@ module stdlib_linalg_lapack_s
               ! generate the elementary reflector h(i) to annihilate
               ! a(k+i+1:n,i)
               call stdlib_slarfg(n - k - i + 1,a(k + i,i),a(min(k + i + 1,n),i),1,tau(i))
-                        
+
               ei = a(k + i,i)
               a(k + i,i) = one
               ! compute  y(k+1:n,i)
@@ -49002,7 +49002,7 @@ module stdlib_linalg_lapack_s
               ! compute t(1:i,i)
               call stdlib_sscal(i - 1,-tau(i),t(1,i),1)
               call stdlib_strmv('UPPER','NO TRANSPOSE','NON-UNIT',i - 1,t,ldt,t(1,i),1)
-                        
+
               t(i,i) = tau(i)
            end do loop_10
            a(k + nb,nb) = ei
@@ -49058,7 +49058,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: a(lda,*),b(ldb,*)
            real(sp),intent(out) :: x(ldx,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: icmax,j
            real(sp) :: bbnd,bi1,bi2,bignum,bnorm,br1,br2,ci21,ci22,cmax,cnorm,cr21, &
@@ -49379,7 +49379,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: difl(*),difr(ldgnum,*),givnum(ldgnum,*),poles(ldgnum,*),z( &
                      *)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,m,n,nlp1
            real(sp) :: diflj,difrj,dj,dsigj,dsigjp,temp
@@ -49470,9 +49470,9 @@ module stdlib_linalg_lapack_s
                     work(1) = negone
                     temp = stdlib_snrm2(k,work,1)
                     call stdlib_sgemv('T',k,nrhs,one,bx,ldbx,work,1,zero,b(j,1),ldb)
-                              
+
                     call stdlib_slascl('G',0,0,temp,one,1,nrhs,b(j,1),ldb,info)
-                              
+
                  end do loop_50
               end if
               ! move the deflated rows of bx to b also.
@@ -49491,7 +49491,7 @@ module stdlib_linalg_lapack_s
                        work(j) = zero
                     else
                        work(j) = -z(j)/difl(j)/(dsigj + poles(j,1))/difr(j,2)
-                                 
+
                     end if
                     do i = 1,j - 1
                        if (z(j) == zero) then
@@ -49510,7 +49510,7 @@ module stdlib_linalg_lapack_s
                        end if
                     end do
                     call stdlib_sgemv('T',k,nrhs,one,b,ldb,work,1,zero,bx(j,1),ldbx)
-                              
+
                  end do
               end if
               ! step (2r): if sqre = 1, apply back the rotation that is
@@ -49612,7 +49612,7 @@ module stdlib_linalg_lapack_s
            end if
            if ((nb <= k) .or. (nb >= max(m,n,k))) then
              call stdlib_sgemlqt(side,trans,m,n,k,mb,a,lda,t,ldt,c,ldc,work,info)
-                       
+
              return
            end if
            if (left .and. tran) then
@@ -49774,7 +49774,7 @@ module stdlib_linalg_lapack_s
            end if
            if ((mb <= k) .or. (mb >= max(m,n,k))) then
              call stdlib_sgemqrt(side,trans,m,n,k,nb,a,lda,t,ldt,c,ldc,work,info)
-                       
+
              return
             end if
            if (left .and. notran) then
@@ -49877,7 +49877,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: multpl = 4.0e+0_sp
-           
+
            ! Local Scalars
            real(sp) :: aa,bb,bcmax,bcmis,cc,cs1,dd,eps,p,sab,sac,scale,sigma,sn1, &
                      tau,temp,z,safmin,safmn2,safmx2
@@ -49930,7 +49930,7 @@ module stdlib_linalg_lapack_s
                  ! make diagonal elements equal.
                  count = 0
                  sigma = b + c
-10               continue
+                 10 continue
                  count = count + 1
                  scale = max(abs(temp),abs(sigma))
                  if (scale >= safmx2) then
@@ -50020,7 +50020,7 @@ module stdlib_linalg_lapack_s
            ! Array Arguments
            real(sp),intent(inout) :: x(*),y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(sp) :: a11,a12,a22,c,ssmax,tau
            ! Executable Statements
@@ -50058,7 +50058,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*),vn1(*),vn2(*)
            real(sp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,itemp,j,mn,offpi,pvt
            real(sp) :: aii,temp,temp2,tol3z
@@ -50083,7 +50083,7 @@ module stdlib_linalg_lapack_s
               ! generate elementary reflector h(i).
               if (offpi < m) then
                  call stdlib_slarfg(m - offpi + 1,a(offpi,i),a(offpi + 1,i),1,tau(i))
-                           
+
               else
                  call stdlib_slarfg(1,a(m,i),a(m,i),1,tau(i))
               end if
@@ -50142,7 +50142,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*),auxv(*),f(ldf,*),vn1(*),vn2(*)
            real(sp),intent(out) :: tau(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: itemp,j,k,lastrk,lsticc,pvt,rk
            real(sp) :: akk,temp,temp2,tol3z
@@ -50154,7 +50154,7 @@ module stdlib_linalg_lapack_s
            k = 0
            tol3z = sqrt(stdlib_slamch('EPSILON'))
            ! beginning of while loop.
-10   continue
+           10 continue
            if ((k < nb) .and. (lsticc == 0)) then
               k = k + 1
               rk = offset + k
@@ -50240,7 +50240,7 @@ module stdlib_linalg_lapack_s
                         lda,f(kb + 1,1),ldf,one,a(rk + 1,kb + 1),lda)
            end if
            ! recomputation of difficult columns.
-40   continue
+           40 continue
            if (lsticc > 0) then
               itemp = nint(vn2(lsticc),KIND=ilp)
               vn1(lsticc) = stdlib_snrm2(m - rk,a(rk + 1,lsticc),1)
@@ -50270,7 +50270,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: h(ldh,*),si(*),sr(*),z(ldz,*)
            real(sp),intent(out) :: u(ldu,*),v(ldv,*),wh(ldwh,*),wv(ldwv,*)
         ! ================================================================
-           
+
            ! Local Scalars
            real(sp) :: alpha,beta,h11,h12,h21,h22,refsum,safmax,safmin,scl,smlnum,swap, &
                       tst1,tst2,ulp
@@ -50419,9 +50419,9 @@ module stdlib_linalg_lapack_s
                              h12 = max(abs(h(k + 1,k)),abs(h(k,k + 1)))
                              h21 = min(abs(h(k + 1,k)),abs(h(k,k + 1)))
                              h11 = max(abs(h(k + 1,k + 1)),abs(h(k,k) - h(k + 1,k + 1)))
-                                       
+
                              h22 = min(abs(h(k + 1,k + 1)),abs(h(k,k) - h(k + 1,k + 1)))
-                                       
+
                              scl = h11 + h12
                              tst2 = h22*(h11/scl)
                              if (tst2 == zero .or. h21*(h12/scl) <= max(smlnum,ulp*tst2)) &
@@ -50637,7 +50637,7 @@ module stdlib_linalg_lapack_s
                     call stdlib_sgemm('C','N',nu,jlen,nu,one,u(k1,k1),ldu,h(incol + k1, &
                               jcol),ldh,zero,wh,ldwh)
                     call stdlib_slacpy('ALL',nu,jlen,wh,ldwh,h(incol + k1,jcol),ldh)
-                              
+
                  end do
                  ! ==== vertical multiply ====
                  do jrow = jtop,max(ktop,incol) - 1,nv
@@ -50645,7 +50645,7 @@ module stdlib_linalg_lapack_s
                     call stdlib_sgemm('N','N',jlen,nu,nu,one,h(jrow,incol + k1),ldh,u( &
                               k1,k1),ldu,zero,wv,ldwv)
                     call stdlib_slacpy('ALL',jlen,nu,wv,ldwv,h(jrow,incol + k1),ldh)
-                              
+
                  end do
                  ! ==== z multiply (also vertical) ====
                  if (wantz) then
@@ -50654,7 +50654,7 @@ module stdlib_linalg_lapack_s
                        call stdlib_sgemm('N','N',jlen,nu,nu,one,z(jrow,incol + k1),ldz,u( &
                                   k1,k1),ldu,zero,wv,ldwv)
                        call stdlib_slacpy('ALL',jlen,nu,wv,ldwv,z(jrow,incol + k1),ldz)
-                                 
+
                     end do
                  end if
               end if
@@ -50695,7 +50695,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(out) :: work(*)
            real(sp),intent(inout) :: x(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran
            integer(ilp) :: i,ierr,j,j1,j2,jnext,k,n1,n2
@@ -50717,7 +50717,7 @@ module stdlib_linalg_lapack_s
            bignum = one/smlnum
            xnorm = stdlib_slange('M',n,n,t,ldt,d)
            if (.not. lreal) xnorm = max(xnorm,abs(w),stdlib_slange('M',n,1,b,n,d))
-                     
+
            smin = max(smlnum,eps*xnorm)
            ! compute 1-norm of each column of strictly upper triangular
            ! part of t to control overflow in triangular solver.
@@ -51034,7 +51034,7 @@ module stdlib_linalg_lapack_s
                        end if
                        x(j1) = x(j1) - stdlib_sdot(j1 - 1,t(1,j1),1,x,1)
                        x(n + j1) = x(n + j1) - stdlib_sdot(j1 - 1,t(1,j1),1,x(n + 1),1)
-                                 
+
                        if (j1 > 1) then
                           x(j1) = x(j1) - b(j1)*x(n + 1)
                           x(n + j1) = x(n + j1) + b(j1)*x(1)
@@ -51068,7 +51068,7 @@ module stdlib_linalg_lapack_s
                        ! scale if necessary to avoid overflow in forming the
                        ! right-hand side element by inner product.
                        xj = max(abs(x(j1)) + abs(x(n + j1)),abs(x(j2)) + abs(x(n + j2)))
-                                 
+
                        if (xmax > one) then
                           rec = one/xmax
                           if (max(work(j1),work(j2)) > (bignum - xj)/xmax) then
@@ -51080,9 +51080,9 @@ module stdlib_linalg_lapack_s
                        d(1,1) = x(j1) - stdlib_sdot(j1 - 1,t(1,j1),1,x,1)
                        d(2,1) = x(j2) - stdlib_sdot(j1 - 1,t(1,j2),1,x,1)
                        d(1,2) = x(n + j1) - stdlib_sdot(j1 - 1,t(1,j1),1,x(n + 1),1)
-                                 
+
                        d(2,2) = x(n + j2) - stdlib_sdot(j1 - 1,t(1,j2),1,x(n + 1),1)
-                                 
+
                        d(1,1) = d(1,1) - b(j1)*x(n + 1)
                        d(2,1) = d(2,1) - b(j2)*x(n + 1)
                        d(1,2) = d(1,2) + b(j1)*x(1)
@@ -51133,7 +51133,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: dsigma(*),vt2(ldvt2,*),z(*)
            real(sp),intent(in) :: u2(ldu2,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: ctemp,i,j,jc,ktemp,m,n,nlp1,nlp2,nrp1
            real(sp) :: rho,temp
@@ -51211,7 +51211,7 @@ module stdlib_linalg_lapack_s
            ! find the new singular values.
            do j = 1,k
               call stdlib_slasd4(k,j,dsigma,z,u(1,j),rho,d(j),vt(1,j),info)
-                        
+
               ! if the zero finder fails, report the convergence failure.
               if (info /= 0) then
                  return
@@ -51272,7 +51272,7 @@ module stdlib_linalg_lapack_s
            call stdlib_sgemm('N','N',nr,k,ctemp,one,u2(nlp2,ktemp),ldu2,q(ktemp,1), &
                      ldq,zero,u(nlp2,1),ldu)
            ! generate the right singular vectors.
-100  continue
+           100 continue
            do i = 1,k
               temp = stdlib_snrm2(k,vt(1,i),1)
               q(i,1) = vt(1,i)/temp
@@ -51284,7 +51284,7 @@ module stdlib_linalg_lapack_s
            ! update the right singular vector matrix.
            if (k == 2) then
               call stdlib_sgemm('N','N',k,m,k,one,q,ldq,vt2,ldvt2,zero,vt,ldvt)
-                        
+
               return
            end if
            ktemp = 1 + ctot(1)
@@ -51347,7 +51347,7 @@ module stdlib_linalg_lapack_s
 
      pure subroutine stdlib_slasd6(icompq,nl,nr,sqre,d,vf,vl,alpha,beta,idxq,perm, &
      givptr,givcol,ldgcol,givnum,ldgnum,poles,difl,difr,z,k,c,s,work,iwork,info)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -51363,7 +51363,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(out) :: difl(*),difr(*),givnum(ldgnum,*),poles(ldgnum,*),work(*), &
                      z(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,idx,idxc,idxp,isigma,ivfw,ivlw,iw,m,n,n1,n2
            real(sp) :: orgnrm
@@ -51455,7 +51455,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: ap(*),tau(*)
            real(sp),intent(out) :: q(ldq,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,iinfo,ij,j
@@ -51548,7 +51548,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: tau(*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: forwrd,left,notran,upper
            integer(ilp) :: i,i1,i2,i3,ic,ii,jc,mi,ni,nq
@@ -51659,7 +51659,7 @@ module stdlib_linalg_lapack_s
                  end if
                  ! apply h(i)
                  call stdlib_slarf(side,mi,ni,ap(ii),1,tau(i),c(ic,jc),ldc,work)
-                           
+
                  ap(ii) = aii
                  if (forwrd) then
                     ii = ii + nq - i + 1
@@ -51700,7 +51700,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(out) :: taup1(*),taup2(*),tauq1(*),work(*)
            real(sp),intent(inout) :: x11(ldx11,*),x21(ldx21,*)
         ! ====================================================================
-           
+
            ! Local Scalars
            real(sp) :: c,s
            integer(ilp) :: childinfo,i,ilarf,iorbdb5,llarf,lorbdb5,lworkmin, &
@@ -51803,7 +51803,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(out) :: taup1(*),taup2(*),tauq1(*),work(*)
            real(sp),intent(inout) :: x11(ldx11,*),x21(ldx21,*)
         ! ====================================================================
-           
+
            ! Local Scalars
            real(sp) :: c,s
            integer(ilp) :: childinfo,i,ilarf,iorbdb5,llarf,lorbdb5,lworkmin, &
@@ -51916,7 +51916,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(out) :: taup1(*),taup2(*),tauq1(*),work(*)
            real(sp),intent(inout) :: x11(ldx11,*),x21(ldx21,*)
         ! ====================================================================
-           
+
            ! Local Scalars
            real(sp) :: c,s
            integer(ilp) :: childinfo,i,ilarf,iorbdb5,llarf,lorbdb5,lworkmin, &
@@ -52028,7 +52028,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(out) :: phantom(*),taup1(*),taup2(*),tauq1(*),work(*)
            real(sp),intent(inout) :: x11(ldx11,*),x21(ldx21,*)
         ! ====================================================================
-           
+
            ! Local Scalars
            real(sp) :: c,s
            integer(ilp) :: childinfo,i,ilarf,iorbdb5,j,llarf,lorbdb5,lworkmin, &
@@ -52088,7 +52088,7 @@ module stdlib_linalg_lapack_s
                  phantom(1) = one
                  phantom(p + 1) = one
                  call stdlib_slarf('L',p,q,phantom(1),1,taup1(1),x11,ldx11,work(ilarf))
-                           
+
                  call stdlib_slarf('L',m - p,q,phantom(p + 1),1,taup2(1),x21,ldx21,work(ilarf) &
                             )
               else
@@ -52133,7 +52133,7 @@ module stdlib_linalg_lapack_s
            ! reduce the bottom-right portion of x21 to [ 0 i ]
            do i = p + 1,q
               call stdlib_slarfgp(q - i + 1,x21(m - q + i - p,i),x21(m - q + i - p,i + 1),ldx21,tauq1(i))
-                        
+
               x21(m - q + i - p,i) = one
               call stdlib_slarf('R',q - i,q - i + 1,x21(m - q + i - p,i),ldx21,tauq1(i),x21(m - q + i - p + 1,i) &
                         ,ldx21,work(ilarf))
@@ -52172,7 +52172,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: x11(ldx11,*),x21(ldx21,*)
            integer(ilp),intent(out) :: iwork(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: childinfo,i,ib11d,ib11e,ib12d,ib12e,ib21d,ib21e,ib22d,ib22e, &
            ibbcsd,iorbdb,iorglq,iorgqr,iphi,itaup1,itaup2,itauq1,j,lbbcsd,lorbdb, &
@@ -52257,13 +52257,13 @@ module stdlib_linalg_lapack_s
                  end if
                  if (wantu2 .and. m - p > 0) then
                     call stdlib_sorgqr(m - p,m - p,q,u2,ldu2,dum1,work(1),-1,childinfo)
-                              
+
                     lorgqrmin = max(lorgqrmin,m - p)
                     lorgqropt = max(lorgqropt,int(work(1),KIND=ilp))
                  end if
                  if (wantv1t .and. q > 0) then
                     call stdlib_sorglq(q - 1,q - 1,q - 1,v1t,ldv1t,dum1,work(1),-1,childinfo)
-                              
+
                     lorglqmin = max(lorglqmin,q - 1)
                     lorglqopt = max(lorglqopt,int(work(1),KIND=ilp))
                  end if
@@ -52283,7 +52283,7 @@ module stdlib_linalg_lapack_s
                  end if
                  if (wantu2 .and. m - p > 0) then
                     call stdlib_sorgqr(m - p,m - p,q,u2,ldu2,dum1,work(1),-1,childinfo)
-                              
+
                     lorgqrmin = max(lorgqrmin,m - p)
                     lorgqropt = max(lorgqropt,int(work(1),KIND=ilp))
                  end if
@@ -52331,7 +52331,7 @@ module stdlib_linalg_lapack_s
                  end if
                  if (wantu2 .and. m - p > 0) then
                     call stdlib_sorgqr(m - p,m - p,m - q,u2,ldu2,dum1,work(1),-1,childinfo)
-                              
+
                     lorgqrmin = max(lorgqrmin,m - p)
                     lorgqropt = max(lorgqropt,int(work(1),KIND=ilp))
                  end if
@@ -52500,7 +52500,7 @@ module stdlib_linalg_lapack_s
               ! simultaneously bidiagonalize x11 and x21
               call stdlib_sorbdb4(m,p,q,x11,ldx11,x21,ldx21,theta,work(iphi),work(itaup1) &
               ,work(itaup2),work(itauq1),work(iorbdb),work(iorbdb + m),lorbdb - m,childinfo)
-                        
+
               ! accumulate householder reflectors
               if (wantu2 .and. m - p > 0) then
                  call stdlib_scopy(m - p,work(iorbdb + p),1,u2,1)
@@ -52527,7 +52527,7 @@ module stdlib_linalg_lapack_s
                  call stdlib_slacpy('U',p - (m - q),q - (m - q),x11(m - q + 1,m - q + 1),ldx11,v1t(m - q + 1,m - q + &
                            1),ldv1t)
                  call stdlib_slacpy('U',-p + q,q - p,x21(m - q + 1,p + 1),ldx21,v1t(p + 1,p + 1),ldv1t)
-                           
+
                  call stdlib_sorglq(q,q,q,v1t,ldv1t,work(itauq1),work(iorglq),lorglq, &
                            childinfo)
               end if
@@ -52575,7 +52575,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: tau(*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper
            integer(ilp) :: i,iinfo,j,lwkopt,nb
@@ -52650,7 +52650,7 @@ module stdlib_linalg_lapack_s
               if (n > 1) then
                  ! generate q(2:n,2:n)
                  call stdlib_sorgqr(n - 1,n - 1,n - 1,a(2,2),lda,tau,work,lwork,iinfo)
-                           
+
               end if
            end if
            work(1) = lwkopt
@@ -52675,7 +52675,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: t(ldt,*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: iinfo,ldc,lworkopt,lc,lw,nblocal,j
@@ -52892,7 +52892,7 @@ module stdlib_linalg_lapack_s
            ! Parameters
            integer(ilp),parameter :: nbmax = 32
            integer(ilp),parameter :: ldwork = nbmax + 1
-           
+
            ! Local Scalars
            integer(ilp) :: i,i2,i3,ib,ii,j,jj,nb
            ! Local Arrays
@@ -53065,7 +53065,7 @@ module stdlib_linalg_lapack_s
               end if
            end if
            return
-150        continue
+           150 continue
            return
      end subroutine stdlib_spbtrf
 
@@ -53084,7 +53084,7 @@ module stdlib_linalg_lapack_s
            ! Array Arguments
            real(sp),intent(inout) :: a(0:*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,nisodd,normaltransr
            integer(ilp) :: n1,n2,k
@@ -53140,7 +53140,7 @@ module stdlib_linalg_lapack_s
                     call stdlib_slauum('L',n1,a(0),n,info)
                     call stdlib_ssyrk('L','T',n1,n2,one,a(n1),n,one,a(0),n)
                     call stdlib_strmm('L','U','N','N',n2,n1,one,a(n),n,a(n1),n)
-                              
+
                     call stdlib_slauum('U',n2,a(n),n,info)
                  else
                     ! srpa for upper, normal and n is odd ( a(0:n-1,0:n2-1)
@@ -53149,7 +53149,7 @@ module stdlib_linalg_lapack_s
                     call stdlib_slauum('L',n1,a(n2),n,info)
                     call stdlib_ssyrk('L','N',n1,n2,one,a(0),n,one,a(n2),n)
                     call stdlib_strmm('R','U','T','N',n1,n2,one,a(n1),n,a(0),n)
-                              
+
                     call stdlib_slauum('U',n2,a(n1),n,info)
                  end if
               else
@@ -53159,7 +53159,7 @@ module stdlib_linalg_lapack_s
                     ! t1 -> a(0), t2 -> a(1), s -> a(0+n1*n1)
                     call stdlib_slauum('U',n1,a(0),n1,info)
                     call stdlib_ssyrk('U','N',n1,n2,one,a(n1*n1),n1,one,a(0),n1)
-                              
+
                     call stdlib_strmm('R','L','N','N',n1,n2,one,a(1),n1,a(n1*n1),n1 &
                               )
                     call stdlib_slauum('L',n2,a(1),n1,info)
@@ -53168,7 +53168,7 @@ module stdlib_linalg_lapack_s
                     ! t1 -> a(0+n2*n2), t2 -> a(0+n1*n2), s -> a(0)
                     call stdlib_slauum('U',n1,a(n2*n2),n2,info)
                     call stdlib_ssyrk('U','T',n1,n2,one,a(0),n2,one,a(n2*n2),n2)
-                              
+
                     call stdlib_strmm('L','L','T','N',n2,n1,one,a(n1*n2),n2,a(0),n2 &
                               )
                     call stdlib_slauum('L',n2,a(n1*n2),n2,info)
@@ -53184,9 +53184,9 @@ module stdlib_linalg_lapack_s
                     ! t1 -> a(1), t2 -> a(0), s -> a(k+1)
                     call stdlib_slauum('L',k,a(1),n + 1,info)
                     call stdlib_ssyrk('L','T',k,k,one,a(k + 1),n + 1,one,a(1),n + 1)
-                              
+
                     call stdlib_strmm('L','U','N','N',k,k,one,a(0),n + 1,a(k + 1),n + 1)
-                              
+
                     call stdlib_slauum('U',k,a(0),n + 1,info)
                  else
                     ! srpa for upper, normal, and n is even ( a(0:n,0:k-1) )
@@ -53194,9 +53194,9 @@ module stdlib_linalg_lapack_s
                     ! t1 -> a(k+1), t2 -> a(k), s -> a(0)
                     call stdlib_slauum('L',k,a(k + 1),n + 1,info)
                     call stdlib_ssyrk('L','N',k,k,one,a(0),n + 1,one,a(k + 1),n + 1)
-                              
+
                     call stdlib_strmm('R','U','T','N',k,k,one,a(k),n + 1,a(0),n + 1)
-                              
+
                     call stdlib_slauum('U',k,a(k),n + 1,info)
                  end if
               else
@@ -53207,7 +53207,7 @@ module stdlib_linalg_lapack_s
                     ! t1 -> a(0+k), t2 -> a(0+0), s -> a(0+k*(k+1)); lda=k
                     call stdlib_slauum('U',k,a(k),k,info)
                     call stdlib_ssyrk('U','N',k,k,one,a(k*(k + 1)),k,one,a(k),k)
-                              
+
                     call stdlib_strmm('R','L','N','N',k,k,one,a(0),k,a(k*(k + 1)),k &
                               )
                     call stdlib_slauum('L',k,a(0),k,info)
@@ -53217,9 +53217,9 @@ module stdlib_linalg_lapack_s
                     ! t1 -> a(0+k*(k+1)), t2 -> a(0+k*k), s -> a(0+0)); lda=k
                     call stdlib_slauum('U',k,a(k*(k + 1)),k,info)
                     call stdlib_ssyrk('U','T',k,k,one,a(0),k,one,a(k*(k + 1)),k)
-                              
+
                     call stdlib_strmm('L','L','T','N',k,k,one,a(k*k),k,a(0),k)
-                              
+
                     call stdlib_slauum('L',k,a(k*k),k,info)
                  end if
               end if
@@ -53246,7 +53246,7 @@ module stdlib_linalg_lapack_s
            ! Array Arguments
            real(sp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,jb,nb
@@ -53315,9 +53315,9 @@ module stdlib_linalg_lapack_s
               end if
            end if
            go to 40
-30         continue
+           30 continue
            info = info + j - 1
-40         continue
+           40 continue
            return
      end subroutine stdlib_spotrf
 
@@ -53327,7 +53327,7 @@ module stdlib_linalg_lapack_s
      !> estimates for the solution.
 
      pure subroutine stdlib_sptrfs(n,nrhs,d,e,df,ef,b,ldb,x,ldx,ferr,berr,work,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -53341,7 +53341,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            integer(ilp) :: count,i,ix,j,nz
            real(sp) :: bi,cx,dx,eps,ex,lstres,s,safe1,safe2,safmin
@@ -53381,7 +53381,7 @@ module stdlib_linalg_lapack_s
            loop_90: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x.  also compute
               ! abs(a)*abs(x) + abs(b) for use in the backward error bound.
@@ -53552,7 +53552,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(out) :: berr(*),ferr(*),work(*),x(ldx,*)
            real(sp),intent(inout) :: df(*),ef(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nofact
            real(sp) :: anorm
@@ -53598,7 +53598,7 @@ module stdlib_linalg_lapack_s
            ! use iterative refinement to improve the computed solutions and
            ! compute error bounds and backward error estimates for them.
            call stdlib_sptrfs(n,nrhs,d,e,df,ef,b,ldb,x,ldx,ferr,berr,work,info)
-                     
+
            ! set info = n+1 if the matrix is singular to working precision.
            if (rcond < stdlib_slamch('EPSILON')) info = n + 1
            return
@@ -53619,7 +53619,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: ab(ldab,*)
            real(sp),intent(out) :: w(*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,wantz
            integer(ilp) :: iinfo,imax,inde,indwrk,iscale
@@ -53726,7 +53726,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: ab(ldab,*)
            real(sp),intent(out) :: q(ldq,*),w(*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,lower,test,valeig,wantz
            character :: order
@@ -53857,7 +53857,7 @@ module stdlib_linalg_lapack_s
                  call stdlib_slacpy('A',n,n,q,ldq,z,ldz)
                  call stdlib_scopy(n - 1,work(inde),1,work(indee),1)
                  call stdlib_ssteqr(jobz,n,w,work(indee),z,ldz,work(indwrk),info)
-                           
+
                  if (info == 0) then
                     do i = 1,n
                        ifail(i) = 0
@@ -53893,7 +53893,7 @@ module stdlib_linalg_lapack_s
               end do
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
-30   continue
+           30 continue
            if (iscale == 1) then
               if (info == 0) then
                  imax = m
@@ -54032,7 +54032,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: ab(ldab,*),bb(ldbb,*)
            real(sp),intent(out) :: q(ldq,*),w(*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,test,upper,valeig,wantz
            character :: order,vect
@@ -54098,7 +54098,7 @@ module stdlib_linalg_lapack_s
            end if
            ! transform problem to standard eigenvalue problem.
            call stdlib_ssbgst(jobz,uplo,n,ka,kb,ab,ldab,bb,ldbb,q,ldq,work,iinfo)
-                     
+
            ! reduce symmetric band matrix to tridiagonal form.
            indd = 1
            inde = indd + n
@@ -54128,7 +54128,7 @@ module stdlib_linalg_lapack_s
               else
                  call stdlib_slacpy('A',n,n,q,ldq,z,ldz)
                  call stdlib_ssteqr(jobz,n,w,work(indee),z,ldz,work(indwrk),info)
-                           
+
                  if (info == 0) then
                     do i = 1,n
                        ifail(i) = 0
@@ -54153,7 +54153,7 @@ module stdlib_linalg_lapack_s
            indiwo = indisp + n
            call stdlib_sstebz(range,order,n,vl,vu,il,iu,abstol,work(indd),work(inde), &
             m,nsplit,w,iwork(indibl),iwork(indisp),work(indwrk),iwork(indiwo),info)
-                      
+
            if (wantz) then
               call stdlib_sstein(n,work(indd),work(inde),m,w,iwork(indibl),iwork( &
                         indisp),z,ldz,work(indwrk),iwork(indiwo),ifail,info)
@@ -54164,7 +54164,7 @@ module stdlib_linalg_lapack_s
                  call stdlib_sgemv('N',n,n,one,q,ldq,work,1,zero,z(1,j),1)
               end do
            end if
-30         continue
+           30 continue
            ! if eigenvalues are not in order, then sort them, along with
            ! eigenvectors.
            if (wantz) then
@@ -54210,7 +54210,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: ap(*)
            real(sp),intent(out) :: w(*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: wantz
            integer(ilp) :: iinfo,imax,inde,indtau,indwrk,iscale
@@ -54273,7 +54273,7 @@ module stdlib_linalg_lapack_s
            else
               indwrk = indtau + n
               call stdlib_sopgtr(uplo,n,ap,work(indtau),z,ldz,work(indwrk),iinfo)
-                        
+
               call stdlib_ssteqr(jobz,n,w,work(inde),z,ldz,work(indtau),info)
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
@@ -54308,7 +54308,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: ap(*)
            real(sp),intent(out) :: w(*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,test,valeig,wantz
            character :: order
@@ -54407,7 +54407,7 @@ module stdlib_linalg_lapack_s
            indd = inde + n
            indwrk = indd + n
            call stdlib_ssptrd(uplo,n,ap,work(indd),work(inde),work(indtau),iinfo)
-                     
+
            ! if all eigenvalues are desired and abstol is less than or equal
            ! to zero, then call stdlib_ssterf or stdlib_sopgtr and stdlib_ssteqr.  if this fails
            ! for some eigenvalue, then try stdlib_sstebz.
@@ -54425,10 +54425,10 @@ module stdlib_linalg_lapack_s
                  call stdlib_ssterf(n,w,work(indee),info)
               else
                  call stdlib_sopgtr(uplo,n,ap,work(indtau),z,ldz,work(indwrk),iinfo)
-                           
+
                  call stdlib_scopy(n - 1,work(inde),1,work(indee),1)
                  call stdlib_ssteqr(jobz,n,w,work(indee),z,ldz,work(indwrk),info)
-                           
+
                  if (info == 0) then
                     do i = 1,n
                        ifail(i) = 0
@@ -54462,7 +54462,7 @@ module stdlib_linalg_lapack_s
                          iinfo)
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
-20   continue
+           20 continue
            if (iscale == 1) then
               if (info == 0) then
                  imax = m
@@ -54712,7 +54712,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: w(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,lquery,wantz
            integer(ilp) :: iinfo,imax,inde,indtau,indwrk,iscale,llwork,lwkopt,nb
@@ -54787,7 +54787,7 @@ module stdlib_linalg_lapack_s
               call stdlib_ssterf(n,w,work(inde),info)
            else
               call stdlib_sorgtr(uplo,n,a,lda,work(indtau),work(indwrk),llwork,iinfo)
-                        
+
               call stdlib_ssteqr(jobz,n,w,work(inde),a,lda,work(indtau),info)
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
@@ -54824,7 +54824,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: w(*),work(*),z(ldz,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,lower,lquery,test,valeig,wantz
            character :: order
@@ -54974,7 +54974,7 @@ module stdlib_linalg_lapack_s
                            iinfo)
                  call stdlib_scopy(n - 1,work(inde),1,work(indee),1)
                  call stdlib_ssteqr(jobz,n,w,work(indee),z,ldz,work(indwrk),info)
-                           
+
                  if (info == 0) then
                     do i = 1,n
                        ifail(i) = 0
@@ -55010,7 +55010,7 @@ module stdlib_linalg_lapack_s
                         indwkn),llwrkn,iinfo)
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
-40   continue
+           40 continue
            if (iscale == 1) then
               if (info == 0) then
                  imax = m
@@ -55069,7 +55069,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*),b(ldb,*)
            real(sp),intent(out) :: w(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper,wantz
            character :: trans
@@ -55134,7 +55134,7 @@ module stdlib_linalg_lapack_s
                     trans = 'T'
                  end if
                  call stdlib_strsm('LEFT',uplo,trans,'NON-UNIT',n,neig,one,b,ldb,a,lda)
-                           
+
               else if (itype == 3) then
                  ! for b*a*x=(lambda)*x;
                  ! backtransform eigenvectors: x = l*y or u**t*y
@@ -55144,7 +55144,7 @@ module stdlib_linalg_lapack_s
                     trans = 'N'
                  end if
                  call stdlib_strmm('LEFT',uplo,trans,'NON-UNIT',n,neig,one,b,ldb,a,lda)
-                           
+
               end if
            end if
            work(1) = lwkopt
@@ -55173,7 +55173,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*),b(ldb,*)
            real(sp),intent(out) :: w(*),work(*),z(ldz,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,lquery,upper,valeig,wantz
            character :: trans
@@ -55261,7 +55261,7 @@ module stdlib_linalg_lapack_s
                     trans = 'T'
                  end if
                  call stdlib_strsm('LEFT',uplo,trans,'NON-UNIT',n,m,one,b,ldb,z,ldz)
-                           
+
               else if (itype == 3) then
                  ! for b*a*x=(lambda)*x;
                  ! backtransform eigenvectors: x = l*y or u**t*y
@@ -55271,7 +55271,7 @@ module stdlib_linalg_lapack_s
                     trans = 'N'
                  end if
                  call stdlib_strmm('LEFT',uplo,trans,'NON-UNIT',n,m,one,b,ldb,z,ldz)
-                           
+
               end if
            end if
            ! set work(1) to optimal workspace size.
@@ -55381,7 +55381,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: af(ldaf,*)
            real(sp),intent(out) :: berr(*),ferr(*),work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,nofact
            integer(ilp) :: lwkopt,nb
@@ -55459,7 +55459,7 @@ module stdlib_linalg_lapack_s
      !> Q**T * A * Q = AB.
 
      pure subroutine stdlib_ssytrd_sy2sb(uplo,n,kd,a,lda,ab,ldab,tau,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -55473,7 +55473,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: rone = 1.0e+0_sp
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper
            integer(ilp) :: i,j,iinfo,lwmin,pn,pk,lk,ldt,ldw,lds2,lds1,ls2,ls1,lw,lt, &
@@ -55616,7 +55616,7 @@ module stdlib_linalg_lapack_s
                    ! do 45 j = i, i+pk-1
                       ! lk = min( kd, n-j ) + 1
                       ! call stdlib_scopy( lk, ab( 1, j ), 1, a( j, j ), 1 )
-45   continue
+                      45 continue
                   ! ==================================================================
                end do loop_40
               ! copy the lower band to ab which is the band storage matrix
@@ -55665,7 +55665,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: safety = 1.0e+2_sp
-           
+
            ! Local Scalars
            logical(lk) :: compl,compr,il2by2,ilabad,ilall,ilback,ilbbad,ilcomp,ilcplx, &
                      lsa,lsb
@@ -55883,7 +55883,7 @@ module stdlib_linalg_lapack_s
                     lsb = abs(salfar) >= safmin .and. abs(bcoefr) < small
                     if (lsa) scale = (small/abs(sbeta))*min(anorm,big)
                     if (lsb) scale = max(scale, (small/abs(salfar))*min(bnorm,big))
-                              
+
                     if (lsa .or. lsb) then
                        scale = min(scale,one/(safmin*max(one,abs(acoef),abs(bcoefr))) &
                                  )
@@ -55922,7 +55922,7 @@ module stdlib_linalg_lapack_s
                               ulp)/bcoefa)
                     if (safmin*acoefa > ascale) scale = ascale/(safmin*acoefa)
                     if (safmin*bcoefa > bscale) scale = min(scale,bscale/(safmin*bcoefa))
-                              
+
                     if (scale /= one) then
                        acoef = scale*acoef
                        acoefa = abs(acoef)
@@ -55973,7 +55973,7 @@ module stdlib_linalg_lapack_s
                     ! check whether scaling is necessary for dot products
                     xscale = one/max(one,xmax)
                     temp = max(work(j),work(n + j),acoefa*work(j) + bcoefa*work(n + j))
-                              
+
                     if (il2by2) temp = max(temp,work(j + 1),work(n + j + 1),acoefa*work(j + 1) + &
                               bcoefa*work(n + j + 1))
                     if (temp > bignum*xscale) then
@@ -56021,7 +56021,7 @@ module stdlib_linalg_lapack_s
                     ! with scaling and perturbation of the denominator
                     call stdlib_slaln2(.true.,na,nw,dmin,acoef,s(j,j),lds,bdiag(1), &
                     bdiag(2),sum,2,bcoefr,bcoefi,work(2*n + j),n,scale,temp,iinfo)
-                              
+
                     if (scale < one) then
                        do jw = 0,nw - 1
                           do jr = je,j - 1
@@ -56137,7 +56137,7 @@ module stdlib_linalg_lapack_s
                     lsb = abs(salfar) >= safmin .and. abs(bcoefr) < small
                     if (lsa) scale = (small/abs(sbeta))*min(anorm,big)
                     if (lsb) scale = max(scale, (small/abs(salfar))*min(bnorm,big))
-                              
+
                     if (lsa .or. lsb) then
                        scale = min(scale,one/(safmin*max(one,abs(acoef),abs(bcoefr))) &
                                  )
@@ -56180,7 +56180,7 @@ module stdlib_linalg_lapack_s
                               ulp)/bcoefa)
                     if (safmin*acoefa > ascale) scale = ascale/(safmin*acoefa)
                     if (safmin*bcoefa > bscale) scale = min(scale,bscale/(safmin*bcoefa))
-                              
+
                     if (scale /= one) then
                        acoef = scale*acoef
                        acoefa = abs(acoef)
@@ -56247,7 +56247,7 @@ module stdlib_linalg_lapack_s
                     ! compute x(j) (and x(j+1), if 2-by-2 block)
                     call stdlib_slaln2(.false.,na,nw,dmin,acoef,s(j,j),lds,bdiag(1), &
                     bdiag(2),work(2*n + j),n,bcoefr,bcoefi,sum,2,scale,temp,iinfo)
-                              
+
                     if (scale < one) then
                        do jw = 0,nw - 1
                           do jr = 1,je
@@ -56267,7 +56267,7 @@ module stdlib_linalg_lapack_s
                        xscale = one/max(one,xmax)
                        temp = acoefa*work(j) + bcoefa*work(n + j)
                        if (il2by2) temp = max(temp,acoefa*work(j + 1) + bcoefa*work(n + j + 1))
-                                 
+
                        temp = max(temp,acoefa,bcoefa)
                        if (temp > bignum*xscale) then
                           do jw = 0,nw - 1
@@ -56389,7 +56389,7 @@ module stdlib_linalg_lapack_s
            real(sp),parameter :: twenty = 2.0e+01_sp
            integer(ilp),parameter :: ldst = 4
            logical(lk),parameter :: wands = .true.
-           
+
            ! Local Scalars
            logical(lk) :: strong,weak
            integer(ilp) :: i,idum,linfo,m
@@ -56461,9 +56461,9 @@ module stdlib_linalg_lapack_s
                  call stdlib_slartg(t(1,1),t(2,1),li(1,1),li(2,1),ddum)
               end if
               call stdlib_srot(2,s(1,1),ldst,s(2,1),ldst,li(1,1),li(2,1))
-                        
+
               call stdlib_srot(2,t(1,1),ldst,t(2,1),ldst,li(1,1),li(2,1))
-                        
+
               li(2,2) = li(1,1)
               li(1,2) = -li(2,1)
               ! weak stability test: |s21| <= o(eps f-norm((a)))
@@ -56477,7 +56477,7 @@ module stdlib_linalg_lapack_s
                      ! f-norm((b-ql**h*t*qr)) <= o(eps*f-norm((b)))
                  call stdlib_slacpy('FULL',m,m,a(j1,j1),lda,work(m*m + 1),m)
                  call stdlib_sgemm('N','N',m,m,m,one,li,ldst,s,ldst,zero,work,m)
-                           
+
                  call stdlib_sgemm('N','T',m,m,m,-one,work,m,ir,ldst,one,work(m*m + 1), &
                             m)
                  dscale = zero
@@ -56486,7 +56486,7 @@ module stdlib_linalg_lapack_s
                  sa = dscale*sqrt(dsum)
                  call stdlib_slacpy('FULL',m,m,b(j1,j1),ldb,work(m*m + 1),m)
                  call stdlib_sgemm('N','N',m,m,m,one,li,ldst,t,ldst,zero,work,m)
-                           
+
                  call stdlib_sgemm('N','T',m,m,m,-one,work,m,ir,ldst,one,work(m*m + 1), &
                             m)
                  dscale = zero
@@ -56499,9 +56499,9 @@ module stdlib_linalg_lapack_s
               ! update (a(j1:j1+m-1, m+j1:n), b(j1:j1+m-1, m+j1:n)) and
                      ! (a(1:j1-1, j1:j1+m), b(1:j1-1, j1:j1+m)).
               call stdlib_srot(j1 + 1,a(1,j1),1,a(1,j1 + 1),1,ir(1,1),ir(2,1))
-                        
+
               call stdlib_srot(j1 + 1,b(1,j1),1,b(1,j1 + 1),1,ir(1,1),ir(2,1))
-                        
+
               call stdlib_srot(n - j1 + 1,a(j1,j1),lda,a(j1 + 1,j1),lda,li(1,1),li(2,1 &
                         ))
               call stdlib_srot(n - j1 + 1,b(j1,j1),ldb,b(j1 + 1,j1),ldb,li(1,1),li(2,1 &
@@ -56525,7 +56525,7 @@ module stdlib_linalg_lapack_s
               ! for r and l. solutions in li and ir.
               call stdlib_slacpy('FULL',n1,n2,t(1,n1 + 1),ldst,li,ldst)
               call stdlib_slacpy('FULL',n1,n2,s(1,n1 + 1),ldst,ir(n2 + 1,n1 + 1),ldst)
-                        
+
               call stdlib_stgsy2('N',0,n1,n2,s,ldst,s(n1 + 1,n1 + 1),ldst,ir(n2 + 1,n1 + 1), &
                ldst,t,ldst,t(n1 + 1,n1 + 1),ldst,li,ldst,scale,dsum,dscale,iwork,idum, &
                          linfo)
@@ -56583,9 +56583,9 @@ module stdlib_linalg_lapack_s
               call stdlib_sgeqr2(m,m,tcpy,ldst,taul,work,linfo)
               if (linfo /= 0) go to 70
               call stdlib_sorm2r('L','T',m,m,m,tcpy,ldst,taul,scpy,ldst,work,info)
-                        
+
               call stdlib_sorm2r('R','N',m,m,m,tcpy,ldst,taul,licop,ldst,work,info)
-                        
+
               if (linfo /= 0) go to 70
               ! compute f-norm(s21) in bqra21. (t21 is 0.)
               dscale = zero
@@ -56614,7 +56614,7 @@ module stdlib_linalg_lapack_s
                      ! f-norm((b-ql**h*t*qr)) <= o(eps*f-norm((b)))
                  call stdlib_slacpy('FULL',m,m,a(j1,j1),lda,work(m*m + 1),m)
                  call stdlib_sgemm('N','N',m,m,m,one,li,ldst,s,ldst,zero,work,m)
-                           
+
                  call stdlib_sgemm('N','N',m,m,m,-one,work,m,ir,ldst,one,work(m*m + 1), &
                             m)
                  dscale = zero
@@ -56623,7 +56623,7 @@ module stdlib_linalg_lapack_s
                  sa = dscale*sqrt(dsum)
                  call stdlib_slacpy('FULL',m,m,b(j1,j1),ldb,work(m*m + 1),m)
                  call stdlib_sgemm('N','N',m,m,m,one,li,ldst,t,ldst,zero,work,m)
-                           
+
                  call stdlib_sgemm('N','N',m,m,m,-one,work,m,ir,ldst,one,work(m*m + 1), &
                             m)
                  dscale = zero
@@ -56658,7 +56658,7 @@ module stdlib_linalg_lapack_s
               if (n1 > 1) then
                  call stdlib_slagv2(a(j1 + n2,j1 + n2),lda,b(j1 + n2,j1 + n2),ldb,taur,taul, &
                  work(m*m + 1),work(n2*m + n2 + 1),work(n2*m + n2 + 2),t(n2 + 1,n2 + 1),t(m,m - 1))
-                           
+
                  work(m*m) = work(n2*m + n2 + 1)
                  work(m*m - 1) = -work(n2*m + n2 + 2)
                  t(m,m) = t(n2 + 1,n2 + 1)
@@ -56716,7 +56716,7 @@ module stdlib_linalg_lapack_s
               return
            end if
            ! exit with info = 1 if swap was rejected.
-70   continue
+           70 continue
            info = 1
            return
      end subroutine stdlib_stgex2
@@ -56748,7 +56748,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*),b(ldb,*),q(ldq,*),z(ldz,*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: here,lwmin,nbf,nbl,nbnext
@@ -56816,7 +56816,7 @@ module stdlib_linalg_lapack_s
               if (nbf == 2 .and. nbl == 1) ilst = ilst - 1
               if (nbf == 1 .and. nbl == 2) ilst = ilst + 1
               here = ifst
-10            continue
+              10 continue
               ! swap with next one below.
               if (nbf == 1 .or. nbf == 2) then
                  ! current block either 1-by-1 or 2-by-2.
@@ -56891,7 +56891,7 @@ module stdlib_linalg_lapack_s
               if (here < ilst) go to 10
            else
               here = ifst
-20            continue
+              20 continue
               ! swap with next one below.
               if (nbf == 1 .or. nbf == 2) then
                  ! current block either 1-by-1 or 2-by-2.
@@ -57009,7 +57009,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: idifjb = 3
-           
+
            ! Local Scalars
            logical(lk) :: lquery,pair,swap,wantd,wantd1,wantd2,wantp
            integer(ilp) :: i,ierr,ijb,k,kase,kk,ks,liwmin,lwmin,mn2,n1,n2
@@ -57210,9 +57210,9 @@ module stdlib_linalg_lapack_s
                  ijb = 0
                  mn2 = 2*n1*n2
                  ! 1-norm-based estimate of difu.
-40   continue
+                 40 continue
                  call stdlib_slacn2(mn2,work(mn2 + 1),work,iwork,dif(1),kase,isave)
-                           
+
                  if (kase /= 0) then
                     if (kase == 1) then
                        ! solve generalized sylvester equation.
@@ -57229,9 +57229,9 @@ module stdlib_linalg_lapack_s
                  end if
                  dif(1) = dscale/dif(1)
                  ! 1-norm-based estimate of difl.
-50   continue
+                 50 continue
                  call stdlib_slacn2(mn2,work(mn2 + 1),work,iwork,dif(2),kase,isave)
-                           
+
                  if (kase /= 0) then
                     if (kase == 1) then
                        ! solve generalized sylvester equation.
@@ -57249,7 +57249,7 @@ module stdlib_linalg_lapack_s
                  dif(2) = dscale/dif(2)
               end if
            end if
-60         continue
+           60 continue
            ! compute generalized eigenvalues of reordered pair (a, b) and
            ! normalize the generalized schur form.
            pair = .false.
@@ -57374,7 +57374,7 @@ module stdlib_linalg_lapack_s
            ! Parameters
            integer(ilp),parameter :: maxit = 40
            real(sp),parameter :: hugenum = huge(zero)
-           
+
            ! Local Scalars
            logical(lk) :: initq,initu,initv,upper,wantq,wantu,wantv
            integer(ilp) :: i,j,kcycle
@@ -57452,7 +57452,7 @@ module stdlib_linalg_lapack_s
                     ! update (n-l+i)-th and (n-l+j)-th columns of matrices
                     ! a and b: a*q and b*q
                     call stdlib_srot(min(k + l,m),a(1,n - l + j),1,a(1,n - l + i),1,csq,snq)
-                              
+
                     call stdlib_srot(l,b(1,n - l + j),1,b(1,n - l + i),1,csq,snq)
                     if (upper) then
                        if (k + i <= m) a(k + i,n - l + j) = zero
@@ -57466,7 +57466,7 @@ module stdlib_linalg_lapack_s
                               csu,snu)
                     if (wantv) call stdlib_srot(p,v(1,j),1,v(1,i),1,csv,snv)
                     if (wantq) call stdlib_srot(n,q(1,n - l + j),1,q(1,n - l + i),1,csq,snq)
-                              
+
                  end do loop_10
               end do loop_20
               if (.not. upper) then
@@ -57488,7 +57488,7 @@ module stdlib_linalg_lapack_s
            ! the algorithm has not converged after maxit cycles.
            info = 1
            go to 100
-50         continue
+           50 continue
            ! if error <= min(tola,tolb), then the algorithm has converged.
            ! compute the generalized singular value pairs (alpha, beta), and
            ! set the triangular matrix r to array a.
@@ -57530,7 +57530,7 @@ module stdlib_linalg_lapack_s
                  beta(i) = zero
               end do
            end if
-100        continue
+           100 continue
            ncycle = kcycle
            return
      end subroutine stdlib_stgsja
@@ -57561,7 +57561,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: difdri = 3
-           
+
            ! Local Scalars
            logical(lk) :: lquery,pair,somcon,wantbh,wantdf,wants
            integer(ilp) :: i,ierr,ifst,ilst,iz,k,ks,lwmin,n1,n2
@@ -57673,21 +57673,21 @@ module stdlib_linalg_lapack_s
                     lnrm = stdlib_slapy2(stdlib_snrm2(n,vl(1,ks),1),stdlib_snrm2(n,vl( &
                               1,ks + 1),1))
                     call stdlib_sgemv('N',n,n,one,a,lda,vr(1,ks),1,zero,work,1)
-                              
+
                     tmprr = stdlib_sdot(n,work,1,vl(1,ks),1)
                     tmpri = stdlib_sdot(n,work,1,vl(1,ks + 1),1)
                     call stdlib_sgemv('N',n,n,one,a,lda,vr(1,ks + 1),1,zero,work,1)
-                              
+
                     tmpii = stdlib_sdot(n,work,1,vl(1,ks + 1),1)
                     tmpir = stdlib_sdot(n,work,1,vl(1,ks),1)
                     uhav = tmprr + tmpii
                     uhavi = tmpir - tmpri
                     call stdlib_sgemv('N',n,n,one,b,ldb,vr(1,ks),1,zero,work,1)
-                              
+
                     tmprr = stdlib_sdot(n,work,1,vl(1,ks),1)
                     tmpri = stdlib_sdot(n,work,1,vl(1,ks + 1),1)
                     call stdlib_sgemv('N',n,n,one,b,ldb,vr(1,ks + 1),1,zero,work,1)
-                              
+
                     tmpii = stdlib_sdot(n,work,1,vl(1,ks + 1),1)
                     tmpir = stdlib_sdot(n,work,1,vl(1,ks),1)
                     uhbv = tmprr + tmpii
@@ -57702,10 +57702,10 @@ module stdlib_linalg_lapack_s
                     rnrm = stdlib_snrm2(n,vr(1,ks),1)
                     lnrm = stdlib_snrm2(n,vl(1,ks),1)
                     call stdlib_sgemv('N',n,n,one,a,lda,vr(1,ks),1,zero,work,1)
-                              
+
                     uhav = stdlib_sdot(n,work,1,vl(1,ks),1)
                     call stdlib_sgemv('N',n,n,one,b,ldb,vr(1,ks),1,zero,work,1)
-                              
+
                     uhbv = stdlib_sdot(n,work,1,vl(1,ks),1)
                     cond = stdlib_slapy2(uhav,uhbv)
                     if (cond == zero) then
@@ -57834,7 +57834,7 @@ module stdlib_linalg_lapack_s
                  lb = nb - n + l - i + 1
               end if
               call stdlib_stplqt2(ib,nb,lb,a(i,i),lda,b(i,1),ldb,t(1,i),ldt,iinfo)
-                        
+
            ! update by applying h**t to b(i+ib:m,:) from the right
               if (i + ib <= m) then
                  call stdlib_stprfb('R','N','F','R',m - i - ib + 1,nb,ib,lb,b(i,1),ldb,t( &
@@ -57896,7 +57896,7 @@ module stdlib_linalg_lapack_s
                  lb = mb - m + l - i + 1
               end if
               call stdlib_stpqrt2(mb,ib,lb,a(i,i),lda,b(1,i),ldb,t(1,i),ldt,iinfo)
-                        
+
            ! update by applying h^h to b(:,i+ib:n) from the left
               if (i + ib <= n) then
                  call stdlib_stprfb('L','T','F','C',mb,n - i - ib + 1,ib,lb,b(1,i),ldb,t( &
@@ -57937,7 +57937,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: vl(ldvl,*),vr(ldvr,*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: allv,bothv,leftv,over,pair,rightv,somev
            integer(ilp) :: i,ierr,ii,ip,is,j,j1,j2,jnxt,k,ki,n2
@@ -58038,7 +58038,7 @@ module stdlib_linalg_lapack_s
                  if (ki == 1) go to 40
                  if (t(ki,ki - 1) == zero) go to 40
                  ip = -1
-40               continue
+                 40 continue
                  if (somev) then
                     if (ip == 0) then
                        if (.not. select(ki)) go to 130
@@ -58089,7 +58089,7 @@ module stdlib_linalg_lapack_s
                           work(j + n) = x(1,1)
                           ! update right-hand side
                           call stdlib_saxpy(j - 1,-x(1,1),t(1,j),1,work(1 + n),1)
-                                    
+
                        else
                           ! 2-by-2 diagonal block
                           call stdlib_slaln2(.false.,2,1,smin,one,t(j - 1,j - 1),ldt,one, &
@@ -58110,9 +58110,9 @@ module stdlib_linalg_lapack_s
                           work(j + n) = x(2,1)
                           ! update right-hand side
                           call stdlib_saxpy(j - 2,-x(1,1),t(1,j - 1),1,work(1 + n),1)
-                                    
+
                           call stdlib_saxpy(j - 2,-x(2,1),t(1,j),1,work(1 + n),1)
-                                    
+
                        end if
                     end do loop_60
                     ! copy the vector x or q*x to vr and normalize.
@@ -58186,9 +58186,9 @@ module stdlib_linalg_lapack_s
                           work(j + n2) = x(1,2)
                           ! update the right-hand side
                           call stdlib_saxpy(j - 1,-x(1,1),t(1,j),1,work(1 + n),1)
-                                    
+
                           call stdlib_saxpy(j - 1,-x(1,2),t(1,j),1,work(1 + n2),1)
-                                    
+
                        else
                           ! 2-by-2 diagonal block
                           call stdlib_slaln2(.false.,2,2,smin,one,t(j - 1,j - 1),ldt,one, &
@@ -58217,13 +58217,13 @@ module stdlib_linalg_lapack_s
                           work(j + n2) = x(2,2)
                           ! update the right-hand side
                           call stdlib_saxpy(j - 2,-x(1,1),t(1,j - 1),1,work(1 + n),1)
-                                    
+
                           call stdlib_saxpy(j - 2,-x(2,1),t(1,j),1,work(1 + n),1)
-                                    
+
                           call stdlib_saxpy(j - 2,-x(1,2),t(1,j - 1),1,work(1 + n2),1)
-                                    
+
                           call stdlib_saxpy(j - 2,-x(2,2),t(1,j),1,work(1 + n2),1)
-                                    
+
                        end if
                     end do loop_90
                     ! copy the vector x or q*x to vr and normalize.
@@ -58262,7 +58262,7 @@ module stdlib_linalg_lapack_s
                  end if
                  is = is - 1
                  if (ip /= 0) is = is - 1
-130              continue
+                 130 continue
                  if (ip == 1) ip = 0
                  if (ip == -1) ip = 1
               end do loop_140
@@ -58276,7 +58276,7 @@ module stdlib_linalg_lapack_s
                  if (ki == n) go to 150
                  if (t(ki + 1,ki) == zero) go to 150
                  ip = 1
-150              continue
+                 150 continue
                  if (somev) then
                     if (.not. select(ki)) go to 250
                  end if
@@ -58325,7 +58325,7 @@ module stdlib_linalg_lapack_s
                                     work(j + n),n,wr,zero,x,2,scale,xnorm,ierr)
                           ! scale if necessary
                           if (scale /= one) call stdlib_sscal(n - ki + 1,scale,work(ki + n),1)
-                                    
+
                           work(j + n) = x(1,1)
                           vmax = max(abs(work(j + n)),vmax)
                           vcrit = bignum/vmax
@@ -58351,7 +58351,7 @@ module stdlib_linalg_lapack_s
                                     work(j + n),n,wr,zero,x,2,scale,xnorm,ierr)
                           ! scale if necessary
                           if (scale /= one) call stdlib_sscal(n - ki + 1,scale,work(ki + n),1)
-                                    
+
                           work(j + n) = x(1,1)
                           work(j + 1 + n) = x(2,1)
                           vmax = max(abs(work(j + n)),abs(work(j + 1 + n)),vmax)
@@ -58511,7 +58511,7 @@ module stdlib_linalg_lapack_s
                  end if
                  is = is + 1
                  if (ip /= 0) is = is + 1
-250              continue
+                 250 continue
                  if (ip == -1) ip = 0
                  if (ip == 1) ip = -1
               end do loop_260
@@ -58554,7 +58554,7 @@ module stdlib_linalg_lapack_s
            ! Parameters
            integer(ilp),parameter :: nbmin = 8
            integer(ilp),parameter :: nbmax = 128
-           
+
            ! Local Scalars
            logical(lk) :: allv,bothv,leftv,lquery,over,pair,rightv,somev
            integer(ilp) :: i,ierr,ii,ip,is,j,j1,j2,jnxt,k,ki,iv,maxwrk,nb, &
@@ -58743,11 +58743,11 @@ module stdlib_linalg_lapack_s
                           end if
                           ! scale if necessary
                           if (scale /= one) call stdlib_sscal(ki,scale,work(1 + iv*n),1)
-                                    
+
                           work(j + iv*n) = x(1,1)
                           ! update right-hand side
                           call stdlib_saxpy(j - 1,-x(1,1),t(1,j),1,work(1 + iv*n),1)
-                                    
+
                        else
                           ! 2-by-2 diagonal block
                           call stdlib_slaln2(.false.,2,1,smin,one,t(j - 1,j - 1),ldt,one, &
@@ -58764,14 +58764,14 @@ module stdlib_linalg_lapack_s
                           end if
                           ! scale if necessary
                           if (scale /= one) call stdlib_sscal(ki,scale,work(1 + iv*n),1)
-                                    
+
                           work(j - 1 + iv*n) = x(1,1)
                           work(j + iv*n) = x(2,1)
                           ! update right-hand side
                           call stdlib_saxpy(j - 2,-x(1,1),t(1,j - 1),1,work(1 + iv*n),1)
-                                    
+
                           call stdlib_saxpy(j - 2,-x(2,1),t(1,j),1,work(1 + iv*n),1)
-                                    
+
                        end if
                     end do loop_60
                     ! copy the vector x or q*x to vr and normalize.
@@ -58859,9 +58859,9 @@ module stdlib_linalg_lapack_s
                           work(j + (iv)*n) = x(1,2)
                           ! update the right-hand side
                           call stdlib_saxpy(j - 1,-x(1,1),t(1,j),1,work(1 + (iv - 1)*n),1)
-                                    
+
                           call stdlib_saxpy(j - 1,-x(1,2),t(1,j),1,work(1 + (iv)*n),1)
-                                    
+
                        else
                           ! 2-by-2 diagonal block
                           call stdlib_slaln2(.false.,2,2,smin,one,t(j - 1,j - 1),ldt,one, &
@@ -58896,7 +58896,7 @@ module stdlib_linalg_lapack_s
                           call stdlib_saxpy(j - 2,-x(1,2),t(1,j - 1),1,work(1 + (iv)*n), &
                                     1)
                           call stdlib_saxpy(j - 2,-x(2,2),t(1,j),1,work(1 + (iv)*n),1)
-                                    
+
                        end if
                     end do loop_90
                     ! copy the vector x or q*x to vr and normalize.
@@ -59071,7 +59071,7 @@ module stdlib_linalg_lapack_s
                                     work(j + iv*n),n,wr,zero,x,2,scale,xnorm,ierr)
                           ! scale if necessary
                           if (scale /= one) call stdlib_sscal(n - ki + 1,scale,work(ki + iv*n),1)
-                                    
+
                           work(j + iv*n) = x(1,1)
                           vmax = max(abs(work(j + iv*n)),vmax)
                           vcrit = bignum/vmax
@@ -59097,11 +59097,11 @@ module stdlib_linalg_lapack_s
                                     work(j + iv*n),n,wr,zero,x,2,scale,xnorm,ierr)
                           ! scale if necessary
                           if (scale /= one) call stdlib_sscal(n - ki + 1,scale,work(ki + iv*n),1)
-                                    
+
                           work(j + iv*n) = x(1,1)
                           work(j + 1 + iv*n) = x(2,1)
                           vmax = max(abs(work(j + iv*n)),abs(work(j + 1 + iv*n)),vmax)
-                                    
+
                           vcrit = bignum/vmax
                        end if
                     end do loop_170
@@ -59197,7 +59197,7 @@ module stdlib_linalg_lapack_s
                           work(j + (iv)*n) = x(1,1)
                           work(j + (iv + 1)*n) = x(1,2)
                           vmax = max(abs(work(j + (iv)*n)),abs(work(j + (iv + 1)*n)),vmax)
-                                    
+
                           vcrit = bignum/vmax
                        else
                           ! 2-by-2 diagonal block
@@ -59243,9 +59243,9 @@ module stdlib_linalg_lapack_s
                        ! ------------------------------
                        ! no back-transform: copy x to vl and normalize.
                        call stdlib_scopy(n - ki + 1,work(ki + (iv)*n),1,vl(ki,is),1)
-                                 
+
                        call stdlib_scopy(n - ki + 1,work(ki + (iv + 1)*n),1,vl(ki,is + 1),1)
-                                 
+
                        emax = zero
                        do k = ki,n
                           emax = max(emax,abs(vl(k,is)) + abs(vl(k,is + 1)))
@@ -59353,7 +59353,7 @@ module stdlib_linalg_lapack_s
      !> off-diagonal elements of opposite sign.
 
      subroutine stdlib_strsyl(trana,tranb,isgn,m,n,a,lda,b,ldb,c,ldc,scale,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -59366,7 +59366,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: a(lda,*),b(ldb,*)
            real(sp),intent(inout) :: c(ldc,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notrna,notrnb
            integer(ilp) :: ierr,j,k,k1,k2,knext,l,l1,l2,lnext
@@ -60016,7 +60016,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: d(*),e(*),taup(*),tauq(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,iinfo,j,ldwrkx,ldwrky,lwkopt,minmn,nb,nbmin,nx,ws
@@ -60124,7 +60124,7 @@ module stdlib_linalg_lapack_s
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,iinfo,iwt,j,ldwork,lwkopt,nb,nbmin,nh,nx
@@ -60316,7 +60316,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*),b(ldb,*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,tpsd
            integer(ilp) :: brow,i,iascl,ibscl,j,mn,nb,scllen,wsize
@@ -60497,7 +60497,7 @@ module stdlib_linalg_lapack_s
            else if (ibscl == 2) then
               call stdlib_slascl('G',0,0,bignum,bnrm,scllen,nrhs,b,ldb,info)
            end if
-50         continue
+           50 continue
            work(1) = real(wsize,KIND=sp)
            return
      end subroutine stdlib_sgels
@@ -60715,7 +60715,7 @@ module stdlib_linalg_lapack_s
            integer(ilp),parameter :: inb = 1
            integer(ilp),parameter :: inbmin = 2
            integer(ilp),parameter :: ixover = 3
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: fjb,iws,j,jb,lwkopt,minmn,minws,na,nb,nbmin,nfxd,nx,sm, &
@@ -60810,7 +60810,7 @@ module stdlib_linalg_lapack_s
                        ! determine the minimum value of nb.
                        nb = (lwork - 2*sn)/(sn + 1)
                        nbmin = max(2,stdlib_ilaenv(inbmin,'SGEQRF',' ',sm,sn,-1,-1))
-                                 
+
                     end if
                  end if
               end if
@@ -60825,7 +60825,7 @@ module stdlib_linalg_lapack_s
                  j = nfxd + 1
                  ! compute factorization: while loop.
                  topbmn = minmn - nx
-30               continue
+                 30 continue
                  if (j <= topbmn) then
                     jb = min(nb,topbmn - j + 1)
                     ! factorize jb columns among columns j:n.
@@ -60862,7 +60862,7 @@ module stdlib_linalg_lapack_s
            ! Local Scalars
            logical(lk),parameter :: use_recursive_qr = .true.
            integer(ilp) :: i,ib,iinfo,k
-           
+
            ! Executable Statements
            ! test the input arguments
            info = 0
@@ -60974,7 +60974,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*),af(ldaf,*),b(ldb,*),c(*),r(*)
            real(sp),intent(out) :: berr(*),ferr(*),work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: colequ,equil,nofact,notran,rowequ
            character :: norm
@@ -61198,7 +61198,7 @@ module stdlib_linalg_lapack_s
            ! Function Arguments
            procedure(stdlib_selctg_s) :: selctg
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: cursl,ilascl,ilbscl,ilvsl,ilvsr,lastsl,lquery,lst2sl, &
                      wantst
@@ -61378,7 +61378,7 @@ module stdlib_linalg_lapack_s
                  call stdlib_slascl('G',0,0,anrmto,anrm,n,1,alphai,n,ierr)
               end if
               if (ilbscl) call stdlib_slascl('G',0,0,bnrmto,bnrm,n,1,beta,n,ierr)
-                        
+
               ! select eigenvalues
               do i = 1,n
                  bwork(i) = selctg(alphar(i),alphai(i),beta(i))
@@ -61468,7 +61468,7 @@ module stdlib_linalg_lapack_s
                  lastsl = cursl
               end do
            end if
-40         continue
+           40 continue
            work(1) = maxwrk
            return
      end subroutine stdlib_sgges
@@ -61521,7 +61521,7 @@ module stdlib_linalg_lapack_s
            ! Function Arguments
            procedure(stdlib_selctg_s) :: selctg
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: cursl,ilascl,ilbscl,ilvsl,ilvsr,lastsl,lquery,lst2sl,wantsb, &
                      wantse,wantsn,wantst,wantsv
@@ -61731,7 +61731,7 @@ module stdlib_linalg_lapack_s
                  call stdlib_slascl('G',0,0,anrmto,anrm,n,1,alphai,n,ierr)
               end if
               if (ilbscl) call stdlib_slascl('G',0,0,bnrmto,bnrm,n,1,beta,n,ierr)
-                        
+
               ! select eigenvalues
               do i = 1,n
                  bwork(i) = selctg(alphar(i),alphai(i),beta(i))
@@ -61837,7 +61837,7 @@ module stdlib_linalg_lapack_s
                  lastsl = cursl
               end do
            end if
-50         continue
+           50 continue
            work(1) = maxwrk
            iwork(1) = liwmin
            return
@@ -61871,9 +61871,9 @@ module stdlib_linalg_lapack_s
            ! Array Arguments
            real(sp),intent(inout) :: a(lda,*),b(ldb,*)
            real(sp),intent(out) :: alphai(*),alphar(*),beta(*),vl(ldvl,*),vr(ldvr,*),work(*)
-                     
+
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: ilascl,ilbscl,ilv,ilvl,ilvr,lquery
            character :: chtemp
@@ -61936,10 +61936,10 @@ module stdlib_linalg_lapack_s
               minwrk = max(1,8*n)
               maxwrk = max(1,n*(7 + stdlib_ilaenv(1,'SGEQRF',' ',n,1,n,0)))
               maxwrk = max(maxwrk,n*(7 + stdlib_ilaenv(1,'SORMQR',' ',n,1,n,0)))
-                        
+
               if (ilvl) then
                  maxwrk = max(maxwrk,n*(7 + stdlib_ilaenv(1,'SORGQR',' ',n,1,n,-1)))
-                           
+
               end if
               work(1) = maxwrk
               if (lwork < minwrk .and. .not. lquery) info = -16
@@ -62129,7 +62129,7 @@ module stdlib_linalg_lapack_s
               ! end of eigenvector calculation
            end if
            ! undo scaling if necessary
-110  continue
+           110 continue
            if (ilascl) then
               call stdlib_slascl('G',0,0,anrmto,anrm,n,1,alphar,n,ierr)
               call stdlib_slascl('G',0,0,anrmto,anrm,n,1,alphai,n,ierr)
@@ -62180,7 +62180,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(out) :: alphai(*),alphar(*),beta(*),lscale(*),rconde(*),rcondv(*) &
                      ,rscale(*),vl(ldvl,*),vr(ldvr,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: ilascl,ilbscl,ilv,ilvl,ilvr,lquery,noscl,pair,wantsb,wantse, &
                      wantsn,wantsv
@@ -62267,12 +62267,12 @@ module stdlib_linalg_lapack_s
                  end if
                  maxwrk = minwrk
                  maxwrk = max(maxwrk,n + n*stdlib_ilaenv(1,'SGEQRF',' ',n,1,n,0))
-                           
+
                  maxwrk = max(maxwrk,n + n*stdlib_ilaenv(1,'SORMQR',' ',n,1,n,0))
-                           
+
                  if (ilvl) then
                     maxwrk = max(maxwrk,n + n*stdlib_ilaenv(1,'SORGQR',' ',n,1,n,0))
-                              
+
                  end if
               end if
               work(1) = maxwrk
@@ -62320,7 +62320,7 @@ module stdlib_linalg_lapack_s
            ! permute and/or balance the matrix pair (a,b)
            ! (workspace: need 6*n if balanc = 's' or 'b', 1 otherwise)
            call stdlib_sggbal(balanc,n,a,lda,b,ldb,ilo,ihi,lscale,rscale,work,ierr)
-                     
+
            ! compute abnrm and bbnrm
            abnrm = stdlib_slange('1',n,n,a,lda,work(1))
            if (ilascl) then
@@ -62466,7 +62466,7 @@ module stdlib_linalg_lapack_s
            ! (workspace: none needed)
            if (ilvl) then
               call stdlib_sggbak(balanc,'L',n,ilo,ihi,lscale,rscale,n,vl,ldvl,ierr)
-                        
+
               loop_70: do jc = 1,n
                  if (alphai(jc) < zero) cycle loop_70
                  temp = zero
@@ -62495,7 +62495,7 @@ module stdlib_linalg_lapack_s
            end if
            if (ilvr) then
               call stdlib_sggbak(balanc,'R',n,ilo,ihi,lscale,rscale,n,vr,ldvr,ierr)
-                        
+
               loop_120: do jc = 1,n
                  if (alphai(jc) < zero) cycle loop_120
                  temp = zero
@@ -62523,7 +62523,7 @@ module stdlib_linalg_lapack_s
               end do loop_120
            end if
            ! undo scaling if necessary
-130  continue
+           130 continue
            if (ilascl) then
               call stdlib_slascl('G',0,0,anrmto,anrm,n,1,alphar,n,ierr)
               call stdlib_slascl('G',0,0,anrmto,anrm,n,1,alphai,n,ierr)
@@ -62565,7 +62565,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*),b(ldb,*),d(*)
            real(sp),intent(out) :: work(*),x(*),y(*)
         ! ===================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,lopt,lwkmin,lwkopt,nb,nb1,nb2,nb3,nb4,np
@@ -62656,7 +62656,7 @@ module stdlib_linalg_lapack_s
            ! solve triangular system: r11*x = d1
            if (m > 0) then
               call stdlib_strtrs('UPPER','NO TRANSPOSE','NON UNIT',m,1,a,lda,d,m,info)
-                        
+
               if (info > 0) then
                  info = 2
                  return
@@ -62695,7 +62695,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*),b(ldb,*),c(*),d(*)
            real(sp),intent(out) :: work(*),x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: lopt,lwkmin,lwkopt,mn,nb,nb1,nb2,nb3,nb4,nr
@@ -62826,7 +62826,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: vl(ldvl,*),vr(ldvr,*),wr(*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: bothv,fromqr,leftv,noinit,pair,rightv
            integer(ilp) :: i,iinfo,k,kl,kln,kr,ksi,ksr,ldwork
@@ -62913,13 +62913,13 @@ module stdlib_linalg_lapack_s
                     do i = k,kl + 1,-1
                        if (h(i,i - 1) == zero) go to 30
                     end do
-30                  continue
+                    30 continue
                     kl = i
                     if (k > kr) then
                        do i = k,n - 1
                           if (h(i + 1,i) == zero) go to 50
                        end do
-50                     continue
+                       50 continue
                        kr = i
                     end if
                  end if
@@ -62942,7 +62942,7 @@ module stdlib_linalg_lapack_s
                  ! h(kl:kr,kl:kr). close roots are modified by eps3.
                  wkr = wr(k)
                  wki = wi(k)
-60               continue
+                 60 continue
                  do i = k - 1,kl,-1
                     if (select(i) .and. abs(wr(i) - wkr) + abs(wi(i) - wki) < eps3) &
                               then
@@ -63120,7 +63120,7 @@ module stdlib_linalg_lapack_s
      !> without guard digits, but we know of none.
 
      pure subroutine stdlib_slaed3(k,n,n1,d,q,ldq,rho,dlamda,q2,indx,ctot,w,s,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -63134,7 +63134,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: dlamda(*),w(*)
            real(sp),intent(in) :: q2(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,ii,iq2,j,n12,n2,n23
            real(sp) :: temp
@@ -63219,7 +63219,7 @@ module stdlib_linalg_lapack_s
               end do
            end do
            ! compute the updated eigenvectors.
-110  continue
+           110 continue
            n2 = n - n1
            n12 = ctot(1) + ctot(2)
            n23 = ctot(2) + ctot(3)
@@ -63237,7 +63237,7 @@ module stdlib_linalg_lapack_s
            else
               call stdlib_slaset('A',n1,k,zero,zero,q(1,1),ldq)
            end if
-120        continue
+           120 continue
            return
      end subroutine stdlib_slaed3
 
@@ -63279,12 +63279,12 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: rho
            ! Array Arguments
            integer(ilp),intent(inout) :: givcol(2,*),givptr(*),perm(*),prmptr(*),qptr(*)
-                     
+
            integer(ilp),intent(out) :: indxq(*),iwork(*)
            real(sp),intent(inout) :: d(*),givnum(2,*),q(ldq,*),qstore(*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: coltyp,curr,i,idlmda,indx,indxc,indxp,iq2,is,iw,iz,k,ldq2, &
                      n1,n2,ptr
@@ -63371,7 +63371,7 @@ module stdlib_linalg_lapack_s
                  indxq(i) = i
               end do
            end if
-30         continue
+           30 continue
            return
      end subroutine stdlib_slaed7
 
@@ -63398,7 +63398,7 @@ module stdlib_linalg_lapack_s
            ! Parameters
            integer(ilp),parameter :: ldd = 4
            integer(ilp),parameter :: ldx = 2
-           
+
            ! Local Scalars
            integer(ilp) :: ierr,j2,j3,j4,k,nd
            real(sp) :: cs,dnorm,eps,scale,smlnum,sn,t11,t22,t33,tau,tau1,tau2,temp, &
@@ -63423,7 +63423,7 @@ module stdlib_linalg_lapack_s
               call stdlib_slartg(t(j1,j2),t22 - t11,cs,sn,temp)
               ! apply transformation to the matrix t.
               if (j3 <= n) call stdlib_srot(n - j1 - 1,t(j1,j3),ldt,t(j2,j3),ldt,cs,sn)
-                        
+
               call stdlib_srot(j1 - 1,t(1,j1),1,t(1,j2),1,cs,sn)
               t(j1,j1) = t22
               t(j2,j2) = t11
@@ -63449,7 +63449,7 @@ module stdlib_linalg_lapack_s
               ! swap the adjacent diagonal blocks.
               k = n1 + n1 + n2 - 3
               go to(10,20,30) k
-10            continue
+              10 continue
               ! n1 = 1, n2 = 2: generate elementary reflector h so that:
               ! ( scale, x11, x12 ) h = ( 0, 0, * )
               u(1) = scale
@@ -63475,7 +63475,7 @@ module stdlib_linalg_lapack_s
                  call stdlib_slarfx('R',n,3,u,tau,q(1,j1),ldq,work)
               end if
               go to 40
-20            continue
+              20 continue
               ! n1 = 2, n2 = 1: generate elementary reflector h so that:
               ! h (  -x11 ) = ( * )
                 ! (  -x21 ) = ( 0 )
@@ -63503,7 +63503,7 @@ module stdlib_linalg_lapack_s
                  call stdlib_slarfx('R',n,3,u,tau,q(1,j1),ldq,work)
               end if
               go to 40
-30            continue
+              30 continue
               ! n1 = 2, n2 = 2: generate elementary reflectors h(1) and h(2) so
               ! that:
               ! h(2) h(1) (  -x11  -x12 ) = (  *  * )
@@ -63543,7 +63543,7 @@ module stdlib_linalg_lapack_s
                  call stdlib_slarfx('R',n,3,u1,tau1,q(1,j1),ldq,work)
                  call stdlib_slarfx('R',n,3,u2,tau2,q(1,j2),ldq,work)
               end if
-40            continue
+              40 continue
               if (n2 == 2) then
                  ! standardize new 2-by-2 block t11
                  call stdlib_slanv2(t(j1,j1),t(j1,j2),t(j2,j1),t(j2,j2),wr1,wi1, &
@@ -63592,7 +63592,7 @@ module stdlib_linalg_lapack_s
            real(sp),parameter :: dat1 = 3.0_sp/4.0_sp
            real(sp),parameter :: dat2 = -0.4375_sp
            integer(ilp),parameter :: kexsh = 10
-           
+
            ! Local Scalars
            real(sp) :: aa,ab,ba,bb,cs,det,h11,h12,h21,h21s,h22,rt1i,rt1r,rt2i,rt2r, &
                      rtdisc,s,safmax,safmin,smlnum,sn,sum,t1,t2,t3,tr,tst,ulp,v2,v3
@@ -63641,7 +63641,7 @@ module stdlib_linalg_lapack_s
            ! eigenvalues i+1 to ihi have already converged. either l = ilo or
            ! h(l,l-1) is negligible so that the matrix splits.
            i = ihi
-20         continue
+           20 continue
            l = ilo
            if (i < ilo) go to 160
            ! perform qr iterations on rows and columns ilo to i until a
@@ -63669,7 +63669,7 @@ module stdlib_linalg_lapack_s
                     if (ba*(ab/s) <= max(smlnum,ulp*(bb*(aa/s)))) go to 40
                  end if
               end do
-40            continue
+              40 continue
               l = k
               if (l > ilo) then
                  ! h(l,l-1) is negligible
@@ -63763,7 +63763,7 @@ module stdlib_linalg_lapack_s
                  if (abs(h(m,m - 1))*(abs(v(2)) + abs(v(3))) <= ulp*abs(v(1))*(abs( &
                            h(m - 1,m - 1)) + abs(h(m,m)) + abs(h(m + 1,m + 1)))) go to 60
               end do
-60            continue
+              60 continue
               ! double-shift qr step
               loop_130: do k = m,i - 1
                  ! the first iteration of this loop determines a reflection g
@@ -63846,7 +63846,7 @@ module stdlib_linalg_lapack_s
            ! failure to converge in remaining number of iterations
            info = i
            return
-150        continue
+           150 continue
            if (l == i) then
               ! h(i,i-1) is negligible: one eigenvalue has converged.
               wr(i) = h(i,i)
@@ -63860,7 +63860,7 @@ module stdlib_linalg_lapack_s
               if (wantt) then
                  ! apply the transformation to the rest of h.
                  if (i2 > i) call stdlib_srot(i2 - i,h(i - 1,i + 1),ldh,h(i,i + 1),ldh,cs,sn)
-                           
+
                  call stdlib_srot(i - i1 - 1,h(i1,i - 1),1,h(i1,i),1,cs,sn)
               end if
               if (wantz) then
@@ -63873,7 +63873,7 @@ module stdlib_linalg_lapack_s
            ! return to start of the main loop with new value of i.
            i = l - 1
            go to 20
-160        continue
+           160 continue
            return
      end subroutine stdlib_slahqr
 
@@ -63900,7 +63900,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: d(*),u(ldu,*),vt(ldvt,*)
            real(sp),intent(out) :: dsigma(*),u2(ldu2,*),vt2(ldvt2,*),z(*)
         ! =====================================================================
-           
+
            ! Local Arrays
            integer(ilp) :: ctot(4),psm(4)
            ! Local Scalars
@@ -64006,9 +64006,9 @@ module stdlib_linalg_lapack_s
                  go to 90
               end if
            end do
-90         continue
+           90 continue
            j = jprev
-100        continue
+           100 continue
            j = j + 1
            if (j > n) go to 110
            if (abs(z(j)) <= tol) then
@@ -64057,13 +64057,13 @@ module stdlib_linalg_lapack_s
               end if
            end if
            go to 100
-110        continue
+           110 continue
            ! record the last singular value.
            k = k + 1
            u2(k,1) = z(jprev)
            dsigma(k) = d(jprev)
            idxp(k) = jprev
-120        continue
+           120 continue
            ! count up the total number of the various types of columns, then
            ! form a permutation which positions the four column types into
            ! four groups of uniform structure (although one or more of these
@@ -64361,7 +64361,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: tau(*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wantq
            integer(ilp) :: i,iinfo,j,lwkopt,mn
@@ -64445,7 +64445,7 @@ module stdlib_linalg_lapack_s
                  if (m > 1) then
                     ! form q(2:m,2:m)
                     call stdlib_sorgqr(m - 1,m - 1,m - 1,a(2,2),lda,tau,work,lwork,iinfo)
-                              
+
                  end if
               end if
            else
@@ -64472,7 +64472,7 @@ module stdlib_linalg_lapack_s
                  if (n > 1) then
                     ! form p**t(2:n,2:n)
                     call stdlib_sorglq(n - 1,n - 1,n - 1,a(2,2),lda,tau,work,lwork,iinfo)
-                              
+
                  end if
               end if
            end if
@@ -64716,7 +64716,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: ab(ldab,*),afb(ldafb,*),b(ldb,*),s(*)
            real(sp),intent(out) :: berr(*),ferr(*),work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: equil,nofact,rcequ,upper
            integer(ilp) :: i,infequ,j,j1,j2
@@ -64805,7 +64805,7 @@ module stdlib_linalg_lapack_s
                  do j = 1,n
                     j1 = max(j - kd,1)
                     call stdlib_scopy(j - j1 + 1,ab(kd + 1 - j + j1,j),1,afb(kd + 1 - j + j1,j),1)
-                              
+
                  end do
               else
                  do j = 1,n
@@ -64867,7 +64867,7 @@ module stdlib_linalg_lapack_s
            ! Array Arguments
            real(sp),intent(inout) :: a(0:*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,nisodd,normaltransr
            integer(ilp) :: n1,n2,k
@@ -64919,7 +64919,7 @@ module stdlib_linalg_lapack_s
                     call stdlib_spotrf('L',n1,a(0),n,info)
                     if (info > 0) return
                     call stdlib_strsm('R','L','T','N',n2,n1,one,a(0),n,a(n1),n)
-                              
+
                     call stdlib_ssyrk('U','N',n2,n1,-one,a(n1),n,one,a(n),n)
                     call stdlib_spotrf('U',n2,a(n),n,info)
                     if (info > 0) info = info + n1
@@ -64930,7 +64930,7 @@ module stdlib_linalg_lapack_s
                     call stdlib_spotrf('L',n1,a(n2),n,info)
                     if (info > 0) return
                     call stdlib_strsm('L','L','N','N',n1,n2,one,a(n2),n,a(0),n)
-                              
+
                     call stdlib_ssyrk('U','T',n2,n1,-one,a(0),n,one,a(n1),n)
                     call stdlib_spotrf('U',n2,a(n1),n,info)
                     if (info > 0) info = info + n1
@@ -64946,7 +64946,7 @@ module stdlib_linalg_lapack_s
                     call stdlib_strsm('L','U','T','N',n1,n2,one,a(0),n1,a(n1*n1),n1 &
                               )
                     call stdlib_ssyrk('L','T',n2,n1,-one,a(n1*n1),n1,one,a(1),n1)
-                              
+
                     call stdlib_spotrf('L',n2,a(1),n1,info)
                     if (info > 0) info = info + n1
                  else
@@ -64958,7 +64958,7 @@ module stdlib_linalg_lapack_s
                     call stdlib_strsm('R','U','N','N',n2,n1,one,a(n2*n2),n2,a(0),n2 &
                               )
                     call stdlib_ssyrk('L','N',n2,n1,-one,a(0),n2,one,a(n1*n2),n2)
-                              
+
                     call stdlib_spotrf('L',n2,a(n1*n2),n2,info)
                     if (info > 0) info = info + n1
                  end if
@@ -64974,9 +64974,9 @@ module stdlib_linalg_lapack_s
                     call stdlib_spotrf('L',k,a(1),n + 1,info)
                     if (info > 0) return
                     call stdlib_strsm('R','L','T','N',k,k,one,a(1),n + 1,a(k + 1),n + 1)
-                              
+
                     call stdlib_ssyrk('U','N',k,k,-one,a(k + 1),n + 1,one,a(0),n + 1)
-                              
+
                     call stdlib_spotrf('U',k,a(0),n + 1,info)
                     if (info > 0) info = info + k
                  else
@@ -64986,9 +64986,9 @@ module stdlib_linalg_lapack_s
                     call stdlib_spotrf('L',k,a(k + 1),n + 1,info)
                     if (info > 0) return
                     call stdlib_strsm('L','L','N','N',k,k,one,a(k + 1),n + 1,a(0),n + 1)
-                              
+
                     call stdlib_ssyrk('U','T',k,k,-one,a(0),n + 1,one,a(k),n + 1)
-                              
+
                     call stdlib_spotrf('U',k,a(k),n + 1,info)
                     if (info > 0) info = info + k
                  end if
@@ -65003,7 +65003,7 @@ module stdlib_linalg_lapack_s
                     call stdlib_strsm('L','U','T','N',k,k,one,a(k),n1,a(k*(k + 1)), &
                               k)
                     call stdlib_ssyrk('L','T',k,k,-one,a(k*(k + 1)),k,one,a(0),k)
-                              
+
                     call stdlib_spotrf('L',k,a(0),k,info)
                     if (info > 0) info = info + k
                  else
@@ -65098,7 +65098,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*),af(ldaf,*),b(ldb,*),s(*)
            real(sp),intent(out) :: berr(*),ferr(*),work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: equil,nofact,rcequ
            integer(ilp) :: i,infequ,j
@@ -65241,7 +65241,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: q(ldq,*),t(ldt,*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: wantq
            integer(ilp) :: here,nbf,nbl,nbnext
@@ -65294,7 +65294,7 @@ module stdlib_linalg_lapack_s
               if (nbf == 2 .and. nbl == 1) ilst = ilst - 1
               if (nbf == 1 .and. nbl == 2) ilst = ilst + 1
               here = ifst
-10            continue
+              10 continue
               ! swap block with next one below
               if (nbf == 1 .or. nbf == 2) then
                  ! current block either 1 by 1 or 2 by 2
@@ -65303,7 +65303,7 @@ module stdlib_linalg_lapack_s
                     if (t(here + nbf + 1,here + nbf) /= zero) nbnext = 2
                  end if
                  call stdlib_slaexc(wantq,n,t,ldt,q,ldq,here,nbf,nbnext,work,info)
-                           
+
                  if (info /= 0) then
                     ilst = here
                     return
@@ -65321,7 +65321,7 @@ module stdlib_linalg_lapack_s
                     if (t(here + 3,here + 2) /= zero) nbnext = 2
                  end if
                  call stdlib_slaexc(wantq,n,t,ldt,q,ldq,here + 1,1,nbnext,work,info)
-                           
+
                  if (info /= 0) then
                     ilst = here
                     return
@@ -65329,7 +65329,7 @@ module stdlib_linalg_lapack_s
                  if (nbnext == 1) then
                     ! swap two 1 by 1 blocks, no problems possible
                     call stdlib_slaexc(wantq,n,t,ldt,q,ldq,here,1,nbnext,work,info)
-                              
+
                     here = here + 1
                  else
                     ! recompute nbnext in case 2 by 2 split
@@ -65337,7 +65337,7 @@ module stdlib_linalg_lapack_s
                     if (nbnext == 2) then
                        ! 2 by 2 block did not split
                        call stdlib_slaexc(wantq,n,t,ldt,q,ldq,here,1,nbnext,work,info)
-                                 
+
                        if (info /= 0) then
                           ilst = here
                           return
@@ -65346,9 +65346,9 @@ module stdlib_linalg_lapack_s
                     else
                        ! 2 by 2 block did split
                        call stdlib_slaexc(wantq,n,t,ldt,q,ldq,here,1,1,work,info)
-                                 
+
                        call stdlib_slaexc(wantq,n,t,ldt,q,ldq,here + 1,1,1,work,info)
-                                 
+
                        here = here + 2
                     end if
                  end if
@@ -65356,7 +65356,7 @@ module stdlib_linalg_lapack_s
               if (here < ilst) go to 10
            else
               here = ifst
-20            continue
+              20 continue
               ! swap block with next one above
               if (nbf == 1 .or. nbf == 2) then
                  ! current block either 1 by 1 or 2 by 2
@@ -65383,7 +65383,7 @@ module stdlib_linalg_lapack_s
                     if (t(here - 1,here - 2) /= zero) nbnext = 2
                  end if
                  call stdlib_slaexc(wantq,n,t,ldt,q,ldq,here - nbnext,nbnext,1,work,info)
-                           
+
                  if (info /= 0) then
                     ilst = here
                     return
@@ -65391,7 +65391,7 @@ module stdlib_linalg_lapack_s
                  if (nbnext == 1) then
                     ! swap two 1 by 1 blocks, no problems possible
                     call stdlib_slaexc(wantq,n,t,ldt,q,ldq,here,nbnext,1,work,info)
-                              
+
                     here = here - 1
                  else
                     ! recompute nbnext in case 2 by 2 split
@@ -65399,7 +65399,7 @@ module stdlib_linalg_lapack_s
                     if (nbnext == 2) then
                        ! 2 by 2 block did not split
                        call stdlib_slaexc(wantq,n,t,ldt,q,ldq,here - 1,2,1,work,info)
-                                 
+
                        if (info /= 0) then
                           ilst = here
                           return
@@ -65408,9 +65408,9 @@ module stdlib_linalg_lapack_s
                     else
                        ! 2 by 2 block did split
                        call stdlib_slaexc(wantq,n,t,ldt,q,ldq,here,1,1,work,info)
-                                 
+
                        call stdlib_slaexc(wantq,n,t,ldt,q,ldq,here - 1,1,1,work,info)
-                                 
+
                        here = here - 2
                     end if
                  end if
@@ -65449,7 +65449,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: q(ldq,*),t(ldt,*)
            real(sp),intent(out) :: wi(*),work(*),wr(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,pair,swap,wantbh,wantq,wants,wantsp
            integer(ilp) :: ierr,k,kase,kk,ks,liwmin,lwmin,n1,n2,nn
@@ -65552,7 +65552,7 @@ module stdlib_linalg_lapack_s
                     ierr = 0
                     kk = k
                     if (k /= ks) call stdlib_strexc(compq,n,t,ldt,q,ldq,kk,ks,work,ierr)
-                              
+
                     if (ierr == 1 .or. ierr == 2) then
                        ! blocks too close to swap: exit.
                        info = 1
@@ -65583,7 +65583,7 @@ module stdlib_linalg_lapack_s
               ! estimate sep(t11,t22).
               est = zero
               kase = 0
-30            continue
+              30 continue
               call stdlib_slacn2(nn,work(nn + 1),work,iwork,est,kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -65599,7 +65599,7 @@ module stdlib_linalg_lapack_s
               end if
               sep = scale/est
            end if
-40         continue
+           40 continue
            ! store the output eigenvalues in wr and wi.
            do k = 1,n
               wr(k) = t(k,k)
@@ -65640,7 +65640,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(out) :: s(*),sep(*),work(ldwork,*)
            real(sp),intent(in) :: t(ldt,*),vl(ldvl,*),vr(ldvr,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: pair,somcon,wantbh,wants,wantsp
            integer(ilp) :: i,ierr,ifst,ilst,j,k,kase,ks,n2,nn
@@ -65823,7 +65823,7 @@ module stdlib_linalg_lapack_s
                     ! estimate norm(inv(c**t))
                     est = zero
                     kase = 0
-50                  continue
+                    50 continue
                     call stdlib_slacn2(nn,work(1,n + 2),work(1,n + 4),iwork,est,kase, &
                               isave)
                     if (kase /= 0) then
@@ -66020,7 +66020,7 @@ module stdlib_linalg_lapack_s
      !> more simple.
 
      subroutine stdlib_sgelsy(m,n,nrhs,a,lda,b,ldb,jpvt,rcond,rank,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -66036,7 +66036,7 @@ module stdlib_linalg_lapack_s
            ! Parameters
            integer(ilp),parameter :: imax = 1
            integer(ilp),parameter :: imin = 2
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,iascl,ibscl,ismax,ismin,j,lwkmin,lwkopt,mn,nb,nb1,nb2, &
@@ -66128,7 +66128,7 @@ module stdlib_linalg_lapack_s
            ! compute qr factorization with column pivoting of a:
               ! a * p = q * r
            call stdlib_sgeqp3(m,n,a,lda,jpvt,work(1),work(mn + 1),lwork - mn,info)
-                     
+
            wsize = mn + work(mn + 1)
            ! workspace: mn+2*n+nb*(n+1).
            ! details of householder rotations stored in work(1:mn).
@@ -66144,7 +66144,7 @@ module stdlib_linalg_lapack_s
            else
               rank = 1
            end if
-10         continue
+           10 continue
            if (rank < mn) then
               i = rank + 1
               call stdlib_slaic1(imin,rank,work(ismin),smin,a(1,i),a(i,i),sminpr, &
@@ -66213,7 +66213,7 @@ module stdlib_linalg_lapack_s
            else if (ibscl == 2) then
               call stdlib_slascl('G',0,0,bignum,bnrm,n,nrhs,b,ldb,info)
            end if
-70         continue
+           70 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_sgelsy
@@ -66364,7 +66364,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*),b(ldb,*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,tran
            integer(ilp) :: i,iascl,ibscl,j,maxmn,brow,scllen,tszo,tszm,lwo,lwm,lw1, &
@@ -66564,7 +66564,7 @@ module stdlib_linalg_lapack_s
            else if (ibscl == 2) then
              call stdlib_slascl('G',0,0,bignum,bnrm,scllen,nrhs,b,ldb,info)
            end if
-50         continue
+           50 continue
            work(1) = real(tszo + lwo,KIND=sp)
            return
      end subroutine stdlib_sgetsls
@@ -66583,7 +66583,7 @@ module stdlib_linalg_lapack_s
      !> of SGEQRT for more details on the format.
 
      pure subroutine stdlib_sgetsqrhrt(m,n,mb1,nb1,nb2,a,lda,t,ldt,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -66594,7 +66594,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: t(ldt,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,iinfo,j,lw1,lw2,lwt,ldwt,lworkopt,nb1local,nb2local, &
@@ -66663,7 +66663,7 @@ module stdlib_linalg_lapack_s
            nb2local = min(nb2,n)
            ! (1) perform tsqr-factorization of the m-by-n matrix a.
            call stdlib_slatsqr(m,n,mb1,nb1local,a,lda,work,ldwt,work(lwt + 1),lw1,iinfo)
-                     
+
            ! (2) copy the factor r_tsqr stored in the upper-triangular part
                ! of a into the square matrix in the work array
                ! work(lwt+1:lwt+n*n) column-by-column.
@@ -66677,7 +66677,7 @@ module stdlib_linalg_lapack_s
            ! (4) perform the reconstruction of householder vectors from
            ! the matrix q (stored in a) in place.
            call stdlib_sorhr_col(m,n,nb2local,a,lda,t,ldt,work(lwt + n*n + 1),iinfo)
-                     
+
            ! (5) copy the factor r_tsqr stored in the square matrix in the
            ! work array work(lwt+1:lwt+n*n) into the upper-triangular
            ! part of a.
@@ -66726,7 +66726,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: mone = -1.0_sp
-           
+
            ! Local Arrays
            integer(ilp) :: ctot(4),psm(4)
            ! Local Scalars
@@ -66820,7 +66820,7 @@ module stdlib_linalg_lapack_s
                  go to 80
               end if
            end do
-80         continue
+           80 continue
            j = j + 1
            nj = indx(j)
            if (j > n) go to 100
@@ -66851,7 +66851,7 @@ module stdlib_linalg_lapack_s
                  d(pj) = t
                  k2 = k2 - 1
                  i = 1
-90               continue
+                 90 continue
                  if (k2 + i <= n) then
                     if (d(pj) < d(indxp(k2 + i))) then
                        indxp(k2 + i - 1) = indxp(k2 + i)
@@ -66874,7 +66874,7 @@ module stdlib_linalg_lapack_s
               end if
            end if
            go to 80
-100        continue
+           100 continue
            ! record the last eigenvalue.
            k = k + 1
            dlamda(k) = d(pj)
@@ -66955,7 +66955,7 @@ module stdlib_linalg_lapack_s
            do j = 1,4
               coltyp(j) = ctot(j)
            end do
-190        continue
+           190 continue
            return
      end subroutine stdlib_slaed2
 
@@ -66985,7 +66985,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: h(ldh,*),z(ldz,*)
            real(sp),intent(out) :: si(*),sr(*),t(ldt,*),v(ldv,*),work(*),wv(ldwv,*)
         ! ================================================================
-           
+
            ! Local Scalars
            real(sp) :: aa,bb,beta,cc,cs,dd,evi,evk,foo,s,safmax,safmin,smlnum,sn, &
                      tau,ulp
@@ -67005,7 +67005,7 @@ module stdlib_linalg_lapack_s
               lwk1 = int(work(1),KIND=ilp)
               ! ==== workspace query call to stdlib_sormhr ====
               call stdlib_sormhr('R','N',jw,jw,1,jw - 1,t,ldt,work,v,ldv,work,-1,info)
-                        
+
               lwk2 = int(work(1),KIND=ilp)
               ! ==== optimal workspace ====
               lwkopt = jw + max(lwk1,lwk2)
@@ -67070,7 +67070,7 @@ module stdlib_linalg_lapack_s
            ! ==== deflation detection loop ====
            ns = jw
            ilst = infqr + 1
-20         continue
+           20 continue
            if (ilst <= ns) then
               if (ns == 1) then
                  bulge = .false.
@@ -67121,7 +67121,7 @@ module stdlib_linalg_lapack_s
               ! .    exchange failures. ====
               sorted = .false.
               i = ns + 1
-30            continue
+              30 continue
               if (sorted) go to 50
               sorted = .true.
               kend = i - 1
@@ -67133,13 +67133,13 @@ module stdlib_linalg_lapack_s
               else
                  k = i + 2
               end if
-40            continue
+              40 continue
               if (k <= kend) then
                  if (k == i + 1) then
                     evi = abs(t(i,i))
                  else
                     evi = abs(t(i,i)) + sqrt(abs(t(i + 1,i)))*sqrt(abs(t(i,i + 1)))
-                              
+
                  end if
                  if (k == kend) then
                     evk = abs(t(k,k))
@@ -67147,7 +67147,7 @@ module stdlib_linalg_lapack_s
                     evk = abs(t(k,k))
                  else
                     evk = abs(t(k,k)) + sqrt(abs(t(k + 1,k)))*sqrt(abs(t(k,k + 1)))
-                              
+
                  end if
                  if (evi >= evk) then
                     i = k
@@ -67172,11 +67172,11 @@ module stdlib_linalg_lapack_s
                  go to 40
               end if
               go to 30
-50            continue
+              50 continue
            end if
            ! ==== restore shift/eigenvalue array from t ====
            i = jw
-60         continue
+           60 continue
            if (i >= infqr + 1) then
               if (i == infqr + 1) then
                  sr(kwtop + i - 1) = t(i,i)
@@ -67209,7 +67209,7 @@ module stdlib_linalg_lapack_s
                  call stdlib_slarf('R',ns,ns,work,1,tau,t,ldt,work(jw + 1))
                  call stdlib_slarf('R',jw,ns,work,1,tau,v,ldv,work(jw + 1))
                  call stdlib_sgehrd(jw,1,ns,t,ldt,work,work(jw + 1),lwork - jw,info)
-                           
+
               end if
               ! ==== copy updated reduced window into place ====
               if (kwtop > 1) h(kwtop,kwtop - 1) = s*v(1,1)
@@ -67307,7 +67307,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: d(*),u(ldu,*),vt(ldvt,*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: coltyp,i,idx,idxc,idxp,iq,isigma,iu2,ivt2,iz,k,ldq,ldu2, &
                      ldvt2,m,n,n1,n2
@@ -67476,7 +67476,7 @@ module stdlib_linalg_lapack_s
                  indxq(i) = i
               end do
            end if
-20         continue
+           20 continue
            return
      end subroutine stdlib_slaed1
 
@@ -67496,7 +67496,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: d(*),e(*),q(ldq,*)
            real(sp),intent(out) :: qstore(ldqs,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: curlvl,curprb,curr,i,igivcl,igivnm,igivpt,indxq,iperm,iprmpt, &
            iq,iqptr,iwrem,j,k,lgn,matsiz,msd2,smlsiz,smm1,spm1,spm2,submat,subpbs, &
@@ -67530,7 +67530,7 @@ module stdlib_linalg_lapack_s
            iwork(1) = n
            subpbs = 1
            tlvls = 0
-10         continue
+           10 continue
            if (iwork(subpbs) > smlsiz) then
               do j = subpbs,1,-1
                  iwork(2*j) = (iwork(j) + 1)/2
@@ -67597,7 +67597,7 @@ module stdlib_linalg_lapack_s
                  if (icompq == 1) then
                     call stdlib_sgemm('N','N',qsiz,matsiz,matsiz,one,q(1,submat),ldq, &
                     work(iq - 1 + iwork(iqptr + curr)),matsiz,zero,qstore(1,submat),ldqs)
-                              
+
                  end if
                  iwork(iqptr + curr + 1) = iwork(iqptr + curr) + matsiz**2
                  curr = curr + 1
@@ -67612,7 +67612,7 @@ module stdlib_linalg_lapack_s
            ! into eigensystem for the corresponding larger matrix.
            ! while ( subpbs > 1 )
            curlvl = 1
-80         continue
+           80 continue
            if (subpbs > 1) then
               spm2 = subpbs - 2
               loop_90: do i = 0,spm2,2
@@ -67637,13 +67637,13 @@ module stdlib_linalg_lapack_s
                  if (icompq == 2) then
                     call stdlib_slaed1(matsiz,d(submat),q(submat,submat),ldq,iwork( &
                     indxq + submat),e(submat + msd2 - 1),msd2,work,iwork(subpbs + 1),info)
-                              
+
                  else
                     call stdlib_slaed7(icompq,matsiz,qsiz,tlvls,curlvl,curprb,d(submat), &
                     qstore(1,submat),ldqs,iwork(indxq + submat),e(submat + msd2 - 1),msd2, &
                     work(iq),iwork(iqptr),iwork(iprmpt),iwork(iperm),iwork(igivpt), &
                     iwork(igivcl),work(igivnm),work(iwrem),iwork(subpbs + 1),info)
-                              
+
                  end if
                  if (info /= 0) go to 130
                  iwork(i/2 + 1) = iwork(i + 2)
@@ -67678,9 +67678,9 @@ module stdlib_linalg_lapack_s
               call stdlib_scopy(n,work,1,d,1)
            end if
            go to 140
-130        continue
+           130 continue
            info = submat*(n + 1) + submat + matsiz - 1
-140        continue
+           140 continue
            return
      end subroutine stdlib_slaed0
 
@@ -67697,7 +67697,7 @@ module stdlib_linalg_lapack_s
      !> without guard digits, but we know of none.  See SLAED3 for details.
 
      pure subroutine stdlib_sstedc(compz,n,d,e,z,ldz,work,lwork,iwork,liwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -67710,7 +67710,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: d(*),e(*),z(ldz,*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: finish,i,icompz,ii,j,k,lgn,liwmin,lwmin,m,smlsiz,start, &
@@ -67813,7 +67813,7 @@ module stdlib_linalg_lapack_s
               eps = stdlib_slamch('EPSILON')
               start = 1
               ! while ( start <= n )
-10   continue
+              10 continue
               if (start <= n) then
                  ! let finish be the position of the next subdiagonal entry
                  ! such that e( finish ) <= tiny or finish = n if no such
@@ -67821,7 +67821,7 @@ module stdlib_linalg_lapack_s
                  ! between start and finish constitutes an independent
                  ! sub-problem.
                  finish = start
-20               continue
+                 20 continue
                  if (finish < n) then
                     tiny = eps*sqrt(abs(d(finish)))*sqrt(abs(d(finish + 1)))
                     if (abs(e(finish)) > tiny) then
@@ -67840,7 +67840,7 @@ module stdlib_linalg_lapack_s
                     orgnrm = stdlib_slanst('M',m,d(start),e(start))
                     call stdlib_slascl('G',0,0,orgnrm,one,m,1,d(start),m,info)
                     call stdlib_slascl('G',0,0,orgnrm,one,m - 1,1,e(start),m - 1,info)
-                              
+
                     if (icompz == 1) then
                        strtrw = 1
                     else
@@ -67863,7 +67863,7 @@ module stdlib_linalg_lapack_s
                        call stdlib_ssteqr('I',m,d(start),e(start),work,m,work(m*m + 1), &
                                  info)
                        call stdlib_slacpy('A',n,m,z(1,start),ldz,work(storez),n)
-                                 
+
                        call stdlib_sgemm('N','N',n,m,m,one,work(storez),n,work,m,zero, &
                                  z(1,start),ldz)
                     else if (icompz == 2) then
@@ -67904,7 +67904,7 @@ module stdlib_linalg_lapack_s
                 end do
               end if
            end if
-50         continue
+           50 continue
            work(1) = lwmin
            iwork(1) = liwmin
            return
@@ -67921,7 +67921,7 @@ module stdlib_linalg_lapack_s
      !> without guard digits, but we know of none.
 
      pure subroutine stdlib_sstevd(jobz,n,d,e,z,ldz,work,lwork,iwork,liwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -67934,7 +67934,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: d(*),e(*)
            real(sp),intent(out) :: work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wantz
            integer(ilp) :: iscale,liwmin,lwmin
@@ -68040,7 +68040,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: w(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,lquery,wantz
            integer(ilp) :: iinfo,inde,indtau,indwk2,indwrk,iscale,liopt,liwmin,llwork, &
@@ -68078,7 +68078,7 @@ module stdlib_linalg_lapack_s
                     lwmin = 2*n + 1
                  end if
                  lopt = max(lwmin,2*n + stdlib_ilaenv(1,'SSYTRD',uplo,n,-1,-1,-1))
-                           
+
                  liopt = liwmin
               end if
               work(1) = lopt
@@ -68175,7 +68175,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*),b(ldb,*)
            real(sp),intent(out) :: w(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper,wantz
            character :: trans
@@ -68252,7 +68252,7 @@ module stdlib_linalg_lapack_s
                     trans = 'T'
                  end if
                  call stdlib_strsm('LEFT',uplo,trans,'NON-UNIT',n,n,one,b,ldb,a,lda)
-                           
+
               else if (itype == 3) then
                  ! for b*a*x=(lambda)*x;
                  ! backtransform eigenvectors: x = l*y or u**t*y
@@ -68262,7 +68262,7 @@ module stdlib_linalg_lapack_s
                     trans = 'N'
                  end if
                  call stdlib_strmm('LEFT',uplo,trans,'NON-UNIT',n,n,one,b,ldb,a,lda)
-                           
+
               end if
            end if
            work(1) = lopt
@@ -68294,7 +68294,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: ab(ldab,*)
            real(sp),intent(out) :: w(*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,lquery,wantz
            integer(ilp) :: iinfo,inde,indwk2,indwrk,iscale,liwmin,llwrk2,lwmin
@@ -68428,7 +68428,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: ab(ldab,*),bb(ldbb,*)
            real(sp),intent(out) :: w(*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper,wantz
            character :: vect
@@ -68495,7 +68495,7 @@ module stdlib_linalg_lapack_s
            indwk2 = indwrk + n*n
            llwrk2 = lwork - indwk2 + 1
            call stdlib_ssbgst(jobz,uplo,n,ka,kb,ab,ldab,bb,ldbb,z,ldz,work,iinfo)
-                     
+
            ! reduce to tridiagonal form.
            if (wantz) then
               vect = 'U'
@@ -68530,7 +68530,7 @@ module stdlib_linalg_lapack_s
      !> without guard digits, but we know of none.
 
      subroutine stdlib_sspevd(jobz,uplo,n,ap,w,z,ldz,work,lwork,iwork,liwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -68543,7 +68543,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: ap(*)
            real(sp),intent(out) :: w(*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wantz
            integer(ilp) :: iinfo,inde,indtau,indwrk,iscale,liwmin,llwork,lwmin
@@ -68732,7 +68732,7 @@ module stdlib_linalg_lapack_s
            ! transform problem to standard eigenvalue problem and solve.
            call stdlib_sspgst(itype,uplo,n,ap,bp,info)
            call stdlib_sspevd(jobz,uplo,n,ap,w,z,ldz,work,lwork,iwork,liwork,info)
-                     
+
            lwmin = max(real(lwmin,KIND=sp),real(work(1),KIND=sp))
            liwmin = max(real(liwmin,KIND=sp),real(iwork(1),KIND=sp))
            if (wantz) then
@@ -68802,7 +68802,7 @@ module stdlib_linalg_lapack_s
         ! changed dimension statement in comment describing e from (n) to
         ! (n-1).  sven, 17 feb 05.
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: difl,difr,givcol,givnum,givptr,i,ic,icompq,ierr,ii,is,iu, &
            iuplo,ivt,j,k,kk,mlvl,nm1,nsize,perm,poles,qstart,smlsiz,smlszp,sqre, &
@@ -68986,7 +68986,7 @@ module stdlib_linalg_lapack_s
            end do loop_30
            ! unscale
            call stdlib_slascl('G',0,0,one,orgnrm,n,1,d,n,ierr)
-40         continue
+           40 continue
            ! use selection sort to minimize swaps of singular vectors
            do ii = 2,n
               i = ii - 1
@@ -69069,7 +69069,7 @@ module stdlib_linalg_lapack_s
            real(sp),parameter :: hndrd = 100.0_sp
            real(sp),parameter :: meigth = -0.125_sp
            integer(ilp),parameter :: maxitr = 6
-           
+
            ! Local Scalars
            logical(lk) :: lower,rotate
            integer(ilp) :: i,idir,isub,iter,iterdivn,j,ll,lll,m,maxitdivn,nm1,nm12, &
@@ -69135,9 +69135,9 @@ module stdlib_linalg_lapack_s
               end do
               ! update singular vectors if desired
               if (nru > 0) call stdlib_slasr('R','V','F',nru,n,work(1),work(n),u,ldu)
-                        
+
               if (ncc > 0) call stdlib_slasr('L','V','F',n,ncc,work(1),work(n),c,ldc)
-                        
+
            end if
            ! compute singular values to relative accuracy tol
            ! (by setting tol to be negative, algorithm will compute
@@ -69163,7 +69163,7 @@ module stdlib_linalg_lapack_s
                  sminoa = min(sminoa,mu)
                  if (sminoa == zero) go to 50
               end do
-50            continue
+              50 continue
               sminoa = sminoa/sqrt(real(n,KIND=sp))
               thresh = max(tol*sminoa,maxitr*(n*(n*unfl)))
            else
@@ -69181,7 +69181,7 @@ module stdlib_linalg_lapack_s
            ! m points to last element of unconverged part of matrix
            m = n
            ! begin main iteration loop
-60   continue
+           60 continue
            ! check for convergence or exceeding iteration count
            if (m <= 1) go to 160
            if (iter >= n) then
@@ -69204,7 +69204,7 @@ module stdlib_linalg_lapack_s
            end do
            ll = 0
            go to 90
-80         continue
+           80 continue
            e(ll) = zero
            ! matrix splits since e(ll) = 0
            if (ll == m - 1) then
@@ -69212,7 +69212,7 @@ module stdlib_linalg_lapack_s
               m = m - 1
               go to 60
            end if
-90         continue
+           90 continue
            ll = ll + 1
            ! e(ll) through e(m-1) are nonzero, e(ll-1) is zero
            if (ll == m - 1) then
@@ -69227,7 +69227,7 @@ module stdlib_linalg_lapack_s
                         )
               if (nru > 0) call stdlib_srot(nru,u(1,m - 1),1,u(1,m),1,cosl,sinl)
               if (ncc > 0) call stdlib_srot(ncc,c(m - 1,1),ldc,c(m,1),ldc,cosl,sinl)
-                        
+
               m = m - 2
               go to 60
            end if
@@ -69443,7 +69443,7 @@ module stdlib_linalg_lapack_s
            ! qr iteration finished, go back and check convergence
            go to 60
            ! all singular values converged, so make them positive
-160  continue
+           160 continue
            do i = 1,n
               if (d(i) < zero) then
                  d(i) = -d(i)
@@ -69468,20 +69468,20 @@ module stdlib_linalg_lapack_s
                  d(isub) = d(n + 1 - i)
                  d(n + 1 - i) = smin
                  if (ncvt > 0) call stdlib_sswap(ncvt,vt(isub,1),ldvt,vt(n + 1 - i,1),ldvt)
-                           
+
                  if (nru > 0) call stdlib_sswap(nru,u(1,isub),1,u(1,n + 1 - i),1)
                  if (ncc > 0) call stdlib_sswap(ncc,c(isub,1),ldc,c(n + 1 - i,1),ldc)
-                           
+
               end if
            end do
            go to 220
            ! maximum number of iterations exceeded, failure to converge
-200  continue
+           200 continue
            info = 0
            do i = 1,n - 1
               if (e(i) /= zero) info = info + 1
            end do
-220        continue
+           220 continue
            return
      end subroutine stdlib_sbdsqr
 
@@ -69515,7 +69515,7 @@ module stdlib_linalg_lapack_s
            ! Function Arguments
            procedure(stdlib_select_s) :: select
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: cursl,lastsl,lquery,lst2sl,scalea,wantst,wantvs
            integer(ilp) :: hswork,i,i1,i2,ibal,icond,ierr,ieval,ihi,ilo,inxt,ip,itau, &
@@ -69769,7 +69769,7 @@ module stdlib_linalg_lapack_s
            ! Function Arguments
            procedure(stdlib_select_s) :: select
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: cursl,lastsl,lquery,lst2sl,scalea,wantsb,wantse,wantsn,wantst, &
                      wantsv,wantvs
@@ -70049,7 +70049,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: vl(ldvl,*),vr(ldvr,*),wi(*),work(*),wr(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,scalea,wantvl,wantvr
            character :: side
@@ -70269,7 +70269,7 @@ module stdlib_linalg_lapack_s
               end do
            end if
            ! undo scaling if necessary
-50   continue
+           50 continue
            if (scalea) then
               call stdlib_slascl('G',0,0,cscale,anrm,n - info,1,wr(info + 1),max(n - info,1 &
                         ),ierr)
@@ -70326,7 +70326,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(out) :: rconde(*),rcondv(*),scale(*),vl(ldvl,*),vr(ldvr,*),wi(*), &
                       work(*),wr(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,scalea,wantvl,wantvr,wntsnb,wntsne,wntsnn,wntsnv
            character :: job,side
@@ -70414,12 +70414,12 @@ module stdlib_linalg_lapack_s
                  else
                     minwrk = 3*n
                     if ((.not. wntsnn) .and. (.not. wntsne)) minwrk = max(minwrk,n*n + 6*n)
-                              
+
                     maxwrk = max(maxwrk,hswork)
                     maxwrk = max(maxwrk,n + (n - 1)*stdlib_ilaenv(1,'SORGHR',' ',n,1,n,- &
                               1))
                     if ((.not. wntsnn) .and. (.not. wntsne)) maxwrk = max(maxwrk,n*n + 6*n)
-                              
+
                     maxwrk = max(maxwrk,3*n)
                  end if
                  maxwrk = max(maxwrk,minwrk)
@@ -70578,7 +70578,7 @@ module stdlib_linalg_lapack_s
               end do
            end if
            ! undo scaling if necessary
-50   continue
+           50 continue
            if (scalea) then
               call stdlib_slascl('G',0,0,cscale,anrm,n - info,1,wr(info + 1),max(n - info,1 &
                         ),ierr)
@@ -70623,7 +70623,7 @@ module stdlib_linalg_lapack_s
            integer(ilp),intent(out) :: iwork(*)
            character,intent(in) :: joba,jobp,jobr,jobt,jobu,jobv
         ! ===========================================================================
-           
+
            ! Local Scalars
            real(sp) :: aapp,aaqq,aatmax,aatmin,big,big1,cond_ok,condr1,condr2,entra, &
                      entrat,epsln,maxprj,scalem,sconda,sfmin,small,temp1,uscal1,uscal2,xsc
@@ -71012,7 +71012,7 @@ module stdlib_linalg_lapack_s
                     go to 3002
                  end if
               end do
-3002          continue
+              3002 continue
            else if (l2rank) then
               ! .. similarly as above, only slightly more gentle (less aggressive).
               ! sudden drop on the diagonal of r1 is used as the criterion for
@@ -71023,7 +71023,7 @@ module stdlib_linalg_lapack_s
                            l2kill .and. (abs(a(p,p)) < temp1))) go to 3402
                  nr = nr + 1
               end do
-3402          continue
+              3402 continue
            else
               ! the goal is high relative accuracy. however, if the matrix
               ! has high scaled condition number the relative accuracy is in
@@ -71038,7 +71038,7 @@ module stdlib_linalg_lapack_s
                            3302
                  nr = nr + 1
               end do
-3302          continue
+              3302 continue
            end if
            almort = .false.
            if (nr == n) then
@@ -71162,7 +71162,7 @@ module stdlib_linalg_lapack_s
                  end do
                  call stdlib_slaset('UPPER',nr - 1,nr - 1,zero,zero,v(1,2),ldv)
                  call stdlib_sgesvj('L','U','N',n,nr,v,ldv,sva,nr,a,lda,work,lwork,info)
-                           
+
                  scalem = work(1)
                  numrank = nint(work(2),KIND=ilp)
               else
@@ -71173,7 +71173,7 @@ module stdlib_linalg_lapack_s
                  call stdlib_slacpy('LOWER',nr,nr,a,lda,v,ldv)
                  call stdlib_slaset('UPPER',nr - 1,nr - 1,zero,zero,v(1,2),ldv)
                  call stdlib_sgeqrf(nr,nr,v,ldv,work(n + 1),work(2*n + 1),lwork - 2*n,ierr)
-                           
+
                  do p = 1,nr
                     call stdlib_scopy(nr - p + 1,v(p,p),ldv,v(p,p),1)
                  end do
@@ -71291,7 +71291,7 @@ module stdlib_linalg_lapack_s
                     ! of a lower triangular matrix.
                     ! r1^t = q2 * r2
                     call stdlib_sgeqrf(n,nr,v,ldv,work(n + 1),work(2*n + 1),lwork - 2*n,ierr)
-                              
+
                     if (l2pert) then
                        xsc = sqrt(small)/epsln
                        do p = 2,nr
@@ -71726,7 +71726,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*),b(ldb,*)
            real(sp),intent(out) :: s(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: iascl,ibscl,ie,il,itau,itaup,itauq,ldwork,liwork,maxmn, &
@@ -71773,7 +71773,7 @@ module stdlib_linalg_lapack_s
                               ! columns.
                     mm = n
                     maxwrk = max(maxwrk,n + n*stdlib_ilaenv(1,'SGEQRF',' ',m,n,-1,-1))
-                              
+
                     maxwrk = max(maxwrk,n + nrhs*stdlib_ilaenv(1,'SORMQR','LT',m,nrhs,n,- &
                               1))
                  end if
@@ -71815,7 +71815,7 @@ module stdlib_linalg_lapack_s
                     else
                        ! path 2 - remaining underdetermined cases.
                        maxwrk = 3*m + (n + m)*stdlib_ilaenv(1,'SGEBRD',' ',m,n,-1,-1)
-                                 
+
                        maxwrk = max(maxwrk,3*m + nrhs*stdlib_ilaenv(1,'SORMBR','QLT',m,nrhs, &
                                   n,-1))
                        maxwrk = max(maxwrk,3*m + m*stdlib_ilaenv(1,'SORMBR','PLN',n,nrhs,m, &
@@ -71936,7 +71936,7 @@ module stdlib_linalg_lapack_s
               ! compute a=l*q.
               ! (workspace: need 2*m, prefer m+m*nb)
               call stdlib_sgelqf(m,n,a,lda,work(itau),work(nwork),lwork - nwork + 1,info)
-                        
+
               il = nwork
               ! copy l to work(il), zeroing out above its diagonal.
               call stdlib_slacpy('L',m,m,a,lda,work(il),ldwork)
@@ -72006,7 +72006,7 @@ module stdlib_linalg_lapack_s
            else if (ibscl == 2) then
               call stdlib_slascl('G',0,0,bignum,bnrm,n,nrhs,b,ldb,info)
            end if
-10         continue
+           10 continue
            work(1) = maxwrk
            iwork(1) = liwork
            return
@@ -72026,7 +72026,7 @@ module stdlib_linalg_lapack_s
      !> value.
 
      subroutine stdlib_sgelss(m,n,nrhs,a,lda,b,ldb,s,rcond,rank,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -72038,7 +72038,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*),b(ldb,*)
            real(sp),intent(out) :: s(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: bdspac,bl,chunk,i,iascl,ibscl,ie,il,itau,itaup,itauq,iwork, &
@@ -72283,7 +72283,7 @@ module stdlib_linalg_lapack_s
               ! (workspace: need n, prefer n*nrhs)
               if (lwork >= ldb*nrhs .and. nrhs > 1) then
                  call stdlib_sgemm('T','N',n,nrhs,n,one,a,lda,b,ldb,zero,work,ldb)
-                           
+
                  call stdlib_slacpy('G',n,nrhs,work,ldb,b,ldb)
               else if (nrhs > 1) then
                  chunk = lwork/n
@@ -72308,7 +72308,7 @@ module stdlib_linalg_lapack_s
               ! compute a=l*q
               ! (workspace: need 2*m, prefer m+m*nb)
               call stdlib_sgelqf(m,n,a,lda,work(itau),work(iwork),lwork - iwork + 1,info)
-                        
+
               il = iwork
               ! copy l to work(il), zeroing out above it
               call stdlib_slacpy('L',m,m,a,lda,work(il),ldwork)
@@ -72418,7 +72418,7 @@ module stdlib_linalg_lapack_s
               ! (workspace: need n, prefer n*nrhs)
               if (lwork >= ldb*nrhs .and. nrhs > 1) then
                  call stdlib_sgemm('T','N',n,nrhs,m,one,a,lda,b,ldb,zero,work,ldb)
-                           
+
                  call stdlib_slacpy('F',n,nrhs,work,ldb,b,ldb)
               else if (nrhs > 1) then
                  chunk = lwork/n
@@ -72446,7 +72446,7 @@ module stdlib_linalg_lapack_s
            else if (ibscl == 2) then
               call stdlib_slascl('G',0,0,bignum,bnrm,n,nrhs,b,ldb,info)
            end if
-70         continue
+           70 continue
            work(1) = maxwrk
            return
      end subroutine stdlib_sgelss
@@ -72472,7 +72472,7 @@ module stdlib_linalg_lapack_s
      !> without guard digits, but we know of none.
 
      subroutine stdlib_sgesdd(jobz,m,n,a,lda,s,u,ldu,vt,ldvt,work,lwork,iwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -72485,7 +72485,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: s(*),u(ldu,*),vt(ldvt,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wntqa,wntqas,wntqn,wntqo,wntqs
            integer(ilp) :: bdspac,blk,chunk,i,ie,ierr,il,ir,iscl,itau,itaup,itauq,iu, &
@@ -72653,7 +72653,7 @@ module stdlib_linalg_lapack_s
                            ierr)
                  lwork_sgebrd_mn = int(dum(1),KIND=ilp)
                  call stdlib_sgebrd(m,m,a,m,s,dum(1),dum(1),dum(1),dum(1),-1,ierr)
-                           
+
                  lwork_sgebrd_mm = int(dum(1),KIND=ilp)
                  call stdlib_sgelqf(m,n,a,m,dum(1),dum(1),-1,ierr)
                  lwork_sgelqf_mn = int(dum(1),KIND=ilp)
@@ -72868,7 +72868,7 @@ module stdlib_linalg_lapack_s
                        call stdlib_sgemm('N','N',chunk,n,n,one,a(i,1),lda,work(iu), &
                                  n,zero,work(ir),ldwrkr)
                        call stdlib_slacpy('F',chunk,n,work(ir),ldwrkr,a(i,1),lda)
-                                 
+
                     end do
                  else if (wntqs) then
                     ! path 3 (m >> n, jobz='s')
@@ -73049,7 +73049,7 @@ module stdlib_linalg_lapack_s
                           call stdlib_sgemm('N','N',chunk,n,n,one,a(i,1),lda,work(iu) &
                                     ,ldwrku,zero,work(ir),ldwrkr)
                           call stdlib_slacpy('F',chunk,n,work(ir),ldwrkr,a(i,1),lda)
-                                    
+
                        end do
                     end if
                  else if (wntqs) then
@@ -73187,7 +73187,7 @@ module stdlib_linalg_lapack_s
                        call stdlib_sgemm('N','N',m,blk,m,one,work(ivt),m,a(1,i),lda, &
                                   zero,work(il),ldwrkl)
                        call stdlib_slacpy('F',m,blk,work(il),ldwrkl,a(1,i),lda)
-                                 
+
                     end do
                  else if (wntqs) then
                     ! path 3t (n >> m, jobz='s')
@@ -73435,7 +73435,7 @@ module stdlib_linalg_lapack_s
      !> Note that the routine returns V**T, not V.
 
      subroutine stdlib_sgesvd(jobu,jobvt,m,n,a,lda,s,u,ldu,vt,ldvt,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -73447,7 +73447,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: s(*),u(ldu,*),vt(ldvt,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wntua,wntuas,wntun,wntuo,wntus,wntva,wntvas,wntvn,wntvo, &
                       wntvs
@@ -73516,7 +73516,7 @@ module stdlib_linalg_lapack_s
                  lwork_sorgqr_m = int(dum(1),KIND=ilp)
                  ! compute space needed for stdlib_sgebrd
                  call stdlib_sgebrd(n,n,a,lda,s,dum(1),dum(1),dum(1),dum(1),-1,ierr)
-                           
+
                  lwork_sgebrd = int(dum(1),KIND=ilp)
                  ! compute space needed for stdlib_sorgbr p
                  call stdlib_sorgbr('P',n,n,n,a,lda,dum(1),dum(1),-1,ierr)
@@ -73616,7 +73616,7 @@ module stdlib_linalg_lapack_s
                  else
                     ! path 10 (m at least n, but not much larger)
                     call stdlib_sgebrd(m,n,a,lda,s,dum(1),dum(1),dum(1),dum(1),-1,ierr)
-                              
+
                     lwork_sgebrd = int(dum(1),KIND=ilp)
                     maxwrk = 3*n + lwork_sgebrd
                     if (wntus .or. wntuo) then
@@ -73649,7 +73649,7 @@ module stdlib_linalg_lapack_s
                  lwork_sorglq_m = int(dum(1),KIND=ilp)
                  ! compute space needed for stdlib_sgebrd
                  call stdlib_sgebrd(m,m,a,lda,s,dum(1),dum(1),dum(1),dum(1),-1,ierr)
-                           
+
                  lwork_sgebrd = int(dum(1),KIND=ilp)
                   ! compute space needed for stdlib_sorgbr p
                  call stdlib_sorgbr('P',m,m,m,a,n,dum(1),dum(1),-1,ierr)
@@ -73750,7 +73750,7 @@ module stdlib_linalg_lapack_s
                  else
                     ! path 10t(n greater than m, but not much larger)
                     call stdlib_sgebrd(m,n,a,lda,s,dum(1),dum(1),dum(1),dum(1),-1,ierr)
-                              
+
                     lwork_sgebrd = int(dum(1),KIND=ilp)
                     maxwrk = 3*m + lwork_sgebrd
                     if (wntvs .or. wntvo) then
@@ -73872,7 +73872,7 @@ module stdlib_linalg_lapack_s
                        ! copy r to work(ir) and zero out below it
                        call stdlib_slacpy('U',n,n,a,lda,work(ir),ldwrkr)
                        call stdlib_slaset('L',n - 1,n - 1,zero,zero,work(ir + 1),ldwrkr)
-                                 
+
                        ! generate q in a
                        ! (workspace: need n*n+2*n, prefer n*n+n+n*nb)
                        call stdlib_sorgqr(m,n,n,a,lda,work(itau),work(iwork),lwork - &
@@ -73904,7 +73904,7 @@ module stdlib_linalg_lapack_s
                           call stdlib_sgemm('N','N',chunk,n,n,one,a(i,1),lda,work(ir) &
                                     ,ldwrkr,zero,work(iu),ldwrku)
                           call stdlib_slacpy('F',chunk,n,work(iu),ldwrku,a(i,1),lda)
-                                    
+
                        end do
                     else
                        ! insufficient workspace for a fast algorithm
@@ -73956,7 +73956,7 @@ module stdlib_linalg_lapack_s
                        ! copy r to vt, zeroing out below it
                        call stdlib_slacpy('U',n,n,a,lda,vt,ldvt)
                        if (n > 1) call stdlib_slaset('L',n - 1,n - 1,zero,zero,vt(2,1),ldvt)
-                                 
+
                        ! generate q in a
                        ! (workspace: need n*n+2*n, prefer n*n+n+n*nb)
                        call stdlib_sorgqr(m,n,n,a,lda,work(itau),work(iwork),lwork - &
@@ -73994,7 +73994,7 @@ module stdlib_linalg_lapack_s
                           call stdlib_sgemm('N','N',chunk,n,n,one,a(i,1),lda,work(ir) &
                                     ,ldwrkr,zero,work(iu),ldwrku)
                           call stdlib_slacpy('F',chunk,n,work(iu),ldwrku,a(i,1),lda)
-                                    
+
                        end do
                     else
                        ! insufficient workspace for a fast algorithm
@@ -74007,7 +74007,7 @@ module stdlib_linalg_lapack_s
                        ! copy r to vt, zeroing out below it
                        call stdlib_slacpy('U',n,n,a,lda,vt,ldvt)
                        if (n > 1) call stdlib_slaset('L',n - 1,n - 1,zero,zero,vt(2,1),ldvt)
-                                 
+
                        ! generate q in a
                        ! (workspace: need 2*n, prefer n+n*nb)
                        call stdlib_sorgqr(m,n,n,a,lda,work(itau),work(iwork),lwork - &
@@ -74060,7 +74060,7 @@ module stdlib_linalg_lapack_s
                           ! copy r to work(ir), zeroing out below it
                           call stdlib_slacpy('U',n,n,a,lda,work(ir),ldwrkr)
                           call stdlib_slaset('L',n - 1,n - 1,zero,zero,work(ir + 1),ldwrkr)
-                                    
+
                           ! generate q in a
                           ! (workspace: need n*n+2*n, prefer n*n+n+n*nb)
                           call stdlib_sorgqr(m,n,n,a,lda,work(itau),work(iwork),lwork - &
@@ -74108,7 +74108,7 @@ module stdlib_linalg_lapack_s
                           ! zero out below r in a
                           if (n > 1) then
                              call stdlib_slaset('L',n - 1,n - 1,zero,zero,a(2,1),lda)
-                                       
+
                           end if
                           ! bidiagonalize r in a
                           ! (workspace: need 4*n, prefer 3*n+2*n*nb)
@@ -74157,7 +74157,7 @@ module stdlib_linalg_lapack_s
                           ! copy r to work(iu), zeroing out below it
                           call stdlib_slacpy('U',n,n,a,lda,work(iu),ldwrku)
                           call stdlib_slaset('L',n - 1,n - 1,zero,zero,work(iu + 1),ldwrku)
-                                    
+
                           ! generate q in a
                           ! (workspace: need 2*n*n+2*n, prefer 2*n*n+n+n*nb)
                           call stdlib_sorgqr(m,n,n,a,lda,work(itau),work(iwork),lwork - &
@@ -74173,7 +74173,7 @@ module stdlib_linalg_lapack_s
                           call stdlib_sgebrd(n,n,work(iu),ldwrku,s,work(ie),work(itauq &
                                     ),work(itaup),work(iwork),lwork - iwork + 1,ierr)
                           call stdlib_slacpy('U',n,n,work(iu),ldwrku,work(ir),ldwrkr)
-                                    
+
                           ! generate left bidiagonalizing vectors in work(iu)
                           ! (workspace: need 2*n*n+4*n, prefer 2*n*n+3*n+n*nb)
                           call stdlib_sorgbr('Q',n,n,n,work(iu),ldwrku,work(itauq), &
@@ -74218,7 +74218,7 @@ module stdlib_linalg_lapack_s
                           ! zero out below r in a
                           if (n > 1) then
                              call stdlib_slaset('L',n - 1,n - 1,zero,zero,a(2,1),lda)
-                                       
+
                           end if
                           ! bidiagonalize r in a
                           ! (workspace: need 4*n, prefer 3*n+2*n*nb)
@@ -74264,7 +74264,7 @@ module stdlib_linalg_lapack_s
                           ! copy r to work(iu), zeroing out below it
                           call stdlib_slacpy('U',n,n,a,lda,work(iu),ldwrku)
                           call stdlib_slaset('L',n - 1,n - 1,zero,zero,work(iu + 1),ldwrku)
-                                    
+
                           ! generate q in a
                           ! (workspace: need n*n+2*n, prefer n*n+n+n*nb)
                           call stdlib_sorgqr(m,n,n,a,lda,work(itau),work(iwork),lwork - &
@@ -74367,7 +74367,7 @@ module stdlib_linalg_lapack_s
                           ! copy r to work(ir), zeroing out below it
                           call stdlib_slacpy('U',n,n,a,lda,work(ir),ldwrkr)
                           call stdlib_slaset('L',n - 1,n - 1,zero,zero,work(ir + 1),ldwrkr)
-                                    
+
                           ! generate q in u
                           ! (workspace: need n*n+n+m, prefer n*n+n+m*nb)
                           call stdlib_sorgqr(m,m,n,u,ldu,work(itau),work(iwork),lwork - &
@@ -74417,7 +74417,7 @@ module stdlib_linalg_lapack_s
                           ! zero out below r in a
                           if (n > 1) then
                              call stdlib_slaset('L',n - 1,n - 1,zero,zero,a(2,1),lda)
-                                       
+
                           end if
                           ! bidiagonalize r in a
                           ! (workspace: need 4*n, prefer 3*n+2*n*nb)
@@ -74472,7 +74472,7 @@ module stdlib_linalg_lapack_s
                           ! copy r to work(iu), zeroing out below it
                           call stdlib_slacpy('U',n,n,a,lda,work(iu),ldwrku)
                           call stdlib_slaset('L',n - 1,n - 1,zero,zero,work(iu + 1),ldwrku)
-                                    
+
                           ie = itau
                           itauq = ie + n
                           itaup = itauq + n
@@ -74484,7 +74484,7 @@ module stdlib_linalg_lapack_s
                           call stdlib_sgebrd(n,n,work(iu),ldwrku,s,work(ie),work(itauq &
                                     ),work(itaup),work(iwork),lwork - iwork + 1,ierr)
                           call stdlib_slacpy('U',n,n,work(iu),ldwrku,work(ir),ldwrkr)
-                                    
+
                           ! generate left bidiagonalizing vectors in work(iu)
                           ! (workspace: need 2*n*n+4*n, prefer 2*n*n+3*n+n*nb)
                           call stdlib_sorgbr('Q',n,n,n,work(iu),ldwrku,work(itauq), &
@@ -74530,7 +74530,7 @@ module stdlib_linalg_lapack_s
                           ! zero out below r in a
                           if (n > 1) then
                              call stdlib_slaset('L',n - 1,n - 1,zero,zero,a(2,1),lda)
-                                       
+
                           end if
                           ! bidiagonalize r in a
                           ! (workspace: need 4*n, prefer 3*n+2*n*nb)
@@ -74582,7 +74582,7 @@ module stdlib_linalg_lapack_s
                           ! copy r to work(iu), zeroing out below it
                           call stdlib_slacpy('U',n,n,a,lda,work(iu),ldwrku)
                           call stdlib_slaset('L',n - 1,n - 1,zero,zero,work(iu + 1),ldwrku)
-                                    
+
                           ie = itau
                           itauq = ie + n
                           itaup = itauq + n
@@ -74803,7 +74803,7 @@ module stdlib_linalg_lapack_s
                        ! copy l to work(ir) and zero out above it
                        call stdlib_slacpy('L',m,m,a,lda,work(ir),ldwrkr)
                        call stdlib_slaset('U',m - 1,m - 1,zero,zero,work(ir + ldwrkr),ldwrkr)
-                                 
+
                        ! generate q in a
                        ! (workspace: need m*m+2*m, prefer m*m+m+m*nb)
                        call stdlib_sorglq(m,n,m,a,lda,work(itau),work(iwork),lwork - &
@@ -74835,7 +74835,7 @@ module stdlib_linalg_lapack_s
                           call stdlib_sgemm('N','N',m,blk,m,one,work(ir),ldwrkr,a(1,i &
                                     ),lda,zero,work(iu),ldwrku)
                           call stdlib_slacpy('F',m,blk,work(iu),ldwrku,a(1,i),lda)
-                                    
+
                        end do
                     else
                        ! insufficient workspace for a fast algorithm
@@ -74927,7 +74927,7 @@ module stdlib_linalg_lapack_s
                           call stdlib_sgemm('N','N',m,blk,m,one,work(ir),ldwrkr,a(1,i &
                                     ),lda,zero,work(iu),ldwrku)
                           call stdlib_slacpy('F',m,blk,work(iu),ldwrku,a(1,i),lda)
-                                    
+
                        end do
                     else
                        ! insufficient workspace for a fast algorithm
@@ -75104,7 +75104,7 @@ module stdlib_linalg_lapack_s
                           call stdlib_sgebrd(m,m,work(iu),ldwrku,s,work(ie),work(itauq &
                                     ),work(itaup),work(iwork),lwork - iwork + 1,ierr)
                           call stdlib_slacpy('L',m,m,work(iu),ldwrku,work(ir),ldwrkr)
-                                    
+
                           ! generate right bidiagonalizing vectors in work(iu)
                           ! (workspace: need 2*m*m+4*m-1,
                                       ! prefer 2*m*m+3*m+(m-1)*nb)
@@ -75409,7 +75409,7 @@ module stdlib_linalg_lapack_s
                           call stdlib_sgebrd(m,m,work(iu),ldwrku,s,work(ie),work(itauq &
                                     ),work(itaup),work(iwork),lwork - iwork + 1,ierr)
                           call stdlib_slacpy('L',m,m,work(iu),ldwrku,work(ir),ldwrkr)
-                                    
+
                           ! generate right bidiagonalizing vectors in work(iu)
                           ! (workspace: need 2*m*m+4*m-1,
                                       ! prefer 2*m*m+3*m+(m-1)*nb)
@@ -75705,7 +75705,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(out) :: s(*),rwork(*)
            integer(ilp),intent(out) :: iwork(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: ierr,iwoff,nr,n1,optratio,p,q
            integer(ilp) :: lwcon,lwqp3,lwrk_sgelqf,lwrk_sgesvd,lwrk_sgesvd2,lwrk_sgeqp3, &
@@ -76037,7 +76037,7 @@ module stdlib_linalg_lapack_s
                      ! .. to prevent overflow in the qr factorization, scale the
                      ! matrix by 1/sqrt(m) if too large entry detected
                      call stdlib_slascl('G',0,0,sqrt(real(m,KIND=sp)),one,m,n,a,lda,ierr)
-                               
+
                      ascaled = .true.
                  end if
                  call stdlib_slaswp(n,a,lda,1,m - 1,iwork(n + 1),1)
@@ -76057,7 +76057,7 @@ module stdlib_linalg_lapack_s
                    ! .. to prevent overflow in the qr factorization, scale the
                    ! matrix by 1/sqrt(m) if too large entry detected
                    call stdlib_slascl('G',0,0,sqrt(real(m,KIND=sp)),one,m,n,a,lda,ierr)
-                             
+
                    ascaled = .true.
                end if
            end if
@@ -76087,7 +76087,7 @@ module stdlib_linalg_lapack_s
                  if (abs(a(p,p)) < (rtmp*abs(a(1,1)))) go to 3002
                     nr = nr + 1
               end do
-3002          continue
+              3002 continue
            elseif (acclm) then
               ! .. similarly as above, only slightly more gentle (less aggressive).
               ! sudden drop on the diagonal of r is used as the criterion for being
@@ -76101,7 +76101,7 @@ module stdlib_linalg_lapack_s
                            to 3402
                  nr = nr + 1
               end do
-3402          continue
+              3402 continue
            else
               ! Rrqr Not Authorized To Determine Numerical Rank Except In The
               ! obvious case of zero pivots.
@@ -76112,7 +76112,7 @@ module stdlib_linalg_lapack_s
                  if (abs(a(p,p)) == zero) go to 3502
                  nr = nr + 1
               end do
-3502          continue
+              3502 continue
               if (conda) then
                  ! estimate the scaled condition number of a. use the fact that it is
                  ! the same as the scaled condition number of r.
@@ -76200,7 +76200,7 @@ module stdlib_linalg_lapack_s
                   ! .. copy r into [u] and overwrite [u] with the left singular vectors
                   call stdlib_slacpy('U',nr,n,a,lda,u,ldu)
                   if (nr > 1) call stdlib_slaset('L',nr - 1,nr - 1,zero,zero,u(2,1),ldu)
-                            
+
                   ! .. the right singular vectors not computed, the nr left singular
                   ! vectors overwrite [u](1:nr,1:nr)
                      call stdlib_sgesvd('O','N',nr,n,u,ldu,s,u,ldu,v,ldv,work(n + 1), &
@@ -76280,7 +76280,7 @@ module stdlib_linalg_lapack_s
                   ! Copy R Into V And Overwrite V With The Right Singular Vectors
                   call stdlib_slacpy('U',nr,n,a,lda,v,ldv)
                   if (nr > 1) call stdlib_slaset('L',nr - 1,nr - 1,zero,zero,v(2,1),ldv)
-                            
+
                   ! .. the right singular vectors overwrite v, the nr left singular
                   ! vectors stored in u(1:nr,1:nr)
                   if (wntvr .or. (nr == n)) then
@@ -76368,7 +76368,7 @@ module stdlib_linalg_lapack_s
                            end do
                         end do
                         if (nr > 1) call stdlib_slaset('U',nr - 1,nr - 1,zero,zero,v(1,2),ldv)
-                                  
+
                         call stdlib_slaset('A',n,n - nr,zero,zero,v(1,nr + 1),ldv)
                         call stdlib_sgesvd('O','A',n,n,v,ldv,s,v,ldv,u,ldu,work(n + 1), &
                                   lwork - n,info)
@@ -76405,7 +76405,7 @@ module stdlib_linalg_lapack_s
                            end do
                         end do
                         if (nr > 1) call stdlib_slaset('U',nr - 1,nr - 1,zero,zero,u(1,nr + 2),ldu)
-                                  
+
                         call stdlib_sgeqrf(n,nr,u(1,nr + 1),ldu,work(n + 1),work(n + nr + 1),lwork - &
                                   n - nr,ierr)
                         do p = 1,nr
@@ -76439,7 +76439,7 @@ module stdlib_linalg_lapack_s
                       ! .. copy r into [v] and overwrite v with the right singular vectors
                       call stdlib_slacpy('U',nr,n,a,lda,v,ldv)
                      if (nr > 1) call stdlib_slaset('L',nr - 1,nr - 1,zero,zero,v(2,1),ldv)
-                               
+
                      ! .. the right singular vectors of r overwrite [v], the nr left
                      ! singular vectors of r stored in [u](1:nr,1:nr)
                      call stdlib_sgesvd('S','O',nr,n,v,ldv,s,u,ldu,v,ldv,work(n + 1), &
@@ -76468,7 +76468,7 @@ module stdlib_linalg_lapack_s
                     if (optratio*nr > n) then
                        call stdlib_slacpy('U',nr,n,a,lda,v,ldv)
                        if (nr > 1) call stdlib_slaset('L',nr - 1,nr - 1,zero,zero,v(2,1),ldv)
-                                 
+
                     ! .. the right singular vectors of r overwrite [v], the nr left
                        ! singular vectors of r stored in [u](1:nr,1:nr)
                        call stdlib_slaset('A',n - nr,n,zero,zero,v(nr + 1,1),ldv)
@@ -76490,7 +76490,7 @@ module stdlib_linalg_lapack_s
                     else
                        call stdlib_slacpy('U',nr,n,a,lda,u(nr + 1,1),ldu)
                        if (nr > 1) call stdlib_slaset('L',nr - 1,nr - 1,zero,zero,u(nr + 2,1),ldu)
-                                 
+
                        call stdlib_sgelqf(nr,n,u(nr + 1,1),ldu,work(n + 1),work(n + nr + 1),lwork - n - &
                                  nr,ierr)
                        call stdlib_slacpy('L',nr,nr,u(nr + 1,1),ldu,v,ldv)
@@ -76531,7 +76531,7 @@ module stdlib_linalg_lapack_s
                if (s(q) > zero) go to 4002
                nr = nr - 1
            end do
-4002       continue
+           4002 continue
            ! .. if numerical rank deficiency is detected, the truncated
            ! singular values are set to zero.
            if (nr < n) call stdlib_slaset('G',n - nr,1,zero,zero,s(nr + 1),n)
@@ -76575,7 +76575,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Local Parameters
            integer(ilp),parameter :: nsweep = 30
-           
+
            ! Local Scalars
            real(sp) :: aapp,aapp0,aapq,aaqq,apoaq,aqoap,big,bigtheta,cs,ctol,epsln, &
            large,mxaapq,mxsinj,rootbig,rooteps,rootsfmin,roottol,skl,sfmin,small,sn,t, &
@@ -76781,7 +76781,7 @@ module stdlib_linalg_lapack_s
        ! #:) quick return for one-column matrix
            if (n == 1) then
               if (lsvec) call stdlib_slascl('G',0,0,sva(1),skl,m,1,a(1,1),lda,ierr)
-                        
+
               work(1) = one/skl
               if (sva(1) >= sfmin) then
                  work(2) = one
@@ -76901,12 +76901,12 @@ module stdlib_linalg_lapack_s
                            tol,2,work(n + 1),lwork - n,ierr)
                  call stdlib_sgsvj0(jobv,n2,n4,a(1,n4 + 1),lda,work(n4 + 1),sva(n4 + 1), &
                  mvl,v(n4*q + 1,n4 + 1),ldv,epsln,sfmin,tol,1,work(n + 1),lwork - n,ierr)
-                           
+
                  call stdlib_sgsvj1(jobv,n2,n2,n4,a,lda,work,sva,mvl,v,ldv,epsln, &
                            sfmin,tol,1,work(n + 1),lwork - n,ierr)
                  call stdlib_sgsvj0(jobv,n2 + n4,n4,a(1,n2 + 1),lda,work(n2 + 1),sva(n2 + 1), &
                   mvl,v(n2*q + 1,n2 + 1),ldv,epsln,sfmin,tol,1,work(n + 1),lwork - n,ierr)
-                            
+
               end if
            end if
            ! .. row-cyclic pivot strategy with de rijk's pivoting ..
@@ -77012,23 +77012,23 @@ module stdlib_linalg_lapack_s
                                          fastr(3) = t*work(p)/work(q)
                                          fastr(4) = -t*work(q)/work(p)
                                          call stdlib_srotm(m,a(1,p),1,a(1,q),1,fastr)
-                                                   
+
                                          if (rsvec) call stdlib_srotm(mvl,v(1,p),1,v(1,q), &
                                                     1,fastr)
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq))
                                          mxsinj = max(mxsinj,abs(t))
                                       else
                        ! Choose Correct Signum For Theta And Rotate
                                          thsign = -sign(one,aapq)
                                          t = one/(theta + thsign*sqrt(one + theta*theta))
-                                                   
+
                                          cs = sqrt(one/(one + t*t))
                                          sn = t*cs
                                          mxsinj = max(mxsinj,abs(sn))
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq))
                                          apoaq = work(p)/work(q)
                                          aqoap = work(q)/work(p)
@@ -77110,7 +77110,7 @@ module stdlib_linalg_lapack_s
                                                 lda,ierr)
                                       temp1 = -aapq*work(p)/work(q)
                                       call stdlib_saxpy(m,temp1,work(n + 1),1,a(1,q),1)
-                                                
+
                                       call stdlib_slascl('G',0,0,one,aaqq,m,1,a(1,q), &
                                                 lda,ierr)
                                       sva(q) = aaqq*sqrt(max(zero,one - aapq*aapq))
@@ -77122,7 +77122,7 @@ module stdlib_linalg_lapack_s
                                    if ((sva(q)/aaqq)**2 <= rooteps) then
                                       if ((aaqq < rootbig) .and. (aaqq > rootsfmin)) then
                                          sva(q) = stdlib_snrm2(m,a(1,q),1)*work(q)
-                                                   
+
                                       else
                                          t = zero
                                          aaqq = one
@@ -77159,7 +77159,7 @@ module stdlib_linalg_lapack_s
                              end if
                           end do loop_2002
            ! end q-loop
-2103 continue
+           2103 continue
            ! bailed out of q-loop
                           sva(p) = aapp
                        else
@@ -77238,11 +77238,11 @@ module stdlib_linalg_lapack_s
                                          fastr(3) = t*work(p)/work(q)
                                          fastr(4) = -t*work(q)/work(p)
                                          call stdlib_srotm(m,a(1,p),1,a(1,q),1,fastr)
-                                                   
+
                                          if (rsvec) call stdlib_srotm(mvl,v(1,p),1,v(1,q), &
                                                     1,fastr)
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq))
                                          mxsinj = max(mxsinj,abs(t))
                                       else
@@ -77250,12 +77250,12 @@ module stdlib_linalg_lapack_s
                                          thsign = -sign(one,aapq)
                                          if (aaqq > aapp0) thsign = -thsign
                                          t = one/(theta + thsign*sqrt(one + theta*theta))
-                                                   
+
                                          cs = sqrt(one/(one + t*t))
                                          sn = t*cs
                                          mxsinj = max(mxsinj,abs(sn))
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq))
                                          apoaq = work(p)/work(q)
                                          aqoap = work(q)/work(p)
@@ -77331,7 +77331,7 @@ module stdlib_linalg_lapack_s
                                    else
                                       if (aapp > aaqq) then
                                          call stdlib_scopy(m,a(1,p),1,work(n + 1),1)
-                                                   
+
                                          call stdlib_slascl('G',0,0,aapp,one,m,1,work(n + 1 &
                                                    ),lda,ierr)
                                          call stdlib_slascl('G',0,0,aaqq,one,m,1,a(1,q), &
@@ -77345,7 +77345,7 @@ module stdlib_linalg_lapack_s
                                          mxsinj = max(mxsinj,sfmin)
                                       else
                                          call stdlib_scopy(m,a(1,q),1,work(n + 1),1)
-                                                   
+
                                          call stdlib_slascl('G',0,0,aaqq,one,m,1,work(n + 1 &
                                                    ),lda,ierr)
                                          call stdlib_slascl('G',0,0,aapp,one,m,1,a(1,p), &
@@ -77365,7 +77365,7 @@ module stdlib_linalg_lapack_s
                                    if ((sva(q)/aaqq)**2 <= rooteps) then
                                       if ((aaqq < rootbig) .and. (aaqq > rootsfmin)) then
                                          sva(q) = stdlib_snrm2(m,a(1,q),1)*work(q)
-                                                   
+
                                       else
                                          t = zero
                                          aaqq = one
@@ -77408,7 +77408,7 @@ module stdlib_linalg_lapack_s
                              end if
                           end do loop_2200
               ! end of the q-loop
-2203 continue
+              2203 continue
                           sva(p) = aapp
                        else
                           if (aapp == zero) notrot = notrot + min(jgl + kbl - 1,n) - jgl + 1
@@ -77418,7 +77418,7 @@ module stdlib_linalg_lapack_s
            ! end of the p-loop
                  end do loop_2010
            ! end of the jbc-loop
-2011 continue
+           2011 continue
       ! 2011 bailed out of the jbc-loop
                  do p = igl,min(igl + kbl - 1,n)
                     sva(p) = abs(sva(p))
@@ -77447,12 +77447,12 @@ module stdlib_linalg_lapack_s
        ! #:( reaching this point means that the procedure has not converged.
            info = nsweep - 1
            go to 1995
-1994       continue
+           1994 continue
        ! #:) reaching this point means numerical convergence after the i-th
            ! sweep.
            info = 0
        ! #:) info = 0 confirms successful iterations.
-1995 continue
+       1995 continue
            ! sort the singular values and find how many are above
            ! the underflow threshold.
            n2 = 0
@@ -77570,7 +77570,7 @@ module stdlib_linalg_lapack_s
            ! Function Arguments
            procedure(stdlib_selctg_s) :: selctg
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: cursl,ilascl,ilbscl,ilvsl,ilvsr,lastsl,lquery,lst2sl, &
                      wantst
@@ -77647,7 +77647,7 @@ module stdlib_linalg_lapack_s
               if (wantst) then
                  call stdlib_stgsen(0,ilvsl,ilvsr,bwork,n,a,lda,b,ldb,alphar,alphai, &
                  beta,vsl,ldvsl,vsr,ldvsr,sdim,pvsl,pvsr,dif,work,-1,idum,1,ierr)
-                           
+
                  lwkopt = max(lwkopt,2*n + int(work(1),KIND=ilp))
               end if
               work(1) = lwkopt
@@ -77746,7 +77746,7 @@ module stdlib_linalg_lapack_s
                  call stdlib_slascl('G',0,0,anrmto,anrm,n,1,alphai,n,ierr)
               end if
               if (ilbscl) call stdlib_slascl('G',0,0,bnrmto,bnrm,n,1,beta,n,ierr)
-                        
+
               ! select eigenvalues
               do i = 1,n
                  bwork(i) = selctg(alphar(i),alphai(i),beta(i))
@@ -77835,7 +77835,7 @@ module stdlib_linalg_lapack_s
                  lastsl = cursl
               end do
            end if
-40         continue
+           40 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_sgges3
@@ -77868,9 +77868,9 @@ module stdlib_linalg_lapack_s
            ! Array Arguments
            real(sp),intent(inout) :: a(lda,*),b(ldb,*)
            real(sp),intent(out) :: alphai(*),alphar(*),beta(*),vl(ldvl,*),vr(ldvr,*),work(*)
-                     
+
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: ilascl,ilbscl,ilv,ilvl,ilvr,lquery
            character :: chtemp
@@ -78123,7 +78123,7 @@ module stdlib_linalg_lapack_s
               ! end of eigenvector calculation
            end if
            ! undo scaling if necessary
-110  continue
+           110 continue
            if (ilascl) then
               call stdlib_slascl('G',0,0,anrmto,anrm,n,1,alphar,n,ierr)
               call stdlib_slascl('G',0,0,anrmto,anrm,n,1,alphai,n,ierr)
@@ -78154,7 +78154,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*),sva(n),d(n),v(ldv,*)
            real(sp),intent(out) :: work(lwork)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(sp) :: aapp,aapp0,aapq,aaqq,apoaq,aqoap,big,bigtheta,cs,mxaapq,mxsinj, &
                      rootbig,rooteps,rootsfmin,roottol,small,sn,t,temp1,theta,thsign
@@ -78331,23 +78331,23 @@ module stdlib_linalg_lapack_s
                                          fastr(3) = t*d(p)/d(q)
                                          fastr(4) = -t*d(q)/d(p)
                                          call stdlib_srotm(m,a(1,p),1,a(1,q),1,fastr)
-                                                   
+
                                          if (rsvec) call stdlib_srotm(mvl,v(1,p),1,v(1,q), &
                                                     1,fastr)
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq))
                                          mxsinj = max(mxsinj,abs(t))
                                       else
                        ! Choose Correct Signum For Theta And Rotate
                                          thsign = -sign(one,aapq)
                                          t = one/(theta + thsign*sqrt(one + theta*theta))
-                                                   
+
                                          cs = sqrt(one/(one + t*t))
                                          sn = t*cs
                                          mxsinj = max(mxsinj,abs(sn))
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq))
                                          apoaq = d(p)/d(q)
                                          aqoap = d(q)/d(p)
@@ -78475,7 +78475,7 @@ module stdlib_linalg_lapack_s
                              end if
                           end do loop_2002
            ! end q-loop
-2103 continue
+           2103 continue
            ! bailed out of q-loop
                           sva(p) = aapp
                        else
@@ -78555,11 +78555,11 @@ module stdlib_linalg_lapack_s
                                          fastr(3) = t*d(p)/d(q)
                                          fastr(4) = -t*d(q)/d(p)
                                          call stdlib_srotm(m,a(1,p),1,a(1,q),1,fastr)
-                                                   
+
                                          if (rsvec) call stdlib_srotm(mvl,v(1,p),1,v(1,q), &
                                                     1,fastr)
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq))
                                          mxsinj = max(mxsinj,abs(t))
                                       else
@@ -78567,12 +78567,12 @@ module stdlib_linalg_lapack_s
                                          thsign = -sign(one,aapq)
                                          if (aaqq > aapp0) thsign = -thsign
                                          t = one/(theta + thsign*sqrt(one + theta*theta))
-                                                   
+
                                          cs = sqrt(one/(one + t*t))
                                          sn = t*cs
                                          mxsinj = max(mxsinj,abs(sn))
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq))
                                          apoaq = d(p)/d(q)
                                          aqoap = d(q)/d(p)
@@ -78654,7 +78654,7 @@ module stdlib_linalg_lapack_s
                                                     lda,ierr)
                                          temp1 = -aapq*d(p)/d(q)
                                          call stdlib_saxpy(m,temp1,work,1,a(1,q),1)
-                                                   
+
                                          call stdlib_slascl('G',0,0,one,aaqq,m,1,a(1,q), &
                                                     lda,ierr)
                                          sva(q) = aaqq*sqrt(max(zero,one - aapq*aapq))
@@ -78667,7 +78667,7 @@ module stdlib_linalg_lapack_s
                                                     lda,ierr)
                                          temp1 = -aapq*d(q)/d(p)
                                          call stdlib_saxpy(m,temp1,work,1,a(1,p),1)
-                                                   
+
                                          call stdlib_slascl('G',0,0,one,aapp,m,1,a(1,p), &
                                                     lda,ierr)
                                          sva(p) = aapp*sqrt(max(zero,one - aapq*aapq))
@@ -78721,7 +78721,7 @@ module stdlib_linalg_lapack_s
                              end if
                           end do loop_2200
               ! end of the q-loop
-2203 continue
+              2203 continue
                           sva(p) = aapp
                        else
                           if (aapp == zero) notrot = notrot + min(jgl + kbl - 1,n) - jgl + 1
@@ -78731,7 +78731,7 @@ module stdlib_linalg_lapack_s
            ! end of the p-loop
                  end do loop_2010
            ! end of the jbc-loop
-2011 continue
+           2011 continue
       ! 2011 bailed out of the jbc-loop
                  do p = igl,min(igl + kbl - 1,n)
                     sva(p) = abs(sva(p))
@@ -78760,12 +78760,12 @@ module stdlib_linalg_lapack_s
            ! number of iterations.
            info = nsweep - 1
            go to 1995
-1994       continue
+           1994 continue
        ! #:) reaching this point means that during the i-th sweep all pivots were
            ! below the given tolerance, causing early exit.
            info = 0
        ! #:) info = 0 confirms successful iterations.
-1995 continue
+       1995 continue
            ! sort the vector d.
            do p = 1,n - 1
               q = stdlib_isamax(n - p + 1,sva(p),1) + p - 1
@@ -78822,7 +78822,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*),d(n),sva(n),v(ldv,*)
            real(sp),intent(out) :: work(lwork)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(sp) :: aapp,aapp0,aapq,aaqq,apoaq,aqoap,big,bigtheta,cs,large,mxaapq, &
            mxsinj,rootbig,rooteps,rootsfmin,roottol,small,sn,t,temp1,theta, &
@@ -78982,11 +78982,11 @@ module stdlib_linalg_lapack_s
                                          fastr(3) = t*d(p)/d(q)
                                          fastr(4) = -t*d(q)/d(p)
                                          call stdlib_srotm(m,a(1,p),1,a(1,q),1,fastr)
-                                                   
+
                                          if (rsvec) call stdlib_srotm(mvl,v(1,p),1,v(1,q), &
                                                     1,fastr)
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq))
                                          mxsinj = max(mxsinj,abs(t))
                                       else
@@ -78994,12 +78994,12 @@ module stdlib_linalg_lapack_s
                                          thsign = -sign(one,aapq)
                                          if (aaqq > aapp0) thsign = -thsign
                                          t = one/(theta + thsign*sqrt(one + theta*theta))
-                                                   
+
                                          cs = sqrt(one/(one + t*t))
                                          sn = t*cs
                                          mxsinj = max(mxsinj,abs(sn))
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq))
                                          apoaq = d(p)/d(q)
                                          aqoap = d(q)/d(p)
@@ -79081,7 +79081,7 @@ module stdlib_linalg_lapack_s
                                                     lda,ierr)
                                          temp1 = -aapq*d(p)/d(q)
                                          call stdlib_saxpy(m,temp1,work,1,a(1,q),1)
-                                                   
+
                                          call stdlib_slascl('G',0,0,one,aaqq,m,1,a(1,q), &
                                                     lda,ierr)
                                          sva(q) = aaqq*sqrt(max(zero,one - aapq*aapq))
@@ -79094,7 +79094,7 @@ module stdlib_linalg_lapack_s
                                                     lda,ierr)
                                          temp1 = -aapq*d(q)/d(p)
                                          call stdlib_saxpy(m,temp1,work,1,a(1,p),1)
-                                                   
+
                                          call stdlib_slascl('G',0,0,one,aapp,m,1,a(1,p), &
                                                     lda,ierr)
                                          sva(p) = aapp*sqrt(max(zero,one - aapq*aapq))
@@ -79150,7 +79150,7 @@ module stdlib_linalg_lapack_s
                              end if
                           end do loop_2200
               ! end of the q-loop
-2203 continue
+              2203 continue
                           sva(p) = aapp
                        else
                           if (aapp == zero) notrot = notrot + min(jgl + kbl - 1,n) - jgl + 1
@@ -79161,7 +79161,7 @@ module stdlib_linalg_lapack_s
            ! end of the p-loop
                  end do loop_2010
            ! end of the jbc-loop
-2011 continue
+           2011 continue
       ! 2011 bailed out of the jbc-loop
                  do p = igl,min(igl + kbl - 1,n)
                     sva(p) = abs(sva(p))
@@ -79191,12 +79191,12 @@ module stdlib_linalg_lapack_s
            ! number of sweeps.
            info = nsweep - 1
            go to 1995
-1994       continue
+           1994 continue
        ! #:) reaching this point means that during the i-th sweep all pivots were
            ! below the given threshold, causing early exit.
            info = 0
        ! #:) info = 0 confirms successful iterations.
-1995 continue
+       1995 continue
            ! sort the vector d
            do p = 1,n - 1
               q = stdlib_isamax(n - p + 1,sva(p),1) + p - 1
@@ -79224,7 +79224,7 @@ module stdlib_linalg_lapack_s
      !> by the orthogonal matrix Q:  A = Q*H*Q**T = (QZ)*T*(QZ)**T.
 
      subroutine stdlib_shseqr(job,compz,n,ilo,ihi,h,ldh,wr,wi,z,ldz,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -79242,14 +79242,14 @@ module stdlib_linalg_lapack_s
            ! ==== matrices of order ntiny or smaller must be processed by
            ! .    stdlib_slahqr because of insufficient subdiagonal scratch space.
            ! .    (this is a hard limit.) ====
-           
+
            ! ==== nl allocates some local workspace to help small matrices
            ! .    through a rare stdlib_slahqr failure.  nl > ntiny = 15 is
            ! .    required and nl <= nmin = stdlib_ilaenv(ispec=12,...) is recom-
            ! .    mended.  (the default value of nmin is 75.)  using nl = 49
            ! .    allows up to six simultaneous shifts and a 16-by-16
            ! .    deflation window.  ====
-           
+
            ! Local Arrays
            real(sp) :: hl(nl,nl),workl(nl)
            ! Local Scalars
@@ -79317,7 +79317,7 @@ module stdlib_linalg_lapack_s
               end if
               ! ==== stdlib_slahqr/stdlib_slaqr0 crossover point ====
               nmin = stdlib_ilaenv(12,'SHSEQR',job(:1)//compz(:1),n,ilo,ihi,lwork)
-                        
+
               nmin = max(ntiny,nmin)
               ! ==== stdlib_slaqr0 for big matrices; stdlib_slahqr for small ones ====
               if (n > nmin) then
@@ -79347,7 +79347,7 @@ module stdlib_linalg_lapack_s
                        call stdlib_slaqr0(wantt,wantz,nl,ilo,kbot,hl,nl,wr,wi,ilo,ihi, &
                                  z,ldz,workl,nl,info)
                        if (wantt .or. info /= 0) call stdlib_slacpy('A',n,n,hl,nl,h,ldh)
-                                 
+
                     end if
                  end if
               end if
@@ -79386,7 +79386,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(in) :: c(*),difl(ldu,*),difr(ldu,*),givnum(ldu,*),poles(ldu,*),s( &
                      *),u(ldu,*),vt(ldu,*),z(ldu,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,i1,ic,im1,inode,j,lf,ll,lvl,lvl2,nd,ndb1,ndiml,ndimr, &
                      nl,nlf,nlp1,nlvl,nr,nrf,nrp1,sqre
@@ -79484,7 +79484,7 @@ module stdlib_linalg_lapack_s
            end do
            go to 90
            ! icompq = 1: applying back the right singular vector factors.
-50   continue
+           50 continue
            ! first now go through the right singular vector matrices of all
            ! the tree nodes top-down.
            j = 0
@@ -79540,7 +79540,7 @@ module stdlib_linalg_lapack_s
               call stdlib_sgemm('T','N',nrp1,nrhs,nrp1,one,vt(nrf,1),ldu,b(nrf,1), &
                         ldb,zero,bx(nrf,1),ldbx)
            end do
-90         continue
+           90 continue
            return
      end subroutine stdlib_slalsa
 
@@ -79574,7 +79574,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: b(ldb,*),d(*),e(*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: bx,bxst,c,difl,difr,givcol,givnum,givptr,i,icmpq1,icmpq2, &
            iwk,j,k,nlvl,nm1,nsize,nsub,nwork,perm,poles,s,sizei,smlszp,sqre,st,st1, &
@@ -79666,7 +79666,7 @@ module stdlib_linalg_lapack_s
                     call stdlib_slaset('A',1,nrhs,zero,zero,b(i,1),ldb)
                  else
                     call stdlib_slascl('G',0,0,d(i),one,1,nrhs,b(i,1),ldb,info)
-                              
+
                     rank = rank + 1
                  end if
               end do
@@ -79749,7 +79749,7 @@ module stdlib_linalg_lapack_s
                        return
                     end if
                     call stdlib_slacpy('A',nsize,nrhs,b(st,1),ldb,work(bx + st1),n)
-                              
+
                  else
                     ! a large problem. solve it using divide and conquer.
                     call stdlib_slasda(icmpq1,smlsiz,nsize,sqre,d(st),e(st),work(u + st1 &
@@ -79783,7 +79783,7 @@ module stdlib_linalg_lapack_s
               else
                  rank = rank + 1
                  call stdlib_slascl('G',0,0,d(i),one,1,nrhs,work(bx + i - 1),n,info)
-                           
+
               end if
               d(i) = abs(d(i))
            end do
@@ -79848,18 +79848,18 @@ module stdlib_linalg_lapack_s
            ! ==== matrices of order ntiny or smaller must be processed by
            ! .    stdlib_slahqr because of insufficient subdiagonal scratch space.
            ! .    (this is a hard limit.) ====
-           
+
            ! ==== exceptional deflation windows:  try to cure rare
            ! .    slow convergence by varying the size of the
            ! .    deflation window after kexnw iterations. ====
-           
+
            ! ==== exceptional shifts: try to cure rare slow convergence
            ! .    with ad-hoc exceptional shifts every kexsh iterations.
            ! .    ====
-           
+
            ! ==== the constants wilk1 and wilk2 are used to form the
            ! .    exceptional shifts. ====
-           
+
            ! Local Scalars
            real(sp) :: aa,bb,cc,cs,dd,sn,ss,swap
            integer(ilp) :: i,inf,it,itmax,k,kacc22,kbot,kdu,ks,kt,ktop,ku,kv,kwh, &
@@ -79959,7 +79959,7 @@ module stdlib_linalg_lapack_s
                     if (h(k,k - 1) == zero) go to 20
                  end do
                  k = ilo
-20               continue
+                 20 continue
                  ktop = k
                  ! ==== select deflation window size:
                  ! .    typical case:
@@ -80066,7 +80066,7 @@ module stdlib_linalg_lapack_s
                           ks = kbot - ns + 1
                           kt = n - ns + 1
                           call stdlib_slacpy('A',ns,ns,h(ks,ks),ldh,h(kt,1),ldh)
-                                    
+
                           if (ns > nmin) then
                              call stdlib_slaqr4(.false.,.false.,ns,1,ns,h(kt,1),ldh,wr( &
                                        ks),wi(ks),1,1,zdum,1,work,lwork,inf)
@@ -80109,7 +80109,7 @@ module stdlib_linalg_lapack_s
                                 end if
                              end do
                           end do
-60                        continue
+                          60 continue
                        end if
                        ! ==== shuffle shifts into pairs of real shifts
                        ! .    and pairs of complex conjugate shifts
@@ -80180,7 +80180,7 @@ module stdlib_linalg_lapack_s
               ! ==== iteration limit exceeded.  set info to show where
               ! .    the problem occurred and exit. ====
               info = kbot
-90            continue
+              90 continue
            end if
            ! ==== return the optimal value of lwork. ====
            work(1) = real(lwkopt,KIND=sp)
@@ -80210,7 +80210,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: h(ldh,*),z(ldz,*)
            real(sp),intent(out) :: si(*),sr(*),t(ldt,*),v(ldv,*),work(*),wv(ldwv,*)
         ! ================================================================
-           
+
            ! Local Scalars
            real(sp) :: aa,bb,beta,cc,cs,dd,evi,evk,foo,s,safmax,safmin,smlnum,sn, &
                      tau,ulp
@@ -80230,7 +80230,7 @@ module stdlib_linalg_lapack_s
               lwk1 = int(work(1),KIND=ilp)
               ! ==== workspace query call to stdlib_sormhr ====
               call stdlib_sormhr('R','N',jw,jw,1,jw - 1,t,ldt,work,v,ldv,work,-1,info)
-                        
+
               lwk2 = int(work(1),KIND=ilp)
               ! ==== workspace query call to stdlib_slaqr4 ====
               call stdlib_slaqr4(.true.,.true.,jw,1,jw,t,ldt,sr,si,1,jw,v,ldv,work,- &
@@ -80305,7 +80305,7 @@ module stdlib_linalg_lapack_s
            ! ==== deflation detection loop ====
            ns = jw
            ilst = infqr + 1
-20         continue
+           20 continue
            if (ilst <= ns) then
               if (ns == 1) then
                  bulge = .false.
@@ -80356,7 +80356,7 @@ module stdlib_linalg_lapack_s
               ! .    exchange failures. ====
               sorted = .false.
               i = ns + 1
-30            continue
+              30 continue
               if (sorted) go to 50
               sorted = .true.
               kend = i - 1
@@ -80368,13 +80368,13 @@ module stdlib_linalg_lapack_s
               else
                  k = i + 2
               end if
-40            continue
+              40 continue
               if (k <= kend) then
                  if (k == i + 1) then
                     evi = abs(t(i,i))
                  else
                     evi = abs(t(i,i)) + sqrt(abs(t(i + 1,i)))*sqrt(abs(t(i,i + 1)))
-                              
+
                  end if
                  if (k == kend) then
                     evk = abs(t(k,k))
@@ -80382,7 +80382,7 @@ module stdlib_linalg_lapack_s
                     evk = abs(t(k,k))
                  else
                     evk = abs(t(k,k)) + sqrt(abs(t(k + 1,k)))*sqrt(abs(t(k,k + 1)))
-                              
+
                  end if
                  if (evi >= evk) then
                     i = k
@@ -80407,11 +80407,11 @@ module stdlib_linalg_lapack_s
                  go to 40
               end if
               go to 30
-50            continue
+              50 continue
            end if
            ! ==== restore shift/eigenvalue array from t ====
            i = jw
-60         continue
+           60 continue
            if (i >= infqr + 1) then
               if (i == infqr + 1) then
                  sr(kwtop + i - 1) = t(i,i)
@@ -80444,7 +80444,7 @@ module stdlib_linalg_lapack_s
                  call stdlib_slarf('R',ns,ns,work,1,tau,t,ldt,work(jw + 1))
                  call stdlib_slarf('R',jw,ns,work,1,tau,v,ldv,work(jw + 1))
                  call stdlib_sgehrd(jw,1,ns,t,ldt,work,work(jw + 1),lwork - jw,info)
-                           
+
               end if
               ! ==== copy updated reduced window into place ====
               if (kwtop > 1) h(kwtop,kwtop - 1) = s*v(1,1)
@@ -80534,18 +80534,18 @@ module stdlib_linalg_lapack_s
            ! ==== matrices of order ntiny or smaller must be processed by
            ! .    stdlib_slahqr because of insufficient subdiagonal scratch space.
            ! .    (this is a hard limit.) ====
-           
+
            ! ==== exceptional deflation windows:  try to cure rare
            ! .    slow convergence by varying the size of the
            ! .    deflation window after kexnw iterations. ====
-           
+
            ! ==== exceptional shifts: try to cure rare slow convergence
            ! .    with ad-hoc exceptional shifts every kexsh iterations.
            ! .    ====
-           
+
            ! ==== the constants wilk1 and wilk2 are used to form the
            ! .    exceptional shifts. ====
-           
+
            ! Local Scalars
            real(sp) :: aa,bb,cc,cs,dd,sn,ss,swap
            integer(ilp) :: i,inf,it,itmax,k,kacc22,kbot,kdu,ks,kt,ktop,ku,kv,kwh, &
@@ -80645,7 +80645,7 @@ module stdlib_linalg_lapack_s
                     if (h(k,k - 1) == zero) go to 20
                  end do
                  k = ilo
-20               continue
+                 20 continue
                  ktop = k
                  ! ==== select deflation window size:
                  ! .    typical case:
@@ -80752,7 +80752,7 @@ module stdlib_linalg_lapack_s
                           ks = kbot - ns + 1
                           kt = n - ns + 1
                           call stdlib_slacpy('A',ns,ns,h(ks,ks),ldh,h(kt,1),ldh)
-                                    
+
                           call stdlib_slahqr(.false.,.false.,ns,1,ns,h(kt,1),ldh,wr(ks &
                                     ),wi(ks),1,1,zdum,1,inf)
                           ks = ks + inf
@@ -80790,7 +80790,7 @@ module stdlib_linalg_lapack_s
                                 end if
                              end do
                           end do
-60                        continue
+                          60 continue
                        end if
                        ! ==== shuffle shifts into pairs of real shifts
                        ! .    and pairs of complex conjugate shifts
@@ -80861,7 +80861,7 @@ module stdlib_linalg_lapack_s
               ! ==== iteration limit exceeded.  set info to show where
               ! .    the problem occurred and exit. ====
               info = kbot
-90            continue
+              90 continue
            end if
            ! ==== return the optimal value of lwork. ====
            work(1) = real(lwkopt,KIND=sp)
@@ -80924,7 +80924,7 @@ module stdlib_linalg_lapack_s
            integer(ilp),intent(out) :: info
            real(sp),intent(inout) :: a(lda,*),b(ldb,*),q(ldq,*),z(ldz,*),alphar( &
                       *),alphai(*),beta(*),work(*)
-           
+
            ! local scalars
            real(sp) :: smlnum,ulp,eshift,safmin,safmax,c1,s1,temp,swap
            integer(ilp) :: istart,istop,iiter,maxit,istart2,k,ld,nshifts,nblock,nw,nmin, &
@@ -81139,7 +81139,7 @@ module stdlib_linalg_lapack_s
                        end if
                        if (k2 < istop) then
                           call stdlib_slartg(a(k2,k2 - 1),a(k2 + 1,k2 - 1),c1,s1,temp)
-                                    
+
                           a(k2,k2 - 1) = temp
                           a(k2 + 1,k2 - 1) = zero
                           call stdlib_srot(istopm - k2 + 1,a(k2,k2),lda,a(k2 + 1,k2),lda,c1, &
@@ -81162,7 +81162,7 @@ module stdlib_linalg_lapack_s
                                  istart2 + 1,istart2 + 1),ldb,c1,s1)
                        if (ilq) then
                           call stdlib_srot(n,q(1,istart2),1,q(1,istart2 + 1),1,c1,s1)
-                                    
+
                        end if
                     end if
                     istart2 = istart2 + 1
@@ -81272,7 +81272,7 @@ module stdlib_linalg_lapack_s
            integer(ilp),intent(out) :: ns,nd,info
            real(sp),intent(inout) :: qc(ldqc,*),zc(ldzc,*)
            real(sp),intent(out) :: work(*)
-           
+
            ! local scalars
            logical(lk) :: bulge
            integer(ilp) :: jw,kwtop,kwbot,istopm,istartm,k,k2,stgexc_info,ifst,ilst, &
@@ -81332,7 +81332,7 @@ module stdlib_linalg_lapack_s
            ! store window in case of convergence failure
            call stdlib_slacpy('ALL',jw,jw,a(kwtop,kwtop),lda,work,jw)
            call stdlib_slacpy('ALL',jw,jw,b(kwtop,kwtop),ldb,work(jw**2 + 1),jw)
-                     
+
            ! transform window to real schur form
            call stdlib_slaset('FULL',jw,jw,zero,one,qc,ldqc)
            call stdlib_slaset('FULL',jw,jw,zero,one,zc,ldzc)
@@ -81345,7 +81345,7 @@ module stdlib_linalg_lapack_s
               ns = jw - qz_small_info
               call stdlib_slacpy('ALL',jw,jw,work,jw,a(kwtop,kwtop),lda)
               call stdlib_slacpy('ALL',jw,jw,work(jw**2 + 1),jw,b(kwtop,kwtop),ldb)
-                        
+
               return
            end if
            ! deflation detection loop
@@ -81377,7 +81377,7 @@ module stdlib_linalg_lapack_s
                        ilst = k2
                        call stdlib_stgexc(.true.,.true.,jw,a(kwtop,kwtop),lda,b(kwtop, &
                        kwtop),ldb,qc,ldqc,zc,ldzc,ifst,ilst,work,lwork,stgexc_info)
-                                 
+
                        k2 = k2 + 2
                     end if
                     k = k + 2
@@ -81397,7 +81397,7 @@ module stdlib_linalg_lapack_s
                        ilst = k2
                        call stdlib_stgexc(.true.,.true.,jw,a(kwtop,kwtop),lda,b(kwtop, &
                        kwtop),ldb,qc,ldqc,zc,ldzc,ifst,ilst,work,lwork,stgexc_info)
-                                 
+
                        k2 = k2 + 1
                     end if
                     k = k + 1
@@ -81439,9 +81439,9 @@ module stdlib_linalg_lapack_s
                  k2 = max(kwtop,k - 1)
                  call stdlib_srot(ihi - k2 + 1,a(k,k2),lda,a(k + 1,k2),lda,c1,s1)
                  call stdlib_srot(ihi - (k - 1) + 1,b(k,k - 1),ldb,b(k + 1,k - 1),ldb,c1,s1)
-                           
+
                  call stdlib_srot(jw,qc(1,k - kwtop + 1),1,qc(1,k + 1 - kwtop + 1),1,c1,s1)
-                           
+
               end do
               ! chase bulges down
               istartm = kwtop
@@ -81480,7 +81480,7 @@ module stdlib_linalg_lapack_s
                     end do
                     ! remove the shift
                     call stdlib_slartg(b(kwbot,kwbot),b(kwbot,kwbot - 1),c1,s1,temp)
-                              
+
                     b(kwbot,kwbot) = temp
                     b(kwbot,kwbot - 1) = zero
                     call stdlib_srot(kwbot - istartm,b(istartm,kwbot),1,b(istartm,kwbot - 1), &
@@ -81573,7 +81573,7 @@ module stdlib_linalg_lapack_s
            integer(ilp),parameter :: allrng = 1
            integer(ilp),parameter :: indrng = 2
            integer(ilp),parameter :: valrng = 3
-           
+
            ! Local Scalars
            logical(lk) :: forceb,norep,usedqd
            integer(ilp) :: cnt,cnt1,cnt2,i,ibegin,idum,iend,iinfo,in,indl,indu,irange, &
@@ -81734,7 +81734,7 @@ module stdlib_linalg_lapack_s
                        goto 21
                     end if
                  end do
-21               continue
+                 21 continue
                  if (mb == 0) then
                     ! no eigenvalue in the current block lies in the desired range
                     ! e( iend ) holds the shift for the initial rrr
@@ -81783,7 +81783,7 @@ module stdlib_linalg_lapack_s
                  isleft = max(gl,w(wbegin) - werr(wbegin) - hndrd*eps*abs(w(wbegin) - werr( &
                            wbegin)))
                  isrght = min(gu,w(wend) + werr(wend) + hndrd*eps*abs(w(wend) + werr(wend)))
-                           
+
               end if
               ! decide whether the base representation for the current block
               ! l_jblk d_jblk l_jblk^t = t_jblk - sigma_jblk i
@@ -81932,7 +81932,7 @@ module stdlib_linalg_lapack_s
               ! found in maxtry iterations.
               info = 2
               return
-83            continue
+              83 continue
               ! at this point, we have found an initial base representation
               ! t - sigma i = l d l^t with not too much element growth.
               ! store the shift.
@@ -82068,7 +82068,7 @@ module stdlib_linalg_lapack_s
      !> and optionally, the singular vectors in compact form.
 
      pure subroutine stdlib_slasd0(n,sqre,d,e,u,ldu,vt,ldvt,smlsiz,iwork,work,info)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -82222,7 +82222,7 @@ module stdlib_linalg_lapack_s
                      s(*),u(ldu,*),vt(ldu,*),work(*),z(ldu,*)
            real(sp),intent(inout) :: d(*),e(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,i1,ic,idxq,idxqi,im1,inode,itemp,iwk,j,lf,ll,lvl,lvl2, &
            m,ncc,nd,ndb1,ndiml,ndimr,nl,nlf,nlp1,nlvl,nr,nrf,nrp1,nru,nwork1, &
@@ -82299,7 +82299,7 @@ module stdlib_linalg_lapack_s
                  call stdlib_slaset('A',nlp1,nlp1,zero,one,work(nwork1),smlszp)
                  call stdlib_slasdq('U',sqrei,nl,nlp1,nru,ncc,d(nlf),e(nlf),work( &
                  nwork1),smlszp,work(nwork2),nl,work(nwork2),nl,work(nwork2),info)
-                           
+
                  itemp = nwork1 + nl*smlszp
                  call stdlib_scopy(nlp1,work(nwork1),1,work(vfi),1)
                  call stdlib_scopy(nlp1,work(itemp),1,work(vli),1)
@@ -82330,7 +82330,7 @@ module stdlib_linalg_lapack_s
                  call stdlib_slaset('A',nrp1,nrp1,zero,one,work(nwork1),smlszp)
                  call stdlib_slasdq('U',sqrei,nr,nrp1,nru,ncc,d(nrf),e(nrf),work( &
                  nwork1),smlszp,work(nwork2),nr,work(nwork2),nr,work(nwork2),info)
-                           
+
                  itemp = nwork1 + (nrp1 - 1)*smlszp
                  call stdlib_scopy(nrp1,work(nwork1),1,work(vfi),1)
                  call stdlib_scopy(nrp1,work(itemp),1,work(vli),1)
@@ -82426,7 +82426,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: c(ldc,*),d(*),e(*),u(ldu,*),vt(ldvt,*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: rotate
            integer(ilp) :: i,isub,iuplo,j,np1,sqre1
@@ -82520,26 +82520,26 @@ module stdlib_linalg_lapack_s
               if (nru > 0) then
                  if (sqre1 == 0) then
                     call stdlib_slasr('R','V','F',nru,n,work(1),work(np1),u,ldu)
-                              
+
                  else
                     call stdlib_slasr('R','V','F',nru,np1,work(1),work(np1),u,ldu)
-                              
+
                  end if
               end if
               if (ncc > 0) then
                  if (sqre1 == 0) then
                     call stdlib_slasr('L','V','F',n,ncc,work(1),work(np1),c,ldc)
-                              
+
                  else
                     call stdlib_slasr('L','V','F',np1,ncc,work(1),work(np1),c,ldc)
-                              
+
                  end if
               end if
            end if
            ! call stdlib_sbdsqr to compute the svd of the reduced real
            ! n-by-n upper bidiagonal matrix.
            call stdlib_sbdsqr('U',n,ncvt,nru,ncc,d,e,vt,ldvt,u,ldu,c,ldc,work,info)
-                     
+
            ! sort the singular values into ascending order (insertion sort on
            ! singular values, but only one transposition per singular vector)
            do i = 1,n
@@ -82557,7 +82557,7 @@ module stdlib_linalg_lapack_s
                  d(isub) = d(i)
                  d(i) = smin
                  if (ncvt > 0) call stdlib_sswap(ncvt,vt(isub,1),ldvt,vt(i,1),ldvt)
-                           
+
                  if (nru > 0) call stdlib_sswap(nru,u(1,isub),1,u(1,i),1)
                  if (ncc > 0) call stdlib_sswap(ncc,c(isub,1),ldc,c(i,1),ldc)
               end if
@@ -82587,7 +82587,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: d(*),e(*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,iinfo
            real(sp) :: eps,scale,safmin,sigmn,sigmx
@@ -82684,7 +82684,7 @@ module stdlib_linalg_lapack_s
            ! Parameters
            real(sp),parameter :: cbias = 1.50_sp
            real(sp),parameter :: hundrd = 100.0_sp
-           
+
            ! Local Scalars
            logical(lk) :: ieee
            integer(ilp) :: i0,i4,iinfo,ipn4,iter,iwhila,iwhilb,k,kmin,n0,nbig,ndiv, &
@@ -82912,7 +82912,7 @@ module stdlib_linalg_lapack_s
                  emin = min(emin,z(i4 - 5))
               end do
               i4 = 4
-100           continue
+              100 continue
               i0 = i4/4
               pp = 0
               if (n0 - i0 > 1) then
@@ -82991,7 +82991,7 @@ module stdlib_linalg_lapack_s
               ! this might need to be done for several blocks
               i1 = i0
               n1 = n0
-145           continue
+              145 continue
               tempq = z(4*i0 - 3)
               z(4*i0 - 3) = z(4*i0 - 3) + sigma
               do k = i0 + 1,n0
@@ -83024,12 +83024,12 @@ module stdlib_linalg_lapack_s
               end do
               return
               ! end iwhilb
-150  continue
+              150 continue
            end do loop_160
            info = 3
            return
            ! end iwhila
-170  continue
+           170 continue
            ! move q's to the front.
            do k = 2,n
               z(k) = z(4*k - 3)
@@ -83072,7 +83072,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*),h(ldh,*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j,k,k1,i1,i2,mj
            real(sp) :: piv,alpha
@@ -83087,7 +83087,7 @@ module stdlib_linalg_lapack_s
               ! .....................................................
               ! factorize a as u**t*d*u using the upper triangle of a
               ! .....................................................
-10   continue
+              10 continue
               if (j > min(m,nb)) go to 20
               ! k is the column to be factorized
                ! when being called from stdlib_ssytrf_aa,
@@ -83141,7 +83141,7 @@ module stdlib_linalg_lapack_s
                     i1 = i1 + j - 1
                     i2 = i2 + j - 1
                     call stdlib_sswap(i2 - i1 - 1,a(j1 + i1 - 1,i1 + 1),lda,a(j1 + i1,i2),1)
-                              
+
                     ! swap a(i1, i2+1:m) with a(i2, i2+1:m)
                     if (i2 < m) call stdlib_sswap(m - i2,a(j1 + i1 - 1,i2 + 1),lda,a(j1 + i2 - 1,i2 + 1), &
                                lda)
@@ -83180,12 +83180,12 @@ module stdlib_linalg_lapack_s
               end if
               j = j + 1
               go to 10
-20            continue
+              20 continue
            else
               ! .....................................................
               ! factorize a as l*d*l**t using the lower triangle of a
               ! .....................................................
-30   continue
+              30 continue
               if (j > min(m,nb)) go to 40
               ! k is the column to be factorized
                ! when being called from stdlib_ssytrf_aa,
@@ -83239,7 +83239,7 @@ module stdlib_linalg_lapack_s
                     i1 = i1 + j - 1
                     i2 = i2 + j - 1
                     call stdlib_sswap(i2 - i1 - 1,a(i1 + 1,j1 + i1 - 1),1,a(i2,j1 + i1),lda)
-                              
+
                     ! swap a(i2+1:m, i1) with a(i2+1:m, i2)
                     if (i2 < m) call stdlib_sswap(m - i2,a(i2 + 1,j1 + i1 - 1),1,a(i2 + 1,j1 + i2 - 1), &
                               1)
@@ -83278,7 +83278,7 @@ module stdlib_linalg_lapack_s
               end if
               j = j + 1
               go to 30
-40            continue
+              40 continue
            end if
            return
      end subroutine stdlib_slasyf_aa
@@ -83311,7 +83311,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: d(*),e(*),z(ldz,*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Arrays
            real(sp) :: c(1,1),vt(1,1)
            ! Local Scalars
@@ -83365,7 +83365,7 @@ module stdlib_linalg_lapack_s
               nru = 0
            end if
            call stdlib_sbdsqr('LOWER',n,0,nru,0,d,e,vt,1,z,ldz,c,1,work,info)
-                     
+
            ! square the singular values.
            if (info == 0) then
               do i = 1,n
@@ -83484,7 +83484,7 @@ module stdlib_linalg_lapack_s
         ! =====================================================================
            ! Parameters
            real(sp),parameter :: minrgp = 3.0e-3_sp
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,lquery,valeig,wantz,zquery
            integer(ilp) :: i,ibegin,iend,ifirst,iil,iindbl,iindw,iindwk,iinfo,iinspl, &
@@ -83563,7 +83563,7 @@ module stdlib_linalg_lapack_s
                  nzcmin = n
               else if (wantz .and. valeig) then
                  call stdlib_slarrc('T',n,vl,vu,d,e,safmin,nzcmin,itmp,itmp2,info)
-                           
+
               else if (wantz .and. indeig) then
                  nzcmin = iiu - iil + 1
               else
@@ -83733,7 +83733,7 @@ module stdlib_linalg_lapack_s
               call stdlib_slarre(range,n,wl,wu,iil,iiu,d,e,work(inde2),rtol1,rtol2, &
               thresh,nsplit,iwork(iinspl),m,w,work(inderr),work(indgp),iwork(iindbl), &
               iwork(iindw),work(indgrs),pivmin,work(indwrk),iwork(iindwk),iinfo)
-                        
+
               if (iinfo /= 0) then
                  info = 10 + abs(iinfo)
                  return
@@ -83772,7 +83772,7 @@ module stdlib_linalg_lapack_s
                     in = iend - ibegin + 1
                     wend = wbegin - 1
                     ! check if any eigenvalues have to be refined in this block
-36   continue
+                    36 continue
                     if (wend < m) then
                        if (iwork(iindbl + wend) == jblk) then
                           wend = wend + 1
@@ -83890,7 +83890,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: d(*),e(*)
            real(sp),intent(out) :: w(*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,test,lquery,valeig,wantz,tryrac
            character :: order
@@ -84051,7 +84051,7 @@ module stdlib_linalg_lapack_s
                         iwork(indiwo),iwork(indifl),info)
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
-10   continue
+           10 continue
            if (iscale == 1) then
               if (info == 0) then
                  imax = m
@@ -84152,7 +84152,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: w(*),work(*),z(ldz,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,lower,lquery,test,valeig,wantz,tryrac
            character :: order
@@ -84366,7 +84366,7 @@ module stdlib_linalg_lapack_s
            end if
            call stdlib_sstebz(range,order,n,vll,vuu,il,iu,abstll,work(indd),work(inde &
            ),m,nsplit,w,iwork(indibl),iwork(indisp),work(indwk),iwork(indiwo),info)
-                     
+
            if (wantz) then
               call stdlib_sstein(n,work(indd),work(inde),m,w,iwork(indibl),iwork( &
                         indisp),z,ldz,work(indwk),iwork(indiwo),iwork(indifl),info)
@@ -84379,7 +84379,7 @@ module stdlib_linalg_lapack_s
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
         ! jump here if stdlib_sstemr/stdlib_sstein succeeded.
-30   continue
+        30 continue
            if (iscale == 1) then
               if (info == 0) then
                  imax = m
@@ -84427,7 +84427,7 @@ module stdlib_linalg_lapack_s
      !> form of A is then used to solve the system of equations A * X = B.
 
      pure subroutine stdlib_ssysv_aa(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -84481,7 +84481,7 @@ module stdlib_linalg_lapack_s
            if (info == 0) then
               ! solve the system a*x = b, overwriting b with x.
               call stdlib_ssytrs_aa(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-                        
+
            end if
            work(1) = lwkopt
            return
@@ -84507,7 +84507,7 @@ module stdlib_linalg_lapack_s
            real(sp),intent(inout) :: a(lda,*)
            real(sp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper
            integer(ilp) :: j,lwkopt
@@ -84563,7 +84563,7 @@ module stdlib_linalg_lapack_s
               ! jb, where jb is the number of columns factorized by stdlib_slasyf;
               ! jb is either nb, or n-j+1 for the last block
               j = 0
-10            continue
+              10 continue
               if (j >= n) go to 20
               ! each step of the main loop
                ! j is the last column of the previous panel
@@ -84595,7 +84595,7 @@ module stdlib_linalg_lapack_s
                     alpha = a(j,j + 1)
                     a(j,j + 1) = one
                     call stdlib_scopy(n - j,a(j - 1,j + 1),lda,work((j + 1 - j1 + 1) + jb*n),1)
-                              
+
                     call stdlib_sscal(n - j,alpha,work((j + 1 - j1 + 1) + jb*n),1)
                     ! k1 identifies if the previous column of the panel has been
                      ! explicitly stored, e.g., k1=1 and k2= 0 for the first panel,
@@ -84640,7 +84640,7 @@ module stdlib_linalg_lapack_s
               ! jb, where jb is the number of columns factorized by stdlib_slasyf;
               ! jb is either nb, or n-j+1 for the last block
               j = 0
-11            continue
+              11 continue
               if (j >= n) go to 20
               ! each step of the main loop
                ! j is the last column of the previous panel
@@ -84706,7 +84706,7 @@ module stdlib_linalg_lapack_s
               end if
               go to 11
            end if
-20         continue
+           20 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_ssytrf_aa

--- a/src/stdlib_linalg_lapack_w.f90
+++ b/src/stdlib_linalg_lapack_w.f90
@@ -538,14 +538,14 @@ module stdlib_linalg_lapack_w
                       b22e(*),rwork(*)
            real(qp),intent(inout) :: phi(*),theta(*)
            complex(qp),intent(inout) :: u1(ldu1,*),u2(ldu2,*),v1t(ldv1t,*),v2t(ldv2t,*)
-                     
+
         ! ===================================================================
            ! Parameters
            integer(ilp),parameter :: maxitr = 6
            real(qp),parameter :: hundred = 100.0_qp
            real(qp),parameter :: meighth = -0.125_qp
            real(qp),parameter :: piover2 = 1.57079632679489661923132169163975144210_qp
-           
+
            ! Local Scalars
            logical(lk) :: colmajor,lquery,restart11,restart12,restart21,restart22,wantu1, &
                      wantu2,wantv1t,wantv2t
@@ -695,9 +695,9 @@ module stdlib_linalg_lapack_w
               else
                  ! compute shifts for b11 and b21 and use the lesser
                  call stdlib_qlas2(b11d(imax - 1),b11e(imax - 1),b11d(imax),sigma11,dummy)
-                           
+
                  call stdlib_qlas2(b21d(imax - 1),b21e(imax - 1),b21d(imax),sigma21,dummy)
-                           
+
                  if (sigma11 <= sigma21) then
                     mu = sigma11
                     nu = sqrt(one - mu**2)
@@ -724,13 +724,13 @@ module stdlib_linalg_lapack_w
               end if
               temp = rwork(iv1tcs + imin - 1)*b11d(imin) + rwork(iv1tsn + imin - 1)*b11e(imin)
               b11e(imin) = rwork(iv1tcs + imin - 1)*b11e(imin) - rwork(iv1tsn + imin - 1)*b11d(imin)
-                        
+
               b11d(imin) = temp
               b11bulge = rwork(iv1tsn + imin - 1)*b11d(imin + 1)
               b11d(imin + 1) = rwork(iv1tcs + imin - 1)*b11d(imin + 1)
               temp = rwork(iv1tcs + imin - 1)*b21d(imin) + rwork(iv1tsn + imin - 1)*b21e(imin)
               b21e(imin) = rwork(iv1tcs + imin - 1)*b21e(imin) - rwork(iv1tsn + imin - 1)*b21d(imin)
-                        
+
               b21d(imin) = temp
               b21bulge = rwork(iv1tsn + imin - 1)*b21d(imin + 1)
               b21d(imin + 1) = rwork(iv1tcs + imin - 1)*b21d(imin + 1)
@@ -762,7 +762,7 @@ module stdlib_linalg_lapack_w
               rwork(iu2sn + imin - 1) = -rwork(iu2sn + imin - 1)
               temp = rwork(iu1cs + imin - 1)*b11e(imin) + rwork(iu1sn + imin - 1)*b11d(imin + 1)
               b11d(imin + 1) = rwork(iu1cs + imin - 1)*b11d(imin + 1) - rwork(iu1sn + imin - 1)*b11e(imin)
-                        
+
               b11e(imin) = temp
               if (imax > imin + 1) then
                  b11bulge = rwork(iu1sn + imin - 1)*b11e(imin + 1)
@@ -775,7 +775,7 @@ module stdlib_linalg_lapack_w
               b12d(imin + 1) = rwork(iu1cs + imin - 1)*b12d(imin + 1)
               temp = rwork(iu2cs + imin - 1)*b21e(imin) + rwork(iu2sn + imin - 1)*b21d(imin + 1)
               b21d(imin + 1) = rwork(iu2cs + imin - 1)*b21d(imin + 1) - rwork(iu2sn + imin - 1)*b21e(imin)
-                        
+
               b21e(imin) = temp
               if (imax > imin + 1) then
                  b21bulge = rwork(iu2sn + imin - 1)*b21e(imin + 1)
@@ -824,7 +824,7 @@ module stdlib_linalg_lapack_w
                  rwork(iv1tsn + i - 1) = -rwork(iv1tsn + i - 1)
                  if (.not. restart12 .and. .not. restart22) then
                     call stdlib_qlartgp(y2,y1,rwork(iv2tsn + i - 1 - 1),rwork(iv2tcs + i - 1 - 1),r)
-                              
+
                  else if (.not. restart12 .and. restart22) then
                     call stdlib_qlartgp(b12bulge,b12d(i - 1),rwork(iv2tsn + i - 1 - 1),rwork(iv2tcs + i - &
                               1 - 1),r)
@@ -877,7 +877,7 @@ module stdlib_linalg_lapack_w
                     call stdlib_qlartgp(x2,x1,rwork(iu1sn + i - 1),rwork(iu1cs + i - 1),r)
                  else if (.not. restart11 .and. restart12) then
                     call stdlib_qlartgp(b11bulge,b11d(i),rwork(iu1sn + i - 1),rwork(iu1cs + i - 1),r)
-                              
+
                  else if (restart11 .and. .not. restart12) then
                     call stdlib_qlartgp(b12bulge,b12e(i - 1),rwork(iu1sn + i - 1),rwork(iu1cs + i - 1), &
                               r)
@@ -886,13 +886,13 @@ module stdlib_linalg_lapack_w
                                )
                  else
                     call stdlib_qlartgs(b12d(i),b12e(i),nu,rwork(iu1cs + i - 1),rwork(iu1sn + i - 1))
-                              
+
                  end if
                  if (.not. restart21 .and. .not. restart22) then
                     call stdlib_qlartgp(y2,y1,rwork(iu2sn + i - 1),rwork(iu2cs + i - 1),r)
                  else if (.not. restart21 .and. restart22) then
                     call stdlib_qlartgp(b21bulge,b21d(i),rwork(iu2sn + i - 1),rwork(iu2cs + i - 1),r)
-                              
+
                  else if (restart21 .and. .not. restart22) then
                     call stdlib_qlartgp(b22bulge,b22e(i - 1),rwork(iu2sn + i - 1),rwork(iu2cs + i - 1), &
                               r)
@@ -901,7 +901,7 @@ module stdlib_linalg_lapack_w
                                )
                  else
                     call stdlib_qlartgs(b22d(i),b22e(i),mu,rwork(iu2cs + i - 1),rwork(iu2sn + i - 1))
-                              
+
                  end if
                  rwork(iu2cs + i - 1) = -rwork(iu2cs + i - 1)
                  rwork(iu2sn + i - 1) = -rwork(iu2sn + i - 1)
@@ -940,7 +940,7 @@ module stdlib_linalg_lapack_w
               restart22 = b22d(imax - 1)**2 + b22bulge**2 <= thresh**2
               if (.not. restart12 .and. .not. restart22) then
                  call stdlib_qlartgp(y2,y1,rwork(iv2tsn + imax - 1 - 1),rwork(iv2tcs + imax - 1 - 1),r)
-                           
+
               else if (.not. restart12 .and. restart22) then
                  call stdlib_qlartgp(b12bulge,b12d(imax - 1),rwork(iv2tsn + imax - 1 - 1),rwork(iv2tcs + &
                            imax - 1 - 1),r)
@@ -955,14 +955,14 @@ module stdlib_linalg_lapack_w
                            iv2tsn + imax - 1 - 1))
               end if
               temp = rwork(iv2tcs + imax - 1 - 1)*b12e(imax - 1) + rwork(iv2tsn + imax - 1 - 1)*b12d(imax)
-                        
+
               b12d(imax) = rwork(iv2tcs + imax - 1 - 1)*b12d(imax) - rwork(iv2tsn + imax - 1 - 1)*b12e(imax - 1)
-                        
+
               b12e(imax - 1) = temp
               temp = rwork(iv2tcs + imax - 1 - 1)*b22e(imax - 1) + rwork(iv2tsn + imax - 1 - 1)*b22d(imax)
-                        
+
               b22d(imax) = rwork(iv2tcs + imax - 1 - 1)*b22d(imax) - rwork(iv2tsn + imax - 1 - 1)*b22e(imax - 1)
-                        
+
               b22e(imax - 1) = temp
               ! update singular vectors
               if (wantu1) then
@@ -1097,9 +1097,9 @@ module stdlib_linalg_lapack_w
                     if (wantu1) call stdlib_wswap(p,u1(1,i),1,u1(1,mini),1)
                     if (wantu2) call stdlib_wswap(m - p,u2(1,i),1,u2(1,mini),1)
                     if (wantv1t) call stdlib_wswap(q,v1t(i,1),ldv1t,v1t(mini,1),ldv1t)
-                              
+
                     if (wantv2t) call stdlib_wswap(m - q,v2t(i,1),ldv2t,v2t(mini,1),ldv2t)
-                              
+
                  else
                     if (wantu1) call stdlib_wswap(p,u1(i,1),ldu1,u1(mini,1),ldu1)
                     if (wantu2) call stdlib_wswap(m - p,u2(i,1),ldu2,u2(mini,1),ldu2)
@@ -1155,7 +1155,7 @@ module stdlib_linalg_lapack_w
            real(qp),parameter :: hndrd = 100.0_qp
            real(qp),parameter :: meigth = -0.125_qp
            integer(ilp),parameter :: maxitr = 6
-           
+
            ! Local Scalars
            logical(lk) :: lower,rotate
            integer(ilp) :: i,idir,isub,iter,j,ll,lll,m,maxit,nm1,nm12,nm13,oldll, &
@@ -1221,9 +1221,9 @@ module stdlib_linalg_lapack_w
               end do
               ! update singular vectors if desired
               if (nru > 0) call stdlib_wlasr('R','V','F',nru,n,rwork(1),rwork(n),u,ldu)
-                        
+
               if (ncc > 0) call stdlib_wlasr('L','V','F',n,ncc,rwork(1),rwork(n),c,ldc)
-                        
+
            end if
            ! compute singular values to relative accuracy tol
            ! (by setting tol to be negative, algorithm will compute
@@ -1249,7 +1249,7 @@ module stdlib_linalg_lapack_w
                  sminoa = min(sminoa,mu)
                  if (sminoa == zero) go to 50
               end do
-50            continue
+              50 continue
               sminoa = sminoa/sqrt(real(n,KIND=qp))
               thresh = max(tol*sminoa,maxitr*n*n*unfl)
            else
@@ -1266,7 +1266,7 @@ module stdlib_linalg_lapack_w
            ! m points to last element of unconverged part of matrix
            m = n
            ! begin main iteration loop
-60   continue
+           60 continue
            ! check for convergence or exceeding iteration count
            if (m <= 1) go to 160
            if (iter > maxit) go to 200
@@ -1285,7 +1285,7 @@ module stdlib_linalg_lapack_w
            end do
            ll = 0
            go to 90
-80         continue
+           80 continue
            e(ll) = zero
            ! matrix splits since e(ll) = 0
            if (ll == m - 1) then
@@ -1293,7 +1293,7 @@ module stdlib_linalg_lapack_w
               m = m - 1
               go to 60
            end if
-90         continue
+           90 continue
            ll = ll + 1
            ! e(ll) through e(m-1) are nonzero, e(ll-1) is zero
            if (ll == m - 1) then
@@ -1307,9 +1307,9 @@ module stdlib_linalg_lapack_w
               if (ncvt > 0) call stdlib_wdrot(ncvt,vt(m - 1,1),ldvt,vt(m,1),ldvt,cosr, &
                         sinr)
               if (nru > 0) call stdlib_wdrot(nru,u(1,m - 1),1,u(1,m),1,cosl,sinl)
-                        
+
               if (ncc > 0) call stdlib_wdrot(ncc,c(m - 1,1),ldc,c(m,1),ldc,cosl,sinl)
-                        
+
               m = m - 2
               go to 60
            end if
@@ -1525,7 +1525,7 @@ module stdlib_linalg_lapack_w
            ! qr iteration finished, go back and check convergence
            go to 60
            ! all singular values converged, so make them positive
-160  continue
+           160 continue
            do i = 1,n
               if (d(i) < zero) then
                  d(i) = -d(i)
@@ -1550,20 +1550,20 @@ module stdlib_linalg_lapack_w
                  d(isub) = d(n + 1 - i)
                  d(n + 1 - i) = smin
                  if (ncvt > 0) call stdlib_wswap(ncvt,vt(isub,1),ldvt,vt(n + 1 - i,1),ldvt)
-                           
+
                  if (nru > 0) call stdlib_wswap(nru,u(1,isub),1,u(1,n + 1 - i),1)
                  if (ncc > 0) call stdlib_wswap(ncc,c(isub,1),ldc,c(n + 1 - i,1),ldc)
-                           
+
               end if
            end do
            go to 220
            ! maximum number of iterations exceeded, failure to converge
-200  continue
+           200 continue
            info = 0
            do i = 1,n - 1
               if (e(i) /= zero) info = info + 1
            end do
-220        continue
+           220 continue
            return
      end subroutine stdlib_wbdsqr
 
@@ -1615,7 +1615,7 @@ module stdlib_linalg_lapack_w
            logical(lk),parameter :: doitref = .true.
            integer(ilp),parameter :: itermax = 30
            real(qp),parameter :: bwdmax = 1.0e+00_qp
-           
+
            ! Local Scalars
            integer(ilp) :: i,iiter,ptsa,ptsx
            real(qp) :: anrm,cte,eps,rnrm,xnrm
@@ -1700,7 +1700,7 @@ module stdlib_linalg_lapack_w
            ! stopping criterion. we are good to exit.
            iter = 0
            return
-10         continue
+           10 continue
            loop_30: do iiter = 1,itermax
               ! convert r (in work) from quad precision to double precision
               ! and store the result in sx.
@@ -1733,14 +1733,14 @@ module stdlib_linalg_lapack_w
               ! stopping criterion, we are good to exit.
               iter = iiter
               return
-20            continue
+              20 continue
            end do loop_30
            ! if we are at this place of the code, this is because we have
            ! performed iter=itermax iterations and never satisfied the stopping
            ! criterion, set up the iter flag accordingly and follow up on double
            ! precision routine.
            iter = -itermax - 1
-40         continue
+           40 continue
            ! single-precision iterative refinement failed to converge to a
            ! satisfactory solution, so we resort to quad precision.
            call stdlib_wgetrf(n,n,a,lda,ipiv,info)
@@ -1799,7 +1799,7 @@ module stdlib_linalg_lapack_w
            logical(lk),parameter :: doitref = .true.
            integer(ilp),parameter :: itermax = 30
            real(qp),parameter :: bwdmax = 1.0e+00_qp
-           
+
            ! Local Scalars
            integer(ilp) :: i,iiter,ptsa,ptsx
            real(qp) :: anrm,cte,eps,rnrm,xnrm
@@ -1873,7 +1873,7 @@ module stdlib_linalg_lapack_w
            ! compute r = b - ax (r is work).
            call stdlib_wlacpy('ALL',n,nrhs,b,ldb,work,n)
            call stdlib_whemm('LEFT',uplo,n,nrhs,cnegone,a,lda,x,ldx,cone,work,n)
-                     
+
            ! check whether the nrhs normwise backward errors satisfy the
            ! stopping criterion. if yes, set iter=0 and return.
            do i = 1,nrhs
@@ -1885,7 +1885,7 @@ module stdlib_linalg_lapack_w
            ! stopping criterion. we are good to exit.
            iter = 0
            return
-10         continue
+           10 continue
            loop_30: do iiter = 1,itermax
               ! convert r (in work) from quad precision to double precision
               ! and store the result in sx.
@@ -1905,7 +1905,7 @@ module stdlib_linalg_lapack_w
               ! compute r = b - ax (r is work).
               call stdlib_wlacpy('ALL',n,nrhs,b,ldb,work,n)
               call stdlib_whemm('L',uplo,n,nrhs,cnegone,a,lda,x,ldx,cone,work,n)
-                        
+
               ! check whether the nrhs normwise backward errors satisfy the
               ! stopping criterion. if yes, set iter=iiter>0 and return.
               do i = 1,nrhs
@@ -1917,14 +1917,14 @@ module stdlib_linalg_lapack_w
               ! stopping criterion, we are good to exit.
               iter = iiter
               return
-20            continue
+              20 continue
            end do loop_30
            ! if we are at this place of the code, this is because we have
            ! performed iter=itermax iterations and never satisfied the
            ! stopping criterion, set up the iter flag accordingly and follow
            ! up on quad precision routine.
            iter = -itermax - 1
-40         continue
+           40 continue
            ! single-precision iterative refinement failed to converge to a
            ! satisfactory solution, so we resort to quad precision.
            call stdlib_wpotrf(uplo,n,a,lda,info)
@@ -1948,7 +1948,7 @@ module stdlib_linalg_lapack_w
            ! Array Arguments
            complex(qp),intent(inout) :: sx(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: done
            real(qp) :: bignum,cden,cden1,cnum,cnum1,mul,smlnum
@@ -1964,7 +1964,7 @@ module stdlib_linalg_lapack_w
            ! initialize the denominator to sa and the numerator to 1.
            cden = sa
            cnum = one
-10         continue
+           10 continue
            cden1 = cden*smlnum
            cnum1 = cnum/bignum
            if (abs(cden1) > abs(cnum) .and. cnum /= zero) then
@@ -2007,7 +2007,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: ab(ldab,*),c(ldc,*)
            complex(qp),intent(out) :: pt(ldpt,*),q(ldq,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: wantb,wantc,wantpt,wantq
            integer(ilp) :: i,inca,j,j1,j2,kb,kb1,kk,klm,klu1,kun,l,minmn,ml,ml0,mu, &
@@ -2203,9 +2203,9 @@ module stdlib_linalg_lapack_w
                     ab(1,i + 1) = rc*ab(1,i + 1)
                  end if
                  if (wantq) call stdlib_wrot(m,q(1,i),1,q(1,i + 1),1,rc,conjg(rs))
-                           
+
                  if (wantc) call stdlib_wrot(ncc,c(i,1),ldc,c(i + 1,1),ldc,rc,rs)
-                           
+
               end do
            else
               ! a has been reduced to complex upper bidiagonal form or is
@@ -2288,7 +2288,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: ab(ldab,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lnoti,onenrm
            character :: normin
@@ -2344,7 +2344,7 @@ module stdlib_linalg_lapack_w
            kd = kl + ku + 1
            lnoti = kl > 0
            kase = 0
-10         continue
+           10 continue
            call stdlib_wlacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == kase1) then
@@ -2373,7 +2373,7 @@ module stdlib_linalg_lapack_w
                     do j = n - 1,1,-1
                        lm = min(kl,n - j)
                        work(j) = work(j) - stdlib_wdotc(lm,ab(kd + 1,j),1,work(j + 1),1)
-                                 
+
                        jp = ipiv(j)
                        if (jp /= j) then
                           t = work(jp)
@@ -2394,7 +2394,7 @@ module stdlib_linalg_lapack_w
            end if
            ! compute the estimate of the reciprocal condition number.
            if (ainvnm /= zero) rcond = (one/ainvnm)/anorm
-40         continue
+           40 continue
            return
      end subroutine stdlib_wgbcon
 
@@ -2409,7 +2409,7 @@ module stdlib_linalg_lapack_w
      !> works well in practice.
 
      pure subroutine stdlib_wgbequ(m,n,kl,ku,ab,ldab,r,c,rowcnd,colcnd,amax,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -2421,7 +2421,7 @@ module stdlib_linalg_lapack_w
            real(qp),intent(out) :: c(*),r(*)
            complex(qp),intent(in) :: ab(ldab,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,kd
            real(qp) :: bignum,rcmax,rcmin,smlnum
@@ -2550,7 +2550,7 @@ module stdlib_linalg_lapack_w
      !> between sqrt(radix) and 1/sqrt(radix).
 
      pure subroutine stdlib_wgbequb(m,n,kl,ku,ab,ldab,r,c,rowcnd,colcnd,amax,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -2562,7 +2562,7 @@ module stdlib_linalg_lapack_w
            real(qp),intent(out) :: c(*),r(*)
            complex(qp),intent(in) :: ab(ldab,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,kd
            real(qp) :: bignum,rcmax,rcmin,smlnum,radix,logrdx
@@ -2705,7 +2705,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: notran
            character :: transn,transt
@@ -2773,7 +2773,7 @@ module stdlib_linalg_lapack_w
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - op(a) * x,
               ! where op(a) = a, a**t, or a**h, depending on trans.
@@ -2855,13 +2855,13 @@ module stdlib_linalg_lapack_w
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_wlacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(op(a)**h).
                     call stdlib_wgbtrs(transt,n,kl,ku,1,afb,ldafb,ipiv,work,n,info)
-                              
+
                     do i = 1,n
                        work(i) = rwork(i)*work(i)
                     end do
@@ -2871,7 +2871,7 @@ module stdlib_linalg_lapack_w
                        work(i) = rwork(i)*work(i)
                     end do
                     call stdlib_wgbtrs(transn,n,kl,ku,1,afb,ldafb,ipiv,work,n,info)
-                              
+
                  end if
                  go to 100
               end if
@@ -2932,7 +2932,7 @@ module stdlib_linalg_lapack_w
            if (info == 0) then
               ! solve the system a*x = b, overwriting b with x.
               call stdlib_wgbtrs('NO TRANSPOSE',n,kl,ku,nrhs,ab,ldab,ipiv,b,ldb,info)
-                        
+
            end if
            return
      end subroutine stdlib_wgbsv
@@ -2965,7 +2965,7 @@ module stdlib_linalg_lapack_w
         ! moved setting of info = n+1 so info does not subsequently get
         ! overwritten.  sven, 17 mar 05.
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: colequ,equil,nofact,notran,rowequ
            character :: norm
@@ -3055,11 +3055,11 @@ module stdlib_linalg_lapack_w
            if (equil) then
               ! compute row and column scalings to equilibrate the matrix a.
               call stdlib_wgbequ(n,n,kl,ku,ab,ldab,r,c,rowcnd,colcnd,amax,infequ)
-                        
+
               if (infequ == 0) then
                  ! equilibrate the matrix.
                  call stdlib_wlaqgb(n,n,kl,ku,ab,ldab,r,c,rowcnd,colcnd,amax,equed)
-                           
+
                  rowequ = stdlib_lsame(equed,'R') .or. stdlib_lsame(equed,'B')
                  colequ = stdlib_lsame(equed,'C') .or. stdlib_lsame(equed,'B')
               end if
@@ -3086,7 +3086,7 @@ module stdlib_linalg_lapack_w
                  j1 = max(j - ku,1)
                  j2 = min(j + kl,n)
                  call stdlib_wcopy(j2 - j1 + 1,ab(ku + 1 - j + j1,j),1,afb(kl + ku + 1 - j + j1,j),1)
-                           
+
               end do
               call stdlib_wgbtrf(n,n,kl,ku,afb,ldafb,ipiv,info)
               ! return if info is non-zero.
@@ -3127,7 +3127,7 @@ module stdlib_linalg_lapack_w
            end if
            ! compute the reciprocal of the condition number of a.
            call stdlib_wgbcon(norm,n,kl,ku,afb,ldafb,ipiv,anorm,rcond,work,rwork,info)
-                     
+
            ! compute the solution matrix x.
            call stdlib_wlacpy('FULL',n,nrhs,b,ldb,x,ldx)
            call stdlib_wgbtrs(trans,n,kl,ku,nrhs,afb,ldafb,ipiv,x,ldx,info)
@@ -3179,7 +3179,7 @@ module stdlib_linalg_lapack_w
            integer(ilp),intent(out) :: ipiv(*)
            complex(qp),intent(inout) :: ab(ldab,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,jp,ju,km,kv
            ! Intrinsic Functions
@@ -3268,7 +3268,7 @@ module stdlib_linalg_lapack_w
            ! Parameters
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldwork = nbmax + 1
-           
+
            ! Local Scalars
            integer(ilp) :: i,i2,i3,ii,ip,j,j2,j3,jb,jj,jm,jp,ju,k2,km,kv,nb, &
                      nw
@@ -3400,7 +3400,7 @@ module stdlib_linalg_lapack_w
                     ! use stdlib_wlaswp to apply the row interchanges to a12, a22, and
                     ! a32.
                     call stdlib_wlaswp(j2,ab(kv + 1 - jb,j + jb),ldab - 1,1,jb,ipiv(j),1)
-                              
+
                     ! adjust the pivot indices.
                     do i = j,j + jb - 1
                        ipiv(i) = ipiv(i) + j - 1
@@ -3452,7 +3452,7 @@ module stdlib_linalg_lapack_w
                           ! update a23
                           call stdlib_wgemm('NO TRANSPOSE','NO TRANSPOSE',i2,j3,jb,-cone,ab( &
                            kv + 1 + jb,j),ldab - 1,work13,ldwork,cone,ab(1 + jb,j + kv),ldab - 1)
-                                     
+
                        end if
                        if (i3 > 0) then
                           ! update a33
@@ -3517,7 +3517,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: ab(ldab,*)
            complex(qp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lnoti,notran
            integer(ilp) :: i,j,kd,l,lm
@@ -3628,7 +3628,7 @@ module stdlib_linalg_lapack_w
            real(qp),intent(in) :: scale(*)
            complex(qp),intent(inout) :: v(ldv,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: leftv,rightv
            integer(ilp) :: i,ii,k
@@ -3683,7 +3683,7 @@ module stdlib_linalg_lapack_w
            ! backward permutation
            ! for  i = ilo-1 step -1 until 1,
                     ! ihi+1 step 1 until n do --
-30   continue
+                    30 continue
            if (stdlib_lsame(job,'P') .or. stdlib_lsame(job,'B')) then
               if (rightv) then
                  loop_40: do ii = 1,n
@@ -3733,7 +3733,7 @@ module stdlib_linalg_lapack_w
            ! Parameters
            real(qp),parameter :: sclfac = 2.0e+0_qp
            real(qp),parameter :: factor = 0.95e+0_qp
-           
+
            ! Local Scalars
            logical(lk) :: noconv
            integer(ilp) :: i,ica,iexc,ira,j,k,l,m
@@ -3767,18 +3767,18 @@ module stdlib_linalg_lapack_w
            ! permutation to isolate eigenvalues if possible
            go to 50
            ! row and column exchange.
-20   continue
+           20 continue
            scale(m) = j
            if (j == m) go to 30
            call stdlib_wswap(l,a(1,j),1,a(1,m),1)
            call stdlib_wswap(n - k + 1,a(j,k),lda,a(m,k),lda)
-30         continue
+           30 continue
            go to(40,80) iexc
            ! search for rows isolating an eigenvalue and push them down.
-40   continue
+           40 continue
            if (l == 1) go to 210
            l = l - 1
-50         continue
+           50 continue
            loop_70: do j = l,1,-1
               loop_60: do i = 1,l
                  if (i == j) cycle loop_60
@@ -3791,9 +3791,9 @@ module stdlib_linalg_lapack_w
            end do loop_70
            go to 90
            ! search for columns isolating an eigenvalue and push them left.
-80   continue
+           80 continue
            k = k + 1
-90         continue
+           90 continue
            loop_110: do j = k,l
               loop_100: do i = k,l
                  if (i == j) cycle loop_100
@@ -3804,7 +3804,7 @@ module stdlib_linalg_lapack_w
               iexc = 2
               go to 20
            end do loop_110
-120        continue
+           120 continue
            do i = k,l
               scale(i) = one
            end do
@@ -3815,7 +3815,7 @@ module stdlib_linalg_lapack_w
            sfmax1 = one/sfmin1
            sfmin2 = sfmin1*sclfac
            sfmax2 = one/sfmin2
-140        continue
+           140 continue
            noconv = .false.
            loop_200: do i = k,l
               c = stdlib_qznrm2(l - k + 1,a(k,i),1)
@@ -3829,7 +3829,7 @@ module stdlib_linalg_lapack_w
               g = r/sclfac
               f = one
               s = c + r
-160           continue
+              160 continue
               if (c >= g .or. max(f,c,ca) >= sfmax2 .or. min(r,g,ra) <= sfmin2) go to 170
                  if (stdlib_qisnan(c + f + ca + r + g + ra)) then
                  ! exit if nan to avoid infinite loop
@@ -3844,9 +3844,9 @@ module stdlib_linalg_lapack_w
               g = g/sclfac
               ra = ra/sclfac
               go to 160
-170           continue
+              170 continue
               g = c/sclfac
-180           continue
+              180 continue
               if (g < r .or. max(r,ra) >= sfmax2 .or. min(f,c,g,ca) <= sfmin2) go to 190
               f = f/sclfac
               c = c/sclfac
@@ -3856,7 +3856,7 @@ module stdlib_linalg_lapack_w
               ra = ra*sclfac
               go to 180
               ! now balance.
-190  continue
+              190 continue
               if ((c + r) >= factor*s) cycle loop_200
               if (f < one .and. scale(i) < one) then
                  if (f*scale(i) <= sfmin1) cycle loop_200
@@ -3871,7 +3871,7 @@ module stdlib_linalg_lapack_w
               call stdlib_wdscal(l,f,a(1,i),1)
            end do loop_200
            if (noconv) go to 140
-210        continue
+           210 continue
            ilo = k
            ihi = l
            return
@@ -3893,7 +3893,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: taup(*),tauq(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            complex(qp) :: alpha
@@ -3991,7 +3991,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: taup(*),tauq(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,iinfo,j,ldwrkx,ldwrky,lwkopt,minmn,nb,nbmin,nx,ws
@@ -4059,7 +4059,7 @@ module stdlib_linalg_lapack_w
               ! an update of the form  a := a - v*y**h - x*u**h
               call stdlib_wgemm('NO TRANSPOSE','CONJUGATE TRANSPOSE',m - i - nb + 1,n - i - nb + 1,nb,- &
               cone,a(i + nb,i),lda,work(ldwrkx*nb + nb + 1),ldwrky,cone,a(i + nb,i + nb),lda)
-                        
+
               call stdlib_wgemm('NO TRANSPOSE','NO TRANSPOSE',m - i - nb + 1,n - i - nb + 1,nb,-cone, &
                         work(nb + 1),ldwrkx,a(i,i + nb),lda,cone,a(i + nb,i + nb),lda)
               ! copy diagonal and off-diagonal elements of b back into a
@@ -4104,7 +4104,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: onenrm
            character :: normin
@@ -4154,7 +4154,7 @@ module stdlib_linalg_lapack_w
               kase1 = 2
            end if
            kase = 0
-10         continue
+           10 continue
            call stdlib_wlacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == kase1) then
@@ -4184,7 +4184,7 @@ module stdlib_linalg_lapack_w
            end if
            ! compute the estimate of the reciprocal condition number.
            if (ainvnm /= zero) rcond = (one/ainvnm)/anorm
-20         continue
+           20 continue
            return
      end subroutine stdlib_wgecon
 
@@ -4210,7 +4210,7 @@ module stdlib_linalg_lapack_w
            real(qp),intent(out) :: c(*),r(*)
            complex(qp),intent(in) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(qp) :: bignum,rcmax,rcmin,smlnum
@@ -4344,7 +4344,7 @@ module stdlib_linalg_lapack_w
            real(qp),intent(out) :: c(*),r(*)
            complex(qp),intent(in) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(qp) :: bignum,rcmax,rcmin,smlnum,radix,logrdx
@@ -4486,7 +4486,7 @@ module stdlib_linalg_lapack_w
            ! Function Arguments
            procedure(stdlib_select_w) :: select
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,scalea,wantst,wantvs
            integer(ilp) :: hswork,i,ibal,icond,ierr,ieval,ihi,ilo,itau,iwrk,maxwrk, &
@@ -4531,7 +4531,7 @@ module stdlib_linalg_lapack_w
                  maxwrk = n + n*stdlib_ilaenv(1,'ZGEHRD',' ',n,1,n,0)
                  minwrk = 2*n
                  call stdlib_whseqr('S',jobvs,n,1,n,a,lda,w,vs,ldvs,work,-1,ieval)
-                           
+
                  hswork = real(work(1),KIND=qp)
                  if (.not. wantvs) then
                     maxwrk = max(maxwrk,hswork)
@@ -4664,7 +4664,7 @@ module stdlib_linalg_lapack_w
            ! Function Arguments
            procedure(stdlib_select_w) :: select
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,scalea,wantsb,wantse,wantsn,wantst,wantsv,wantvs
            integer(ilp) :: hswork,i,ibal,icond,ierr,ieval,ihi,ilo,itau,iwrk,lwrk, &
@@ -4719,7 +4719,7 @@ module stdlib_linalg_lapack_w
                  maxwrk = n + n*stdlib_ilaenv(1,'ZGEHRD',' ',n,1,n,0)
                  minwrk = 2*n
                  call stdlib_whseqr('S',jobvs,n,1,n,a,lda,w,vs,ldvs,work,-1,ieval)
-                           
+
                  hswork = real(work(1),KIND=qp)
                  if (.not. wantvs) then
                     maxwrk = max(maxwrk,hswork)
@@ -4858,7 +4858,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: vl(ldvl,*),vr(ldvr,*),w(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,scalea,wantvl,wantvr
            character :: side
@@ -4915,7 +4915,7 @@ module stdlib_linalg_lapack_w
                     lwork_trevc = int(work(1),KIND=ilp)
                     maxwrk = max(maxwrk,n + lwork_trevc)
                     call stdlib_whseqr('S','V',n,1,n,a,lda,w,vl,ldvl,work,-1,info)
-                              
+
                  else if (wantvr) then
                     maxwrk = max(maxwrk,n + (n - 1)*stdlib_ilaenv(1,'ZUNGHR',' ',n,1,n,- &
                               1))
@@ -4924,10 +4924,10 @@ module stdlib_linalg_lapack_w
                     lwork_trevc = int(work(1),KIND=ilp)
                     maxwrk = max(maxwrk,n + lwork_trevc)
                     call stdlib_whseqr('S','V',n,1,n,a,lda,w,vr,ldvr,work,-1,info)
-                              
+
                  else
                     call stdlib_whseqr('E','N',n,1,n,a,lda,w,vr,ldvr,work,-1,info)
-                              
+
                  end if
                  hswork = int(work(1),KIND=ilp)
                  maxwrk = max(maxwrk,hswork,minwrk)
@@ -5070,7 +5070,7 @@ module stdlib_linalg_lapack_w
               end do
            end if
            ! undo scaling if necessary
-50   continue
+           50 continue
            if (scalea) then
               call stdlib_wlascl('G',0,0,cscale,anrm,n - info,1,w(info + 1),max(n - info,1) &
                         ,ierr)
@@ -5123,7 +5123,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: vl(ldvl,*),vr(ldvr,*),w(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,scalea,wantvl,wantvr,wntsnb,wntsne,wntsnn,wntsnv
            character :: job,side
@@ -5187,21 +5187,21 @@ module stdlib_linalg_lapack_w
                     lwork_trevc = int(work(1),KIND=ilp)
                     maxwrk = max(maxwrk,lwork_trevc)
                     call stdlib_whseqr('S','V',n,1,n,a,lda,w,vl,ldvl,work,-1,info)
-                              
+
                  else if (wantvr) then
                     call stdlib_wtrevc3('R','B',select,n,a,lda,vl,ldvl,vr,ldvr,n,nout, &
                               work,-1,rwork,-1,ierr)
                     lwork_trevc = int(work(1),KIND=ilp)
                     maxwrk = max(maxwrk,lwork_trevc)
                     call stdlib_whseqr('S','V',n,1,n,a,lda,w,vr,ldvr,work,-1,info)
-                              
+
                  else
                     if (wntsnn) then
                        call stdlib_whseqr('E','N',n,1,n,a,lda,w,vr,ldvr,work,-1,info)
-                                 
+
                     else
                        call stdlib_whseqr('S','N',n,1,n,a,lda,w,vr,ldvr,work,-1,info)
-                                 
+
                     end if
                  end if
                  hswork = int(work(1),KIND=ilp)
@@ -5369,7 +5369,7 @@ module stdlib_linalg_lapack_w
               end do
            end if
            ! undo scaling if necessary
-50   continue
+           50 continue
            if (scalea) then
               call stdlib_wlascl('G',0,0,cscale,anrm,n - info,1,w(info + 1),max(n - info,1) &
                         ,ierr)
@@ -5398,7 +5398,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            complex(qp) :: alpha
@@ -5454,7 +5454,7 @@ module stdlib_linalg_lapack_w
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,iinfo,iwt,j,ldwork,lwkopt,nb,nbmin,nh,nx
@@ -5591,7 +5591,7 @@ module stdlib_linalg_lapack_w
            integer(ilp),intent(out) :: iwork(*)
            character,intent(in) :: joba,jobp,jobr,jobt,jobu,jobv
         ! ===========================================================================
-           
+
            ! Local Scalars
            complex(qp) :: ctemp
            real(qp) :: aapp,aaqq,aatmax,aatmin,big,big1,cond_ok,condr1,condr2,entra, &
@@ -5679,7 +5679,7 @@ module stdlib_linalg_lapack_w
                lrwsvdj = n
                if (lquery) then
                    call stdlib_wgeqp3(m,n,a,lda,iwork,cdummy,cdummy,-1,rdummy,ierr)
-                             
+
                    lwrk_wgeqp3 = real(cdummy(1),KIND=qp)
                    call stdlib_wgeqrf(n,n,a,lda,cdummy,cdummy,-1,ierr)
                    lwrk_wgeqrf = real(cdummy(1),KIND=qp)
@@ -5703,7 +5703,7 @@ module stdlib_linalg_lapack_w
                        lwrk_wgesvj = real(cdummy(1),KIND=qp)
                        if (errest) then
                            optwrk = max(n + lwrk_wgeqp3,n**2 + lwcon,n + lwrk_wgeqrf,lwrk_wgesvj)
-                                     
+
                        else
                            optwrk = max(n + lwrk_wgeqp3,n + lwrk_wgeqrf,lwrk_wgesvj)
                        end if
@@ -5730,7 +5730,7 @@ module stdlib_linalg_lapack_w
                                 lwunmlq)
                   else
                       minwrk = max(n + lwqp3,lwsvdj,n + lwlqf,2*n + lwqrf,n + lwsvdj,n + lwunmlq)
-                                
+
                   end if
                   if (lquery) then
                       call stdlib_wgesvj('L','U','N',n,n,u,ldu,sva,n,a,lda,cdummy,-1, &
@@ -5781,7 +5781,7 @@ module stdlib_linalg_lapack_w
                                 lwrk_wunmqrm)
                       else
                       optwrk = n + max(lwrk_wgeqp3,n + lwrk_wgeqrf,lwrk_wgesvj,lwrk_wunmqrm)
-                                
+
                       end if
                   end if
                   if (l2tran .or. rowpiv) then
@@ -5834,7 +5834,7 @@ module stdlib_linalg_lapack_w
                       lwrk_wunmqr = real(cdummy(1),KIND=qp)
                       if (.not. jracc) then
                           call stdlib_wgeqp3(n,n,a,lda,iwork,cdummy,cdummy,-1,rdummy,ierr)
-                                    
+
                           lwrk_wgeqp3n = real(cdummy(1),KIND=qp)
                           call stdlib_wgesvj('L','U','N',n,n,u,ldu,sva,n,v,ldv,cdummy, &
                                     -1,rdummy,-1,ierr)
@@ -6220,7 +6220,7 @@ module stdlib_linalg_lapack_w
               iwork(p) = 0
            end do
            call stdlib_wgeqp3(m,n,a,lda,iwork,cwork,cwork(n + 1),lwork - n,rwork,ierr)
-                     
+
            ! the upper triangular matrix r1 from the first qrf is inspected for
            ! rank deficiency and possibilities for deflation, or possible
            ! ill-conditioning. depending on the user specified flag l2rank,
@@ -6242,7 +6242,7 @@ module stdlib_linalg_lapack_w
                     go to 3002
                  end if
               end do
-3002          continue
+              3002 continue
            else if (l2rank) then
               ! .. similarly as above, only slightly more gentle (less aggressive).
               ! sudden drop on the diagonal of r1 is used as the criterion for
@@ -6253,7 +6253,7 @@ module stdlib_linalg_lapack_w
                            l2kill .and. (abs(a(p,p)) < temp1))) go to 3402
                  nr = nr + 1
               end do
-3402          continue
+              3402 continue
            else
               ! the goal is high relative accuracy. however, if the matrix
               ! has high scaled condition number the relative accuracy is in
@@ -6268,7 +6268,7 @@ module stdlib_linalg_lapack_w
                            3302
                  nr = nr + 1
               end do
-3302          continue
+              3302 continue
            end if
            almort = .false.
            if (nr == n) then
@@ -6293,10 +6293,10 @@ module stdlib_linalg_lapack_w
                     end do
                     if (lsvec) then
                         call stdlib_wpocon('U',n,v,ldv,one,temp1,cwork(n + 1),rwork,ierr)
-                                  
+
                     else
                         call stdlib_wpocon('U',n,v,ldv,one,temp1,cwork,rwork,ierr)
-                                  
+
                     end if
                  else if (lsvec) then
                     ! U Is Available As Workspace
@@ -6306,7 +6306,7 @@ module stdlib_linalg_lapack_w
                        call stdlib_wdscal(p,one/temp1,u(1,p),1)
                     end do
                     call stdlib_wpocon('U',n,u,ldu,one,temp1,cwork(n + 1),rwork,ierr)
-                              
+
                  else
                     call stdlib_wlacpy('U',n,n,a,lda,cwork,n)
       ! []            call stdlib_wlacpy( 'u', n, n, a, lda, cwork(n+1), n )
@@ -6321,7 +6321,7 @@ module stdlib_linalg_lapack_w
       ! []               call stdlib_wpocon( 'u', n, cwork(n+1), n, one, temp1,
       ! []     $              cwork(n+n*n+1), rwork, ierr )
                     call stdlib_wpocon('U',n,cwork,n,one,temp1,cwork(n*n + 1),rwork,ierr)
-                              
+
                  end if
                  if (temp1 /= zero) then
                     sconda = one/sqrt(temp1)
@@ -6425,7 +6425,7 @@ module stdlib_linalg_lapack_w
                  call stdlib_wlacpy('L',nr,nr,a,lda,v,ldv)
                  call stdlib_wlaset('U',nr - 1,nr - 1,czero,czero,v(1,2),ldv)
                  call stdlib_wgeqrf(nr,nr,v,ldv,cwork(n + 1),cwork(2*n + 1),lwork - 2*n,ierr)
-                           
+
                  do p = 1,nr
                     call stdlib_wcopy(nr - p + 1,v(p,p),ldv,v(p,p),1)
                     call stdlib_wlacgv(nr - p + 1,v(p,p),1)
@@ -6446,7 +6446,7 @@ module stdlib_linalg_lapack_w
                ! Permute The Rows Of V
                ! do 8991 p = 1, n
                   ! call stdlib_wcopy( n, v(p,1), ldv, a(iwork(p),1), lda )
-8991 continue
+                  8991 continue
                ! call stdlib_wlacpy( 'all', n, n, a, lda, v, ldv )
               call stdlib_wlapmr(.false.,n,n,v,ldv,iwork)
                if (transp) then
@@ -6469,7 +6469,7 @@ module stdlib_linalg_lapack_w
               end do
               call stdlib_wlaset('U',nr - 1,nr - 1,czero,czero,u(1,2),ldu)
               call stdlib_wgeqrf(n,nr,u,ldu,cwork(n + 1),cwork(2*n + 1),lwork - 2*n,ierr)
-                        
+
               do p = 1,nr - 1
                  call stdlib_wcopy(nr - p,u(p,p + 1),ldu,u(p + 1,p),1)
                  call stdlib_wlacgv(n - p + 1,u(p,p),1)
@@ -6558,7 +6558,7 @@ module stdlib_linalg_lapack_w
                     ! of a lower triangular matrix.
                     ! r1^* = q2 * r2
                     call stdlib_wgeqrf(n,nr,v,ldv,cwork(n + 1),cwork(2*n + 1),lwork - 2*n,ierr)
-                              
+
                     if (l2pert) then
                        xsc = sqrt(small)/epsln
                        do p = 2,nr
@@ -6570,7 +6570,7 @@ module stdlib_linalg_lapack_w
                        end do
                     end if
                     if (nr /= n) call stdlib_wlacpy('A',n,nr,v,ldv,cwork(2*n + 1),n)
-                              
+
                     ! .. save ...
                  ! This Transposed Copy Should Be Better Than Naive
                     do p = 1,nr - 1
@@ -6871,7 +6871,7 @@ module stdlib_linalg_lapack_w
                  call stdlib_wlaset('U',nr - 1,nr - 1,czero,czero,v(1,2),ldv)
               end if
               call stdlib_wgeqrf(n,nr,v,ldv,cwork(n + 1),cwork(2*n + 1),lwork - 2*n,ierr)
-                        
+
               call stdlib_wlacpy('L',n,nr,v,ldv,cwork(2*n + 1),n)
               do p = 1,nr
                  call stdlib_wcopy(nr - p + 1,v(p,p),ldv,u(p,p),1)
@@ -7112,7 +7112,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            complex(qp) :: alpha
@@ -7234,7 +7234,7 @@ module stdlib_linalg_lapack_w
                     ! apply h to a(i+ib:m,i:n) from the right
                     call stdlib_wlarfb('RIGHT','NO TRANSPOSE','FORWARD','ROWWISE',m - i - ib + 1,n - &
                     i + 1,ib,a(i,i),lda,work,ldwork,a(i + ib,i),lda,work(ib + 1),ldwork)
-                              
+
                  end if
               end do
            else
@@ -7242,7 +7242,7 @@ module stdlib_linalg_lapack_w
            end if
            ! use unblocked code to factor the last or only block.
            if (i <= k) call stdlib_wgelq2(m - i + 1,n - i + 1,a(i,i),lda,tau(i),work,iinfo)
-                     
+
            work(1) = iws
            return
      end subroutine stdlib_wgelqf
@@ -7314,7 +7314,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,i1,j,j1,m1,m2,iinfo
            ! Executable Statements
@@ -7351,15 +7351,15 @@ module stdlib_linalg_lapack_w
                  end do
               end do
               call stdlib_wtrmm('R','U','C','U',m2,m1,cone,a,lda,t(i1,1),ldt)
-                        
+
               call stdlib_wgemm('N','C',m2,m1,n - m1,cone,a(i1,i1),lda,a(1,i1),lda, &
                         cone,t(i1,1),ldt)
               call stdlib_wtrmm('R','U','N','N',m2,m1,cone,t,ldt,t(i1,1),ldt)
-                        
+
               call stdlib_wgemm('N','N',m2,n - m1,m1,-cone,t(i1,1),ldt,a(1,i1),lda, &
                         cone,a(i1,i1),lda)
               call stdlib_wtrmm('R','U','N','U',m2,m1,cone,a,lda,t(i1,1),ldt)
-                        
+
               do i = 1,m2
                  do j = 1,m1
                     a(i + m1,j) = a(i + m1,j) - t(i + m1,j)
@@ -7379,7 +7379,7 @@ module stdlib_linalg_lapack_w
               call stdlib_wgemm('N','C',m1,m2,n - m,cone,a(1,j1),lda,a(i1,j1),lda, &
                         cone,t(1,i1),ldt)
               call stdlib_wtrmm('L','U','N','N',m1,m2,-cone,t,ldt,t(1,i1),ldt)
-                        
+
               call stdlib_wtrmm('R','U','N','N',m1,m2,cone,t(i1,i1),ldt,t(1,i1), &
                         ldt)
               ! y = (y1,y2); l = [ l1            0  ];  t = [t1 t3]
@@ -7419,7 +7419,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,tpsd
            integer(ilp) :: brow,i,iascl,ibscl,j,mn,nb,scllen,wsize
@@ -7600,7 +7600,7 @@ module stdlib_linalg_lapack_w
            else if (ibscl == 2) then
               call stdlib_wlascl('G',0,0,bignum,bnrm,scllen,nrhs,b,ldb,info)
            end if
-50         continue
+           50 continue
            work(1) = real(wsize,KIND=qp)
            return
      end subroutine stdlib_wgels
@@ -7646,7 +7646,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: iascl,ibscl,ie,il,itau,itaup,itauq,ldwork,liwork,lrwork, &
@@ -7694,9 +7694,9 @@ module stdlib_linalg_lapack_w
                               ! columns.
                     mm = n
                     maxwrk = max(maxwrk,n*stdlib_ilaenv(1,'ZGEQRF',' ',m,n,-1,-1))
-                              
+
                     maxwrk = max(maxwrk,nrhs*stdlib_ilaenv(1,'ZUNMQR','LC',m,nrhs,n,-1))
-                              
+
                  end if
                  if (m >= n) then
                     ! path 1 - overdetermined or exactly determined.
@@ -7736,7 +7736,7 @@ module stdlib_linalg_lapack_w
                     else
                        ! path 2 - underdetermined.
                        maxwrk = 2*m + (n + m)*stdlib_ilaenv(1,'ZGEBRD',' ',m,n,-1,-1)
-                                 
+
                        maxwrk = max(maxwrk,2*m + nrhs*stdlib_ilaenv(1,'ZUNMBR','QLC',m,nrhs, &
                                   m,-1))
                        maxwrk = max(maxwrk,2*m + m*stdlib_ilaenv(1,'ZUNMBR','PLN',n,nrhs,m, &
@@ -7861,7 +7861,7 @@ module stdlib_linalg_lapack_w
               ! compute a=l*q.
               ! (cworkspace: need 2*m, prefer m+m*nb)
               call stdlib_wgelqf(m,n,a,lda,work(itau),work(nwork),lwork - nwork + 1,info)
-                        
+
               il = nwork
               ! copy l to work(il), zeroing out above its diagonal.
               call stdlib_wlacpy('L',m,m,a,lda,work(il),ldwork)
@@ -7935,7 +7935,7 @@ module stdlib_linalg_lapack_w
            else if (ibscl == 2) then
               call stdlib_wlascl('G',0,0,bignum,bnrm,n,nrhs,b,ldb,info)
            end if
-10         continue
+           10 continue
            work(1) = maxwrk
            iwork(1) = liwork
            rwork(1) = lrwork
@@ -7969,7 +7969,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: bl,chunk,i,iascl,ibscl,ie,il,irwork,itau,itaup,itauq,iwork, &
@@ -8023,7 +8023,7 @@ module stdlib_linalg_lapack_w
                     lwork_wunmqr = real(dum(1),KIND=qp)
                     mm = n
                     maxwrk = max(maxwrk,n + n*stdlib_ilaenv(1,'ZGEQRF',' ',m,n,-1,-1))
-                              
+
                     maxwrk = max(maxwrk,n + nrhs*stdlib_ilaenv(1,'ZUNMQR','LC',m,nrhs,n,- &
                               1))
                  end if
@@ -8031,7 +8031,7 @@ module stdlib_linalg_lapack_w
                     ! path 1 - overdetermined or exactly determined
                     ! compute space needed for stdlib_wgebrd
                     call stdlib_wgebrd(mm,n,a,lda,s,s,dum(1),dum(1),dum(1),-1,info)
-                              
+
                     lwork_wgebrd = real(dum(1),KIND=qp)
                     ! compute space needed for stdlib_wunmbr
                     call stdlib_wunmbr('Q','L','C',mm,nrhs,n,a,lda,dum(1),b,ldb,dum(1), &
@@ -8057,7 +8057,7 @@ module stdlib_linalg_lapack_w
                        lwork_wgelqf = real(dum(1),KIND=qp)
                        ! compute space needed for stdlib_wgebrd
                        call stdlib_wgebrd(m,m,a,lda,s,s,dum(1),dum(1),dum(1),-1,info)
-                                 
+
                        lwork_wgebrd = real(dum(1),KIND=qp)
                        ! compute space needed for stdlib_wunmbr
                        call stdlib_wunmbr('Q','L','C',m,nrhs,n,a,lda,dum(1),b,ldb,dum( &
@@ -8085,7 +8085,7 @@ module stdlib_linalg_lapack_w
                        ! path 2 - underdetermined
                        ! compute space needed for stdlib_wgebrd
                        call stdlib_wgebrd(m,n,a,lda,s,s,dum(1),dum(1),dum(1),-1,info)
-                                 
+
                        lwork_wgebrd = real(dum(1),KIND=qp)
                        ! compute space needed for stdlib_wunmbr
                        call stdlib_wunmbr('Q','L','C',m,nrhs,m,a,lda,dum(1),b,ldb,dum( &
@@ -8219,7 +8219,7 @@ module stdlib_linalg_lapack_w
               ! (rworkspace: none)
               if (lwork >= ldb*nrhs .and. nrhs > 1) then
                  call stdlib_wgemm('C','N',n,nrhs,n,cone,a,lda,b,ldb,czero,work,ldb)
-                           
+
                  call stdlib_wlacpy('G',n,nrhs,work,ldb,b,ldb)
               else if (nrhs > 1) then
                  chunk = lwork/n
@@ -8245,7 +8245,7 @@ module stdlib_linalg_lapack_w
               ! (cworkspace: need 2*m, prefer m+m*nb)
               ! (rworkspace: none)
               call stdlib_wgelqf(m,n,a,lda,work(itau),work(iwork),lwork - iwork + 1,info)
-                        
+
               il = iwork
               ! copy l to work(il), zeroing out above it
               call stdlib_wlacpy('L',m,m,a,lda,work(il),ldwork)
@@ -8366,7 +8366,7 @@ module stdlib_linalg_lapack_w
               ! (rworkspace: none)
               if (lwork >= ldb*nrhs .and. nrhs > 1) then
                  call stdlib_wgemm('C','N',n,nrhs,m,cone,a,lda,b,ldb,czero,work,ldb)
-                           
+
                  call stdlib_wlacpy('G',n,nrhs,work,ldb,b,ldb)
               else if (nrhs > 1) then
                  chunk = lwork/n
@@ -8394,7 +8394,7 @@ module stdlib_linalg_lapack_w
            else if (ibscl == 2) then
               call stdlib_wlascl('G',0,0,bignum,bnrm,n,nrhs,b,ldb,info)
            end if
-70         continue
+           70 continue
            work(1) = maxwrk
            return
      end subroutine stdlib_wgelss
@@ -8450,7 +8450,7 @@ module stdlib_linalg_lapack_w
            ! Parameters
            integer(ilp),parameter :: imax = 1
            integer(ilp),parameter :: imin = 2
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,iascl,ibscl,ismax,ismin,j,lwkopt,mn,nb,nb1,nb2,nb3, &
@@ -8532,7 +8532,7 @@ module stdlib_linalg_lapack_w
            ! compute qr factorization with column pivoting of a:
               ! a * p = q * r
            call stdlib_wgeqp3(m,n,a,lda,jpvt,work(1),work(mn + 1),lwork - mn,rwork,info)
-                     
+
            wsize = mn + real(work(mn + 1),KIND=qp)
            ! complex workspace: mn+nb*(n+1). real workspace 2*n.
            ! details of householder rotations stored in work(1:mn).
@@ -8548,7 +8548,7 @@ module stdlib_linalg_lapack_w
            else
               rank = 1
            end if
-10         continue
+           10 continue
            if (rank < mn) then
               i = rank + 1
               call stdlib_wlaic1(imin,rank,work(ismin),smin,a(1,i),a(i,i),sminpr, &
@@ -8617,7 +8617,7 @@ module stdlib_linalg_lapack_w
            else if (ibscl == 2) then
               call stdlib_wlascl('G',0,0,bignum,bnrm,n,nrhs,b,ldb,info)
            end if
-70         continue
+           70 continue
            work(1) = cmplx(lwkopt,KIND=qp)
            return
      end subroutine stdlib_wgelsy
@@ -8730,7 +8730,7 @@ module stdlib_linalg_lapack_w
      !> Q is of order M if SIDE = 'L' and of order N  if SIDE = 'R'.
 
      pure subroutine stdlib_wgemlqt(side,trans,m,n,k,mb,v,ldv,t,ldt,c,ldc,work,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -8925,7 +8925,7 @@ module stdlib_linalg_lapack_w
      !> Q is of order M if SIDE = 'L' and of order N  if SIDE = 'R'.
 
      pure subroutine stdlib_wgemqrt(side,trans,m,n,k,nb,v,ldv,t,ldt,c,ldc,work,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -9026,7 +9026,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            complex(qp) :: alpha
@@ -9143,7 +9143,7 @@ module stdlib_linalg_lapack_w
                  ! compute the ql factorization of the current block
                  ! a(1:m-k+i+ib-1,n-k+i:n-k+i+ib-1)
                  call stdlib_wgeql2(m - k + i + ib - 1,ib,a(1,n - k + i),lda,tau(i),work,iinfo)
-                           
+
                  if (n - k + i > 1) then
                     ! form the triangular factor of the block reflector
                     ! h = h(i+ib-1) . . . h(i+1) h(i)
@@ -9187,7 +9187,7 @@ module stdlib_linalg_lapack_w
            integer(ilp),parameter :: inb = 1
            integer(ilp),parameter :: inbmin = 2
            integer(ilp),parameter :: ixover = 3
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: fjb,iws,j,jb,lwkopt,minmn,minws,na,nb,nbmin,nfxd,nx,sm, &
@@ -9284,7 +9284,7 @@ module stdlib_linalg_lapack_w
                        ! determine the minimum value of nb.
                        nb = lwork/(sn + 1)
                        nbmin = max(2,stdlib_ilaenv(inbmin,'ZGEQRF',' ',sm,sn,-1,-1))
-                                 
+
                     end if
                  end if
               end if
@@ -9299,7 +9299,7 @@ module stdlib_linalg_lapack_w
                  j = nfxd + 1
                  ! compute factorization: while loop.
                  topbmn = minmn - nx
-30               continue
+                 30 continue
                  if (j <= topbmn) then
                     jb = min(nb,topbmn - j + 1)
                     ! factorize jb columns among columns j:n.
@@ -9453,7 +9453,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            complex(qp) :: alpha
@@ -9509,7 +9509,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            complex(qp) :: alpha
@@ -9642,7 +9642,7 @@ module stdlib_linalg_lapack_w
            end if
            ! use unblocked code to factor the last or only block.
            if (i <= k) call stdlib_wgeqr2(m - i + 1,n - i + 1,a(i,i),lda,tau(i),work,iinfo)
-                     
+
            work(1) = iws
            return
      end subroutine stdlib_wgeqrf
@@ -9741,7 +9741,7 @@ module stdlib_linalg_lapack_w
            end if
            ! use unblocked code to factor the last or only block.
            if (i <= k) call stdlib_wgeqr2p(m - i + 1,n - i + 1,a(i,i),lda,tau(i),work,iinfo)
-                     
+
            work(1) = iws
            return
      end subroutine stdlib_wgeqrfp
@@ -9763,7 +9763,7 @@ module stdlib_linalg_lapack_w
            ! Local Scalars
            logical(lk),parameter :: use_recursive_qr = .true.
            integer(ilp) :: i,ib,iinfo,k
-           
+
            ! Executable Statements
            ! test the input arguments
            info = 0
@@ -9817,7 +9817,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            complex(qp) :: aii,alpha
@@ -9887,7 +9887,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,i1,j,j1,n1,n2,iinfo
            ! Executable Statements
@@ -9923,15 +9923,15 @@ module stdlib_linalg_lapack_w
                  end do
               end do
               call stdlib_wtrmm('L','L','C','U',n1,n2,cone,a,lda,t(1,j1),ldt)
-                        
+
               call stdlib_wgemm('C','N',n1,n2,m - n1,cone,a(j1,1),lda,a(j1,j1),lda, &
                         cone,t(1,j1),ldt)
               call stdlib_wtrmm('L','U','C','N',n1,n2,cone,t,ldt,t(1,j1),ldt)
-                        
+
               call stdlib_wgemm('N','N',m - n1,n2,n1,-cone,a(j1,1),lda,t(1,j1),ldt, &
                         cone,a(j1,j1),lda)
               call stdlib_wtrmm('L','L','N','U',n1,n2,cone,a,lda,t(1,j1),ldt)
-                        
+
               do j = 1,n2
                  do i = 1,n1
                     a(i,j + n1) = a(i,j + n1) - t(i,j + n1)
@@ -9950,7 +9950,7 @@ module stdlib_linalg_lapack_w
               call stdlib_wgemm('C','N',n1,n2,m - n,cone,a(i1,1),lda,a(i1,j1),lda, &
                         cone,t(1,j1),ldt)
               call stdlib_wtrmm('L','U','N','N',n1,n2,-cone,t,ldt,t(1,j1),ldt)
-                        
+
               call stdlib_wtrmm('R','U','N','N',n1,n2,cone,t(j1,j1),ldt,t(1,j1), &
                         ldt)
               ! y = (y1,y2); r = [ r1  a(1:n1,j1:n) ];  t = [t1 t3]
@@ -9981,7 +9981,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: notran
            character :: transn,transt
@@ -10045,7 +10045,7 @@ module stdlib_linalg_lapack_w
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - op(a) * x,
               ! where op(a) = a, a**t, or a**h, depending on trans.
@@ -10124,7 +10124,7 @@ module stdlib_linalg_lapack_w
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_wlacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -10166,7 +10166,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            complex(qp) :: alpha
@@ -10285,7 +10285,7 @@ module stdlib_linalg_lapack_w
                  ! compute the rq factorization of the current block
                  ! a(m-k+i:m-k+i+ib-1,1:n-k+i+ib-1)
                  call stdlib_wgerq2(ib,n - k + i + ib - 1,a(m - k + i,1),lda,tau(i),work,iinfo)
-                           
+
                  if (m - k + i > 1) then
                     ! form the triangular factor of the block reflector
                     ! h = h(i+ib-1) . . . h(i+1) h(i)
@@ -10294,7 +10294,7 @@ module stdlib_linalg_lapack_w
                     ! apply h to a(1:m-k+i-1,1:n-k+i+ib-1) from the right
                     call stdlib_wlarfb('RIGHT','NO TRANSPOSE','BACKWARD','ROWWISE',m - k + i - 1,n - &
                     k + i + ib - 1,ib,a(m - k + i,1),lda,work,ldwork,a,lda,work(ib + 1),ldwork)
-                              
+
                  end if
               end do
               mu = m - k + i + nb - 1
@@ -10326,7 +10326,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: a(lda,*)
            complex(qp),intent(inout) :: rhs(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(qp) :: bignum,eps,smlnum
@@ -10401,7 +10401,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: u(ldu,*),vt(ldvt,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wntqa,wntqas,wntqn,wntqo,wntqs
            integer(ilp) :: blk,chunk,i,ie,ierr,il,ir,iru,irvt,iscl,itau,itaup,itauq, &
@@ -10826,7 +10826,7 @@ module stdlib_linalg_lapack_w
                        call stdlib_wgemm('N','N',chunk,n,n,cone,a(i,1),lda,work(iu), &
                                  ldwrku,czero,work(ir),ldwrkr)
                        call stdlib_wlacpy('F',chunk,n,work(ir),ldwrkr,a(i,1),lda)
-                                 
+
                     end do
                  else if (wntqs) then
                     ! path 3 (m >> n, jobz='s')
@@ -11040,7 +11040,7 @@ module stdlib_linalg_lapack_w
                        call stdlib_wlacrm(chunk,n,a(i,1),lda,rwork(iru),n,work(iu), &
                                  ldwrku,rwork(nrwork))
                        call stdlib_wlacpy('F',chunk,n,work(iu),ldwrku,a(i,1),lda)
-                                 
+
                     end do
                  else if (wntqs) then
                     ! path 5s (m >> n, jobz='s')
@@ -11073,7 +11073,7 @@ module stdlib_linalg_lapack_w
                     ! cworkspace: need   0
                     ! rworkspace: need   n [e] + n*n [ru] + n*n [rvt] + 2*n*n [rwork]
                     call stdlib_wlarcm(n,n,rwork(irvt),n,vt,ldvt,a,lda,rwork(nrwork))
-                              
+
                     call stdlib_wlacpy('F',n,n,a,lda,vt,ldvt)
                     ! multiply q in u by realmatrix rwork(iru,KIND=qp), storing the
                     ! result in a, copying to u
@@ -11081,7 +11081,7 @@ module stdlib_linalg_lapack_w
                     ! rworkspace: need   n [e] + n*n [ru] + 2*m*n [rwork] < n + 5*n*n since m < 2*n here
                     nrwork = irvt
                     call stdlib_wlacrm(m,n,u,ldu,rwork(iru),n,a,lda,rwork(nrwork))
-                              
+
                     call stdlib_wlacpy('F',m,n,a,lda,u,ldu)
                  else
                     ! path 5a (m >> n, jobz='a')
@@ -11114,7 +11114,7 @@ module stdlib_linalg_lapack_w
                     ! cworkspace: need   0
                     ! rworkspace: need   n [e] + n*n [ru] + n*n [rvt] + 2*n*n [rwork]
                     call stdlib_wlarcm(n,n,rwork(irvt),n,vt,ldvt,a,lda,rwork(nrwork))
-                              
+
                     call stdlib_wlacpy('F',n,n,a,lda,vt,ldvt)
                     ! multiply q in u by realmatrix rwork(iru,KIND=qp), storing the
                     ! result in a, copying to u
@@ -11122,7 +11122,7 @@ module stdlib_linalg_lapack_w
                     ! rworkspace: need   n [e] + n*n [ru] + 2*m*n [rwork] < n + 5*n*n since m < 2*n here
                     nrwork = irvt
                     call stdlib_wlacrm(m,n,u,ldu,rwork(iru),n,a,lda,rwork(nrwork))
-                              
+
                     call stdlib_wlacpy('F',m,n,a,lda,u,ldu)
                  end if
               else
@@ -11210,7 +11210,7 @@ module stdlib_linalg_lapack_w
                           call stdlib_wlacrm(chunk,n,a(i,1),lda,rwork(iru),n,work(iu) &
                                     ,ldwrku,rwork(nrwork))
                           call stdlib_wlacpy('F',chunk,n,work(iu),ldwrku,a(i,1),lda)
-                                    
+
                        end do
                     end if
                  else if (wntqs) then
@@ -11339,7 +11339,7 @@ module stdlib_linalg_lapack_w
                     ! copy l to work(il), zeroing about above it
                     call stdlib_wlacpy('L',m,m,a,lda,work(il),ldwrkl)
                     call stdlib_wlaset('U',m - 1,m - 1,czero,czero,work(il + ldwrkl),ldwrkl)
-                              
+
                     ! generate q in a
                     ! cworkspace: need   m*m [vt] + m*m [l] + m [tau] + m    [work]
                     ! cworkspace: prefer m*m [vt] + m*m [l] + m [tau] + m*nb [work]
@@ -11392,7 +11392,7 @@ module stdlib_linalg_lapack_w
                        call stdlib_wgemm('N','N',m,blk,m,cone,work(ivt),m,a(1,i), &
                                  lda,czero,work(il),ldwrkl)
                        call stdlib_wlacpy('F',m,blk,work(il),ldwrkl,a(1,i),lda)
-                                 
+
                     end do
                  else if (wntqs) then
                     ! path 3t (n >> m, jobz='s')
@@ -11412,7 +11412,7 @@ module stdlib_linalg_lapack_w
                     ! copy l to work(il), zeroing out above it
                     call stdlib_wlacpy('L',m,m,a,lda,work(il),ldwrkl)
                     call stdlib_wlaset('U',m - 1,m - 1,czero,czero,work(il + ldwrkl),ldwrkl)
-                              
+
                     ! generate q in a
                     ! cworkspace: need   m*m [l] + m [tau] + m    [work]
                     ! cworkspace: prefer m*m [l] + m [tau] + m*nb [work]
@@ -11609,7 +11609,7 @@ module stdlib_linalg_lapack_w
                        call stdlib_wlarcm(m,blk,rwork(irvt),m,a(1,i),lda,work(ivt), &
                                  ldwkvt,rwork(nrwork))
                        call stdlib_wlacpy('F',m,blk,work(ivt),ldwkvt,a(1,i),lda)
-                                 
+
                     end do
                  else if (wntqs) then
                     ! path 5ts (n >> m, jobz='s')
@@ -11642,7 +11642,7 @@ module stdlib_linalg_lapack_w
                     ! cworkspace: need   0
                     ! rworkspace: need   m [e] + m*m [rvt] + m*m [ru] + 2*m*m [rwork]
                     call stdlib_wlacrm(m,m,u,ldu,rwork(iru),m,a,lda,rwork(nrwork))
-                              
+
                     call stdlib_wlacpy('F',m,m,a,lda,u,ldu)
                     ! multiply realmatrix rwork(irvt,KIND=qp) by p**h in vt,
                     ! storing the result in a, copying to vt
@@ -11650,7 +11650,7 @@ module stdlib_linalg_lapack_w
                     ! rworkspace: need   m [e] + m*m [rvt] + 2*m*n [rwork] < m + 5*m*m since n < 2*m here
                     nrwork = iru
                     call stdlib_wlarcm(m,n,rwork(irvt),m,vt,ldvt,a,lda,rwork(nrwork))
-                              
+
                     call stdlib_wlacpy('F',m,n,a,lda,vt,ldvt)
                  else
                     ! path 5ta (n >> m, jobz='a')
@@ -11683,7 +11683,7 @@ module stdlib_linalg_lapack_w
                     ! cworkspace: need   0
                     ! rworkspace: need   m [e] + m*m [rvt] + m*m [ru] + 2*m*m [rwork]
                     call stdlib_wlacrm(m,m,u,ldu,rwork(iru),m,a,lda,rwork(nrwork))
-                              
+
                     call stdlib_wlacpy('F',m,m,a,lda,u,ldu)
                     ! multiply realmatrix rwork(irvt,KIND=qp) by p**h in vt,
                     ! storing the result in a, copying to vt
@@ -11691,7 +11691,7 @@ module stdlib_linalg_lapack_w
                     ! rworkspace: need   m [e] + m*m [rvt] + 2*m*n [rwork] < m + 5*m*m since n < 2*m here
                     nrwork = iru
                     call stdlib_wlarcm(m,n,rwork(irvt),m,vt,ldvt,a,lda,rwork(nrwork))
-                              
+
                     call stdlib_wlacpy('F',m,n,a,lda,vt,ldvt)
                  end if
               else
@@ -11757,7 +11757,7 @@ module stdlib_linalg_lapack_w
                        ! cworkspace: prefer 2*m [tauq, taup] + m*n [vt] + m*nb [work]
                        ! rworkspace: need   m [e] + m*m [rvt]
                        call stdlib_wlacp2('F',m,m,rwork(irvt),m,work(ivt),ldwkvt)
-                                 
+
                        call stdlib_wunmbr('P','R','C',m,n,m,a,lda,work(itaup),work( &
                                  ivt),ldwkvt,work(nwork),lwork - nwork + 1,ierr)
                        call stdlib_wlacpy('F',m,n,work(ivt),ldwkvt,a,lda)
@@ -11781,7 +11781,7 @@ module stdlib_linalg_lapack_w
                           call stdlib_wlarcm(m,blk,rwork(irvt),m,a(1,i),lda,work(ivt) &
                                     ,ldwkvt,rwork(nrwork))
                           call stdlib_wlacpy('F',m,blk,work(ivt),ldwkvt,a(1,i),lda)
-                                    
+
                        end do
                     end if
                  else if (wntqs) then
@@ -11936,7 +11936,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: u(ldu,*),vt(ldvt,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wntua,wntuas,wntun,wntuo,wntus,wntva,wntvas,wntvn,wntvo, &
                       wntvs
@@ -12006,7 +12006,7 @@ module stdlib_linalg_lapack_w
                  lwork_wungqr_m = int(cdum(1),KIND=ilp)
                  ! compute space needed for stdlib_wgebrd
                  call stdlib_wgebrd(n,n,a,lda,s,dum(1),cdum(1),cdum(1),cdum(1),-1,ierr)
-                           
+
                  lwork_wgebrd = int(cdum(1),KIND=ilp)
                  ! compute space needed for stdlib_wungbr
                  call stdlib_wungbr('P',n,n,n,a,lda,cdum(1),cdum(1),-1,ierr)
@@ -12101,13 +12101,13 @@ module stdlib_linalg_lapack_w
                     maxwrk = 2*n + lwork_wgebrd
                     if (wntus .or. wntuo) then
                        call stdlib_wungbr('Q',m,n,n,a,lda,cdum(1),cdum(1),-1,ierr)
-                                 
+
                        lwork_wungbr_q = int(cdum(1),KIND=ilp)
                        maxwrk = max(maxwrk,2*n + lwork_wungbr_q)
                     end if
                     if (wntua) then
                        call stdlib_wungbr('Q',m,m,n,a,lda,cdum(1),cdum(1),-1,ierr)
-                                 
+
                        lwork_wungbr_q = int(cdum(1),KIND=ilp)
                        maxwrk = max(maxwrk,2*n + lwork_wungbr_q)
                     end if
@@ -12129,7 +12129,7 @@ module stdlib_linalg_lapack_w
                  lwork_wunglq_m = int(cdum(1),KIND=ilp)
                  ! compute space needed for stdlib_wgebrd
                  call stdlib_wgebrd(m,m,a,lda,s,dum(1),cdum(1),cdum(1),cdum(1),-1,ierr)
-                           
+
                  lwork_wgebrd = int(cdum(1),KIND=ilp)
                   ! compute space needed for stdlib_wungbr p
                  call stdlib_wungbr('P',m,m,m,a,n,cdum(1),cdum(1),-1,ierr)
@@ -12346,7 +12346,7 @@ module stdlib_linalg_lapack_w
                        ! copy r to work(ir) and zero out below it
                        call stdlib_wlacpy('U',n,n,a,lda,work(ir),ldwrkr)
                        call stdlib_wlaset('L',n - 1,n - 1,czero,czero,work(ir + 1),ldwrkr)
-                                 
+
                        ! generate q in a
                        ! (cworkspace: need n*n+2*n, prefer n*n+n+n*nb)
                        ! (rworkspace: 0)
@@ -12383,7 +12383,7 @@ module stdlib_linalg_lapack_w
                           call stdlib_wgemm('N','N',chunk,n,n,cone,a(i,1),lda,work(ir &
                                     ),ldwrkr,czero,work(iu),ldwrku)
                           call stdlib_wlacpy('F',chunk,n,work(iu),ldwrku,a(i,1),lda)
-                                    
+
                        end do
                     else
                        ! insufficient workspace for a fast algorithm
@@ -12439,7 +12439,7 @@ module stdlib_linalg_lapack_w
                        ! copy r to vt, zeroing out below it
                        call stdlib_wlacpy('U',n,n,a,lda,vt,ldvt)
                        if (n > 1) call stdlib_wlaset('L',n - 1,n - 1,czero,czero,vt(2,1),ldvt)
-                                 
+
                        ! generate q in a
                        ! (cworkspace: need n*n+2*n, prefer n*n+n+n*nb)
                        ! (rworkspace: 0)
@@ -12483,7 +12483,7 @@ module stdlib_linalg_lapack_w
                           call stdlib_wgemm('N','N',chunk,n,n,cone,a(i,1),lda,work(ir &
                                     ),ldwrkr,czero,work(iu),ldwrku)
                           call stdlib_wlacpy('F',chunk,n,work(iu),ldwrku,a(i,1),lda)
-                                    
+
                        end do
                     else
                        ! insufficient workspace for a fast algorithm
@@ -12497,7 +12497,7 @@ module stdlib_linalg_lapack_w
                        ! copy r to vt, zeroing out below it
                        call stdlib_wlacpy('U',n,n,a,lda,vt,ldvt)
                        if (n > 1) call stdlib_wlaset('L',n - 1,n - 1,czero,czero,vt(2,1),ldvt)
-                                 
+
                        ! generate q in a
                        ! (cworkspace: need 2*n, prefer n+n*nb)
                        ! (rworkspace: 0)
@@ -12556,7 +12556,7 @@ module stdlib_linalg_lapack_w
                           ! copy r to work(ir), zeroing out below it
                           call stdlib_wlacpy('U',n,n,a,lda,work(ir),ldwrkr)
                           call stdlib_wlaset('L',n - 1,n - 1,czero,czero,work(ir + 1),ldwrkr)
-                                    
+
                           ! generate q in a
                           ! (cworkspace: need n*n+2*n, prefer n*n+n+n*nb)
                           ! (rworkspace: 0)
@@ -12611,7 +12611,7 @@ module stdlib_linalg_lapack_w
                           ! zero out below r in a
                           if (n > 1) then
                              call stdlib_wlaset('L',n - 1,n - 1,czero,czero,a(2,1),lda)
-                                       
+
                           end if
                           ! bidiagonalize r in a
                           ! (cworkspace: need 3*n, prefer 2*n+2*n*nb)
@@ -12664,7 +12664,7 @@ module stdlib_linalg_lapack_w
                           ! copy r to work(iu), zeroing out below it
                           call stdlib_wlacpy('U',n,n,a,lda,work(iu),ldwrku)
                           call stdlib_wlaset('L',n - 1,n - 1,czero,czero,work(iu + 1),ldwrku)
-                                    
+
                           ! generate q in a
                           ! (cworkspace: need 2*n*n+2*n, prefer 2*n*n+n+n*nb)
                           ! (rworkspace: 0)
@@ -12682,7 +12682,7 @@ module stdlib_linalg_lapack_w
                           call stdlib_wgebrd(n,n,work(iu),ldwrku,s,rwork(ie),work( &
                                     itauq),work(itaup),work(iwork),lwork - iwork + 1,ierr)
                           call stdlib_wlacpy('U',n,n,work(iu),ldwrku,work(ir),ldwrkr)
-                                    
+
                           ! generate left bidiagonalizing vectors in work(iu)
                           ! (cworkspace: need 2*n*n+3*n, prefer 2*n*n+2*n+n*nb)
                           ! (rworkspace: 0)
@@ -12734,7 +12734,7 @@ module stdlib_linalg_lapack_w
                           ! zero out below r in a
                           if (n > 1) then
                              call stdlib_wlaset('L',n - 1,n - 1,czero,czero,a(2,1),lda)
-                                       
+
                           end if
                           ! bidiagonalize r in a
                           ! (cworkspace: need 3*n, prefer 2*n+2*n*nb)
@@ -12785,7 +12785,7 @@ module stdlib_linalg_lapack_w
                           ! copy r to work(iu), zeroing out below it
                           call stdlib_wlacpy('U',n,n,a,lda,work(iu),ldwrku)
                           call stdlib_wlaset('L',n - 1,n - 1,czero,czero,work(iu + 1),ldwrku)
-                                    
+
                           ! generate q in a
                           ! (cworkspace: need n*n+2*n, prefer n*n+n+n*nb)
                           ! (rworkspace: 0)
@@ -12901,7 +12901,7 @@ module stdlib_linalg_lapack_w
                           ! copy r to work(ir), zeroing out below it
                           call stdlib_wlacpy('U',n,n,a,lda,work(ir),ldwrkr)
                           call stdlib_wlaset('L',n - 1,n - 1,czero,czero,work(ir + 1),ldwrkr)
-                                    
+
                           ! generate q in u
                           ! (cworkspace: need n*n+n+m, prefer n*n+n+m*nb)
                           ! (rworkspace: 0)
@@ -12958,7 +12958,7 @@ module stdlib_linalg_lapack_w
                           ! zero out below r in a
                           if (n > 1) then
                              call stdlib_wlaset('L',n - 1,n - 1,czero,czero,a(2,1),lda)
-                                       
+
                           end if
                           ! bidiagonalize r in a
                           ! (cworkspace: need 3*n, prefer 2*n+2*n*nb)
@@ -13018,7 +13018,7 @@ module stdlib_linalg_lapack_w
                           ! copy r to work(iu), zeroing out below it
                           call stdlib_wlacpy('U',n,n,a,lda,work(iu),ldwrku)
                           call stdlib_wlaset('L',n - 1,n - 1,czero,czero,work(iu + 1),ldwrku)
-                                    
+
                           ie = 1
                           itauq = itau
                           itaup = itauq + n
@@ -13031,7 +13031,7 @@ module stdlib_linalg_lapack_w
                           call stdlib_wgebrd(n,n,work(iu),ldwrku,s,rwork(ie),work( &
                                     itauq),work(itaup),work(iwork),lwork - iwork + 1,ierr)
                           call stdlib_wlacpy('U',n,n,work(iu),ldwrku,work(ir),ldwrkr)
-                                    
+
                           ! generate left bidiagonalizing vectors in work(iu)
                           ! (cworkspace: need 2*n*n+3*n, prefer 2*n*n+2*n+n*nb)
                           ! (rworkspace: 0)
@@ -13083,7 +13083,7 @@ module stdlib_linalg_lapack_w
                           ! zero out below r in a
                           if (n > 1) then
                              call stdlib_wlaset('L',n - 1,n - 1,czero,czero,a(2,1),lda)
-                                       
+
                           end if
                           ! bidiagonalize r in a
                           ! (cworkspace: need 3*n, prefer 2*n+2*n*nb)
@@ -13141,7 +13141,7 @@ module stdlib_linalg_lapack_w
                           ! copy r to work(iu), zeroing out below it
                           call stdlib_wlacpy('U',n,n,a,lda,work(iu),ldwrku)
                           call stdlib_wlaset('L',n - 1,n - 1,czero,czero,work(iu + 1),ldwrku)
-                                    
+
                           ie = 1
                           itauq = itau
                           itaup = itauq + n
@@ -13386,7 +13386,7 @@ module stdlib_linalg_lapack_w
                        ! copy l to work(ir) and zero out above it
                        call stdlib_wlacpy('L',m,m,a,lda,work(ir),ldwrkr)
                        call stdlib_wlaset('U',m - 1,m - 1,czero,czero,work(ir + ldwrkr),ldwrkr)
-                                 
+
                        ! generate q in a
                        ! (cworkspace: need m*m+2*m, prefer m*m+m+m*nb)
                        ! (rworkspace: 0)
@@ -13423,7 +13423,7 @@ module stdlib_linalg_lapack_w
                           call stdlib_wgemm('N','N',m,blk,m,cone,work(ir),ldwrkr,a(1, &
                                     i),lda,czero,work(iu),ldwrku)
                           call stdlib_wlacpy('F',m,blk,work(iu),ldwrku,a(1,i),lda)
-                                    
+
                        end do
                     else
                        ! insufficient workspace for a fast algorithm
@@ -13525,7 +13525,7 @@ module stdlib_linalg_lapack_w
                           call stdlib_wgemm('N','N',m,blk,m,cone,work(ir),ldwrkr,a(1, &
                                     i),lda,czero,work(iu),ldwrku)
                           call stdlib_wlacpy('F',m,blk,work(iu),ldwrku,a(1,i),lda)
-                                    
+
                        end do
                     else
                        ! insufficient workspace for a fast algorithm
@@ -13722,7 +13722,7 @@ module stdlib_linalg_lapack_w
                           call stdlib_wgebrd(m,m,work(iu),ldwrku,s,rwork(ie),work( &
                                     itauq),work(itaup),work(iwork),lwork - iwork + 1,ierr)
                           call stdlib_wlacpy('L',m,m,work(iu),ldwrku,work(ir),ldwrkr)
-                                    
+
                           ! generate right bidiagonalizing vectors in work(iu)
                           ! (cworkspace: need   2*m*m+3*m-1,
                                        ! prefer 2*m*m+2*m+(m-1)*nb)
@@ -14065,7 +14065,7 @@ module stdlib_linalg_lapack_w
                           call stdlib_wgebrd(m,m,work(iu),ldwrku,s,rwork(ie),work( &
                                     itauq),work(itaup),work(iwork),lwork - iwork + 1,ierr)
                           call stdlib_wlacpy('L',m,m,work(iu),ldwrku,work(ir),ldwrkr)
-                                    
+
                           ! generate right bidiagonalizing vectors in work(iu)
                           ! (cworkspace: need   2*m*m+3*m-1,
                                        ! prefer 2*m*m+2*m+(m-1)*nb)
@@ -14378,7 +14378,7 @@ module stdlib_linalg_lapack_w
            real(qp),intent(out) :: s(*),rwork(*)
            integer(ilp),intent(out) :: iwork(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: ierr,nr,n1,optratio,p,q
            integer(ilp) :: lwcon,lwqp3,lwrk_wgelqf,lwrk_wgesvd,lwrk_wgesvd2,lwrk_wgeqp3, &
@@ -14466,7 +14466,7 @@ module stdlib_linalg_lapack_w
               lwsvd = max(3*n,1)
               if (lquery) then
                   call stdlib_wgeqp3(m,n,a,lda,iwork,cdummy,cdummy,-1,rdummy,ierr)
-                            
+
                   lwrk_wgeqp3 = int(cdummy(1),KIND=ilp)
                   if (wntus .or. wntur) then
                       call stdlib_wunmqr('L','N',m,n,n,a,lda,cdummy,u,ldu,cdummy,-1, &
@@ -14703,7 +14703,7 @@ module stdlib_linalg_lapack_w
                      ! .. to prevent overflow in the qr factorization, scale the
                      ! matrix by 1/sqrt(m) if too large entry detected
                      call stdlib_wlascl('G',0,0,sqrt(real(m,KIND=qp)),one,m,n,a,lda,ierr)
-                               
+
                      ascaled = .true.
                  end if
                  call stdlib_wlaswp(n,a,lda,1,m - 1,iwork(n + 1),1)
@@ -14723,7 +14723,7 @@ module stdlib_linalg_lapack_w
                    ! .. to prevent overflow in the qr factorization, scale the
                    ! matrix by 1/sqrt(m) if too large entry detected
                    call stdlib_wlascl('G',0,0,sqrt(real(m,KIND=qp)),one,m,n,a,lda,ierr)
-                             
+
                    ascaled = .true.
                end if
            end if
@@ -14735,7 +14735,7 @@ module stdlib_linalg_lapack_w
               iwork(p) = 0
            end do
            call stdlib_wgeqp3(m,n,a,lda,iwork,cwork,cwork(n + 1),lcwork - n,rwork,ierr)
-                     
+
           ! if the user requested accuracy level allows truncation in the
           ! computed upper triangular factor, the matrix r is examined and,
           ! if possible, replaced with its leading upper trapezoidal part.
@@ -14754,7 +14754,7 @@ module stdlib_linalg_lapack_w
                  if (abs(a(p,p)) < (rtmp*abs(a(1,1)))) go to 3002
                     nr = nr + 1
               end do
-3002          continue
+              3002 continue
            elseif (acclm) then
               ! .. similarly as above, only slightly more gentle (less aggressive).
               ! sudden drop on the diagonal of r is used as the criterion for being
@@ -14768,7 +14768,7 @@ module stdlib_linalg_lapack_w
                            to 3402
                  nr = nr + 1
               end do
-3402          continue
+              3402 continue
            else
               ! Rrqr Not Authorized To Determine Numerical Rank Except In The
               ! obvious case of zero pivots.
@@ -14779,7 +14779,7 @@ module stdlib_linalg_lapack_w
                  if (abs(a(p,p)) == zero) go to 3502
                  nr = nr + 1
               end do
-3502          continue
+              3502 continue
               if (conda) then
                  ! estimate the scaled condition number of a. use the fact that it is
                  ! the same as the scaled condition number of r.
@@ -14796,10 +14796,10 @@ module stdlib_linalg_lapack_w
                     end do
                     if (.not. (lsvec .or. rsvec)) then
                         call stdlib_wpocon('U',nr,v,ldv,one,rtmp,cwork,rwork,ierr)
-                                  
+
                     else
                         call stdlib_wpocon('U',nr,v,ldv,one,rtmp,cwork(n + 1),rwork,ierr)
-                                  
+
                     end if
                     sconda = one/sqrt(rtmp)
                  ! for nr=n, sconda is an estimate of sqrt(||(r^* * r)^(-1)||_1),
@@ -14834,7 +14834,7 @@ module stdlib_linalg_lapack_w
               else
                  ! .. compute the singular values of r = [a](1:nr,1:n)
                  if (nr > 1) call stdlib_wlaset('L',nr - 1,nr - 1,czero,czero,a(2,1),lda)
-                           
+
                  call stdlib_wgesvd('N','N',nr,n,a,lda,s,u,ldu,v,ldv,cwork,lcwork, &
                            rwork,info)
               end if
@@ -14852,7 +14852,7 @@ module stdlib_linalg_lapack_w
                     end do
                  end do
                  if (nr > 1) call stdlib_wlaset('U',nr - 1,nr - 1,czero,czero,u(1,2),ldu)
-                           
+
                  ! .. the left singular vectors not computed, the nr right singular
                  ! vectors overwrite [u](1:nr,1:nr) as conjugate transposed. these
                  ! will be pre-multiplied by q to build the left singular vectors of a.
@@ -14871,7 +14871,7 @@ module stdlib_linalg_lapack_w
                   ! .. copy r into [u] and overwrite [u] with the left singular vectors
                   call stdlib_wlacpy('U',nr,n,a,lda,u,ldu)
                   if (nr > 1) call stdlib_wlaset('L',nr - 1,nr - 1,czero,czero,u(2,1),ldu)
-                            
+
                   ! .. the right singular vectors not computed, the nr left singular
                   ! vectors overwrite [u](1:nr,1:nr)
                      call stdlib_wgesvd('O','N',nr,n,u,ldu,s,u,ldu,v,ldv,cwork(n + 1), &
@@ -14908,7 +14908,7 @@ module stdlib_linalg_lapack_w
                     end do
                  end do
                  if (nr > 1) call stdlib_wlaset('U',nr - 1,nr - 1,czero,czero,v(1,2),ldv)
-                           
+
                  ! .. the left singular vectors of r**h overwrite v, the right singular
                  ! vectors not computed
                  if (wntvr .or. (nr == n)) then
@@ -14954,7 +14954,7 @@ module stdlib_linalg_lapack_w
                   ! Copy R Into V And Overwrite V With The Right Singular Vectors
                   call stdlib_wlacpy('U',nr,n,a,lda,v,ldv)
                   if (nr > 1) call stdlib_wlaset('L',nr - 1,nr - 1,czero,czero,v(2,1),ldv)
-                            
+
                   ! .. the right singular vectors overwrite v, the nr left singular
                   ! vectors stored in u(1:nr,1:nr)
                   if (wntvr .or. (nr == n)) then
@@ -14991,7 +14991,7 @@ module stdlib_linalg_lapack_w
                     end do
                  end do
                  if (nr > 1) call stdlib_wlaset('U',nr - 1,nr - 1,czero,czero,v(1,2),ldv)
-                           
+
                  ! .. the left singular vectors of r**h overwrite [v], the nr right
                  ! singular vectors of r**h stored in [u](1:nr,1:nr) as conjugate
                  ! transposed
@@ -15027,7 +15027,7 @@ module stdlib_linalg_lapack_w
                        if (nr < n1) then
                           call stdlib_wlaset('A',nr,n1 - nr,czero,czero,u(1,nr + 1),ldu)
                           call stdlib_wlaset('A',m - nr,n1 - nr,czero,cone,u(nr + 1,nr + 1),ldu)
-                                    
+
                        end if
                     end if
                  else
@@ -15047,7 +15047,7 @@ module stdlib_linalg_lapack_w
                            end do
                         end do
                         if (nr > 1) call stdlib_wlaset('U',nr - 1,nr - 1,czero,czero,v(1,2),ldv)
-                                  
+
                         call stdlib_wlaset('A',n,n - nr,czero,czero,v(1,nr + 1),ldv)
                         call stdlib_wgesvd('O','A',n,n,v,ldv,s,v,ldv,u,ldu,cwork(n + 1), &
                                   lcwork - n,rwork,info)
@@ -15086,7 +15086,7 @@ module stdlib_linalg_lapack_w
                            end do
                         end do
                         if (nr > 1) call stdlib_wlaset('U',nr - 1,nr - 1,czero,czero,u(1,nr + 2),ldu)
-                                  
+
                         call stdlib_wgeqrf(n,nr,u(1,nr + 1),ldu,cwork(n + 1),cwork(n + nr + 1), &
                                   lcwork - n - nr,ierr)
                         do p = 1,nr
@@ -15120,7 +15120,7 @@ module stdlib_linalg_lapack_w
                       ! .. copy r into [v] and overwrite v with the right singular vectors
                       call stdlib_wlacpy('U',nr,n,a,lda,v,ldv)
                      if (nr > 1) call stdlib_wlaset('L',nr - 1,nr - 1,czero,czero,v(2,1),ldv)
-                               
+
                      ! .. the right singular vectors of r overwrite [v], the nr left
                      ! singular vectors of r stored in [u](1:nr,1:nr)
                      call stdlib_wgesvd('S','O',nr,n,v,ldv,s,u,ldu,v,ldv,cwork(n + 1), &
@@ -15134,7 +15134,7 @@ module stdlib_linalg_lapack_w
                        if (nr < n1) then
                           call stdlib_wlaset('A',nr,n1 - nr,czero,czero,u(1,nr + 1),ldu)
                           call stdlib_wlaset('A',m - nr,n1 - nr,czero,cone,u(nr + 1,nr + 1),ldu)
-                                    
+
                        end if
                     end if
                   else
@@ -15150,7 +15150,7 @@ module stdlib_linalg_lapack_w
                     if (optratio*nr > n) then
                        call stdlib_wlacpy('U',nr,n,a,lda,v,ldv)
                        if (nr > 1) call stdlib_wlaset('L',nr - 1,nr - 1,czero,czero,v(2,1),ldv)
-                                 
+
                     ! .. the right singular vectors of r overwrite [v], the nr left
                        ! singular vectors of r stored in [u](1:nr,1:nr)
                        call stdlib_wlaset('A',n - nr,n,czero,czero,v(nr + 1,1),ldv)
@@ -15172,12 +15172,12 @@ module stdlib_linalg_lapack_w
                     else
                        call stdlib_wlacpy('U',nr,n,a,lda,u(nr + 1,1),ldu)
                        if (nr > 1) call stdlib_wlaset('L',nr - 1,nr - 1,czero,czero,u(nr + 2,1),ldu)
-                                 
+
                        call stdlib_wgelqf(nr,n,u(nr + 1,1),ldu,cwork(n + 1),cwork(n + nr + 1), &
                                  lcwork - n - nr,ierr)
                        call stdlib_wlacpy('L',nr,nr,u(nr + 1,1),ldu,v,ldv)
                        if (nr > 1) call stdlib_wlaset('U',nr - 1,nr - 1,czero,czero,v(1,2),ldv)
-                                 
+
                        call stdlib_wgesvd('S','O',nr,nr,v,ldv,s,u,ldu,v,ldv,cwork(n + nr + &
                                  1),lcwork - n - nr,rwork,info)
                        call stdlib_wlaset('A',n - nr,nr,czero,czero,v(nr + 1,1),ldv)
@@ -15193,7 +15193,7 @@ module stdlib_linalg_lapack_w
                           if (nr < n1) then
                           call stdlib_wlaset('A',nr,n1 - nr,czero,czero,u(1,nr + 1),ldu)
                           call stdlib_wlaset('A',m - nr,n1 - nr,czero,cone,u(nr + 1,nr + 1),ldu)
-                                    
+
                           end if
                        end if
                     end if
@@ -15215,7 +15215,7 @@ module stdlib_linalg_lapack_w
                if (s(q) > zero) go to 4002
                nr = nr - 1
            end do
-4002       continue
+           4002 continue
            ! .. if numerical rank deficiency is detected, the truncated
            ! singular values are set to zero.
            if (nr < n) call stdlib_qlaset('G',n - nr,1,zero,zero,s(nr + 1),n)
@@ -15258,7 +15258,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Local Parameters
            integer(ilp),parameter :: nsweep = 30
-           
+
            ! Local Scalars
            complex(qp) :: aapq,ompq
            real(qp) :: aapp,aapp0,aapq1,aaqq,apoaq,aqoap,big,bigtheta,cs,ctol,epsln, &
@@ -15470,7 +15470,7 @@ module stdlib_linalg_lapack_w
        ! #:) quick return for one-column matrix
            if (n == 1) then
               if (lsvec) call stdlib_wlascl('G',0,0,sva(1),skl,m,1,a(1,1),lda,ierr)
-                        
+
               rwork(1) = one/skl
               if (sva(1) >= sfmin) then
                  rwork(2) = one
@@ -15586,12 +15586,12 @@ module stdlib_linalg_lapack_w
                            tol,2,cwork(n + 1),lwork - n,ierr)
                  call stdlib_wgsvj0(jobv,n2,n4,a(1,n4 + 1),lda,cwork(n4 + 1),sva(n4 + 1), &
                  mvl,v(n4*q + 1,n4 + 1),ldv,epsln,sfmin,tol,1,cwork(n + 1),lwork - n,ierr)
-                           
+
                  call stdlib_wgsvj1(jobv,n2,n2,n4,a,lda,cwork,sva,mvl,v,ldv,epsln, &
                            sfmin,tol,1,cwork(n + 1),lwork - n,ierr)
                  call stdlib_wgsvj0(jobv,n2 + n4,n4,a(1,n2 + 1),lda,cwork(n2 + 1),sva(n2 + 1) &
                  ,mvl,v(n2*q + 1,n2 + 1),ldv,epsln,sfmin,tol,1,cwork(n + 1),lwork - n,ierr)
-                           
+
               end if
            end if
            ! .. row-cyclic pivot strategy with de rijk's pivoting ..
@@ -15705,19 +15705,19 @@ module stdlib_linalg_lapack_w
                                                        conjg(ompq)*t)
                                          end if
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq1))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq1))
                                          mxsinj = max(mxsinj,abs(t))
                                       else
                        ! Choose Correct Signum For Theta And Rotate
                                          thsign = -sign(one,aapq1)
                                          t = one/(theta + thsign*sqrt(one + theta*theta))
-                                                   
+
                                          cs = sqrt(one/(one + t*t))
                                          sn = t*cs
                                          mxsinj = max(mxsinj,abs(sn))
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq1))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq1))
                                          call stdlib_wrot(m,a(1,p),1,a(1,q),1,cs,conjg(ompq) &
                                                    *sn)
@@ -15735,7 +15735,7 @@ module stdlib_linalg_lapack_w
                                       call stdlib_wlascl('G',0,0,aaqq,one,m,1,a(1,q), &
                                                 lda,ierr)
                                       call stdlib_waxpy(m,-aapq,cwork(n + 1),1,a(1,q),1)
-                                                
+
                                       call stdlib_wlascl('G',0,0,one,aaqq,m,1,a(1,q), &
                                                 lda,ierr)
                                       sva(q) = aaqq*sqrt(max(zero,one - aapq1*aapq1))
@@ -15783,7 +15783,7 @@ module stdlib_linalg_lapack_w
                              end if
                           end do loop_2002
            ! end q-loop
-2103 continue
+           2103 continue
            ! bailed out of q-loop
                           sva(p) = aapp
                        else
@@ -15870,7 +15870,7 @@ module stdlib_linalg_lapack_w
                                                        conjg(ompq)*t)
                                          end if
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq1))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq1))
                                          mxsinj = max(mxsinj,abs(t))
                                       else
@@ -15878,12 +15878,12 @@ module stdlib_linalg_lapack_w
                                          thsign = -sign(one,aapq1)
                                          if (aaqq > aapp0) thsign = -thsign
                                          t = one/(theta + thsign*sqrt(one + theta*theta))
-                                                   
+
                                          cs = sqrt(one/(one + t*t))
                                          sn = t*cs
                                          mxsinj = max(mxsinj,abs(sn))
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq1))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq1))
                                          call stdlib_wrot(m,a(1,p),1,a(1,q),1,cs,conjg(ompq) &
                                                    *sn)
@@ -15897,17 +15897,17 @@ module stdlib_linalg_lapack_w
                     ! .. have to use modified gram-schmidt like transformation
                                     if (aapp > aaqq) then
                                          call stdlib_wcopy(m,a(1,p),1,cwork(n + 1),1)
-                                                   
+
                                          call stdlib_wlascl('G',0,0,aapp,one,m,1,cwork(n + 1) &
                                                    ,lda,ierr)
                                          call stdlib_wlascl('G',0,0,aaqq,one,m,1,a(1,q), &
                                                     lda,ierr)
                                          call stdlib_waxpy(m,-aapq,cwork(n + 1),1,a(1,q),1)
-                                                   
+
                                          call stdlib_wlascl('G',0,0,one,aaqq,m,1,a(1,q), &
                                                     lda,ierr)
                                          sva(q) = aaqq*sqrt(max(zero,one - aapq1*aapq1))
-                                                   
+
                                          mxsinj = max(mxsinj,sfmin)
                                     else
                                         call stdlib_wcopy(m,a(1,q),1,cwork(n + 1),1)
@@ -15920,7 +15920,7 @@ module stdlib_linalg_lapack_w
                                          call stdlib_wlascl('G',0,0,one,aapp,m,1,a(1,p), &
                                                     lda,ierr)
                                          sva(p) = aapp*sqrt(max(zero,one - aapq1*aapq1))
-                                                   
+
                                          mxsinj = max(mxsinj,sfmin)
                                     end if
                                    end if
@@ -15972,7 +15972,7 @@ module stdlib_linalg_lapack_w
                              end if
                           end do loop_2200
               ! end of the q-loop
-2203 continue
+              2203 continue
                           sva(p) = aapp
                        else
                           if (aapp == zero) notrot = notrot + min(jgl + kbl - 1,n) - jgl + 1
@@ -15982,7 +15982,7 @@ module stdlib_linalg_lapack_w
            ! end of the p-loop
                  end do loop_2010
            ! end of the jbc-loop
-2011 continue
+           2011 continue
       ! 2011 bailed out of the jbc-loop
                  do p = igl,min(igl + kbl - 1,n)
                     sva(p) = abs(sva(p))
@@ -16011,12 +16011,12 @@ module stdlib_linalg_lapack_w
        ! #:( reaching this point means that the procedure has not converged.
            info = nsweep - 1
            go to 1995
-1994       continue
+           1994 continue
        ! #:) reaching this point means numerical convergence after the i-th
            ! sweep.
            info = 0
        ! #:) info = 0 confirms successful iterations.
-1995 continue
+       1995 continue
            ! sort the singular values and find how many are above
            ! the underflow threshold.
            n2 = 0
@@ -16107,7 +16107,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*),af(ldaf,*),b(ldb,*)
            complex(qp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: colequ,equil,nofact,notran,rowequ
            character :: norm
@@ -16304,7 +16304,7 @@ module stdlib_linalg_lapack_w
            integer(ilp),intent(out) :: ipiv(*),jpiv(*)
            complex(qp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,ip,ipv,j,jp,jpv
            real(qp) :: bignum,eps,smin,smlnum,xmax
@@ -16391,7 +16391,7 @@ module stdlib_linalg_lapack_w
            integer(ilp),intent(out) :: ipiv(*)
            complex(qp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(qp) :: sfmin
            integer(ilp) :: i,j,jp
@@ -16464,7 +16464,7 @@ module stdlib_linalg_lapack_w
            integer(ilp),intent(out) :: ipiv(*)
            complex(qp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,iinfo,j,jb,nb
            ! Intrinsic Functions
@@ -16514,7 +16514,7 @@ module stdlib_linalg_lapack_w
                        ! update trailing submatrix.
                        call stdlib_wgemm('NO TRANSPOSE','NO TRANSPOSE',m - j - jb + 1,n - j - jb + 1,jb,- &
                        cone,a(j + jb,j),lda,a(j,j + jb),lda,cone,a(j + jb,j + jb),lda)
-                                 
+
                     end if
                  end if
               end do
@@ -16553,7 +16553,7 @@ module stdlib_linalg_lapack_w
            integer(ilp),intent(out) :: ipiv(*)
            complex(qp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(qp) :: sfmin
            complex(qp) :: temp
@@ -16621,7 +16621,7 @@ module stdlib_linalg_lapack_w
               call stdlib_wlaswp(n2,a(1,n1 + 1),lda,1,n1,ipiv,1)
               ! solve a12
               call stdlib_wtrsm('L','L','N','U',n1,n2,cone,a,lda,a(1,n1 + 1),lda)
-                        
+
               ! update a22
               call stdlib_wgemm('N','N',m - n1,n2,n1,-cone,a(n1 + 1,1),lda,a(1,n1 + 1), &
                         lda,cone,a(n1 + 1,n1 + 1),lda)
@@ -16655,7 +16655,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,iws,j,jb,jj,jp,ldwork,lwkopt,nb,nbmin,nn
@@ -16758,7 +16758,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: a(lda,*)
            complex(qp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran
            ! Intrinsic Functions
@@ -16802,7 +16802,7 @@ module stdlib_linalg_lapack_w
                         )
               ! solve l**t *x = b, or l**h *x = b overwriting b with x.
               call stdlib_wtrsm('LEFT','LOWER',trans,'UNIT',n,nrhs,cone,a,lda,b,ldb)
-                        
+
               ! apply row interchanges to the solution vectors.
               call stdlib_wlaswp(nrhs,b,ldb,1,n,ipiv,-1)
            end if
@@ -16840,7 +16840,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,tran
            integer(ilp) :: i,iascl,ibscl,j,maxmn,brow,scllen,tszo,tszm,lwo,lwm,lw1, &
@@ -17040,7 +17040,7 @@ module stdlib_linalg_lapack_w
            else if (ibscl == 2) then
              call stdlib_wlascl('G',0,0,bignum,bnrm,scllen,nrhs,b,ldb,info)
            end if
-50         continue
+           50 continue
            work(1) = real(tszo + lwo,KIND=qp)
            return
      end subroutine stdlib_wgetsls
@@ -17059,7 +17059,7 @@ module stdlib_linalg_lapack_w
      !> of ZGEQRT for more details on the format.
 
      pure subroutine stdlib_wgetsqrhrt(m,n,mb1,nb1,nb2,a,lda,t,ldt,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -17070,7 +17070,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: t(ldt,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,iinfo,j,lw1,lw2,lwt,ldwt,lworkopt,nb1local,nb2local, &
@@ -17139,7 +17139,7 @@ module stdlib_linalg_lapack_w
            nb2local = min(nb2,n)
            ! (1) perform tsqr-factorization of the m-by-n matrix a.
            call stdlib_wlatsqr(m,n,mb1,nb1local,a,lda,work,ldwt,work(lwt + 1),lw1,iinfo)
-                     
+
            ! (2) copy the factor r_tsqr stored in the upper-triangular part
                ! of a into the square matrix in the work array
                ! work(lwt+1:lwt+n*n) column-by-column.
@@ -17153,7 +17153,7 @@ module stdlib_linalg_lapack_w
            ! (4) perform the reconstruction of householder vectors from
            ! the matrix q (stored in a) in place.
            call stdlib_wunhr_col(m,n,nb2local,a,lda,t,ldt,work(lwt + n*n + 1),iinfo)
-                     
+
            ! (5) copy the factor r_tsqr stored in the square matrix in the
            ! work array work(lwt+1:lwt+n*n) into the upper-triangular
            ! part of a.
@@ -17184,7 +17184,7 @@ module stdlib_linalg_lapack_w
      !> ZGGBAL.
 
      pure subroutine stdlib_wggbak(job,side,n,ilo,ihi,lscale,rscale,m,v,ldv,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -17251,7 +17251,7 @@ module stdlib_linalg_lapack_w
               end if
            end if
            ! backward permutation
-30   continue
+           30 continue
            if (stdlib_lsame(job,'P') .or. stdlib_lsame(job,'B')) then
               ! backward permutation on right eigenvectors
               if (rightv) then
@@ -17261,7 +17261,7 @@ module stdlib_linalg_lapack_w
                     if (k == i) cycle loop_40
                     call stdlib_wswap(m,v(i,1),ldv,v(k,1),ldv)
                  end do loop_40
-50               continue
+                 50 continue
                  if (ihi == n) go to 70
                  loop_60: do i = ihi + 1,n
                     k = int(rscale(i),KIND=ilp)
@@ -17270,7 +17270,7 @@ module stdlib_linalg_lapack_w
                  end do loop_60
               end if
               ! backward permutation on left eigenvectors
-70   continue
+              70 continue
               if (leftv) then
                  if (ilo == 1) go to 90
                  loop_80: do i = ilo - 1,1,-1
@@ -17278,7 +17278,7 @@ module stdlib_linalg_lapack_w
                     if (k == i) cycle loop_80
                     call stdlib_wswap(m,v(i,1),ldv,v(k,1),ldv)
                  end do loop_80
-90               continue
+                 90 continue
                  if (ihi == n) go to 110
                  loop_100: do i = ihi + 1,n
                     k = int(lscale(i),KIND=ilp)
@@ -17287,7 +17287,7 @@ module stdlib_linalg_lapack_w
                  end do loop_100
               end if
            end if
-110        continue
+           110 continue
            return
      end subroutine stdlib_wggbak
 
@@ -17302,7 +17302,7 @@ module stdlib_linalg_lapack_w
      !> generalized eigenvalue problem A*x = lambda*B*x.
 
      pure subroutine stdlib_wggbal(job,n,a,lda,b,ldb,ilo,ihi,lscale,rscale,work,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -17316,7 +17316,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: sclfac = 1.0e+1_qp
-           
+
            ! Local Scalars
            integer(ilp) :: i,icab,iflow,ip1,ir,irab,it,j,jc,jp1,k,kount,l,lcab,lm1, &
                      lrab,lsfmax,lsfmin,m,nr,nrp2
@@ -17374,13 +17374,13 @@ module stdlib_linalg_lapack_w
            go to 30
            ! permute the matrices a and b to isolate the eigenvalues.
            ! find row with one nonzero in columns 1 through l
-20   continue
+           20 continue
            l = lm1
            if (l /= 1) go to 30
            rscale(1) = 1
            lscale(1) = 1
            go to 190
-30         continue
+           30 continue
            lm1 = l - 1
            loop_80: do i = l,1,-1
               do j = 1,lm1
@@ -17389,21 +17389,21 @@ module stdlib_linalg_lapack_w
               end do
               j = l
               go to 70
-50            continue
+              50 continue
               do j = jp1,l
                  if (a(i,j) /= czero .or. b(i,j) /= czero) cycle loop_80
               end do
               j = jp1 - 1
-70            continue
+              70 continue
               m = l
               iflow = 1
               go to 160
            end do loop_80
            go to 100
            ! find column with one nonzero in rows k through n
-90   continue
+           90 continue
            k = k + 1
-100        continue
+           100 continue
            loop_150: do j = k,l
               do i = k,lm1
                  ip1 = i + 1
@@ -17411,32 +17411,32 @@ module stdlib_linalg_lapack_w
               end do
               i = l
               go to 140
-120           continue
+              120 continue
               do i = ip1,l
                  if (a(i,j) /= czero .or. b(i,j) /= czero) cycle loop_150
               end do
               i = ip1 - 1
-140           continue
+              140 continue
               m = k
               iflow = 2
               go to 160
            end do loop_150
            go to 190
            ! permute rows m and i
-160  continue
+           160 continue
            lscale(m) = i
            if (i == m) go to 170
            call stdlib_wswap(n - k + 1,a(i,k),lda,a(m,k),lda)
            call stdlib_wswap(n - k + 1,b(i,k),ldb,b(m,k),ldb)
            ! permute columns m and j
-170  continue
+           170 continue
            rscale(m) = j
            if (j == m) go to 180
            call stdlib_wswap(l,a(1,j),1,a(1,m),1)
            call stdlib_wswap(l,b(1,j),1,b(1,m),1)
-180        continue
+           180 continue
            go to(20,90) iflow
-190        continue
+           190 continue
            ilo = k
            ihi = l
            if (stdlib_lsame(job,'P')) then
@@ -17468,13 +17468,13 @@ module stdlib_linalg_lapack_w
                     go to 210
                  end if
                  ta = log10(cabs1(a(i,j)))/basl
-210              continue
+                 210 continue
                  if (b(i,j) == czero) then
                     tb = zero
                     go to 220
                  end if
                  tb = log10(cabs1(b(i,j)))/basl
-220              continue
+                 220 continue
                  work(i + 4*n) = work(i + 4*n) - ta - tb
                  work(j + 5*n) = work(j + 5*n) - ta - tb
               end do
@@ -17486,7 +17486,7 @@ module stdlib_linalg_lapack_w
            beta = zero
            it = 1
            ! start generalized conjugate gradient iteration
-250  continue
+           250 continue
            gamma = stdlib_qdot(nr,work(ilo + 4*n),1,work(ilo + 4*n),1) + stdlib_qdot(nr, &
                      work(ilo + 5*n),1,work(ilo + 5*n),1)
            ew = zero
@@ -17516,7 +17516,7 @@ module stdlib_linalg_lapack_w
                  if (a(i,j) == czero) go to 280
                  kount = kount + 1
                  sum = sum + work(j)
-280              continue
+                 280 continue
                  if (b(i,j) == czero) cycle loop_290
                  kount = kount + 1
                  sum = sum + work(j)
@@ -17530,7 +17530,7 @@ module stdlib_linalg_lapack_w
                  if (a(i,j) == czero) go to 310
                  kount = kount + 1
                  sum = sum + work(i + n)
-310              continue
+                 310 continue
                  if (b(i,j) == czero) cycle loop_320
                  kount = kount + 1
                  sum = sum + work(i + n)
@@ -17557,7 +17557,7 @@ module stdlib_linalg_lapack_w
            it = it + 1
            if (it <= nrp2) go to 250
            ! end generalized conjugate gradient iteration
-350  continue
+           350 continue
            sfmin = stdlib_qlamch('S')
            sfmax = one/sfmin
            lsfmin = int(log10(sfmin)/basl + one,KIND=ilp)
@@ -17628,11 +17628,11 @@ module stdlib_linalg_lapack_w
            real(qp),intent(out) :: rwork(*)
            complex(qp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(qp),intent(out) :: alpha(*),beta(*),vsl(ldvsl,*),vsr(ldvsr,*),work(*)
-                     
+
            ! Function Arguments
            procedure(stdlib_selctg_w) :: selctg
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: cursl,ilascl,ilbscl,ilvsl,ilvsr,lastsl,lquery,wantst
            integer(ilp) :: i,icols,ierr,ihi,ijobvl,ijobvr,ileft,ilo,iright,irows,irwrk, &
@@ -17698,7 +17698,7 @@ module stdlib_linalg_lapack_w
               lwkopt = max(lwkopt,n + n*stdlib_ilaenv(1,'ZUNMQR',' ',n,1,n,-1))
               if (ilvsl) then
                  lwkopt = max(lwkopt,n + n*stdlib_ilaenv(1,'ZUNGQR',' ',n,1,n,-1))
-                           
+
               end if
               work(1) = lwkopt
               if (lwork < lwkmin .and. .not. lquery) info = -18
@@ -17801,16 +17801,16 @@ module stdlib_linalg_lapack_w
            if (wantst) then
               ! undo scaling on eigenvalues before selecting
               if (ilascl) call stdlib_wlascl('G',0,0,anrm,anrmto,n,1,alpha,n,ierr)
-                        
+
               if (ilbscl) call stdlib_wlascl('G',0,0,bnrm,bnrmto,n,1,beta,n,ierr)
-                        
+
               ! select eigenvalues
               do i = 1,n
                  bwork(i) = selctg(alpha(i),beta(i))
               end do
               call stdlib_wtgsen(0,ilvsl,ilvsr,bwork,n,a,lda,b,ldb,alpha,beta,vsl, &
               ldvsl,vsr,ldvsr,sdim,pvsl,pvsr,dif,work(iwrk),lwork - iwrk + 1,idum,1,ierr)
-                        
+
               if (ierr == 1) info = n + 3
            end if
            ! apply back-permutation to vsl and vsr
@@ -17839,7 +17839,7 @@ module stdlib_linalg_lapack_w
                  lastsl = cursl
               end do
            end if
-30         continue
+           30 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_wgges
@@ -17879,11 +17879,11 @@ module stdlib_linalg_lapack_w
            real(qp),intent(out) :: rwork(*)
            complex(qp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(qp),intent(out) :: alpha(*),beta(*),vsl(ldvsl,*),vsr(ldvsr,*),work(*)
-                     
+
            ! Function Arguments
            procedure(stdlib_selctg_w) :: selctg
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: cursl,ilascl,ilbscl,ilvsl,ilvsr,lastsl,lquery,wantst
            integer(ilp) :: i,icols,ierr,ihi,ijobvl,ijobvr,ileft,ilo,iright,irows,irwrk, &
@@ -18052,16 +18052,16 @@ module stdlib_linalg_lapack_w
            if (wantst) then
               ! undo scaling on eigenvalues before selecting
               if (ilascl) call stdlib_wlascl('G',0,0,anrm,anrmto,n,1,alpha,n,ierr)
-                        
+
               if (ilbscl) call stdlib_wlascl('G',0,0,bnrm,bnrmto,n,1,beta,n,ierr)
-                        
+
               ! select eigenvalues
               do i = 1,n
                  bwork(i) = selctg(alpha(i),beta(i))
               end do
               call stdlib_wtgsen(0,ilvsl,ilvsr,bwork,n,a,lda,b,ldb,alpha,beta,vsl, &
               ldvsl,vsr,ldvsr,sdim,pvsl,pvsr,dif,work(iwrk),lwork - iwrk + 1,idum,1,ierr)
-                        
+
               if (ierr == 1) info = n + 3
            end if
            ! apply back-permutation to vsl and vsr
@@ -18089,7 +18089,7 @@ module stdlib_linalg_lapack_w
                  lastsl = cursl
               end do
            end if
-30         continue
+           30 continue
            work(1) = cmplx(lwkopt,KIND=qp)
            return
      end subroutine stdlib_wgges3
@@ -18119,7 +18119,7 @@ module stdlib_linalg_lapack_w
 
      subroutine stdlib_wggesx(jobvsl,jobvsr,sort,selctg,sense,n,a,lda,b,ldb,sdim,alpha, &
       beta,vsl,ldvsl,vsr,ldvsr,rconde,rcondv,work,lwork,rwork,iwork,liwork,bwork,info)
-                
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -18133,11 +18133,11 @@ module stdlib_linalg_lapack_w
            real(qp),intent(out) :: rconde(2),rcondv(2),rwork(*)
            complex(qp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(qp),intent(out) :: alpha(*),beta(*),vsl(ldvsl,*),vsr(ldvsr,*),work(*)
-                     
+
            ! Function Arguments
            procedure(stdlib_selctg_w) :: selctg
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: cursl,ilascl,ilbscl,ilvsl,ilvsr,lastsl,lquery,wantsb,wantse, &
                      wantsn,wantst,wantsv
@@ -18218,7 +18218,7 @@ module stdlib_linalg_lapack_w
                  minwrk = 2*n
                  maxwrk = n*(1 + stdlib_ilaenv(1,'ZGEQRF',' ',n,1,n,0))
                  maxwrk = max(maxwrk,n*(1 + stdlib_ilaenv(1,'ZUNMQR',' ',n,1,n,-1)))
-                           
+
                  if (ilvsl) then
                     maxwrk = max(maxwrk,n*(1 + stdlib_ilaenv(1,'ZUNGQR',' ',n,1,n,-1)) &
                               )
@@ -18341,9 +18341,9 @@ module stdlib_linalg_lapack_w
            if (wantst) then
               ! undo scaling on eigenvalues before selctging
               if (ilascl) call stdlib_wlascl('G',0,0,anrmto,anrm,n,1,alpha,n,ierr)
-                        
+
               if (ilbscl) call stdlib_wlascl('G',0,0,bnrmto,bnrm,n,1,beta,n,ierr)
-                        
+
               ! select eigenvalues
               do i = 1,n
                  bwork(i) = selctg(alpha(i),beta(i))
@@ -18397,7 +18397,7 @@ module stdlib_linalg_lapack_w
                  lastsl = cursl
               end do
            end if
-40         continue
+           40 continue
            work(1) = maxwrk
            iwork(1) = liwmin
            return
@@ -18433,7 +18433,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(qp),intent(out) :: alpha(*),beta(*),vl(ldvl,*),vr(ldvr,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: ilascl,ilbscl,ilv,ilvl,ilvr,lquery
            character :: chtemp
@@ -18503,7 +18503,7 @@ module stdlib_linalg_lapack_w
               lwkopt = max(lwkopt,n + n*stdlib_ilaenv(1,'ZUNMQR',' ',n,1,n,0))
               if (ilvl) then
                  lwkopt = max(lwkopt,n + n*stdlib_ilaenv(1,'ZUNGQR',' ',n,1,n,-1))
-                           
+
               end if
               work(1) = lwkopt
               if (lwork < lwkmin .and. .not. lquery) info = -15
@@ -18665,7 +18665,7 @@ module stdlib_linalg_lapack_w
               end if
            end if
            ! undo scaling if necessary
-70   continue
+           70 continue
            if (ilascl) call stdlib_wlascl('G',0,0,anrmto,anrm,n,1,alpha,n,ierr)
            if (ilbscl) call stdlib_wlascl('G',0,0,bnrmto,bnrm,n,1,beta,n,ierr)
            work(1) = lwkopt
@@ -18702,7 +18702,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(qp),intent(out) :: alpha(*),beta(*),vl(ldvl,*),vr(ldvr,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: ilascl,ilbscl,ilv,ilvl,ilvr,lquery
            character :: chtemp
@@ -18936,7 +18936,7 @@ module stdlib_linalg_lapack_w
               end if
            end if
            ! undo scaling if necessary
-70   continue
+           70 continue
            if (ilascl) call stdlib_wlascl('G',0,0,anrmto,anrm,n,1,alpha,n,ierr)
            if (ilbscl) call stdlib_wlascl('G',0,0,bnrmto,bnrm,n,1,beta,n,ierr)
            work(1) = cmplx(lwkopt,KIND=qp)
@@ -18982,7 +18982,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(qp),intent(out) :: alpha(*),beta(*),vl(ldvl,*),vr(ldvr,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: ilascl,ilbscl,ilv,ilvl,ilvr,lquery,noscl,wantsb,wantse,wantsn, &
                      wantsv
@@ -19070,12 +19070,12 @@ module stdlib_linalg_lapack_w
                  end if
                  maxwrk = minwrk
                  maxwrk = max(maxwrk,n + n*stdlib_ilaenv(1,'ZGEQRF',' ',n,1,n,0))
-                           
+
                  maxwrk = max(maxwrk,n + n*stdlib_ilaenv(1,'ZUNMQR',' ',n,1,n,0))
-                           
+
                  if (ilvl) then
                     maxwrk = max(maxwrk,n + n*stdlib_ilaenv(1,'ZUNGQR',' ',n,1,n,0))
-                              
+
                  end if
               end if
               work(1) = maxwrk
@@ -19123,7 +19123,7 @@ module stdlib_linalg_lapack_w
            ! permute and/or balance the matrix pair (a,b)
            ! (real workspace: need 6*n if balanc = 's' or 'b', 1 otherwise)
            call stdlib_wggbal(balanc,n,a,lda,b,ldb,ilo,ihi,lscale,rscale,rwork,ierr)
-                     
+
            ! compute abnrm and bbnrm
            abnrm = stdlib_wlange('1',n,n,a,lda,rwork(1))
            if (ilascl) then
@@ -19254,7 +19254,7 @@ module stdlib_linalg_lapack_w
            ! (workspace: none needed)
            if (ilvl) then
               call stdlib_wggbak(balanc,'L',n,ilo,ihi,lscale,rscale,n,vl,ldvl,ierr)
-                        
+
               loop_50: do jc = 1,n
                  temp = zero
                  do jr = 1,n
@@ -19269,7 +19269,7 @@ module stdlib_linalg_lapack_w
            end if
            if (ilvr) then
               call stdlib_wggbak(balanc,'R',n,ilo,ihi,lscale,rscale,n,vr,ldvr,ierr)
-                        
+
               loop_80: do jc = 1,n
                  temp = zero
                  do jr = 1,n
@@ -19283,7 +19283,7 @@ module stdlib_linalg_lapack_w
               end do loop_80
            end if
            ! undo scaling if necessary
-90   continue
+           90 continue
            if (ilascl) call stdlib_wlascl('G',0,0,anrmto,anrm,n,1,alpha,n,ierr)
            if (ilbscl) call stdlib_wlascl('G',0,0,bnrmto,bnrm,n,1,beta,n,ierr)
            work(1) = maxwrk
@@ -19320,7 +19320,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*),b(ldb,*),d(*)
            complex(qp),intent(out) :: work(*),x(*),y(*)
         ! ===================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,lopt,lwkmin,lwkopt,nb,nb1,nb2,nb3,nb4,np
@@ -19411,7 +19411,7 @@ module stdlib_linalg_lapack_w
            ! solve triangular system: r11*x = d1
            if (m > 0) then
               call stdlib_wtrtrs('UPPER','NO TRANSPOSE','NON UNIT',m,1,a,lda,d,m,info)
-                        
+
               if (info > 0) then
                  info = 2
                  return
@@ -19465,7 +19465,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*),b(ldb,*),q(ldq,*),z(ldz,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: blk22,initq,initz,lquery,wantq,wantz
            character :: compq2,compz2
@@ -19564,7 +19564,7 @@ module stdlib_linalg_lapack_w
                  pw = nblst*nblst + 1
                  do i = 1,n2nb
                     call stdlib_wlaset('ALL',2*nnb,2*nnb,czero,cone,work(pw),2*nnb)
-                              
+
                     pw = pw + 4*nnb*nnb
                  end do
                  ! reduce columns jcol:jcol+nnb-1 of a to hessenberg form.
@@ -19634,7 +19634,7 @@ module stdlib_linalg_lapack_w
                           call stdlib_wlartg(temp,b(jj + 1,jj),c,s,b(jj + 1,jj + 1))
                           b(jj + 1,jj) = czero
                           call stdlib_wrot(jj - top,b(top + 1,jj + 1),1,b(top + 1,jj),1,c,s)
-                                    
+
                           a(jj + 1,j) = cmplx(c,KIND=qp)
                           b(jj + 1,j) = -conjg(s)
                        end if
@@ -19690,7 +19690,7 @@ module stdlib_linalg_lapack_w
                                  len*nblst + 1),nblst,work(pw + len),1)
                        call stdlib_wgemv('CONJUGATE',len,nblst - len,cone,work((len + 1)*nblst - &
                        len + 1),nblst,a(jrow + nblst - len,j + 1),1,cone,work(pw + len),1)
-                                 
+
                        ppw = pw
                        do i = jrow,jrow + nblst - 1
                           a(i,j + 1) = work(ppw)
@@ -19742,7 +19742,7 @@ module stdlib_linalg_lapack_w
                  call stdlib_wgemm('CONJUGATE','NO TRANSPOSE',nblst,cola,nblst,cone,work, &
                            nblst,a(j,jcol + nnb),lda,czero,work(pw),nblst)
                  call stdlib_wlacpy('ALL',nblst,cola,work(pw),nblst,a(j,jcol + nnb),lda)
-                           
+
                  ppwo = nblst*nblst + 1
                  j0 = j - nnb
                  do j = j0,jcol + 1,-nnb
@@ -19759,7 +19759,7 @@ module stdlib_linalg_lapack_w
                        ! ignore the structure of u.
                        call stdlib_wgemm('CONJUGATE','NO TRANSPOSE',2*nnb,cola,2*nnb,cone, &
                        work(ppwo),2*nnb,a(j,jcol + nnb),lda,czero,work(pw),2*nnb)
-                                 
+
                        call stdlib_wlacpy('ALL',2*nnb,cola,work(pw),2*nnb,a(j,jcol + nnb), &
                                   lda)
                     end if
@@ -19778,7 +19778,7 @@ module stdlib_linalg_lapack_w
                     call stdlib_wgemm('NO TRANSPOSE','NO TRANSPOSE',nh,nblst,nblst,cone,q( &
                               topq,j),ldq,work,nblst,czero,work(pw),nh)
                     call stdlib_wlacpy('ALL',nh,nblst,work(pw),nh,q(topq,j),ldq)
-                              
+
                     ppwo = nblst*nblst + 1
                     j0 = j - nnb
                     do j = j0,jcol + 1,-nnb
@@ -19794,9 +19794,9 @@ module stdlib_linalg_lapack_w
                           ! ignore the structure of u.
                           call stdlib_wgemm('NO TRANSPOSE','NO TRANSPOSE',nh,2*nnb,2*nnb, &
                           cone,q(topq,j),ldq,work(ppwo),2*nnb,czero,work(pw),nh)
-                                    
+
                           call stdlib_wlacpy('ALL',nh,2*nnb,work(pw),nh,q(topq,j),ldq)
-                                    
+
                        end if
                        ppwo = ppwo + 4*nnb*nnb
                     end do
@@ -19809,7 +19809,7 @@ module stdlib_linalg_lapack_w
                     pw = nblst*nblst + 1
                     do i = 1,n2nb
                        call stdlib_wlaset('ALL',2*nnb,2*nnb,czero,cone,work(pw),2*nnb)
-                                 
+
                        pw = pw + 4*nnb*nnb
                     end do
                     ! accumulate givens rotations into workspace array.
@@ -19863,7 +19863,7 @@ module stdlib_linalg_lapack_w
                     call stdlib_wgemm('NO TRANSPOSE','NO TRANSPOSE',top,nblst,nblst,cone,a( &
                               1,j),lda,work,nblst,czero,work(pw),top)
                     call stdlib_wlacpy('ALL',top,nblst,work(pw),top,a(1,j),lda)
-                              
+
                     ppwo = nblst*nblst + 1
                     j0 = j - nnb
                     do j = j0,jcol + 1,-nnb
@@ -19875,9 +19875,9 @@ module stdlib_linalg_lapack_w
                           ! ignore the structure of u.
                           call stdlib_wgemm('NO TRANSPOSE','NO TRANSPOSE',top,2*nnb,2*nnb, &
                           cone,a(1,j),lda,work(ppwo),2*nnb,czero,work(pw),top)
-                                    
+
                           call stdlib_wlacpy('ALL',top,2*nnb,work(pw),top,a(1,j),lda)
-                                    
+
                        end if
                        ppwo = ppwo + 4*nnb*nnb
                     end do
@@ -19885,7 +19885,7 @@ module stdlib_linalg_lapack_w
                     call stdlib_wgemm('NO TRANSPOSE','NO TRANSPOSE',top,nblst,nblst,cone,b( &
                               1,j),ldb,work,nblst,czero,work(pw),top)
                     call stdlib_wlacpy('ALL',top,nblst,work(pw),top,b(1,j),ldb)
-                              
+
                     ppwo = nblst*nblst + 1
                     j0 = j - nnb
                     do j = j0,jcol + 1,-nnb
@@ -19897,9 +19897,9 @@ module stdlib_linalg_lapack_w
                           ! ignore the structure of u.
                           call stdlib_wgemm('NO TRANSPOSE','NO TRANSPOSE',top,2*nnb,2*nnb, &
                           cone,b(1,j),ldb,work(ppwo),2*nnb,czero,work(pw),top)
-                                    
+
                           call stdlib_wlacpy('ALL',top,2*nnb,work(pw),top,b(1,j),ldb)
-                                    
+
                        end if
                        ppwo = ppwo + 4*nnb*nnb
                     end do
@@ -19917,7 +19917,7 @@ module stdlib_linalg_lapack_w
                     call stdlib_wgemm('NO TRANSPOSE','NO TRANSPOSE',nh,nblst,nblst,cone,z( &
                               topq,j),ldz,work,nblst,czero,work(pw),nh)
                     call stdlib_wlacpy('ALL',nh,nblst,work(pw),nh,z(topq,j),ldz)
-                              
+
                     ppwo = nblst*nblst + 1
                     j0 = j - nnb
                     do j = j0,jcol + 1,-nnb
@@ -19933,9 +19933,9 @@ module stdlib_linalg_lapack_w
                           ! ignore the structure of u.
                           call stdlib_wgemm('NO TRANSPOSE','NO TRANSPOSE',nh,2*nnb,2*nnb, &
                           cone,z(topq,j),ldz,work(ppwo),2*nnb,czero,work(pw),nh)
-                                    
+
                           call stdlib_wlacpy('ALL',nh,2*nnb,work(pw),nh,z(topq,j),ldz)
-                                    
+
                        end if
                        ppwo = ppwo + 4*nnb*nnb
                     end do
@@ -19992,7 +19992,7 @@ module stdlib_linalg_lapack_w
            ! Array Arguments
            complex(qp),intent(inout) :: a(lda,*),b(ldb,*),q(ldq,*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: ilq,ilz
            integer(ilp) :: icompq,icompz,jcol,jrow
@@ -20071,11 +20071,11 @@ module stdlib_linalg_lapack_w
                  call stdlib_wlartg(ctemp,a(jrow,jcol),c,s,a(jrow - 1,jcol))
                  a(jrow,jcol) = czero
                  call stdlib_wrot(n - jcol,a(jrow - 1,jcol + 1),lda,a(jrow,jcol + 1),lda,c,s)
-                           
+
                  call stdlib_wrot(n + 2 - jrow,b(jrow - 1,jrow - 1),ldb,b(jrow,jrow - 1),ldb,c, &
                            s)
                  if (ilq) call stdlib_wrot(n,q(1,jrow - 1),1,q(1,jrow),1,c,conjg(s))
-                           
+
                  ! step 2: rotate columns jrow, jrow-1 to kill b(jrow,jrow-1)
                  ctemp = b(jrow,jrow)
                  call stdlib_wlartg(ctemp,b(jrow,jrow - 1),c,s,b(jrow,jrow))
@@ -20112,7 +20112,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*),b(ldb,*),c(*),d(*)
            complex(qp),intent(out) :: work(*),x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: lopt,lwkmin,lwkopt,mn,nb,nb1,nb2,nb3,nb4,nr
@@ -20240,7 +20240,7 @@ module stdlib_linalg_lapack_w
      !> conjugate transpose of matrix Z.
 
      pure subroutine stdlib_wggqrf(n,m,p,a,lda,taua,b,ldb,taub,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -20318,7 +20318,7 @@ module stdlib_linalg_lapack_w
      !> conjugate transpose of the matrix Z.
 
      pure subroutine stdlib_wggrqf(m,p,n,a,lda,taua,b,ldb,taub,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -20396,7 +20396,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(out) :: work(lwork)
            real(qp),intent(inout) :: sva(n)
         ! =====================================================================
-           
+
            ! Local Scalars
            complex(qp) :: aapq,ompq
            real(qp) :: aapp,aapp0,aapq1,aaqq,apoaq,aqoap,big,bigtheta,cs,mxaapq,mxsinj, &
@@ -20589,19 +20589,19 @@ module stdlib_linalg_lapack_w
                                                        conjg(ompq)*t)
                                          end if
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq1))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq1))
                                          mxsinj = max(mxsinj,abs(t))
                                       else
                        ! Choose Correct Signum For Theta And Rotate
                                          thsign = -sign(one,aapq1)
                                          t = one/(theta + thsign*sqrt(one + theta*theta))
-                                                   
+
                                          cs = sqrt(one/(one + t*t))
                                          sn = t*cs
                                          mxsinj = max(mxsinj,abs(sn))
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq1))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq1))
                                          call stdlib_wrot(m,a(1,p),1,a(1,q),1,cs,conjg(ompq) &
                                                    *sn)
@@ -20666,7 +20666,7 @@ module stdlib_linalg_lapack_w
                              end if
                           end do loop_2002
            ! end q-loop
-2103 continue
+           2103 continue
            ! bailed out of q-loop
                           sva(p) = aapp
                        else
@@ -20753,7 +20753,7 @@ module stdlib_linalg_lapack_w
                                                        conjg(ompq)*t)
                                          end if
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq1))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq1))
                                          mxsinj = max(mxsinj,abs(t))
                                       else
@@ -20761,12 +20761,12 @@ module stdlib_linalg_lapack_w
                                          thsign = -sign(one,aapq1)
                                          if (aaqq > aapp0) thsign = -thsign
                                          t = one/(theta + thsign*sqrt(one + theta*theta))
-                                                   
+
                                          cs = sqrt(one/(one + t*t))
                                          sn = t*cs
                                          mxsinj = max(mxsinj,abs(sn))
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq1))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq1))
                                          call stdlib_wrot(m,a(1,p),1,a(1,q),1,cs,conjg(ompq) &
                                                    *sn)
@@ -20785,11 +20785,11 @@ module stdlib_linalg_lapack_w
                                          call stdlib_wlascl('G',0,0,aaqq,one,m,1,a(1,q), &
                                                     lda,ierr)
                                          call stdlib_waxpy(m,-aapq,work,1,a(1,q),1)
-                                                   
+
                                          call stdlib_wlascl('G',0,0,one,aaqq,m,1,a(1,q), &
                                                     lda,ierr)
                                          sva(q) = aaqq*sqrt(max(zero,one - aapq1*aapq1))
-                                                   
+
                                          mxsinj = max(mxsinj,sfmin)
                                     else
                                         call stdlib_wcopy(m,a(1,q),1,work,1)
@@ -20802,7 +20802,7 @@ module stdlib_linalg_lapack_w
                                          call stdlib_wlascl('G',0,0,one,aapp,m,1,a(1,p), &
                                                     lda,ierr)
                                          sva(p) = aapp*sqrt(max(zero,one - aapq1*aapq1))
-                                                   
+
                                          mxsinj = max(mxsinj,sfmin)
                                     end if
                                    end if
@@ -20854,7 +20854,7 @@ module stdlib_linalg_lapack_w
                              end if
                           end do loop_2200
               ! end of the q-loop
-2203 continue
+              2203 continue
                           sva(p) = aapp
                        else
                           if (aapp == zero) notrot = notrot + min(jgl + kbl - 1,n) - jgl + 1
@@ -20864,7 +20864,7 @@ module stdlib_linalg_lapack_w
            ! end of the p-loop
                  end do loop_2010
            ! end of the jbc-loop
-2011 continue
+           2011 continue
       ! 2011 bailed out of the jbc-loop
                  do p = igl,min(igl + kbl - 1,n)
                     sva(p) = abs(sva(p))
@@ -20893,12 +20893,12 @@ module stdlib_linalg_lapack_w
        ! #:( reaching this point means that the procedure has not converged.
            info = nsweep - 1
            go to 1995
-1994       continue
+           1994 continue
        ! #:) reaching this point means numerical convergence after the i-th
            ! sweep.
            info = 0
        ! #:) info = 0 confirms successful iterations.
-1995 continue
+       1995 continue
            ! sort the vector sva() of column norms.
            do p = 1,n - 1
               q = stdlib_iqamax(n - p + 1,sva(p),1) + p - 1
@@ -20956,7 +20956,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(out) :: work(lwork)
            real(qp),intent(inout) :: sva(n)
         ! =====================================================================
-           
+
            ! Local Scalars
            complex(qp) :: aapq,ompq
            real(qp) :: aapp,aapp0,aapq1,aaqq,apoaq,aqoap,big,bigtheta,cs,mxaapq,mxsinj, &
@@ -21126,7 +21126,7 @@ module stdlib_linalg_lapack_w
                                                        conjg(ompq)*t)
                                          end if
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq1))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq1))
                                          mxsinj = max(mxsinj,abs(t))
                                       else
@@ -21134,12 +21134,12 @@ module stdlib_linalg_lapack_w
                                          thsign = -sign(one,aapq1)
                                          if (aaqq > aapp0) thsign = -thsign
                                          t = one/(theta + thsign*sqrt(one + theta*theta))
-                                                   
+
                                          cs = sqrt(one/(one + t*t))
                                          sn = t*cs
                                          mxsinj = max(mxsinj,abs(sn))
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq1))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq1))
                                          call stdlib_wrot(m,a(1,p),1,a(1,q),1,cs,conjg(ompq) &
                                                    *sn)
@@ -21158,11 +21158,11 @@ module stdlib_linalg_lapack_w
                                          call stdlib_wlascl('G',0,0,aaqq,one,m,1,a(1,q), &
                                                     lda,ierr)
                                          call stdlib_waxpy(m,-aapq,work,1,a(1,q),1)
-                                                   
+
                                          call stdlib_wlascl('G',0,0,one,aaqq,m,1,a(1,q), &
                                                     lda,ierr)
                                          sva(q) = aaqq*sqrt(max(zero,one - aapq1*aapq1))
-                                                   
+
                                          mxsinj = max(mxsinj,sfmin)
                                     else
                                         call stdlib_wcopy(m,a(1,q),1,work,1)
@@ -21175,7 +21175,7 @@ module stdlib_linalg_lapack_w
                                          call stdlib_wlascl('G',0,0,one,aapp,m,1,a(1,p), &
                                                     lda,ierr)
                                          sva(p) = aapp*sqrt(max(zero,one - aapq1*aapq1))
-                                                   
+
                                          mxsinj = max(mxsinj,sfmin)
                                     end if
                                    end if
@@ -21227,7 +21227,7 @@ module stdlib_linalg_lapack_w
                              end if
                           end do loop_2200
               ! end of the q-loop
-2203 continue
+              2203 continue
                           sva(p) = aapp
                        else
                           if (aapp == zero) notrot = notrot + min(jgl + kbl - 1,n) - jgl + 1
@@ -21237,7 +21237,7 @@ module stdlib_linalg_lapack_w
            ! end of the p-loop
                  end do loop_2010
            ! end of the jbc-loop
-2011 continue
+           2011 continue
       ! 2011 bailed out of the jbc-loop
                  do p = igl,min(igl + kbl - 1,n)
                     sva(p) = abs(sva(p))
@@ -21266,12 +21266,12 @@ module stdlib_linalg_lapack_w
        ! #:( reaching this point means that the procedure has not converged.
            info = nsweep - 1
            go to 1995
-1994       continue
+           1994 continue
        ! #:) reaching this point means numerical convergence after the i-th
            ! sweep.
            info = 0
        ! #:) info = 0 confirms successful iterations.
-1995 continue
+       1995 continue
            ! sort the vector sva() of column norms.
            do p = 1,n - 1
               q = stdlib_iqamax(n - p + 1,sva(p),1) + p - 1
@@ -21296,7 +21296,7 @@ module stdlib_linalg_lapack_w
      !> condition number is computed as RCOND = 1 / (ANORM * norm(inv(A))).
 
      pure subroutine stdlib_wgtcon(norm,n,dl,d,du,du2,ipiv,anorm,rcond,work,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -21311,7 +21311,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: d(*),dl(*),du(*),du2(*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: onenrm
            integer(ilp) :: i,kase,kase1
@@ -21354,13 +21354,13 @@ module stdlib_linalg_lapack_w
               kase1 = 2
            end if
            kase = 0
-20         continue
+           20 continue
            call stdlib_wlacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == kase1) then
                  ! multiply by inv(u)*inv(l).
                  call stdlib_wgttrs('NO TRANSPOSE',n,1,dl,d,du,du2,ipiv,work,n,info)
-                           
+
               else
                  ! multiply by inv(l**h)*inv(u**h).
                  call stdlib_wgttrs('CONJUGATE TRANSPOSE',n,1,dl,d,du,du2,ipiv,work,n, &
@@ -21390,13 +21390,13 @@ module stdlib_linalg_lapack_w
            integer(ilp),intent(in) :: ipiv(*)
            real(qp),intent(out) :: berr(*),ferr(*),rwork(*)
            complex(qp),intent(in) :: b(ldb,*),d(*),df(*),dl(*),dlf(*),du(*),du2(*),duf(*)
-                     
+
            complex(qp),intent(out) :: work(*)
            complex(qp),intent(inout) :: x(ldx,*)
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: notran
            character :: transn,transt
@@ -21456,13 +21456,13 @@ module stdlib_linalg_lapack_w
            loop_110: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - op(a) * x,
               ! where op(a) = a, a**t, or a**h, depending on trans.
               call stdlib_wcopy(n,b(1,j),1,work,1)
               call stdlib_wlagtm(trans,n,1,-one,dl,d,du,x(1,j),ldx,one,work,n)
-                        
+
               ! compute abs(op(a))*abs(x) + abs(b) for use in the backward
               ! error bound.
               if (notran) then
@@ -21474,7 +21474,7 @@ module stdlib_linalg_lapack_w
                     do i = 2,n - 1
                        rwork(i) = cabs1(b(i,j)) + cabs1(dl(i - 1))*cabs1(x(i - 1,j)) + &
                        cabs1(d(i))*cabs1(x(i,j)) + cabs1(du(i))*cabs1(x(i + 1,j))
-                                 
+
                     end do
                     rwork(n) = cabs1(b(n,j)) + cabs1(dl(n - 1))*cabs1(x(n - 1,j)) + &
                               cabs1(d(n))*cabs1(x(n,j))
@@ -21488,7 +21488,7 @@ module stdlib_linalg_lapack_w
                     do i = 2,n - 1
                        rwork(i) = cabs1(b(i,j)) + cabs1(du(i - 1))*cabs1(x(i - 1,j)) + &
                        cabs1(d(i))*cabs1(x(i,j)) + cabs1(dl(i))*cabs1(x(i + 1,j))
-                                 
+
                     end do
                     rwork(n) = cabs1(b(n,j)) + cabs1(du(n - 1))*cabs1(x(n - 1,j)) + &
                               cabs1(d(n))*cabs1(x(n,j))
@@ -21547,13 +21547,13 @@ module stdlib_linalg_lapack_w
                  end if
               end do
               kase = 0
-70            continue
+              70 continue
               call stdlib_wlacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(op(a)**h).
                     call stdlib_wgttrs(transt,n,1,dlf,df,duf,du2,ipiv,work,n,info)
-                              
+
                     do i = 1,n
                        work(i) = rwork(i)*work(i)
                     end do
@@ -21563,7 +21563,7 @@ module stdlib_linalg_lapack_w
                        work(i) = rwork(i)*work(i)
                     end do
                     call stdlib_wgttrs(transn,n,1,dlf,df,duf,du2,ipiv,work,n,info)
-                              
+
                  end if
                  go to 70
               end if
@@ -21594,7 +21594,7 @@ module stdlib_linalg_lapack_w
            ! Array Arguments
            complex(qp),intent(inout) :: b(ldb,*),d(*),dl(*),du(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j,k
            complex(qp) :: mult,temp,zdum
@@ -21663,7 +21663,7 @@ module stdlib_linalg_lapack_w
               if (n > 1) b(n - 1,j) = (b(n - 1,j) - du(n - 1)*b(n,j))/d(n - 1)
               do k = n - 2,1,-1
                  b(k,j) = (b(k,j) - du(k)*b(k + 1,j) - dl(k)*b(k + 2,j))/d(k)
-                           
+
               end do
            end do
            return
@@ -21693,7 +21693,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: df(*),dlf(*),du2(*),duf(*)
            complex(qp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nofact,notran
            character :: norm
@@ -21777,7 +21777,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: d(*),dl(*),du(*)
            complex(qp),intent(out) :: du2(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            complex(qp) :: fact,temp,zdum
@@ -21849,7 +21849,7 @@ module stdlib_linalg_lapack_w
                  go to 50
               end if
            end do
-50         continue
+           50 continue
            return
      end subroutine stdlib_wgttrf
 
@@ -21948,7 +21948,7 @@ module stdlib_linalg_lapack_w
               ! overwriting each right hand side vector with its solution.
               if (nrhs <= 1) then
                  j = 1
-10               continue
+                 10 continue
                  ! solve l*x = b.
                  do i = 1,n - 1
                     if (ipiv(i) == i) then
@@ -21964,7 +21964,7 @@ module stdlib_linalg_lapack_w
                  if (n > 1) b(n - 1,j) = (b(n - 1,j) - du(n - 1)*b(n,j))/d(n - 1)
                  do i = n - 2,1,-1
                     b(i,j) = (b(i,j) - du(i)*b(i + 1,j) - du2(i)*b(i + 2,j))/d(i)
-                              
+
                  end do
                  if (j < nrhs) then
                     j = j + 1
@@ -21987,7 +21987,7 @@ module stdlib_linalg_lapack_w
                     if (n > 1) b(n - 1,j) = (b(n - 1,j) - du(n - 1)*b(n,j))/d(n - 1)
                     do i = n - 2,1,-1
                        b(i,j) = (b(i,j) - du(i)*b(i + 1,j) - du2(i)*b(i + 2,j))/d(i)
-                                 
+
                     end do
                  end do
               end if
@@ -21995,7 +21995,7 @@ module stdlib_linalg_lapack_w
               ! solve a**t * x = b.
               if (nrhs <= 1) then
                  j = 1
-70               continue
+                 70 continue
                  ! solve u**t * x = b.
                  b(1,j) = b(1,j)/d(1)
                  if (n > 1) b(2,j) = (b(2,j) - du(1)*b(1,j))/d(2)
@@ -22042,11 +22042,11 @@ module stdlib_linalg_lapack_w
               ! solve a**h * x = b.
               if (nrhs <= 1) then
                  j = 1
-130              continue
+                 130 continue
                  ! solve u**h * x = b.
                  b(1,j) = b(1,j)/conjg(d(1))
                  if (n > 1) b(2,j) = (b(2,j) - conjg(du(1))*b(1,j))/conjg(d(2))
-                           
+
                  do i = 3,n
                     b(i,j) = (b(i,j) - conjg(du(i - 1))*b(i - 1,j) - conjg(du2(i - 2))*b( &
                               i - 2,j))/conjg(d(i))
@@ -22070,7 +22070,7 @@ module stdlib_linalg_lapack_w
                  ! solve u**h * x = b.
                     b(1,j) = b(1,j)/conjg(d(1))
                     if (n > 1) b(2,j) = (b(2,j) - conjg(du(1))*b(1,j))/conjg(d(2))
-                              
+
                     do i = 3,n
                        b(i,j) = (b(i,j) - conjg(du(i - 1))*b(i - 1,j) - conjg(du2(i - 2)) &
                                  *b(i - 2,j))/conjg(d(i))
@@ -22106,7 +22106,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: v(*),tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,j1,j2,lm,ln,vpos,taupos,dpos,ofdpos,ajeter
@@ -22195,7 +22195,7 @@ module stdlib_linalg_lapack_w
                        a(ofdpos + i,st - 1) = czero
                    end do
                    call stdlib_wlarfg(lm,a(ofdpos,st - 1),v(vpos + 1),1,tau(taupos))
-                             
+
                    lm = ed - st + 1
                    call stdlib_wlarfy(uplo,lm,v(vpos),1,conjg(tau(taupos)),a(dpos,st) &
                              ,lda - 1,work)
@@ -22226,7 +22226,7 @@ module stdlib_linalg_lapack_w
                            a(dpos + nb + i,st) = czero
                        end do
                        call stdlib_wlarfg(lm,a(dpos + nb,st),v(vpos + 1),1,tau(taupos))
-                                 
+
                        call stdlib_wlarfx('LEFT',lm,ln - 1,v(vpos),conjg(tau(taupos)),a( &
                                  dpos + nb - 1,st + 1),lda - 1,work)
                    end if
@@ -22251,7 +22251,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: ab(ldab,*)
            complex(qp),intent(out) :: work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,wantz
            integer(ilp) :: iinfo,imax,inde,indrwk,iscale
@@ -22318,14 +22318,14 @@ module stdlib_linalg_lapack_w
            ! call stdlib_whbtrd to reduce hermitian band matrix to tridiagonal form.
            inde = 1
            call stdlib_whbtrd(jobz,uplo,n,kd,ab,ldab,w,rwork(inde),z,ldz,work,iinfo)
-                     
+
            ! for eigenvalues only, call stdlib_qsterf.  for eigenvectors, call stdlib_wsteqr.
            if (.not. wantz) then
               call stdlib_qsterf(n,w,rwork(inde),info)
            else
               indrwk = inde + n
               call stdlib_wsteqr(jobz,n,w,rwork(inde),z,ldz,rwork(indrwk),info)
-                        
+
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
            if (iscale == 1) then
@@ -22364,7 +22364,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: ab(ldab,*)
            complex(qp),intent(out) :: work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,lquery,wantz
            integer(ilp) :: iinfo,imax,inde,indwk2,indwrk,iscale,liwmin,llrwk,llwk2, &
@@ -22462,7 +22462,7 @@ module stdlib_linalg_lapack_w
            llwk2 = lwork - indwk2 + 1
            llrwk = lrwork - indwrk + 1
            call stdlib_whbtrd(jobz,uplo,n,kd,ab,ldab,w,rwork(inde),z,ldz,work,iinfo)
-                     
+
            ! for eigenvalues only, call stdlib_qsterf.  for eigenvectors, call stdlib_wstedc.
            if (.not. wantz) then
               call stdlib_qsterf(n,w,rwork(inde),info)
@@ -22509,7 +22509,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: ab(ldab,*)
            complex(qp),intent(out) :: q(ldq,*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,lower,test,valeig,wantz
            character :: order
@@ -22643,7 +22643,7 @@ module stdlib_linalg_lapack_w
                  call stdlib_wlacpy('A',n,n,q,ldq,z,ldz)
                  call stdlib_qcopy(n - 1,rwork(inde),1,rwork(indee),1)
                  call stdlib_wsteqr(jobz,n,w,rwork(indee),z,ldz,rwork(indrwk),info)
-                           
+
                  if (info == 0) then
                     do i = 1,n
                        ifail(i) = 0
@@ -22679,7 +22679,7 @@ module stdlib_linalg_lapack_w
               end do
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
-30   continue
+           30 continue
            if (iscale == 1) then
               if (info == 0) then
                  imax = m
@@ -22741,7 +22741,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: bb(ldbb,*)
            complex(qp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: update,upper,wantx
            integer(ilp) :: i,i0,i1,i2,inca,j,j1,j1t,j2,j2t,k,ka1,kb1,kbt,l,m,nr, &
@@ -22832,7 +22832,7 @@ module stdlib_linalg_lapack_w
            ! to avoid duplicating code, the two loops are merged.
            update = .true.
            i = n + 1
-10         continue
+           10 continue
            if (update) then
               i = i - 1
               kbt = min(kb,i - 1)
@@ -22876,7 +22876,7 @@ module stdlib_linalg_lapack_w
                  do j = i,i1
                     do k = max(j - ka,i - kbt),i - 1
                        ab(k - j + ka1,j) = ab(k - j + ka1,j) - bb(k - i + kb1,i)*ab(i - j + ka1,j)
-                                 
+
                     end do
                  end do
                  if (wantx) then
@@ -22905,7 +22905,7 @@ module stdlib_linalg_lapack_w
                        work(i - k) = rwork(i - k + ka - m)*t - conjg(work(i - k + ka - m))*ab(1,i - k + ka &
                                  )
                        ab(1,i - k + ka) = work(i - k + ka - m)*t + rwork(i - k + ka - m)*ab(1,i - k + ka)
-                                 
+
                        ra1 = ra
                     end if
                  end if
@@ -22997,7 +22997,7 @@ module stdlib_linalg_lapack_w
                     ! generate rotations in 2nd set to annihilate elements
                     ! which have been created outside the band
                     call stdlib_wlargv(nr,ab(1,j2),inca,work(j2),ka1,rwork(j2),ka1)
-                              
+
                     ! apply rotations in 2nd set from the right
                     do l = 1,ka - 1
                        call stdlib_wlartv(nr,ab(ka1 - l,j2),inca,ab(ka - l,j2 + 1),inca, &
@@ -23058,7 +23058,7 @@ module stdlib_linalg_lapack_w
                     end do
                     do j = max(1,i - ka),i - kbt - 1
                        ab(k - j + 1,j) = ab(k - j + 1,j) - conjg(bb(i - k + 1,k))*ab(i - j + 1,j)
-                                 
+
                     end do
                  end do
                  do j = i,i1
@@ -23090,9 +23090,9 @@ module stdlib_linalg_lapack_w
                        ! band and store it in work(i-k)
                        t = -bb(k + 1,i - k)*ra1
                        work(i - k) = rwork(i - k + ka - m)*t - conjg(work(i - k + ka - m))*ab(ka1,i - k)
-                                 
+
                        ab(ka1,i - k) = work(i - k + ka - m)*t + rwork(i - k + ka - m)*ab(ka1,i - k)
-                                 
+
                        ra1 = ra
                     end if
                  end if
@@ -23227,7 +23227,7 @@ module stdlib_linalg_lapack_w
               end if
            end if
            go to 10
-480        continue
+           480 continue
            ! **************************** phase 2 *****************************
            ! the logical structure of this phase is:
            ! update = .true.
@@ -23242,7 +23242,7 @@ module stdlib_linalg_lapack_w
            ! to avoid duplicating code, the two loops are merged.
            update = .true.
            i = 0
-490        continue
+           490 continue
            if (update) then
               i = i + 1
               kbt = min(kb,m - i)
@@ -23291,7 +23291,7 @@ module stdlib_linalg_lapack_w
                  do j = i1,i
                     do k = i + 1,min(j + ka,i + kbt)
                        ab(j - k + ka1,k) = ab(j - k + ka1,k) - bb(i - k + kb1,k)*ab(j - i + ka1,i)
-                                 
+
                     end do
                  end do
                  if (wantx) then
@@ -23312,12 +23312,12 @@ module stdlib_linalg_lapack_w
                     if (i + k - ka1 > 0 .and. i + k < m) then
                        ! generate rotation to annihilate a(i+k-ka-1,i)
                        call stdlib_wlartg(ab(k + 1,i),ra1,rwork(i + k - ka),work(i + k - ka),ra)
-                                 
+
                        ! create nonzero element a(i+k-ka-1,i+k) outside the
                        ! band and store it in work(m-kb+i+k)
                        t = -bb(kb1 - k,i + k)*ra1
                        work(m - kb + i + k) = rwork(i + k - ka)*t - conjg(work(i + k - ka))*ab(1,i + k)
-                                 
+
                        ab(1,i + k) = work(i + k - ka)*t + rwork(i + k - ka)*ab(1,i + k)
                        ra1 = ra
                     end if
@@ -23364,7 +23364,7 @@ module stdlib_linalg_lapack_w
                     ! post-multiply x by product of rotations in 1st set
                     do j = j1,j2,ka1
                        call stdlib_wrot(nx,x(1,j),1,x(1,j - 1),1,rwork(j),work(j))
-                                 
+
                     end do
                  end if
               end do loop_610
@@ -23475,7 +23475,7 @@ module stdlib_linalg_lapack_w
                     end do
                     do j = i + kbt + 1,min(n,i + ka)
                        ab(j - k + 1,k) = ab(j - k + 1,k) - conjg(bb(k - i + 1,i))*ab(j - i + 1,i)
-                                 
+
                     end do
                  end do
                  do j = i1,i
@@ -23508,7 +23508,7 @@ module stdlib_linalg_lapack_w
                        work(m - kb + i + k) = rwork(i + k - ka)*t - conjg(work(i + k - ka))*ab(ka1,i + k - &
                                  ka)
                        ab(ka1,i + k - ka) = work(i + k - ka)*t + rwork(i + k - ka)*ab(ka1,i + k - ka)
-                                 
+
                        ra1 = ra
                     end if
                  end if
@@ -23718,13 +23718,13 @@ module stdlib_linalg_lapack_w
               vect = 'N'
            end if
            call stdlib_whbtrd(vect,uplo,n,ka,ab,ldab,w,rwork(inde),z,ldz,work,iinfo)
-                     
+
            ! for eigenvalues only, call stdlib_qsterf.  for eigenvectors, call stdlib_wsteqr.
            if (.not. wantz) then
               call stdlib_qsterf(n,w,rwork(inde),info)
            else
               call stdlib_wsteqr(jobz,n,w,rwork(inde),z,ldz,rwork(indwrk),info)
-                        
+
            end if
            return
      end subroutine stdlib_whbgv
@@ -23756,7 +23756,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: ab(ldab,*),bb(ldbb,*)
            complex(qp),intent(out) :: work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper,wantz
            character :: vect
@@ -23839,7 +23839,7 @@ module stdlib_linalg_lapack_w
               vect = 'N'
            end if
            call stdlib_whbtrd(vect,uplo,n,ka,ab,ldab,w,rwork(inde),z,ldz,work,iinfo)
-                     
+
            ! for eigenvalues only, call stdlib_qsterf.  for eigenvectors, call stdlib_wstedc.
            if (.not. wantz) then
               call stdlib_qsterf(n,w,rwork(inde),info)
@@ -23879,7 +23879,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: ab(ldab,*),bb(ldbb,*)
            complex(qp),intent(out) :: q(ldq,*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,test,upper,valeig,wantz
            character :: order,vect
@@ -23977,7 +23977,7 @@ module stdlib_linalg_lapack_w
               else
                  call stdlib_wlacpy('A',n,n,q,ldq,z,ldz)
                  call stdlib_wsteqr(jobz,n,w,rwork(indee),z,ldz,rwork(indrwk),info)
-                           
+
                  if (info == 0) then
                     do i = 1,n
                        ifail(i) = 0
@@ -24013,7 +24013,7 @@ module stdlib_linalg_lapack_w
                  call stdlib_wgemv('N',n,n,cone,q,ldq,work,1,czero,z(1,j),1)
               end do
            end if
-30         continue
+           30 continue
            ! if eigenvalues are not in order, then sort them, along with
            ! eigenvectors.
            if (wantz) then
@@ -24061,7 +24061,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: ab(ldab,*),q(ldq,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: initq,upper,wantq
            integer(ilp) :: i,i2,ibl,inca,incx,iqaend,iqb,iqend,j,j1,j1end,j1inc,j2, &
@@ -24428,7 +24428,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: a(lda,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,kase
@@ -24476,7 +24476,7 @@ module stdlib_linalg_lapack_w
            end if
            ! estimate the 1-norm of the inverse.
            kase = 0
-30         continue
+           30 continue
            call stdlib_wlacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               ! multiply by inv(l*d*l**h) or inv(u*d*u**h).
@@ -24509,7 +24509,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: a(lda,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,kase
@@ -24557,7 +24557,7 @@ module stdlib_linalg_lapack_w
            end if
            ! estimate the 1-norm of the inverse.
            kase = 0
-30         continue
+           30 continue
            call stdlib_wlacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               ! multiply by inv(l*d*l**h) or inv(u*d*u**h).
@@ -24593,7 +24593,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: max_iter = 100
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,iter
            real(qp) :: avg,std,tol,c0,c1,c2,t,u,si,d,base,smin,smax,smlnum,bignum, &
@@ -24734,7 +24734,7 @@ module stdlib_linalg_lapack_w
                  s(i) = si
               end do
            end do
-999        continue
+           999 continue
            smlnum = stdlib_qlamch('SAFEMIN')
            bignum = one/smlnum
            smin = bignum
@@ -24766,7 +24766,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,lquery,wantz
            integer(ilp) :: iinfo,imax,inde,indtau,indwrk,iscale,llwork,lwkopt,nb
@@ -24841,10 +24841,10 @@ module stdlib_linalg_lapack_w
               call stdlib_qsterf(n,w,rwork(inde),info)
            else
               call stdlib_wungtr(uplo,n,a,lda,work(indtau),work(indwrk),llwork,iinfo)
-                        
+
               indwrk = inde + n
               call stdlib_wsteqr(jobz,n,w,rwork(inde),a,lda,rwork(indwrk),info)
-                        
+
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
            if (iscale == 1) then
@@ -24885,7 +24885,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,lquery,wantz
            integer(ilp) :: iinfo,imax,inde,indrwk,indtau,indwk2,indwrk,iscale,liopt, &
@@ -25079,7 +25079,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,lower,lquery,test,valeig,wantz,tryrac
            character :: order
@@ -25276,7 +25276,7 @@ module stdlib_linalg_lapack_w
                  end if
                  call stdlib_wstemr(jobz,'A',n,rwork(indrdd),rwork(indree),vl,vu,il, &
                  iu,m,w,z,ldz,n,isuppz,tryrac,rwork(indrwk),llrwork,iwork,liwork,info)
-                           
+
                  ! apply unitary matrix used in reduction to tridiagonal
                  ! form to eigenvectors returned by stdlib_wstemr.
                  if (wantz .and. info == 0) then
@@ -25313,7 +25313,7 @@ module stdlib_linalg_lapack_w
                         indwkn),llwrkn,iinfo)
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
-30   continue
+           30 continue
            if (iscale == 1) then
               if (info == 0) then
                  imax = m
@@ -25372,7 +25372,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,lower,lquery,test,valeig,wantz
            character :: order
@@ -25522,7 +25522,7 @@ module stdlib_linalg_lapack_w
                            iinfo)
                  call stdlib_qcopy(n - 1,rwork(inde),1,rwork(indee),1)
                  call stdlib_wsteqr(jobz,n,w,rwork(indee),z,ldz,rwork(indrwk),info)
-                           
+
                  if (info == 0) then
                     do i = 1,n
                        ifail(i) = 0
@@ -25556,7 +25556,7 @@ module stdlib_linalg_lapack_w
                         indwrk),llwork,iinfo)
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
-40   continue
+           40 continue
            if (iscale == 1) then
               if (info == 0) then
                  imax = m
@@ -25616,7 +25616,7 @@ module stdlib_linalg_lapack_w
            ! Array Arguments
            complex(qp),intent(inout) :: a(lda,*),b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: k
@@ -25699,7 +25699,7 @@ module stdlib_linalg_lapack_w
                     ct = half*akk
                     call stdlib_waxpy(k - 1,ct,b(1,k),1,a(1,k),1)
                     call stdlib_wher2(uplo,k - 1,cone,a(1,k),1,b(1,k),1,a,lda)
-                              
+
                     call stdlib_waxpy(k - 1,ct,b(1,k),1,a(1,k),1)
                     call stdlib_wdscal(k - 1,bkk,a(1,k),1)
                     a(k,k) = akk*bkk**2
@@ -25717,7 +25717,7 @@ module stdlib_linalg_lapack_w
                     call stdlib_wlacgv(k - 1,b(k,1),ldb)
                     call stdlib_waxpy(k - 1,ct,b(k,1),ldb,a(k,1),lda)
                     call stdlib_wher2(uplo,k - 1,cone,a(k,1),lda,b(k,1),ldb,a,lda)
-                              
+
                     call stdlib_waxpy(k - 1,ct,b(k,1),ldb,a(k,1),lda)
                     call stdlib_wlacgv(k - 1,b(k,1),ldb)
                     call stdlib_wdscal(k - 1,bkk,a(k,1),lda)
@@ -25748,7 +25748,7 @@ module stdlib_linalg_lapack_w
            ! Array Arguments
            complex(qp),intent(inout) :: a(lda,*),b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: k,kb,nb
@@ -25789,7 +25789,7 @@ module stdlib_linalg_lapack_w
                        kb = min(n - k + 1,nb)
                        ! update the upper triangle of a(k:n,k:n)
                        call stdlib_whegs2(itype,uplo,kb,a(k,k),lda,b(k,k),ldb,info)
-                                 
+
                        if (k + kb <= n) then
                           call stdlib_wtrsm('LEFT',uplo,'CONJUGATE TRANSPOSE','NON-UNIT',kb, &
                                     n - k - kb + 1,cone,b(k,k),ldb,a(k,k + kb),lda)
@@ -25809,7 +25809,7 @@ module stdlib_linalg_lapack_w
                        kb = min(n - k + 1,nb)
                        ! update the lower triangle of a(k:n,k:n)
                        call stdlib_whegs2(itype,uplo,kb,a(k,k),lda,b(k,k),ldb,info)
-                                 
+
                        if (k + kb <= n) then
                           call stdlib_wtrsm('RIGHT',uplo,'CONJUGATE TRANSPOSE','NON-UNIT',n - k - &
                                     kb + 1,kb,cone,b(k,k),ldb,a(k + kb,k),lda)
@@ -25841,7 +25841,7 @@ module stdlib_linalg_lapack_w
                        call stdlib_wtrmm('RIGHT',uplo,'CONJUGATE TRANSPOSE','NON-UNIT',k - 1, &
                                  kb,cone,b(k,k),ldb,a(1,k),lda)
                        call stdlib_whegs2(itype,uplo,kb,a(k,k),lda,b(k,k),ldb,info)
-                                 
+
                     end do
                  else
                     ! compute l**h*a*l
@@ -25859,7 +25859,7 @@ module stdlib_linalg_lapack_w
                        call stdlib_wtrmm('LEFT',uplo,'CONJUGATE TRANSPOSE','NON-UNIT',kb,k - 1, &
                                   cone,b(k,k),ldb,a(k,1),lda)
                        call stdlib_whegs2(itype,uplo,kb,a(k,k),lda,b(k,k),ldb,info)
-                                 
+
                     end do
                  end if
               end if
@@ -25874,7 +25874,7 @@ module stdlib_linalg_lapack_w
      !> positive definite.
 
      subroutine stdlib_whegv(itype,jobz,uplo,n,a,lda,b,ldb,w,work,lwork,rwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -25887,7 +25887,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper,wantz
            character :: trans
@@ -25995,7 +25995,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper,wantz
            character :: trans
@@ -26081,7 +26081,7 @@ module stdlib_linalg_lapack_w
                     trans = 'C'
                  end if
                  call stdlib_wtrsm('LEFT',uplo,trans,'NON-UNIT',n,n,cone,b,ldb,a,lda)
-                           
+
               else if (itype == 3) then
                  ! for b*a*x=(lambda)*x;
                  ! backtransform eigenvectors: x = l*y or u**h *y
@@ -26091,7 +26091,7 @@ module stdlib_linalg_lapack_w
                     trans = 'N'
                  end if
                  call stdlib_wtrmm('LEFT',uplo,trans,'NON-UNIT',n,n,cone,b,ldb,a,lda)
-                           
+
               end if
            end if
            work(1) = lopt
@@ -26123,7 +26123,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(qp),intent(out) :: work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,lquery,upper,valeig,wantz
            character :: trans
@@ -26210,7 +26210,7 @@ module stdlib_linalg_lapack_w
                     trans = 'C'
                  end if
                  call stdlib_wtrsm('LEFT',uplo,trans,'NON-UNIT',n,m,cone,b,ldb,z,ldz)
-                           
+
               else if (itype == 3) then
                  ! for b*a*x=(lambda)*x;
                  ! backtransform eigenvectors: x = l*y or u**h *y
@@ -26220,7 +26220,7 @@ module stdlib_linalg_lapack_w
                     trans = 'N'
                  end if
                  call stdlib_wtrmm('LEFT',uplo,trans,'NON-UNIT',n,m,cone,b,ldb,z,ldz)
-                           
+
               end if
            end if
            ! set work(1) to optimal complex workspace size.
@@ -26250,7 +26250,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,j,k,kase,nz
@@ -26305,7 +26305,7 @@ module stdlib_linalg_lapack_w
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_wcopy(n,b(1,j),1,work,1)
@@ -26389,7 +26389,7 @@ module stdlib_linalg_lapack_w
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_wlacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -26507,7 +26507,7 @@ module stdlib_linalg_lapack_w
      !> of A is then used to solve the system of equations A * X = B.
 
      pure subroutine stdlib_whesv_aa(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -26561,7 +26561,7 @@ module stdlib_linalg_lapack_w
            if (info == 0) then
               ! solve the system a*x = b, overwriting b with x.
               call stdlib_whetrs_aa(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-                        
+
            end if
            work(1) = lwkopt
            return
@@ -26583,7 +26583,7 @@ module stdlib_linalg_lapack_w
      !> the system of equations A * X = B by calling BLAS3 routine ZHETRS_3.
 
      pure subroutine stdlib_whesv_rk(uplo,n,nrhs,a,lda,e,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -26662,7 +26662,7 @@ module stdlib_linalg_lapack_w
      !> of equations A * X = B by calling ZHETRS_ROOK (uses BLAS 2).
 
      pure subroutine stdlib_whesv_rook(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -26747,7 +26747,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: af(ldaf,*)
            complex(qp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,nofact
            integer(ilp) :: lwkopt,nb
@@ -26909,7 +26909,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: tau(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i
@@ -26947,7 +26947,7 @@ module stdlib_linalg_lapack_w
                     a(i,i + 1) = cone
                     ! compute  x := tau * a * v  storing x in tau(1:i)
                     call stdlib_whemv(uplo,i,taui,a,lda,a(1,i + 1),1,czero,tau,1)
-                              
+
                     ! compute  w := x - 1/2 * tau * (x**h * v) * v
                     alpha = -chalf*taui*stdlib_wdotc(i,tau,1,a(1,i + 1),1)
                     call stdlib_waxpy(i,alpha,a(1,i + 1),1,tau,1)
@@ -27018,7 +27018,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: sevten = 17.0e+0_qp
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,imax,j,jmax,k,kk,kp,kstep
@@ -27052,7 +27052,7 @@ module stdlib_linalg_lapack_w
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 90
               kstep = 1
@@ -27150,7 +27150,7 @@ module stdlib_linalg_lapack_w
                        ! = a - ( w(k-1) w(k) )*inv(d(k))*( w(k-1) w(k) )**h
                     if (k > 2) then
                        d = stdlib_qlapy2(real(a(k - 1,k),KIND=qp),aimag(a(k - 1,k)))
-                                 
+
                        d22 = real(a(k - 1,k - 1),KIND=qp)/d
                        d11 = real(a(k,k),KIND=qp)/d
                        tt = one/(d11*d22 - one)
@@ -27185,7 +27185,7 @@ module stdlib_linalg_lapack_w
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2
               k = 1
-50            continue
+              50 continue
               ! if k > n, exit from loop
               if (k > n) go to 90
               kstep = 1
@@ -27243,7 +27243,7 @@ module stdlib_linalg_lapack_w
                     ! interchange rows and columns kk and kp in the trailing
                     ! submatrix a(k:n,k:n)
                     if (kp < n) call stdlib_wswap(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     do j = kk + 1,kp - 1
                        t = conjg(a(j,kk))
                        a(j,kk) = conjg(a(kp,j))
@@ -27273,7 +27273,7 @@ module stdlib_linalg_lapack_w
                        ! a := a - l(k)*d(k)*l(k)**h = a - w(k)*(1/d(k))*w(k)**h
                        r1 = one/real(a(k,k),KIND=qp)
                        call stdlib_wher(uplo,n - k,-r1,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                 
+
                        ! store l(k) in column k
                        call stdlib_wdscal(n - k,r1,a(k + 1,k),1)
                     end if
@@ -27286,7 +27286,7 @@ module stdlib_linalg_lapack_w
                        ! where l(k) and l(k+1) are the k-th and (k+1)-th
                        ! columns of l
                        d = stdlib_qlapy2(real(a(k + 1,k),KIND=qp),aimag(a(k + 1,k)))
-                                 
+
                        d11 = real(a(k + 1,k + 1),KIND=qp)/d
                        d22 = real(a(k,k),KIND=qp)/d
                        tt = one/(d11*d22 - one)
@@ -27317,7 +27317,7 @@ module stdlib_linalg_lapack_w
               k = k + kstep
               go to 50
            end if
-90         continue
+           90 continue
            return
      end subroutine stdlib_whetf2
 
@@ -27346,7 +27346,7 @@ module stdlib_linalg_lapack_w
         ! ======================================================================
            ! Parameters
            real(qp),parameter :: sevten = 17.0e+0_qp
-           
+
            ! Local Scalars
            logical(lk) :: done,upper
            integer(ilp) :: i,ii,imax,itemp,j,jmax,k,kk,kp,kstep,p
@@ -27385,7 +27385,7 @@ module stdlib_linalg_lapack_w
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 34
               kstep = 1
@@ -27421,7 +27421,7 @@ module stdlib_linalg_lapack_w
                  else
                     done = .false.
                     ! loop until pivot found
-12   continue
+                    12 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -27570,7 +27570,7 @@ module stdlib_linalg_lapack_w
                     if (k > 2) then
                        ! d = |a12|
                        d = stdlib_qlapy2(real(a(k - 1,k),KIND=qp),aimag(a(k - 1,k)))
-                                 
+
                        d11 = real(a(k,k)/d,KIND=qp)
                        d22 = real(a(k - 1,k - 1)/d,KIND=qp)
                        d12 = a(k - 1,k)/d
@@ -27609,7 +27609,7 @@ module stdlib_linalg_lapack_w
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-34            continue
+              34 continue
            else
               ! factorize a as l*d*l**h using the lower triangle of a
               ! initialize the unused last entry of the subdiagonal array e.
@@ -27617,7 +27617,7 @@ module stdlib_linalg_lapack_w
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop
               if (k > n) go to 64
               kstep = 1
@@ -27653,7 +27653,7 @@ module stdlib_linalg_lapack_w
                  else
                     done = .false.
                     ! loop until pivot found
-42   continue
+                    42 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -27731,7 +27731,7 @@ module stdlib_linalg_lapack_w
                  if (kp /= kk) then
                     ! (1) swap columnar parts
                     if (kp < n) call stdlib_wswap(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     ! (2) swap and conjugate middle parts
                     do j = kk + 1,kp - 1
                        t = conjg(a(j,kk))
@@ -27775,7 +27775,7 @@ module stdlib_linalg_lapack_w
                              ! = a - w(k)*(1/d(k))*w(k)**t
                           d11 = one/real(a(k,k),KIND=qp)
                           call stdlib_wher(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                           ! store l(k) in column k
                           call stdlib_wdscal(n - k,d11,a(k + 1,k),1)
                        else
@@ -27789,7 +27789,7 @@ module stdlib_linalg_lapack_w
                              ! = a - w(k)*(1/d(k))*w(k)**t
                              ! = a - (w(k)/d(k))*(d(k))*(w(k)/d(k))**t
                           call stdlib_wher(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                        end if
                        ! store the subdiagonal element of d in array e
                        e(k) = czero
@@ -27806,7 +27806,7 @@ module stdlib_linalg_lapack_w
                     if (k < n - 1) then
                        ! d = |a21|
                        d = stdlib_qlapy2(real(a(k + 1,k),KIND=qp),aimag(a(k + 1,k)))
-                                 
+
                        d11 = real(a(k + 1,k + 1),KIND=qp)/d
                        d22 = real(a(k,k),KIND=qp)/d
                        d21 = a(k + 1,k)/d
@@ -27845,7 +27845,7 @@ module stdlib_linalg_lapack_w
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 40
-64            continue
+              64 continue
            end if
            return
      end subroutine stdlib_whetf2_rk
@@ -27872,7 +27872,7 @@ module stdlib_linalg_lapack_w
         ! ======================================================================
            ! Parameters
            real(qp),parameter :: sevten = 17.0e+0_qp
-           
+
            ! Local Scalars
            logical(lk) :: done,upper
            integer(ilp) :: i,ii,imax,itemp,j,jmax,k,kk,kp,kstep,p
@@ -27908,7 +27908,7 @@ module stdlib_linalg_lapack_w
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 70
               kstep = 1
@@ -27942,7 +27942,7 @@ module stdlib_linalg_lapack_w
                  else
                     done = .false.
                     ! loop until pivot found
-12   continue
+                    12 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -28083,7 +28083,7 @@ module stdlib_linalg_lapack_w
                     if (k > 2) then
                        ! d = |a12|
                        d = stdlib_qlapy2(real(a(k - 1,k),KIND=qp),aimag(a(k - 1,k)))
-                                 
+
                        d11 = real(a(k,k)/d,KIND=qp)
                        d22 = real(a(k - 1,k - 1)/d,KIND=qp)
                        d12 = a(k - 1,k)/d
@@ -28121,7 +28121,7 @@ module stdlib_linalg_lapack_w
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop
               if (k > n) go to 70
               kstep = 1
@@ -28155,7 +28155,7 @@ module stdlib_linalg_lapack_w
                  else
                     done = .false.
                     ! loop until pivot found
-42   continue
+                    42 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -28230,7 +28230,7 @@ module stdlib_linalg_lapack_w
                  if (kp /= kk) then
                     ! (1) swap columnar parts
                     if (kp < n) call stdlib_wswap(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     ! (2) swap and conjugate middle parts
                     do j = kk + 1,kp - 1
                        t = conjg(a(j,kk))
@@ -28271,7 +28271,7 @@ module stdlib_linalg_lapack_w
                              ! = a - w(k)*(1/d(k))*w(k)**t
                           d11 = one/real(a(k,k),KIND=qp)
                           call stdlib_wher(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                           ! store l(k) in column k
                           call stdlib_wdscal(n - k,d11,a(k + 1,k),1)
                        else
@@ -28285,7 +28285,7 @@ module stdlib_linalg_lapack_w
                              ! = a - w(k)*(1/d(k))*w(k)**t
                              ! = a - (w(k)/d(k))*(d(k))*(w(k)/d(k))**t
                           call stdlib_wher(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                        end if
                     end if
                  else
@@ -28300,7 +28300,7 @@ module stdlib_linalg_lapack_w
                     if (k < n - 1) then
                        ! d = |a21|
                        d = stdlib_qlapy2(real(a(k + 1,k),KIND=qp),aimag(a(k + 1,k)))
-                                 
+
                        d11 = real(a(k + 1,k + 1),KIND=qp)/d
                        d22 = real(a(k,k),KIND=qp)/d
                        d21 = a(k + 1,k)/d
@@ -28334,7 +28334,7 @@ module stdlib_linalg_lapack_w
               k = k + kstep
               go to 40
            end if
-70         continue
+           70 continue
            return
      end subroutine stdlib_whetf2_rook
 
@@ -28355,7 +28355,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper
            integer(ilp) :: i,iinfo,iws,j,kk,ldwork,lwkopt,nb,nbmin,nx
@@ -28459,7 +28459,7 @@ module stdlib_linalg_lapack_w
               end do
               ! use unblocked code to reduce the last or only block
               call stdlib_whetd2(uplo,n - i + 1,a(i,i),lda,d(i),e(i),tau(i),iinfo)
-                        
+
            end if
            work(1) = lwkopt
            return
@@ -28487,7 +28487,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: rzero = 0.0e+0_qp
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wantq,upper,afters1
            integer(ilp) :: i,m,k,ib,sweepid,myid,shift,stt,st,ed,stind,edind, &
@@ -28754,7 +28754,7 @@ module stdlib_linalg_lapack_w
      !> Q**H * A * Q = AB.
 
      pure subroutine stdlib_whetrd_he2hb(uplo,n,kd,a,lda,ab,ldab,tau,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -28768,7 +28768,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: rone = 1.0e+0_qp
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper
            integer(ilp) :: i,j,iinfo,lwmin,pn,pk,lk,ldt,ldw,lds2,lds1,ls2,ls1,lw,lt, &
@@ -28911,7 +28911,7 @@ module stdlib_linalg_lapack_w
                    ! do 45 j = i, i+pk-1
                       ! lk = min( kd, n-j ) + 1
                       ! call stdlib_wcopy( lk, ab( 1, j ), 1, a( j, j ), 1 )
-45   continue
+                      45 continue
                   ! ==================================================================
                end do loop_40
               ! copy the lower band to ab which is the band storage matrix
@@ -28995,7 +28995,7 @@ module stdlib_linalg_lapack_w
               ! kb, where kb is the number of columns factorized by stdlib_wlahef;
               ! kb is either nb or nb-1, or k for the last block
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 40
               if (k > nb) then
@@ -29018,7 +29018,7 @@ module stdlib_linalg_lapack_w
               ! kb, where kb is the number of columns factorized by stdlib_wlahef;
               ! kb is either nb or nb-1, or n-k+1 for the last block
               k = 1
-20            continue
+              20 continue
               ! if k > n, exit from loop
               if (k > n) go to 40
               if (k <= n - nb) then
@@ -29045,7 +29045,7 @@ module stdlib_linalg_lapack_w
               k = k + kb
               go to 20
            end if
-40         continue
+           40 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_whetrf
@@ -29070,7 +29070,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper
            integer(ilp) :: j,lwkopt
@@ -29127,7 +29127,7 @@ module stdlib_linalg_lapack_w
               ! jb, where jb is the number of columns factorized by stdlib_wlahef;
               ! jb is either nb, or n-j+1 for the last block
               j = 0
-10            continue
+              10 continue
               if (j >= n) go to 20
               ! each step of the main loop
                ! j is the last column of the previous panel
@@ -29159,7 +29159,7 @@ module stdlib_linalg_lapack_w
                     alpha = conjg(a(j,j + 1))
                     a(j,j + 1) = cone
                     call stdlib_wcopy(n - j,a(j - 1,j + 1),lda,work((j + 1 - j1 + 1) + jb*n),1)
-                              
+
                     call stdlib_wscal(n - j,alpha,work((j + 1 - j1 + 1) + jb*n),1)
                     ! k1 identifies if the previous column of the panel has been
                      ! explicitly stored, e.g., k1=0 and k2=1 for the first panel,
@@ -29180,7 +29180,7 @@ module stdlib_linalg_lapack_w
                        do mj = nj - 1,1,-1
                           call stdlib_wgemm('CONJUGATE TRANSPOSE','TRANSPOSE',1,mj,jb + 1,-cone, &
                            a(j1 - k2,j3),lda,work((j3 - j1 + 1) + k1*n),n,cone,a(j3,j3),lda)
-                                     
+
                           j3 = j3 + 1
                        end do
                        ! update off-diagonal block of j2-th block row with stdlib_wgemm
@@ -29206,7 +29206,7 @@ module stdlib_linalg_lapack_w
               ! jb, where jb is the number of columns factorized by stdlib_wlahef;
               ! jb is either nb, or n-j+1 for the last block
               j = 0
-11            continue
+              11 continue
               if (j >= n) go to 20
               ! each step of the main loop
                ! j is the last column of the previous panel
@@ -29274,7 +29274,7 @@ module stdlib_linalg_lapack_w
               end if
               go to 11
            end if
-20         continue
+           20 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_whetrf_aa
@@ -29351,14 +29351,14 @@ module stdlib_linalg_lapack_w
               ! kb, where kb is the number of columns factorized by stdlib_wlahef_rk;
               ! kb is either nb or nb-1, or k for the last block
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 15
               if (k > nb) then
                  ! factorize columns k-kb+1:k of a and use blocked code to
                  ! update columns 1:k-kb
                  call stdlib_wlahef_rk(uplo,k,nb,kb,a,lda,e,ipiv,work,ldwork,iinfo)
-                           
+
               else
                  ! use unblocked code to factorize columns 1:k of a
                  call stdlib_whetf2_rk(uplo,k,a,lda,e,ipiv,iinfo)
@@ -29387,14 +29387,14 @@ module stdlib_linalg_lapack_w
               go to 10
               ! this label is the exit from main loop over k decreasing
               ! from n to 1 in steps of kb
-15   continue
+              15 continue
            else
               ! factorize a as l*d*l**t using the lower triangle of a
               ! k is the main loop index, increasing from 1 to n in steps of
               ! kb, where kb is the number of columns factorized by stdlib_wlahef_rk;
               ! kb is either nb or nb-1, or n-k+1 for the last block
               k = 1
-20            continue
+              20 continue
               ! if k > n, exit from loop
               if (k > n) go to 35
               if (k <= n - nb) then
@@ -29405,7 +29405,7 @@ module stdlib_linalg_lapack_w
               else
                  ! use unblocked code to factorize columns k:n of a
                  call stdlib_whetf2_rk(uplo,n - k + 1,a(k,k),lda,e(k),ipiv(k),iinfo)
-                           
+
                  kb = n - k + 1
               end if
               ! set info on the first occurrence of a zero pivot
@@ -29438,7 +29438,7 @@ module stdlib_linalg_lapack_w
               go to 20
               ! this label is the exit from main loop over k increasing
               ! from 1 to n in steps of kb
-35   continue
+              35 continue
            ! end lower
            end if
            work(1) = lwkopt
@@ -29516,14 +29516,14 @@ module stdlib_linalg_lapack_w
               ! kb, where kb is the number of columns factorized by stdlib_wlahef_rook;
               ! kb is either nb or nb-1, or k for the last block
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 40
               if (k > nb) then
                  ! factorize columns k-kb+1:k of a and use blocked code to
                  ! update columns 1:k-kb
                  call stdlib_wlahef_rook(uplo,k,nb,kb,a,lda,ipiv,work,ldwork,iinfo)
-                           
+
               else
                  ! use unblocked code to factorize columns 1:k of a
                  call stdlib_whetf2_rook(uplo,k,a,lda,ipiv,iinfo)
@@ -29541,7 +29541,7 @@ module stdlib_linalg_lapack_w
               ! kb, where kb is the number of columns factorized by stdlib_wlahef_rook;
               ! kb is either nb or nb-1, or n-k+1 for the last block
               k = 1
-20            continue
+              20 continue
               ! if k > n, exit from loop
               if (k > n) go to 40
               if (k <= n - nb) then
@@ -29568,7 +29568,7 @@ module stdlib_linalg_lapack_w
               k = k + kb
               go to 20
            end if
-40         continue
+           40 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_whetrf_rook
@@ -29590,7 +29590,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kp,kstep
@@ -29633,7 +29633,7 @@ module stdlib_linalg_lapack_w
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-30            continue
+              30 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               if (ipiv(k) > 0) then
@@ -29644,7 +29644,7 @@ module stdlib_linalg_lapack_w
                  if (k > 1) then
                     call stdlib_wcopy(k - 1,a(1,k),1,work,1)
                     call stdlib_whemv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - real(stdlib_wdotc(k - 1,work,1,a(1,k),1), &
                               KIND=qp)
                  end if
@@ -29664,14 +29664,14 @@ module stdlib_linalg_lapack_w
                  if (k > 1) then
                     call stdlib_wcopy(k - 1,a(1,k),1,work,1)
                     call stdlib_whemv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - real(stdlib_wdotc(k - 1,work,1,a(1,k),1), &
                               KIND=qp)
                     a(k,k + 1) = a(k,k + 1) - stdlib_wdotc(k - 1,a(1,k),1,a(1,k + 1),1)
-                              
+
                     call stdlib_wcopy(k - 1,a(1,k + 1),1,work,1)
                     call stdlib_whemv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k + 1),1)
-                              
+
                     a(k + 1,k + 1) = a(k + 1,k + 1) - real(stdlib_wdotc(k - 1,work,1,a(1,k + 1), &
                               1),KIND=qp)
                  end if
@@ -29699,13 +29699,13 @@ module stdlib_linalg_lapack_w
               end if
               k = k + kstep
               go to 30
-50            continue
+              50 continue
            else
               ! compute inv(a) from the factorization a = l*d*l**h.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-60            continue
+              60 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 80
               if (ipiv(k) > 0) then
@@ -29771,7 +29771,7 @@ module stdlib_linalg_lapack_w
               end if
               k = k - kstep
               go to 60
-80            continue
+              80 continue
            end if
            return
      end subroutine stdlib_whetri
@@ -29793,7 +29793,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kp,kstep
@@ -29836,7 +29836,7 @@ module stdlib_linalg_lapack_w
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-30            continue
+              30 continue
               ! if k > n, exit from loop.
               if (k > n) go to 70
               if (ipiv(k) > 0) then
@@ -29847,7 +29847,7 @@ module stdlib_linalg_lapack_w
                  if (k > 1) then
                     call stdlib_wcopy(k - 1,a(1,k),1,work,1)
                     call stdlib_whemv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - real(stdlib_wdotc(k - 1,work,1,a(1,k),1), &
                               KIND=qp)
                  end if
@@ -29867,14 +29867,14 @@ module stdlib_linalg_lapack_w
                  if (k > 1) then
                     call stdlib_wcopy(k - 1,a(1,k),1,work,1)
                     call stdlib_whemv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - real(stdlib_wdotc(k - 1,work,1,a(1,k),1), &
                               KIND=qp)
                     a(k,k + 1) = a(k,k + 1) - stdlib_wdotc(k - 1,a(1,k),1,a(1,k + 1),1)
-                              
+
                     call stdlib_wcopy(k - 1,a(1,k + 1),1,work,1)
                     call stdlib_whemv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k + 1),1)
-                              
+
                     a(k + 1,k + 1) = a(k + 1,k + 1) - real(stdlib_wdotc(k - 1,work,1,a(1,k + 1), &
                               1),KIND=qp)
                  end if
@@ -29934,13 +29934,13 @@ module stdlib_linalg_lapack_w
               end if
               k = k + 1
               go to 30
-70            continue
+              70 continue
            else
               ! compute inv(a) from the factorization a = l*d*l**h.
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-80            continue
+              80 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 120
               if (ipiv(k) > 0) then
@@ -30038,7 +30038,7 @@ module stdlib_linalg_lapack_w
               end if
               k = k - 1
               go to 80
-120           continue
+              120 continue
            end if
            return
      end subroutine stdlib_whetri_rook
@@ -30060,7 +30060,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: a(lda,*)
            complex(qp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kp
@@ -30094,7 +30094,7 @@ module stdlib_linalg_lapack_w
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 30
               if (ipiv(k) > 0) then
@@ -30135,12 +30135,12 @@ module stdlib_linalg_lapack_w
                  k = k - 2
               end if
               go to 10
-30            continue
+              30 continue
               ! next solve u**h *x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               if (ipiv(k) > 0) then
@@ -30177,14 +30177,14 @@ module stdlib_linalg_lapack_w
                  k = k + 2
               end if
               go to 40
-50            continue
+              50 continue
            else
               ! solve a*x = b, where a = l*d*l**h.
               ! first solve l*d*x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-60            continue
+              60 continue
               ! if k > n, exit from loop.
               if (k > n) go to 80
               if (ipiv(k) > 0) then
@@ -30227,12 +30227,12 @@ module stdlib_linalg_lapack_w
                  k = k + 2
               end if
               go to 60
-80            continue
+              80 continue
               ! next solve l**h *x = b, overwriting b with x.
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-90            continue
+              90 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 100
               if (ipiv(k) > 0) then
@@ -30269,7 +30269,7 @@ module stdlib_linalg_lapack_w
                  k = k - 2
               end if
               go to 90
-100           continue
+              100 continue
            end if
            return
      end subroutine stdlib_whetrs
@@ -30291,7 +30291,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,iinfo,j,k,kp
@@ -30402,7 +30402,7 @@ module stdlib_linalg_lapack_w
                  ! interchange rows k and -ipiv(k+1).
                  kp = -ipiv(k + 1)
                  if (kp == -ipiv(k)) call stdlib_wswap(nrhs,b(k + 1,1),ldb,b(kp,1),ldb)
-                           
+
                  k = k + 2
               end if
              end do
@@ -30478,7 +30478,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: a(lda,*),e(*)
            complex(qp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,j,k,kp
@@ -30620,7 +30620,7 @@ module stdlib_linalg_lapack_w
      !> A = L*T*L**H computed by ZHETRF_AA.
 
      pure subroutine stdlib_whetrs_aa(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -30634,7 +30634,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: b(ldb,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            logical(lk) :: lquery,upper
            integer(ilp) :: k,kp,lwkopt
            ! Intrinsic Functions
@@ -30753,7 +30753,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: a(lda,*)
            complex(qp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kp
@@ -30787,7 +30787,7 @@ module stdlib_linalg_lapack_w
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 30
               if (ipiv(k) > 0) then
@@ -30830,12 +30830,12 @@ module stdlib_linalg_lapack_w
                  k = k - 2
               end if
               go to 10
-30            continue
+              30 continue
               ! next solve u**h *x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               if (ipiv(k) > 0) then
@@ -30874,14 +30874,14 @@ module stdlib_linalg_lapack_w
                  k = k + 2
               end if
               go to 40
-50            continue
+              50 continue
            else
               ! solve a*x = b, where a = l*d*l**h.
               ! first solve l*d*x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-60            continue
+              60 continue
               ! if k > n, exit from loop.
               if (k > n) go to 80
               if (ipiv(k) > 0) then
@@ -30926,12 +30926,12 @@ module stdlib_linalg_lapack_w
                  k = k + 2
               end if
               go to 60
-80            continue
+              80 continue
               ! next solve l**h *x = b, overwriting b with x.
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-90            continue
+              90 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 100
               if (ipiv(k) > 0) then
@@ -30970,7 +30970,7 @@ module stdlib_linalg_lapack_w
                  k = k - 2
               end if
               go to 90
-100           continue
+              100 continue
            end if
            return
      end subroutine stdlib_whetrs_rook
@@ -30996,7 +30996,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: a(lda,*)
            complex(qp),intent(inout) :: c(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,normaltransr,nisodd,notrans
            integer(ilp) :: info,nrowa,j,nk,n1,n2
@@ -31069,7 +31069,7 @@ module stdlib_linalg_lapack_w
                     if (notrans) then
                        ! n is odd, transr = 'n', uplo = 'l', and trans = 'n'
                        call stdlib_wherk('L','N',n1,k,alpha,a(1,1),lda,beta,c(1),n)
-                                 
+
                        call stdlib_wherk('U','N',n2,k,alpha,a(n1 + 1,1),lda,beta,c(n + 1) &
                                  ,n)
                        call stdlib_wgemm('N','C',n2,n1,k,calpha,a(n1 + 1,1),lda,a(1,1) &
@@ -31077,7 +31077,7 @@ module stdlib_linalg_lapack_w
                     else
                        ! n is odd, transr = 'n', uplo = 'l', and trans = 'c'
                        call stdlib_wherk('L','C',n1,k,alpha,a(1,1),lda,beta,c(1),n)
-                                 
+
                        call stdlib_wherk('U','C',n2,k,alpha,a(1,n1 + 1),lda,beta,c(n + 1) &
                                  ,n)
                        call stdlib_wgemm('C','N',n2,n1,k,calpha,a(1,n1 + 1),lda,a(1,1) &
@@ -31282,7 +31282,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(out) :: alpha(*),beta(*),work(*)
            complex(qp),intent(inout) :: h(ldh,*),q(ldq,*),t(ldt,*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: ilazr2,ilazro,ilq,ilschr,ilz,lquery
            integer(ilp) :: icompq,icompz,ifirst,ifrstm,iiter,ilast,ilastm,in,ischur, &
@@ -31512,7 +31512,7 @@ module stdlib_linalg_lapack_w
                        do jch = j,ilast - 1
                           ctemp = t(jch,jch + 1)
                           call stdlib_wlartg(ctemp,t(jch + 1,jch + 1),c,s,t(jch,jch + 1))
-                                    
+
                           t(jch + 1,jch + 1) = czero
                           if (jch < ilastm - 1) call stdlib_wrot(ilastm - jch - 1,t(jch,jch + 2),ldt, &
                                     t(jch + 1,jch + 2),ldt,c,s)
@@ -31522,14 +31522,14 @@ module stdlib_linalg_lapack_w
                                      s))
                           ctemp = h(jch + 1,jch)
                           call stdlib_wlartg(ctemp,h(jch + 1,jch - 1),c,s,h(jch + 1,jch))
-                                    
+
                           h(jch + 1,jch - 1) = czero
                           call stdlib_wrot(jch + 1 - ifrstm,h(ifrstm,jch),1,h(ifrstm,jch - 1), &
                                     1,c,s)
                           call stdlib_wrot(jch - ifrstm,t(ifrstm,jch),1,t(ifrstm,jch - 1),1, &
                                      c,s)
                           if (ilz) call stdlib_wrot(n,z(1,jch),1,z(1,jch - 1),1,c,s)
-                                    
+
                        end do
                        go to 50
                     end if
@@ -31545,7 +31545,7 @@ module stdlib_linalg_lapack_w
               go to 210
               ! t(ilast,ilast)=0 -- clear h(ilast,ilast-1) to split off a
               ! 1x1 block.
-50   continue
+              50 continue
               ctemp = h(ilast,ilast)
               call stdlib_wlartg(ctemp,h(ilast,ilast - 1),c,s,h(ilast,ilast))
               h(ilast,ilast - 1) = czero
@@ -31555,7 +31555,7 @@ module stdlib_linalg_lapack_w
                         )
               if (ilz) call stdlib_wrot(n,z(1,ilast),1,z(1,ilast - 1),1,c,s)
               ! h(ilast,ilast-1)=0 -- standardize b, set alpha and beta
-60   continue
+              60 continue
               absb = abs(t(ilast,ilast))
               if (absb > safmin) then
                  signbc = conjg(t(ilast,ilast)/absb)
@@ -31586,7 +31586,7 @@ module stdlib_linalg_lapack_w
               ! qz step
               ! this iteration only involves rows/columns ifirst:ilast.  we
               ! assume ifirst < ilast, and that the diagonal of b is non-zero.
-70   continue
+              70 continue
               iiter = iiter + 1
               if (.not. ilschr) then
                  ifrstm = ifirst
@@ -31627,7 +31627,7 @@ module stdlib_linalg_lapack_w
                  if ((iiter/20)*20 == iiter .and. bscale*abs1(t(ilast,ilast)) > safmin) &
                            then
                     eshift = eshift + (ascale*h(ilast,ilast))/(bscale*t(ilast,ilast))
-                              
+
                  else
                     eshift = eshift + (ascale*h(ilast,ilast - 1))/(bscale*t(ilast - 1,ilast - 1) &
                                )
@@ -31649,7 +31649,7 @@ module stdlib_linalg_lapack_w
               end do
               istart = ifirst
               ctemp = ascale*h(ifirst,ifirst) - shift*(bscale*t(ifirst,ifirst))
-90            continue
+              90 continue
               ! do an implicit-shift qz sweep.
               ! initial q
               ctemp2 = ascale*h(istart + 1,istart)
@@ -31697,14 +31697,14 @@ module stdlib_linalg_lapack_w
                     end do
                  end if
               end do loop_150
-160           continue
+              160 continue
            end do loop_170
            ! drop-through = non-convergence
-180  continue
+           180 continue
            info = ilast
            go to 210
            ! successful completion of all qz steps
-190  continue
+           190 continue
            ! set eigenvalues 1:ilo-1
            do j = 1,ilo - 1
               absb = abs(t(j,j))
@@ -31727,7 +31727,7 @@ module stdlib_linalg_lapack_w
            ! normal termination
            info = 0
            ! exit (other than argument error) -- return optimal workspace size
-210  continue
+           210 continue
            work(1) = cmplx(n,KIND=qp)
            return
      end subroutine stdlib_whgeqz
@@ -31753,7 +31753,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: ap(*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,ip,kase
@@ -31801,7 +31801,7 @@ module stdlib_linalg_lapack_w
            end if
            ! estimate the 1-norm of the inverse.
            kase = 0
-30         continue
+           30 continue
            call stdlib_wlacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               ! multiply by inv(l*d*l**h) or inv(u*d*u**h).
@@ -31829,7 +31829,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: ap(*)
            complex(qp),intent(out) :: work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: wantz
            integer(ilp) :: iinfo,imax,inde,indrwk,indtau,indwrk,iscale
@@ -31893,10 +31893,10 @@ module stdlib_linalg_lapack_w
            else
               indwrk = indtau + n
               call stdlib_wupgtr(uplo,n,ap,work(indtau),z,ldz,work(indwrk),iinfo)
-                        
+
               indrwk = inde + n
               call stdlib_wsteqr(jobz,n,w,rwork(inde),z,ldz,rwork(indrwk),info)
-                        
+
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
            if (iscale == 1) then
@@ -31935,7 +31935,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: ap(*)
            complex(qp),intent(out) :: work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wantz
            integer(ilp) :: iinfo,imax,inde,indrwk,indtau,indwrk,iscale,liwmin,llrwk, &
@@ -32072,7 +32072,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: ap(*)
            complex(qp),intent(out) :: work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,test,valeig,wantz
            character :: order
@@ -32172,7 +32172,7 @@ module stdlib_linalg_lapack_w
            indtau = 1
            indwrk = indtau + n
            call stdlib_whptrd(uplo,n,ap,rwork(indd),rwork(inde),work(indtau),iinfo)
-                     
+
            ! if all eigenvalues are desired and abstol is less than or equal
            ! to zero, then call stdlib_qsterf or stdlib_wupgtr and stdlib_wsteqr.  if this fails
            ! for some eigenvalue, then try stdlib_qstebz.
@@ -32190,10 +32190,10 @@ module stdlib_linalg_lapack_w
                  call stdlib_qsterf(n,w,rwork(indee),info)
               else
                  call stdlib_wupgtr(uplo,n,ap,work(indtau),z,ldz,work(indwrk),iinfo)
-                           
+
                  call stdlib_qcopy(n - 1,rwork(inde),1,rwork(indee),1)
                  call stdlib_wsteqr(jobz,n,w,rwork(indee),z,ldz,rwork(indrwk),info)
-                           
+
                  if (info == 0) then
                     do i = 1,n
                        ifail(i) = 0
@@ -32228,7 +32228,7 @@ module stdlib_linalg_lapack_w
                          iinfo)
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
-20   continue
+           20 continue
            if (iscale == 1) then
               if (info == 0) then
                  imax = m
@@ -32287,7 +32287,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: ap(*)
            complex(qp),intent(in) :: bp(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,j1,j1j1,jj,k,k1,k1k1,kk
@@ -32324,7 +32324,7 @@ module stdlib_linalg_lapack_w
                     call stdlib_wtpsv(uplo,'CONJUGATE TRANSPOSE','NON-UNIT',j,bp,ap(j1),1 &
                               )
                     call stdlib_whpmv(uplo,j - 1,-cone,ap,bp(j1),1,cone,ap(j1),1)
-                              
+
                     call stdlib_wdscal(j - 1,one/bjj,ap(j1),1)
                     ap(jj) = (ap(jj) - stdlib_wdotc(j - 1,ap(j1),1,bp(j1),1))/ &
                               bjj
@@ -32365,7 +32365,7 @@ module stdlib_linalg_lapack_w
                     akk = real(ap(kk),KIND=qp)
                     bkk = real(bp(kk),KIND=qp)
                     call stdlib_wtpmv(uplo,'NO TRANSPOSE','NON-UNIT',k - 1,bp,ap(k1),1)
-                              
+
                     ct = half*akk
                     call stdlib_waxpy(k - 1,ct,bp(k1),1,ap(k1),1)
                     call stdlib_whpr2(uplo,k - 1,cone,ap(k1),1,bp(k1),1,ap)
@@ -32748,7 +32748,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,ik,j,k,kase,kk,nz
@@ -32799,7 +32799,7 @@ module stdlib_linalg_lapack_w
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_wcopy(n,b(1,j),1,work,1)
@@ -32890,7 +32890,7 @@ module stdlib_linalg_lapack_w
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_wlacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -32993,7 +32993,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: ap(*),b(ldb,*)
            complex(qp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nofact
            real(qp) :: anorm
@@ -33064,7 +33064,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: ap(*)
            complex(qp),intent(out) :: tau(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,i1,i1i1,ii
@@ -33139,7 +33139,7 @@ module stdlib_linalg_lapack_w
                     ! apply the transformation as a rank-2 update:
                        ! a := a - v * w**h - w * v**h
                     call stdlib_whpr2(uplo,n - i,-cone,ap(ii + 1),1,tau(i),1,ap(i1i1))
-                              
+
                  end if
                  ap(ii + 1) = e(i)
                  d(i) = real(ap(ii),KIND=qp)
@@ -33172,7 +33172,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: sevten = 17.0e+0_qp
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,imax,j,jmax,k,kc,kk,knc,kp,kpc,kstep,kx,npp
@@ -33205,7 +33205,7 @@ module stdlib_linalg_lapack_w
               ! 1 or 2
               k = n
               kc = (n - 1)*n/2 + 1
-10            continue
+              10 continue
               knc = kc
               ! if k < 1, exit from loop
               if (k < 1) go to 110
@@ -33320,7 +33320,7 @@ module stdlib_linalg_lapack_w
                           wkm1 = d*(d11*ap(j + (k - 2)*(k - 1)/2) - conjg(d12)*ap(j + (k - 1)*k &
                                     /2))
                           wk = d*(d22*ap(j + (k - 1)*k/2) - d12*ap(j + (k - 2)*(k - 1)/2))
-                                    
+
                           do i = j,1,-1
                              ap(i + (j - 1)*j/2) = ap(i + (j - 1)*j/2) - ap(i + (k - 1)*k/2) &
                                        *conjg(wk) - ap(i + (k - 2)*(k - 1)/2)*conjg(wkm1)
@@ -33351,7 +33351,7 @@ module stdlib_linalg_lapack_w
               k = 1
               kc = 1
               npp = n*(n + 1)/2
-60            continue
+              60 continue
               knc = kc
               ! if k > n, exit from loop
               if (k > n) go to 110
@@ -33413,7 +33413,7 @@ module stdlib_linalg_lapack_w
                     ! interchange rows and columns kk and kp in the trailing
                     ! submatrix a(k:n,k:n)
                     if (kp < n) call stdlib_wswap(n - kp,ap(knc + kp - kk + 1),1,ap(kpc + 1),1)
-                              
+
                     kx = knc + kp - kk
                     do j = kk + 1,kp - 1
                        kx = kx + n - j + 1
@@ -33496,7 +33496,7 @@ module stdlib_linalg_lapack_w
               kc = knc + n - k + 2
               go to 60
            end if
-110        continue
+           110 continue
            return
      end subroutine stdlib_whptrf
 
@@ -33517,7 +33517,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: ap(*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kc,kcnext,kp,kpc,kstep,kx,npp
@@ -33563,7 +33563,7 @@ module stdlib_linalg_lapack_w
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
               kc = 1
-30            continue
+              30 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               kcnext = kc + k
@@ -33600,7 +33600,7 @@ module stdlib_linalg_lapack_w
                               kcnext),1)
                     call stdlib_wcopy(k - 1,ap(kcnext),1,work,1)
                     call stdlib_whpmv(uplo,k - 1,-cone,ap,work,1,czero,ap(kcnext),1)
-                              
+
                     ap(kcnext + k) = ap(kcnext + k) - real(stdlib_wdotc(k - 1,work,1,ap(kcnext &
                               ),1),KIND=qp)
                  end if
@@ -33633,7 +33633,7 @@ module stdlib_linalg_lapack_w
               k = k + kstep
               kc = kcnext
               go to 30
-50            continue
+              50 continue
            else
               ! compute inv(a) from the factorization a = l*d*l**h.
               ! k is the main loop index, increasing from 1 to n in steps of
@@ -33641,7 +33641,7 @@ module stdlib_linalg_lapack_w
               npp = n*(n + 1)/2
               k = n
               kc = npp
-60            continue
+              60 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 80
               kcnext = kc - (n - k + 2)
@@ -33713,7 +33713,7 @@ module stdlib_linalg_lapack_w
               k = k - kstep
               kc = kcnext
               go to 60
-80            continue
+              80 continue
            end if
            return
      end subroutine stdlib_whptri
@@ -33735,7 +33735,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: ap(*)
            complex(qp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kc,kp
@@ -33768,7 +33768,7 @@ module stdlib_linalg_lapack_w
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
               kc = n*(n + 1)/2 + 1
-10            continue
+              10 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 30
               kc = kc - k
@@ -33780,7 +33780,7 @@ module stdlib_linalg_lapack_w
                  ! multiply by inv(u(k)), where u(k) is the transformation
                  ! stored in column k of a.
                  call stdlib_wgeru(k - 1,nrhs,-cone,ap(kc),1,b(k,1),ldb,b(1,1),ldb)
-                           
+
                  ! multiply by the inverse of the diagonal block.
                  s = real(cone,KIND=qp)/real(ap(kc + k - 1),KIND=qp)
                  call stdlib_wdscal(nrhs,s,b(k,1),ldb)
@@ -33793,7 +33793,7 @@ module stdlib_linalg_lapack_w
                  ! multiply by inv(u(k)), where u(k) is the transformation
                  ! stored in columns k-1 and k of a.
                  call stdlib_wgeru(k - 2,nrhs,-cone,ap(kc),1,b(k,1),ldb,b(1,1),ldb)
-                           
+
                  call stdlib_wgeru(k - 2,nrhs,-cone,ap(kc - (k - 1)),1,b(k - 1,1),ldb,b(1, &
                            1),ldb)
                  ! multiply by the inverse of the diagonal block.
@@ -33811,13 +33811,13 @@ module stdlib_linalg_lapack_w
                  k = k - 2
               end if
               go to 10
-30            continue
+              30 continue
               ! next solve u**h *x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
               kc = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               if (ipiv(k) > 0) then
@@ -33856,7 +33856,7 @@ module stdlib_linalg_lapack_w
                  k = k + 2
               end if
               go to 40
-50            continue
+              50 continue
            else
               ! solve a*x = b, where a = l*d*l**h.
               ! first solve l*d*x = b, overwriting b with x.
@@ -33864,7 +33864,7 @@ module stdlib_linalg_lapack_w
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
               kc = 1
-60            continue
+              60 continue
               ! if k > n, exit from loop.
               if (k > n) go to 80
               if (ipiv(k) > 0) then
@@ -33909,13 +33909,13 @@ module stdlib_linalg_lapack_w
                  k = k + 2
               end if
               go to 60
-80            continue
+              80 continue
               ! next solve l**h *x = b, overwriting b with x.
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
               kc = n*(n + 1)/2 + 1
-90            continue
+              90 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 100
               kc = kc - (n - k + 1)
@@ -33954,7 +33954,7 @@ module stdlib_linalg_lapack_w
                  k = k - 2
               end if
               go to 90
-100           continue
+              100 continue
            end if
            return
      end subroutine stdlib_whptrs
@@ -33985,7 +33985,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: rzero = 0.0e+0_qp
-           
+
            ! Local Scalars
            logical(lk) :: bothv,fromqr,leftv,noinit,rightv
            integer(ilp) :: i,iinfo,k,kl,kln,kr,ks,ldwork
@@ -34062,13 +34062,13 @@ module stdlib_linalg_lapack_w
                     do i = k,kl + 1,-1
                        if (h(i,i - 1) == czero) go to 30
                     end do
-30                  continue
+                    30 continue
                     kl = i
                     if (k > kr) then
                        do i = k,n - 1
                           if (h(i + 1,i) == czero) go to 50
                        end do
-50                     continue
+                       50 continue
                        kr = i
                     end if
                  end if
@@ -34090,7 +34090,7 @@ module stdlib_linalg_lapack_w
                  ! selected eigenvalues affiliated to the submatrix
                  ! h(kl:kr,kl:kr). close roots are modified by eps3.
                  wk = w(k)
-60               continue
+                 60 continue
                  do i = k - 1,kl,-1
                     if (select(i) .and. cabs1(w(i) - wk) < eps3) then
                        wk = wk + eps3
@@ -34142,7 +34142,7 @@ module stdlib_linalg_lapack_w
      !> by the unitary matrix Q:  A = Q*H*Q**H = (QZ)*T*(QZ)**H.
 
      pure subroutine stdlib_whseqr(job,compz,n,ilo,ihi,h,ldh,w,z,ldz,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -34161,14 +34161,14 @@ module stdlib_linalg_lapack_w
            ! ==== matrices of order ntiny or smaller must be processed by
            ! .    stdlib_wlahqr because of insufficient subdiagonal scratch space.
            ! .    (this is a hard limit.) ====
-           
+
            ! ==== nl allocates some local workspace to help small matrices
            ! .    through a rare stdlib_wlahqr failure.  nl > ntiny = 15 is
            ! .    required and nl <= nmin = stdlib_ilaenv(ispec=12,...) is recom-
            ! .    mended.  (the default value of nmin is 75.)  using nl = 49
            ! .    allows up to six simultaneous shifts and a 16-by-16
            ! .    deflation window.  ====
-           
+
            ! Local Arrays
            complex(qp) :: hl(nl,nl),workl(nl)
            ! Local Scalars
@@ -34221,7 +34221,7 @@ module stdlib_linalg_lapack_w
               ! ==== copy eigenvalues isolated by stdlib_wgebal ====
               if (ilo > 1) call stdlib_wcopy(ilo - 1,h,ldh + 1,w,1)
               if (ihi < n) call stdlib_wcopy(n - ihi,h(ihi + 1,ihi + 1),ldh + 1,w(ihi + 1),1)
-                        
+
               ! ==== initialize z, if requested ====
               if (initz) call stdlib_wlaset('A',n,n,czero,cone,z,ldz)
               ! ==== quick return if possible ====
@@ -34231,7 +34231,7 @@ module stdlib_linalg_lapack_w
               end if
               ! ==== stdlib_wlahqr/stdlib_wlaqr0 crossover point ====
               nmin = stdlib_ilaenv(12,'ZHSEQR',job(:1)//compz(:1),n,ilo,ihi,lwork)
-                        
+
               nmin = max(ntiny,nmin)
               ! ==== stdlib_wlaqr0 for big matrices; stdlib_wlahqr for small ones ====
               if (n > nmin) then
@@ -34240,7 +34240,7 @@ module stdlib_linalg_lapack_w
               else
                  ! ==== small matrix ====
                  call stdlib_wlahqr(wantt,wantz,n,ilo,ihi,h,ldh,w,ilo,ihi,z,ldz,info)
-                           
+
                  if (info > 0) then
                     ! ==== a rare stdlib_wlahqr failure!  stdlib_wlaqr0 sometimes succeeds
                     ! .    when stdlib_wlahqr fails. ====
@@ -34261,7 +34261,7 @@ module stdlib_linalg_lapack_w
                        call stdlib_wlaqr0(wantt,wantz,nl,ilo,kbot,hl,nl,w,ilo,ihi,z, &
                                  ldz,workl,nl,info)
                        if (wantt .or. info /= 0) call stdlib_wlacpy('A',n,n,hl,nl,h,ldh)
-                                 
+
                     end if
                  end if
               end if
@@ -34290,7 +34290,7 @@ module stdlib_linalg_lapack_w
      !> in computing that entry have at least one zero multiplicand.
 
      subroutine stdlib_wla_gbamv(trans,m,n,kl,ku,alpha,ab,ldab,x,incx,beta,y,incy)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -34301,7 +34301,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: ab(ldab,*),x(*)
            real(qp),intent(inout) :: y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: symb_wero
            real(qp) :: temp,safe1
@@ -34386,7 +34386,7 @@ module stdlib_linalg_lapack_w
                        do j = max(i - kl,1),min(i + ku,lenx)
                           temp = cabs1(ab(kd + i - j,j))
                           symb_wero = symb_wero .and. (x(j) == czero .or. temp == czero)
-                                    
+
                           y(iy) = y(iy) + alpha*cabs1(x(j))*temp
                        end do
                     end if
@@ -34408,7 +34408,7 @@ module stdlib_linalg_lapack_w
                        do j = max(i - kl,1),min(i + ku,lenx)
                           temp = cabs1(ab(ke - i + j,i))
                           symb_wero = symb_wero .and. (x(j) == czero .or. temp == czero)
-                                    
+
                           y(iy) = y(iy) + alpha*cabs1(x(j))*temp
                        end do
                     end if
@@ -34433,7 +34433,7 @@ module stdlib_linalg_lapack_w
                        do j = max(i - kl,1),min(i + ku,lenx)
                           temp = cabs1(ab(kd + i - j,j))
                           symb_wero = symb_wero .and. (x(jx) == czero .or. temp == czero)
-                                    
+
                           y(iy) = y(iy) + alpha*cabs1(x(jx))*temp
                           jx = jx + incx
                        end do
@@ -34457,7 +34457,7 @@ module stdlib_linalg_lapack_w
                        do j = max(i - kl,1),min(i + ku,lenx)
                           temp = cabs1(ab(ke - i + j,i))
                           symb_wero = symb_wero .and. (x(jx) == czero .or. temp == czero)
-                                    
+
                           y(iy) = y(iy) + alpha*cabs1(x(jx))*temp
                           jx = jx + incx
                        end do
@@ -34571,7 +34571,7 @@ module stdlib_linalg_lapack_w
            ! estimate the norm of inv(op(a)).
            ainvnm = zero
            kase = 0
-10         continue
+           10 continue
            call stdlib_wlacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == 2) then
@@ -34689,7 +34689,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: a(lda,*),x(*)
            real(qp),intent(inout) :: y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: symb_wero
            real(qp) :: temp,safe1
@@ -34768,7 +34768,7 @@ module stdlib_linalg_lapack_w
                        do j = 1,lenx
                           temp = cabs1(a(i,j))
                           symb_wero = symb_wero .and. (x(j) == czero .or. temp == czero)
-                                    
+
                           y(iy) = y(iy) + alpha*cabs1(x(j))*temp
                        end do
                     end if
@@ -34790,7 +34790,7 @@ module stdlib_linalg_lapack_w
                        do j = 1,lenx
                           temp = cabs1(a(j,i))
                           symb_wero = symb_wero .and. (x(j) == czero .or. temp == czero)
-                                    
+
                           y(iy) = y(iy) + alpha*cabs1(x(j))*temp
                        end do
                     end if
@@ -34815,7 +34815,7 @@ module stdlib_linalg_lapack_w
                        do j = 1,lenx
                           temp = cabs1(a(i,j))
                           symb_wero = symb_wero .and. (x(jx) == czero .or. temp == czero)
-                                    
+
                           y(iy) = y(iy) + alpha*cabs1(x(jx))*temp
                           jx = jx + incx
                        end do
@@ -34839,7 +34839,7 @@ module stdlib_linalg_lapack_w
                        do j = 1,lenx
                           temp = cabs1(a(j,i))
                           symb_wero = symb_wero .and. (x(jx) == czero .or. temp == czero)
-                                    
+
                           y(iy) = y(iy) + alpha*cabs1(x(jx))*temp
                           jx = jx + incx
                        end do
@@ -34946,7 +34946,7 @@ module stdlib_linalg_lapack_w
            ! estimate the norm of inv(op(a)).
            ainvnm = zero
            kase = 0
-10         continue
+           10 continue
            call stdlib_wlacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == 2) then
@@ -34956,7 +34956,7 @@ module stdlib_linalg_lapack_w
                  end do
                  if (notrans) then
                     call stdlib_wgetrs('NO TRANSPOSE',n,1,af,ldaf,ipiv,work,n,info)
-                              
+
                  else
                     call stdlib_wgetrs('CONJUGATE TRANSPOSE',n,1,af,ldaf,ipiv,work,n,info &
                               )
@@ -34979,7 +34979,7 @@ module stdlib_linalg_lapack_w
                               )
                  else
                     call stdlib_wgetrs('NO TRANSPOSE',n,1,af,ldaf,ipiv,work,n,info)
-                              
+
                  end if
                  ! multiply by r.
                  do i = 1,n
@@ -35061,7 +35061,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: a(lda,*),x(*)
            real(qp),intent(inout) :: y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: symb_wero
            real(qp) :: temp,safe1
@@ -35338,7 +35338,7 @@ module stdlib_linalg_lapack_w
            ! estimate the norm of inv(op(a)).
            ainvnm = zero
            kase = 0
-10         continue
+           10 continue
            call stdlib_wlacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == 2) then
@@ -35723,7 +35723,7 @@ module stdlib_linalg_lapack_w
            ! estimate the norm of inv(op(a)).
            ainvnm = zero
            kase = 0
-10         continue
+           10 continue
            call stdlib_wlacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == 2) then
@@ -35884,7 +35884,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: a(lda,*),x(*)
            real(qp),intent(inout) :: y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: symb_wero
            real(qp) :: temp,safe1
@@ -36162,7 +36162,7 @@ module stdlib_linalg_lapack_w
            ! estimate the norm of inv(op(a)).
            ainvnm = zero
            kase = 0
-10         continue
+           10 continue
            call stdlib_wlacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == 2) then
@@ -36417,7 +36417,7 @@ module stdlib_linalg_lapack_w
              s = (s + s) - s
              y(i) = ((x(i) - s) + w(i)) + y(i)
              x(i) = s
-10           continue
+             10 continue
            return
      end subroutine stdlib_wla_wwaddw
 
@@ -36440,7 +36440,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: taup(*),tauq(*),x(ldx,*),y(ldy,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            complex(qp) :: alpha
@@ -36620,7 +36620,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            integer(ilp) :: i,jlast
            real(qp) :: absxi,altsgn,estold,safmin,temp
@@ -36639,7 +36639,7 @@ module stdlib_linalg_lapack_w
            go to(20,40,70,90,120) isave(1)
            ! ................ entry   (isave( 1 ) = 1)
            ! first iteration.  x has been overwritten by a*x.
-20   continue
+           20 continue
            if (n == 1) then
               v(1) = x(1)
               est = abs(v(1))
@@ -36651,7 +36651,7 @@ module stdlib_linalg_lapack_w
               absxi = abs(x(i))
               if (absxi > safmin) then
                  x(i) = cmplx(real(x(i),KIND=qp)/absxi,aimag(x(i))/absxi,KIND=qp)
-                           
+
               else
                  x(i) = cone
               end if
@@ -36661,11 +36661,11 @@ module stdlib_linalg_lapack_w
            return
            ! ................ entry   (isave( 1 ) = 2)
            ! first iteration.  x has been overwritten by ctrans(a)*x.
-40   continue
+           40 continue
            isave(2) = stdlib_iwmax1(n,x,1)
            isave(3) = 2
            ! main loop - iterations 2,3,...,itmax.
-50   continue
+           50 continue
            do i = 1,n
               x(i) = czero
            end do
@@ -36675,7 +36675,7 @@ module stdlib_linalg_lapack_w
            return
            ! ................ entry   (isave( 1 ) = 3)
            ! x has been overwritten by a*x.
-70   continue
+           70 continue
            call stdlib_wcopy(n,x,1,v,1)
            estold = est
            est = stdlib_qzsum1(n,v,1)
@@ -36685,7 +36685,7 @@ module stdlib_linalg_lapack_w
               absxi = abs(x(i))
               if (absxi > safmin) then
                  x(i) = cmplx(real(x(i),KIND=qp)/absxi,aimag(x(i))/absxi,KIND=qp)
-                           
+
               else
                  x(i) = cone
               end if
@@ -36695,7 +36695,7 @@ module stdlib_linalg_lapack_w
            return
            ! ................ entry   (isave( 1 ) = 4)
            ! x has been overwritten by ctrans(a)*x.
-90   continue
+           90 continue
            jlast = isave(2)
            isave(2) = stdlib_iwmax1(n,x,1)
            if ((abs(x(jlast)) /= abs(x(isave(2)))) .and. (isave(3) < itmax)) &
@@ -36704,11 +36704,11 @@ module stdlib_linalg_lapack_w
               go to 50
            end if
            ! iteration complete.  final stage.
-100  continue
+           100 continue
            altsgn = one
            do i = 1,n
               x(i) = cmplx(altsgn*(one + real(i - 1,KIND=qp)/real(n - 1,KIND=qp)),KIND=qp)
-                        
+
               altsgn = -altsgn
            end do
            kase = 1
@@ -36716,13 +36716,13 @@ module stdlib_linalg_lapack_w
            return
            ! ................ entry   (isave( 1 ) = 5)
            ! x has been overwritten by a*x.
-120  continue
+           120 continue
            temp = two*(stdlib_qzsum1(n,x,1)/real(3*n,KIND=qp))
            if (temp > est) then
               call stdlib_wcopy(n,x,1,v,1)
               est = temp
            end if
-130        continue
+           130 continue
            kase = 0
            return
      end subroutine stdlib_wlacn2
@@ -36744,7 +36744,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            integer(ilp) :: i,iter,j,jlast,jump
            real(qp) :: absxi,altsgn,estold,safmin,temp
@@ -36765,7 +36765,7 @@ module stdlib_linalg_lapack_w
            go to(20,40,70,90,120) jump
            ! ................ entry   (jump = 1)
            ! first iteration.  x has been overwritten by a*x.
-20   continue
+           20 continue
            if (n == 1) then
               v(1) = x(1)
               est = abs(v(1))
@@ -36777,7 +36777,7 @@ module stdlib_linalg_lapack_w
               absxi = abs(x(i))
               if (absxi > safmin) then
                  x(i) = cmplx(real(x(i),KIND=qp)/absxi,aimag(x(i))/absxi,KIND=qp)
-                           
+
               else
                  x(i) = cone
               end if
@@ -36787,11 +36787,11 @@ module stdlib_linalg_lapack_w
            return
            ! ................ entry   (jump = 2)
            ! first iteration.  x has been overwritten by ctrans(a)*x.
-40   continue
+           40 continue
            j = stdlib_iwmax1(n,x,1)
            iter = 2
            ! main loop - iterations 2,3,...,itmax.
-50   continue
+           50 continue
            do i = 1,n
               x(i) = czero
            end do
@@ -36801,7 +36801,7 @@ module stdlib_linalg_lapack_w
            return
            ! ................ entry   (jump = 3)
            ! x has been overwritten by a*x.
-70   continue
+           70 continue
            call stdlib_wcopy(n,x,1,v,1)
            estold = est
            est = stdlib_qzsum1(n,v,1)
@@ -36811,7 +36811,7 @@ module stdlib_linalg_lapack_w
               absxi = abs(x(i))
               if (absxi > safmin) then
                  x(i) = cmplx(real(x(i),KIND=qp)/absxi,aimag(x(i))/absxi,KIND=qp)
-                           
+
               else
                  x(i) = cone
               end if
@@ -36821,7 +36821,7 @@ module stdlib_linalg_lapack_w
            return
            ! ................ entry   (jump = 4)
            ! x has been overwritten by ctrans(a)*x.
-90   continue
+           90 continue
            jlast = j
            j = stdlib_iwmax1(n,x,1)
            if ((abs(x(jlast)) /= abs(x(j))) .and. (iter < itmax)) then
@@ -36829,11 +36829,11 @@ module stdlib_linalg_lapack_w
               go to 50
            end if
            ! iteration complete.  final stage.
-100  continue
+           100 continue
            altsgn = one
            do i = 1,n
               x(i) = cmplx(altsgn*(one + real(i - 1,KIND=qp)/real(n - 1,KIND=qp)),KIND=qp)
-                        
+
               altsgn = -altsgn
            end do
            kase = 1
@@ -36841,13 +36841,13 @@ module stdlib_linalg_lapack_w
            return
            ! ................ entry   (jump = 5)
            ! x has been overwritten by a*x.
-120  continue
+           120 continue
            temp = two*(stdlib_qzsum1(n,x,1)/real(3*n,KIND=qp))
            if (temp > est) then
               call stdlib_wcopy(n,x,1,v,1)
               est = temp
            end if
-130        continue
+           130 continue
            kase = 0
            return
      end subroutine stdlib_wlacon
@@ -36951,7 +36951,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: a(lda,*)
            complex(qp),intent(out) :: c(ldc,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,l
            ! Intrinsic Functions
@@ -36966,7 +36966,7 @@ module stdlib_linalg_lapack_w
            end do
            l = m*n + 1
            call stdlib_qgemm('N','N',m,n,n,one,rwork,m,b,ldb,zero,rwork(l),m)
-                     
+
            do j = 1,n
               do i = 1,m
                  c(i,j) = rwork(l + (j - 1)*m + i - 1)
@@ -36978,11 +36978,11 @@ module stdlib_linalg_lapack_w
               end do
            end do
            call stdlib_qgemm('N','N',m,n,n,one,rwork,m,b,ldb,zero,rwork(l),m)
-                     
+
            do j = 1,n
               do i = 1,m
                  c(i,j) = cmplx(real(c(i,j),KIND=qp),rwork(l + (j - 1)*m + i - 1),KIND=qp)
-                           
+
               end do
            end do
            return
@@ -37023,7 +37023,7 @@ module stdlib_linalg_lapack_w
            end do
            return
            ! code for both increments equal to 1
-20   continue
+           20 continue
            do i = 1,n
               ctemp = c*cx(i) + s*cy(i)
               cy(i) = c*cy(i) - s*cx(i)
@@ -37049,7 +37049,7 @@ module stdlib_linalg_lapack_w
            intrinsic :: real,cmplx,aimag
            ! Executable Statements
            call stdlib_qladiv(real(x,KIND=qp),aimag(x),real(y,KIND=qp),aimag(y),zr,zi)
-                     
+
            stdlib_wladiv = cmplx(zr,zi,KIND=qp)
            return
      end function stdlib_wladiv
@@ -37060,7 +37060,7 @@ module stdlib_linalg_lapack_w
      !> corresponding eigenvectors of the dense or band matrix.
 
      pure subroutine stdlib_wlaed0(qsiz,n,d,e,q,ldq,qstore,ldqs,rwork,iwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -37075,7 +37075,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(out) :: qstore(ldqs,*)
         ! =====================================================================
         ! warning:      n could be as big as qsiz!
-           
+
            ! Local Scalars
            integer(ilp) :: curlvl,curprb,curr,i,igivcl,igivnm,igivpt,indxq,iperm,iprmpt, &
            iq,iqptr,iwrem,j,k,lgn,ll,matsiz,msd2,smlsiz,smm1,spm1,spm2,submat, &
@@ -37111,7 +37111,7 @@ module stdlib_linalg_lapack_w
            iwork(1) = n
            subpbs = 1
            tlvls = 0
-10         continue
+           10 continue
            if (iwork(subpbs) > smlsiz) then
               do j = subpbs,1,-1
                  iwork(2*j) = (iwork(j) + 1)/2
@@ -37186,7 +37186,7 @@ module stdlib_linalg_lapack_w
            ! into eigensystem for the corresponding larger matrix.
            ! while ( subpbs > 1 )
            curlvl = 1
-80         continue
+           80 continue
            if (subpbs > 1) then
               spm2 = subpbs - 2
               do i = 0,spm2,2
@@ -37268,7 +37268,7 @@ module stdlib_linalg_lapack_w
            real(qp),intent(inout) :: rho
            ! Array Arguments
            integer(ilp),intent(inout) :: givcol(2,*),givptr(*),perm(*),prmptr(*),qptr(*)
-                     
+
            integer(ilp),intent(out) :: indxq(*),iwork(*)
            real(qp),intent(inout) :: d(*),givnum(2,*),qstore(*)
            real(qp),intent(out) :: rwork(*)
@@ -37333,7 +37333,7 @@ module stdlib_linalg_lapack_w
            call stdlib_wlaed8(k,n,qsiz,q,ldq,d,rho,cutpnt,rwork(iz),rwork(idlmda), &
            work,qsiz,rwork(iw),iwork(indxp),iwork(indx),indxq,perm(prmptr(curr)), &
            givptr(curr + 1),givcol(1,givptr(curr)),givnum(1,givptr(curr)),info)
-                     
+
            prmptr(curr + 1) = prmptr(curr) + n
            givptr(curr + 1) = givptr(curr + 1) + givptr(curr)
            ! solve secular equation.
@@ -37385,7 +37385,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: mone = -1.0_qp
-           
+
            ! Local Scalars
            integer(ilp) :: i,imax,j,jlam,jmax,jp,k2,n1,n1p1,n2
            real(qp) :: c,eps,s,t,tau,tol
@@ -37479,7 +37479,7 @@ module stdlib_linalg_lapack_w
                  go to 70
               end if
            end do
-70         continue
+           70 continue
            j = j + 1
            if (j > n) go to 90
            if (rho*abs(z(j)) <= tol) then
@@ -37513,7 +37513,7 @@ module stdlib_linalg_lapack_w
                  d(jlam) = t
                  k2 = k2 - 1
                  i = 1
-80               continue
+                 80 continue
                  if (k2 + i <= n) then
                     if (d(jlam) < d(indxp(k2 + i))) then
                        indxp(k2 + i - 1) = indxp(k2 + i)
@@ -37536,13 +37536,13 @@ module stdlib_linalg_lapack_w
               end if
            end if
            go to 70
-90         continue
+           90 continue
            ! record the last eigenvalue.
            k = k + 1
            w(k) = z(jlam)
            dlamda(k) = d(jlam)
            indxp(k) = jlam
-100        continue
+           100 continue
            ! sort the eigenvalues and corresponding eigenvectors into dlamda
            ! and q2 respectively.  the eigenvalues/vectors which were not
            ! deflated go into the first k slots of dlamda and q2 respectively,
@@ -37585,7 +37585,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: tenth = 1.0e-1_qp
-           
+
            ! Local Scalars
            character :: normin,trans
            integer(ilp) :: i,ierr,its,j
@@ -37698,7 +37698,7 @@ module stdlib_linalg_lapack_w
            end do
            ! failure to find eigenvector in n iterations.
            info = 1
-120        continue
+           120 continue
            ! normalize eigenvector.
            i = stdlib_iwamax(n,v,1)
            call stdlib_wdscal(n,one/cabs1(v(i)),v,1)
@@ -37725,7 +37725,7 @@ module stdlib_linalg_lapack_w
        ! =====================================================================
            ! Parameters
            real(qp),parameter :: thresh = 0.1_qp
-           
+
            ! Local Scalars
            real(qp) :: babs,evnorm,tabs,z
            complex(qp) :: s,t,tmp
@@ -37809,7 +37809,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: a,b,c
            complex(qp),intent(out) :: sn1
        ! =====================================================================
-           
+
            ! Local Scalars
            real(qp) :: t
            complex(qp) :: w
@@ -37822,7 +37822,7 @@ module stdlib_linalg_lapack_w
               w = conjg(b)/abs(b)
            end if
            call stdlib_qlaev2(real(a,KIND=qp),abs(b),real(c,KIND=qp),rt1,rt2,cs1,t)
-                     
+
            sn1 = w*t
            return
      end subroutine stdlib_wlaev2
@@ -37862,7 +37862,7 @@ module stdlib_linalg_lapack_w
               end do
            end do
            info = 0
-30         continue
+           30 continue
            return
      end subroutine stdlib_wlag2c
 
@@ -37892,7 +37892,7 @@ module stdlib_linalg_lapack_w
      !> zero.
 
      pure subroutine stdlib_wlags2(upper,a1,a2,a3,b1,b2,b3,csu,snu,csv,snv,csq,snq)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -37903,7 +37903,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: a2,b2
            complex(qp),intent(out) :: snq,snu,snv
         ! =====================================================================
-           
+
            ! Local Scalars
            real(qp) :: a,aua11,aua12,aua21,aua22,avb12,avb11,avb21,avb22,csl,csr,d,fb, &
                       fc,s1,s2,snl,snr,ua11r,ua22r,vb11r,vb22r
@@ -37943,17 +37943,17 @@ module stdlib_linalg_lapack_w
                  ! zero (1,2) elements of u**h *a and v**h *b
                  if ((abs(ua11r) + abs1(ua12)) == zero) then
                     call stdlib_wlartg(-cmplx(vb11r,KIND=qp),conjg(vb12),csq,snq,r)
-                              
+
                  else if ((abs(vb11r) + abs1(vb12)) == zero) then
                     call stdlib_wlartg(-cmplx(ua11r,KIND=qp),conjg(ua12),csq,snq,r)
-                              
+
                  else if (aua12/(abs(ua11r) + abs1(ua12)) <= avb12/(abs(vb11r) + abs1(vb12 &
                            ))) then
                     call stdlib_wlartg(-cmplx(ua11r,KIND=qp),conjg(ua12),csq,snq,r)
-                              
+
                  else
                     call stdlib_wlartg(-cmplx(vb11r,KIND=qp),conjg(vb12),csq,snq,r)
-                              
+
                  end if
                  csu = csl
                  snu = -d1*snl
@@ -38060,7 +38060,7 @@ module stdlib_linalg_lapack_w
      !> 0., 1., or -1.
 
      pure subroutine stdlib_wlagtm(trans,n,nrhs,alpha,dl,d,du,x,ldx,beta,b,ldb)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -38072,7 +38072,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: b(ldb,*)
            complex(qp),intent(in) :: d(*),dl(*),du(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            ! Intrinsic Functions
@@ -38218,7 +38218,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: sevten = 17.0e+0_qp
-           
+
            ! Local Scalars
            integer(ilp) :: imax,j,jb,jj,jmax,jp,k,kk,kkw,kp,kstep,kw
            real(qp) :: absakk,alpha,colmax,r1,rowmax,t
@@ -38240,7 +38240,7 @@ module stdlib_linalg_lapack_w
               ! k is the main loop index, decreasing from n in steps of 1 or 2
               ! kw is the column of w which corresponds to column k of a
               k = n
-10            continue
+              10 continue
               kw = nb + k - n
               ! exit from loop
               if ((k <= n - nb + 1 .and. nb < n) .or. k < 1) go to 30
@@ -38283,7 +38283,7 @@ module stdlib_linalg_lapack_w
                     call stdlib_wcopy(imax - 1,a(1,imax),1,w(1,kw - 1),1)
                     w(imax,kw - 1) = real(a(imax,imax),KIND=qp)
                     call stdlib_wcopy(k - imax,a(imax,imax + 1),lda,w(imax + 1,kw - 1),1)
-                              
+
                     call stdlib_wlacgv(k - imax,w(imax + 1,kw - 1),1)
                     if (k < n) then
                        call stdlib_wgemv('NO TRANSPOSE',k,n - k,-cone,a(1,k + 1),lda,w(imax, &
@@ -38441,7 +38441,7 @@ module stdlib_linalg_lapack_w
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-30            continue
+              30 continue
               ! update the upper triangle of a11 (= a(1:k,1:k)) as
               ! a11 := a11 - u12*d*u12**h = a11 - u12*w**h
               ! computing blocks of nb columns at a time (note that conjg(w) is
@@ -38462,7 +38462,7 @@ module stdlib_linalg_lapack_w
               ! put u12 in standard form by partially undoing the interchanges
               ! in columns k+1:n looping backwards from k+1 to n
               j = k + 1
-60            continue
+              60 continue
                  ! undo the interchanges (if any) of rows jj and jp at each
                  ! step j
                  ! (here, j is a diagonal index)
@@ -38487,7 +38487,7 @@ module stdlib_linalg_lapack_w
               ! for use in updating a22 (note that conjg(w) is actually stored)
               ! k is the main loop index, increasing from 1 in steps of 1 or 2
               k = 1
-70            continue
+              70 continue
               ! exit from loop
               if ((k >= nb .and. nb < n) .or. k > n) go to 90
               kstep = 1
@@ -38576,7 +38576,7 @@ module stdlib_linalg_lapack_w
                     call stdlib_wcopy(kp - kk - 1,a(kk + 1,kk),1,a(kp,kk + 1),lda)
                     call stdlib_wlacgv(kp - kk - 1,a(kp,kk + 1),lda)
                     if (kp < n) call stdlib_wcopy(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     ! interchange rows kk and kp in first k-1 columns of a
                     ! (columns k (or k and k+1 for 2-by-2 pivot) of a will be
                     ! later overwritten). interchange rows kk and kp
@@ -38682,7 +38682,7 @@ module stdlib_linalg_lapack_w
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 70
-90            continue
+              90 continue
               ! update the lower triangle of a22 (= a(k:n,k:n)) as
               ! a22 := a22 - l21*d*l21**h = a22 - l21*w**h
               ! computing blocks of nb columns at a time (note that conjg(w) is
@@ -38703,7 +38703,7 @@ module stdlib_linalg_lapack_w
               ! put l21 in standard form by partially undoing the interchanges
               ! of rows in columns 1:k-1 looping backwards from k-1 to 1
               j = k - 1
-120           continue
+              120 continue
                  ! undo the interchanges (if any) of rows jj and jp at each
                  ! step j
                  ! (here, j is a diagonal index)
@@ -38718,7 +38718,7 @@ module stdlib_linalg_lapack_w
                  ! of the rows to swap back doesn't include diagonal element)
                  j = j - 1
                  if (jp /= jj .and. j >= 1) call stdlib_wswap(j,a(jp,1),lda,a(jj,1),lda)
-                           
+
               if (j > 1) go to 120
               ! set kb to the number of columns factorized
               kb = k - 1
@@ -38749,7 +38749,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*),h(ldh,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j,k,k1,i1,i2,mj
            complex(qp) :: piv,alpha
@@ -38764,7 +38764,7 @@ module stdlib_linalg_lapack_w
               ! .....................................................
               ! factorize a as u**t*d*u using the upper triangle of a
               ! .....................................................
-10   continue
+              10 continue
               if (j > min(m,nb)) go to 20
               ! k is the column to be factorized
                ! when being called from stdlib_whetrf_aa,
@@ -38820,7 +38820,7 @@ module stdlib_linalg_lapack_w
                     i1 = i1 + j - 1
                     i2 = i2 + j - 1
                     call stdlib_wswap(i2 - i1 - 1,a(j1 + i1 - 1,i1 + 1),lda,a(j1 + i1,i2),1)
-                              
+
                     call stdlib_wlacgv(i2 - i1,a(j1 + i1 - 1,i1 + 1),lda)
                     call stdlib_wlacgv(i2 - i1 - 1,a(j1 + i1,i2),1)
                     ! swap a(i1, i2+1:n) with a(i2, i2+1:n)
@@ -38856,18 +38856,18 @@ module stdlib_linalg_lapack_w
                        call stdlib_wscal(m - j - 1,alpha,a(k,j + 2),lda)
                     else
                        call stdlib_wlaset('FULL',1,m - j - 1,czero,czero,a(k,j + 2),lda)
-                                 
+
                     end if
                  end if
               end if
               j = j + 1
               go to 10
-20            continue
+              20 continue
            else
               ! .....................................................
               ! factorize a as l*d*l**t using the lower triangle of a
               ! .....................................................
-30   continue
+              30 continue
               if (j > min(m,nb)) go to 40
               ! k is the column to be factorized
                ! when being called from stdlib_whetrf_aa,
@@ -38923,7 +38923,7 @@ module stdlib_linalg_lapack_w
                     i1 = i1 + j - 1
                     i2 = i2 + j - 1
                     call stdlib_wswap(i2 - i1 - 1,a(i1 + 1,j1 + i1 - 1),1,a(i2,j1 + i1),lda)
-                              
+
                     call stdlib_wlacgv(i2 - i1,a(i1 + 1,j1 + i1 - 1),1)
                     call stdlib_wlacgv(i2 - i1 - 1,a(i2,j1 + i1),lda)
                     ! swap a(i2+1:n, i1) with a(i2+1:n, i2)
@@ -38959,13 +38959,13 @@ module stdlib_linalg_lapack_w
                        call stdlib_wscal(m - j - 1,alpha,a(j + 2,k),1)
                     else
                        call stdlib_wlaset('FULL',m - j - 1,1,czero,czero,a(j + 2,k),lda)
-                                 
+
                     end if
                  end if
               end if
               j = j + 1
               go to 30
-40            continue
+              40 continue
            end if
            return
      end subroutine stdlib_wlahef_aa
@@ -38998,7 +38998,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: sevten = 17.0e+0_qp
-           
+
            ! Local Scalars
            logical(lk) :: done
            integer(ilp) :: imax,itemp,ii,j,jb,jj,jmax,k,kk,kkw,kp,kstep,kw,p
@@ -39025,7 +39025,7 @@ module stdlib_linalg_lapack_w
               e(1) = czero
               ! k is the main loop index, decreasing from n in steps of 1 or 2
               k = n
-10            continue
+              10 continue
               ! kw is the column of w which corresponds to column k of a
               kw = nb + k - n
               ! exit from loop
@@ -39072,14 +39072,14 @@ module stdlib_linalg_lapack_w
                  else
                     ! lop until pivot found
                     done = .false.
-12                  continue
+                    12 continue
                        ! begin pivot search loop body
                        ! copy column imax to column kw-1 of w and update it
                        if (imax > 1) call stdlib_wcopy(imax - 1,a(1,imax),1,w(1,kw - 1),1)
-                                 
+
                        w(imax,kw - 1) = real(a(imax,imax),KIND=qp)
                        call stdlib_wcopy(k - imax,a(imax,imax + 1),lda,w(imax + 1,kw - 1),1)
-                                 
+
                        call stdlib_wlacgv(k - imax,w(imax + 1,kw - 1),1)
                        if (k < n) then
                           call stdlib_wgemv('NO TRANSPOSE',k,n - k,-cone,a(1,k + 1),lda,w( &
@@ -39292,7 +39292,7 @@ module stdlib_linalg_lapack_w
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-30            continue
+              30 continue
               ! update the upper triangle of a11 (= a(1:k,1:k)) as
               ! a11 := a11 - u12*d*u12**h = a11 - u12*w**h
               ! computing blocks of nb columns at a time (note that conjg(w) is
@@ -39320,7 +39320,7 @@ module stdlib_linalg_lapack_w
               e(n) = czero
               ! k is the main loop index, increasing from 1 in steps of 1 or 2
               k = 1
-70            continue
+              70 continue
               ! exit from loop
               if ((k >= nb .and. nb < n) .or. k > n) go to 90
               kstep = 1
@@ -39365,7 +39365,7 @@ module stdlib_linalg_lapack_w
                  else
                     done = .false.
                     ! loop until pivot found
-72   continue
+                    72 continue
                        ! begin pivot search loop body
                        ! copy column imax to column k+1 of w and update it
                        call stdlib_wcopy(imax - k,a(imax,k),lda,w(k,k + 1),1)
@@ -39461,7 +39461,7 @@ module stdlib_linalg_lapack_w
                     call stdlib_wcopy(kp - kk - 1,a(kk + 1,kk),1,a(kp,kk + 1),lda)
                     call stdlib_wlacgv(kp - kk - 1,a(kp,kk + 1),lda)
                     if (kp < n) call stdlib_wcopy(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     ! interchange rows kk and kp in first k-1 columns of a
                     ! (column k (or k and k+1 for 2-by-2 pivot) of a will be
                     ! later overwritten). interchange rows kk and kp
@@ -39583,7 +39583,7 @@ module stdlib_linalg_lapack_w
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 70
-90            continue
+              90 continue
               ! update the lower triangle of a22 (= a(k:n,k:n)) as
               ! a22 := a22 - l21*d*l21**h = a22 - l21*w**h
               ! computing blocks of nb columns at a time (note that conjg(w) is
@@ -39636,7 +39636,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: sevten = 17.0e+0_qp
-           
+
            ! Local Scalars
            logical(lk) :: done
            integer(ilp) :: imax,itemp,ii,j,jb,jj,jmax,jp1,jp2,k,kk,kkw,kp,kstep,kw, &
@@ -39661,7 +39661,7 @@ module stdlib_linalg_lapack_w
               ! for use in updating a11 (note that conjg(w) is actually stored)
               ! k is the main loop index, decreasing from n in steps of 1 or 2
               k = n
-10            continue
+              10 continue
               ! kw is the column of w which corresponds to column k of a
               kw = nb + k - n
               ! exit from loop
@@ -39706,14 +39706,14 @@ module stdlib_linalg_lapack_w
                  else
                     ! lop until pivot found
                     done = .false.
-12                  continue
+                    12 continue
                        ! begin pivot search loop body
                        ! copy column imax to column kw-1 of w and update it
                        if (imax > 1) call stdlib_wcopy(imax - 1,a(1,imax),1,w(1,kw - 1),1)
-                                 
+
                        w(imax,kw - 1) = real(a(imax,imax),KIND=qp)
                        call stdlib_wcopy(k - imax,a(imax,imax + 1),lda,w(imax + 1,kw - 1),1)
-                                 
+
                        call stdlib_wlacgv(k - imax,w(imax + 1,kw - 1),1)
                        if (k < n) then
                           call stdlib_wgemv('NO TRANSPOSE',k,n - k,-cone,a(1,k + 1),lda,w( &
@@ -39919,7 +39919,7 @@ module stdlib_linalg_lapack_w
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-30            continue
+              30 continue
               ! update the upper triangle of a11 (= a(1:k,1:k)) as
               ! a11 := a11 - u12*d*u12**h = a11 - u12*w**h
               ! computing blocks of nb columns at a time (note that conjg(w) is
@@ -39940,7 +39940,7 @@ module stdlib_linalg_lapack_w
               ! put u12 in standard form by partially undoing the interchanges
               ! in of rows in columns k+1:n looping backwards from k+1 to n
               j = k + 1
-60            continue
+              60 continue
                  ! undo the interchanges (if any) of rows j and jp2
                  ! (or j and jp2, and j+1 and jp1) at each step j
                  kstep = 1
@@ -39972,7 +39972,7 @@ module stdlib_linalg_lapack_w
               ! for use in updating a22 (note that conjg(w) is actually stored)
               ! k is the main loop index, increasing from 1 in steps of 1 or 2
               k = 1
-70            continue
+              70 continue
               ! exit from loop
               if ((k >= nb .and. nb < n) .or. k > n) go to 90
               kstep = 1
@@ -40015,7 +40015,7 @@ module stdlib_linalg_lapack_w
                  else
                     done = .false.
                     ! loop until pivot found
-72   continue
+                    72 continue
                        ! begin pivot search loop body
                        ! copy column imax to column k+1 of w and update it
                        call stdlib_wcopy(imax - k,a(imax,k),lda,w(k,k + 1),1)
@@ -40111,7 +40111,7 @@ module stdlib_linalg_lapack_w
                     call stdlib_wcopy(kp - kk - 1,a(kk + 1,kk),1,a(kp,kk + 1),lda)
                     call stdlib_wlacgv(kp - kk - 1,a(kp,kk + 1),lda)
                     if (kp < n) call stdlib_wcopy(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     ! interchange rows kk and kp in first k-1 columns of a
                     ! (column k (or k and k+1 for 2-by-2 pivot) of a will be
                     ! later overwritten). interchange rows kk and kp
@@ -40226,7 +40226,7 @@ module stdlib_linalg_lapack_w
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 70
-90            continue
+              90 continue
               ! update the lower triangle of a22 (= a(k:n,k:n)) as
               ! a22 := a22 - l21*d*l21**h = a22 - l21*w**h
               ! computing blocks of nb columns at a time (note that conjg(w) is
@@ -40247,7 +40247,7 @@ module stdlib_linalg_lapack_w
               ! put l21 in standard form by partially undoing the interchanges
               ! of rows in columns 1:k-1 looping backwards from k-1 to 1
               j = k - 1
-120           continue
+              120 continue
                  ! undo the interchanges (if any) of rows j and jp2
                  ! (or j and jp2, and j-1 and jp1) at each step j
                  kstep = 1
@@ -40266,7 +40266,7 @@ module stdlib_linalg_lapack_w
                  ! of the rows to swap back doesn't include diagonal element)
                  j = j - 1
                  if (jp2 /= jj .and. j >= 1) call stdlib_wswap(j,a(jp2,1),lda,a(jj,1),lda)
-                           
+
                  jj = jj - 1
                  if (kstep == 2 .and. jp1 /= jj .and. j >= 1) call stdlib_wswap(j,a(jp1,1),lda,a( &
                             jj,1),lda)
@@ -40300,7 +40300,7 @@ module stdlib_linalg_lapack_w
            real(qp),parameter :: rone = 1.0_qp
            real(qp),parameter :: dat1 = 3.0_qp/4.0_qp
            integer(ilp),parameter :: kexsh = 10
-           
+
            ! Local Scalars
            complex(qp) :: cdum,h11,h11s,h22,sc,sum,t,t1,temp,u,v2,x,y
            real(qp) :: aa,ab,ba,bb,h10,h21,rtemp,s,safmax,safmin,smlnum,sx,t2,tst, &
@@ -40374,7 +40374,7 @@ module stdlib_linalg_lapack_w
            ! eigenvalues i+1 to ihi have already converged. either l = ilo, or
            ! h(l,l-1) is negligible so that the matrix splits.
            i = ihi
-30         continue
+           30 continue
            if (i < ilo) go to 150
            ! perform qr iterations on rows and columns ilo to i until a
            ! submatrix of order 1 splits off at the bottom because a
@@ -40402,7 +40402,7 @@ module stdlib_linalg_lapack_w
                     if (ba*(ab/s) <= max(smlnum,ulp*(bb*(aa/s)))) go to 50
                  end if
               end do
-50            continue
+              50 continue
               l = k
               if (l > ilo) then
                  ! h(l,l-1) is negligible
@@ -40470,7 +40470,7 @@ module stdlib_linalg_lapack_w
               h21 = h21/s
               v(1) = h11s
               v(2) = h21
-70            continue
+              70 continue
               ! single-shift qr step
               loop_120: do k = m,i - 1
                  ! the first iteration of this loop determines a reflection g
@@ -40548,7 +40548,7 @@ module stdlib_linalg_lapack_w
            ! failure to converge in remaining number of iterations
            info = i
            return
-140        continue
+           140 continue
            ! h(i,i-1) is negligible: cone eigenvalue has converged.
            w(i) = h(i,i)
            ! reset deflation counter
@@ -40556,7 +40556,7 @@ module stdlib_linalg_lapack_w
            ! return to start of the main loop with new value of i.
            i = l - 1
            go to 30
-150        continue
+           150 continue
            return
      end subroutine stdlib_wlahqr
 
@@ -40577,7 +40577,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: t(ldt,nb),tau(nb),y(ldy,nb)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            complex(qp) :: ei
@@ -40621,7 +40621,7 @@ module stdlib_linalg_lapack_w
               ! generate the elementary reflector h(i) to annihilate
               ! a(k+i+1:n,i)
               call stdlib_wlarfg(n - k - i + 1,a(k + i,i),a(min(k + i + 1,n),i),1,tau(i))
-                        
+
               ei = a(k + i,i)
               a(k + i,i) = cone
               ! compute  y(k+1:n,i)
@@ -40635,7 +40635,7 @@ module stdlib_linalg_lapack_w
               ! compute t(1:i,i)
               call stdlib_wscal(i - 1,-tau(i),t(1,i),1)
               call stdlib_wtrmv('UPPER','NO TRANSPOSE','NON-UNIT',i - 1,t,ldt,t(1,i),1)
-                        
+
               t(i,i) = tau(i)
            end do loop_10
            a(k + nb,nb) = ei
@@ -40684,7 +40684,7 @@ module stdlib_linalg_lapack_w
            ! Array Arguments
            complex(qp),intent(in) :: w(j),x(j)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(qp) :: absalp,absest,absgam,b,eps,norma,s1,s2,scl,t,test,tmp,zeta1, &
                      zeta2
@@ -40767,7 +40767,7 @@ module stdlib_linalg_lapack_w
                  sine = -(alpha/absest)/t
                  cosine = -(gamma/absest)/(one + t)
                  tmp = real(sqrt(sine*conjg(sine) + cosine*conjg(cosine)),KIND=qp)
-                           
+
                  s = sine/tmp
                  c = cosine/tmp
                  sestpr = sqrt(t + one)*absest
@@ -40856,7 +40856,7 @@ module stdlib_linalg_lapack_w
                     sestpr = sqrt(one + t + four*eps*eps*norma)*absest
                  end if
                  tmp = real(sqrt(sine*conjg(sine) + cosine*conjg(cosine)),KIND=qp)
-                           
+
                  s = sine/tmp
                  c = cosine/tmp
                  return
@@ -40904,7 +40904,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: b(ldb,*)
            complex(qp),intent(out) :: bx(ldbx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,jcol,jrow,m,n,nlp1
            real(qp) :: diflj,difrj,dj,dsigj,dsigjp,temp
@@ -41020,7 +41020,7 @@ module stdlib_linalg_lapack_w
                        b(j,jcol) = cmplx(rwork(jcol + k),rwork(jcol + k + nrhs),KIND=qp)
                     end do
                     call stdlib_wlascl('G',0,0,temp,one,1,nrhs,b(j,1),ldb,info)
-                              
+
                  end do loop_100
               end if
               ! move the deflated rows of bx to b also.
@@ -41039,7 +41039,7 @@ module stdlib_linalg_lapack_w
                        rwork(j) = zero
                     else
                        rwork(j) = -z(j)/difl(j)/(dsigj + poles(j,1))/difr(j,2)
-                                 
+
                     end if
                     do i = 1,j - 1
                        if (z(j) == zero) then
@@ -41081,7 +41081,7 @@ module stdlib_linalg_lapack_w
                               zero,rwork(1 + k + nrhs),1)
                     do jcol = 1,nrhs
                        bx(j,jcol) = cmplx(rwork(jcol + k),rwork(jcol + k + nrhs),KIND=qp)
-                                 
+
                     end do
                  end do loop_180
               end if
@@ -41137,7 +41137,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: b(ldb,*)
            complex(qp),intent(out) :: bx(ldbx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,i1,ic,im1,inode,j,jcol,jimag,jreal,jrow,lf,ll,lvl,lvl2, &
                      nd,ndb1,ndiml,ndimr,nl,nlf,nlp1,nlvl,nr,nrf,nrp1,sqre
@@ -41295,7 +41295,7 @@ module stdlib_linalg_lapack_w
            end do
            go to 330
            ! icompq = 1: applying back the right singular vector factors.
-170  continue
+           170 continue
            ! first now go through the right singular vector matrices of all
            ! the tree nodes top-down.
            j = 0
@@ -41409,7 +41409,7 @@ module stdlib_linalg_lapack_w
                  end do
               end do
            end do loop_320
-330        continue
+           330 continue
            return
      end subroutine stdlib_wlalsa
 
@@ -41445,7 +41445,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: b(ldb,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: bx,bxst,c,difl,difr,givcol,givnum,givptr,i,icmpq1,icmpq2, &
            irwb,irwib,irwrb,irwu,irwvt,irwwrk,iwk,j,jcol,jimag,jreal,jrow,k,nlvl, &
@@ -41574,7 +41574,7 @@ module stdlib_linalg_lapack_w
                     call stdlib_wlaset('A',1,nrhs,czero,czero,b(i,1),ldb)
                  else
                     call stdlib_wlascl('G',0,0,d(i),one,1,nrhs,b(i,1),ldb,info)
-                              
+
                     rank = rank + 1
                  end if
               end do
@@ -41686,7 +41686,7 @@ module stdlib_linalg_lapack_w
                     call stdlib_qlaset('A',nsize,nsize,zero,one,rwork(u + st1),n)
                     call stdlib_qlasdq('U',0,nsize,nsize,nsize,0,d(st),e(st),rwork( &
                     vt + st1),n,rwork(u + st1),n,rwork(nrwork),1,rwork(nrwork),info)
-                              
+
                     if (info /= 0) then
                        return
                     end if
@@ -41721,7 +41721,7 @@ module stdlib_linalg_lapack_w
                        end do
                     end do
                     call stdlib_wlacpy('A',nsize,nrhs,b(st,1),ldb,work(bx + st1),n)
-                              
+
                  else
                     ! a large problem. solve it using divide and conquer.
                     call stdlib_qlasda(icmpq1,smlsiz,nsize,sqre,d(st),e(st),rwork(u + &
@@ -41755,7 +41755,7 @@ module stdlib_linalg_lapack_w
               else
                  rank = rank + 1
                  call stdlib_wlascl('G',0,0,d(i),one,1,nrhs,work(bx + i - 1),n,info)
-                           
+
               end if
               d(i) = abs(d(i))
            end do
@@ -41897,7 +41897,7 @@ module stdlib_linalg_lapack_w
            end if
            if ((nb <= k) .or. (nb >= max(m,n,k))) then
              call stdlib_wgemlqt(side,trans,m,n,k,mb,a,lda,t,ldt,c,ldc,work,info)
-                       
+
              return
            end if
            if (left .and. tran) then
@@ -42059,7 +42059,7 @@ module stdlib_linalg_lapack_w
            end if
            if ((mb <= k) .or. (mb >= max(m,n,k))) then
              call stdlib_wgemqrt(side,trans,m,n,k,nb,a,lda,t,ldt,c,ldc,work,info)
-                       
+
              return
             end if
            if (left .and. notran) then
@@ -42158,7 +42158,7 @@ module stdlib_linalg_lapack_w
            real(qp),intent(out) :: work(*)
            complex(qp),intent(in) :: ab(ldab,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,k,l
            real(qp) :: scale,sum,value,temp
@@ -42233,7 +42233,7 @@ module stdlib_linalg_lapack_w
            real(qp),intent(out) :: work(*)
            complex(qp),intent(in) :: a(lda,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(qp) :: scale,sum,value,temp
@@ -42304,7 +42304,7 @@ module stdlib_linalg_lapack_w
            ! Array Arguments
            complex(qp),intent(in) :: d(*),dl(*),du(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(qp) :: anorm,scale,sum,temp
@@ -42318,11 +42318,11 @@ module stdlib_linalg_lapack_w
               anorm = abs(d(n))
               do i = 1,n - 1
                  if (anorm < abs(dl(i)) .or. stdlib_qisnan(abs(dl(i)))) anorm = abs(dl(i))
-                           
+
                  if (anorm < abs(d(i)) .or. stdlib_qisnan(abs(d(i)))) anorm = abs(d(i))
-                           
+
                  if (anorm < abs(du(i)) .or. stdlib_qisnan(abs(du(i)))) anorm = abs(du(i))
-                           
+
               end do
            else if (stdlib_lsame(norm,'O') .or. norm == '1') then
               ! find norm1(a).
@@ -42381,7 +42381,7 @@ module stdlib_linalg_lapack_w
            real(qp),intent(out) :: work(*)
            complex(qp),intent(in) :: ab(ldab,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,l
            real(qp) :: absa,scale,sum,value
@@ -42455,7 +42455,7 @@ module stdlib_linalg_lapack_w
                  if (stdlib_lsame(uplo,'U')) then
                     do j = 2,n
                        call stdlib_wlassq(min(j - 1,k),ab(max(k + 2 - j,1),j),1,scale,sum)
-                                 
+
                     end do
                     l = k + 1
                  else
@@ -42500,7 +42500,7 @@ module stdlib_linalg_lapack_w
            real(qp),intent(out) :: work(*)
            complex(qp),intent(in) :: a(lda,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(qp) :: absa,scale,sum,value
@@ -42610,7 +42610,7 @@ module stdlib_linalg_lapack_w
            real(qp),intent(out) :: work(0:*)
            complex(qp),intent(in) :: a(0:*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,ifm,ilu,noe,n1,k,l,lda
            real(qp) :: scale,s,value,aa,temp
@@ -42982,7 +42982,7 @@ module stdlib_linalg_lapack_w
                           end do
                           work(j) = work(j) + s
                        end do
-10                     continue
+                       10 continue
                        value = work(0)
                        do i = 1,n - 1
                           temp = work(i)
@@ -43830,7 +43830,7 @@ module stdlib_linalg_lapack_w
            real(qp),intent(out) :: work(*)
            complex(qp),intent(in) :: ap(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,k
            real(qp) :: absa,scale,sum,value
@@ -43958,7 +43958,7 @@ module stdlib_linalg_lapack_w
            real(qp),intent(out) :: work(*)
            complex(qp),intent(in) :: a(lda,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(qp) :: scale,sum,value
@@ -44030,7 +44030,7 @@ module stdlib_linalg_lapack_w
            real(qp),intent(in) :: d(*)
            complex(qp),intent(in) :: e(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(qp) :: anorm,scale,sum
@@ -44093,7 +44093,7 @@ module stdlib_linalg_lapack_w
            real(qp),intent(out) :: work(*)
            complex(qp),intent(in) :: ab(ldab,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,l
            real(qp) :: absa,scale,sum,value
@@ -44163,7 +44163,7 @@ module stdlib_linalg_lapack_w
                  if (stdlib_lsame(uplo,'U')) then
                     do j = 2,n
                        call stdlib_wlassq(min(j - 1,k),ab(max(k + 2 - j,1),j),1,scale,sum)
-                                 
+
                     end do
                     l = k + 1
                  else
@@ -44198,7 +44198,7 @@ module stdlib_linalg_lapack_w
            real(qp),intent(out) :: work(*)
            complex(qp),intent(in) :: ap(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,k
            real(qp) :: absa,scale,sum,value
@@ -44331,7 +44331,7 @@ module stdlib_linalg_lapack_w
            real(qp),intent(out) :: work(*)
            complex(qp),intent(in) :: a(lda,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(qp) :: absa,scale,sum,value
@@ -44427,7 +44427,7 @@ module stdlib_linalg_lapack_w
            real(qp),intent(out) :: work(*)
            complex(qp),intent(in) :: ab(ldab,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: udiag
            integer(ilp) :: i,j,l
@@ -44579,7 +44579,7 @@ module stdlib_linalg_lapack_w
                     sum = one
                     do j = 1,n
                        call stdlib_wlassq(min(j,k + 1),ab(max(k + 2 - j,1),j),1,scale,sum)
-                                 
+
                     end do
                  end if
               else
@@ -44620,7 +44620,7 @@ module stdlib_linalg_lapack_w
            real(qp),intent(out) :: work(*)
            complex(qp),intent(in) :: ap(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: udiag
            integer(ilp) :: i,j,k
@@ -44826,7 +44826,7 @@ module stdlib_linalg_lapack_w
            real(qp),intent(out) :: work(*)
            complex(qp),intent(in) :: a(lda,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: udiag
            integer(ilp) :: i,j
@@ -45014,7 +45014,7 @@ module stdlib_linalg_lapack_w
            ! Array Arguments
            complex(qp),intent(inout) :: x(*),y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(qp) :: ssmax
            complex(qp) :: a11,a12,a22,c,tau
@@ -45073,7 +45073,7 @@ module stdlib_linalg_lapack_w
                  j = i
                  k(j) = -k(j)
                  in = k(j)
-20               continue
+                 20 continue
                  if (k(in) > 0) go to 40
                  do jj = 1,n
                     temp = x(j,jj)
@@ -45084,7 +45084,7 @@ module stdlib_linalg_lapack_w
                  j = in
                  in = k(in)
                  go to 20
-40               continue
+                 40 continue
               end do
            else
               ! backward permutation
@@ -45092,7 +45092,7 @@ module stdlib_linalg_lapack_w
                  if (k(i) > 0) go to 80
                  k(i) = -k(i)
                  j = k(i)
-60               continue
+                 60 continue
                  if (j == i) go to 80
                  do jj = 1,n
                     temp = x(i,jj)
@@ -45102,7 +45102,7 @@ module stdlib_linalg_lapack_w
                  k(j) = -k(j)
                  j = k(j)
                  go to 60
-80               continue
+                 80 continue
               end do
            end if
            return
@@ -45141,7 +45141,7 @@ module stdlib_linalg_lapack_w
                  j = i
                  k(j) = -k(j)
                  in = k(j)
-20               continue
+                 20 continue
                  if (k(in) > 0) go to 40
                  do ii = 1,m
                     temp = x(ii,j)
@@ -45152,7 +45152,7 @@ module stdlib_linalg_lapack_w
                  j = in
                  in = k(in)
                  go to 20
-40               continue
+                 40 continue
               end do
            else
               ! backward permutation
@@ -45160,7 +45160,7 @@ module stdlib_linalg_lapack_w
                  if (k(i) > 0) go to 80
                  k(i) = -k(i)
                  j = k(i)
-60               continue
+                 60 continue
                  if (j == i) go to 80
                  do ii = 1,m
                     temp = x(ii,i)
@@ -45170,7 +45170,7 @@ module stdlib_linalg_lapack_w
                  k(j) = -k(j)
                  j = k(j)
                  go to 60
-80               continue
+                 80 continue
               end do
            end if
            return
@@ -45181,7 +45181,7 @@ module stdlib_linalg_lapack_w
      !> in the vectors R and C.
 
      pure subroutine stdlib_wlaqgb(m,n,kl,ku,ab,ldab,r,c,rowcnd,colcnd,amax,equed)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -45195,7 +45195,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: thresh = 0.1e+0_qp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(qp) :: cj,large,small
@@ -45263,7 +45263,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: thresh = 0.1e+0_qp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(qp) :: cj,large,small
@@ -45330,7 +45330,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: thresh = 0.1e+0_qp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(qp) :: cj,large,small
@@ -45392,7 +45392,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: thresh = 0.1e+0_qp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(qp) :: cj,large,small
@@ -45454,7 +45454,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: thresh = 0.1e+0_qp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,jc
            real(qp) :: cj,large,small
@@ -45518,7 +45518,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,itemp,j,mn,offpi,pvt
            real(qp) :: temp,temp2,tol3z
@@ -45544,7 +45544,7 @@ module stdlib_linalg_lapack_w
               ! generate elementary reflector h(i).
               if (offpi < m) then
                  call stdlib_wlarfg(m - offpi + 1,a(offpi,i),a(offpi + 1,i),1,tau(i))
-                           
+
               else
                  call stdlib_wlarfg(1,a(m,i),a(m,i),1,tau(i))
               end if
@@ -45604,7 +45604,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*),auxv(*),f(ldf,*)
            complex(qp),intent(out) :: tau(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: itemp,j,k,lastrk,lsticc,pvt,rk
            real(qp) :: temp,temp2,tol3z
@@ -45617,7 +45617,7 @@ module stdlib_linalg_lapack_w
            k = 0
            tol3z = sqrt(stdlib_qlamch('EPSILON'))
            ! beginning of while loop.
-10   continue
+           10 continue
            if ((k < nb) .and. (lsticc == 0)) then
               k = k + 1
               rk = offset + k
@@ -45709,7 +45709,7 @@ module stdlib_linalg_lapack_w
                         rk + 1,1),lda,f(kb + 1,1),ldf,cone,a(rk + 1,kb + 1),lda)
            end if
            ! recomputation of difficult columns.
-60   continue
+           60 continue
            if (lsticc > 0) then
               itemp = nint(vn2(lsticc),KIND=ilp)
               vn1(lsticc) = stdlib_qznrm2(m - rk,a(rk + 1,lsticc),1)
@@ -45753,18 +45753,18 @@ module stdlib_linalg_lapack_w
            ! ==== matrices of order ntiny or smaller must be processed by
            ! .    stdlib_wlahqr because of insufficient subdiagonal scratch space.
            ! .    (this is a hard limit.) ====
-           
+
            ! ==== exceptional deflation windows:  try to cure rare
            ! .    slow convergence by varying the size of the
            ! .    deflation window after kexnw iterations. ====
-           
+
            ! ==== exceptional shifts: try to cure rare slow convergence
            ! .    with ad-hoc exceptional shifts every kexsh iterations.
            ! .    ====
-           
+
            ! ==== the constant wilk1 is used to form the exceptional
            ! .    shifts. ====
-           
+
            ! Local Scalars
            complex(qp) :: aa,bb,cc,cdum,dd,det,rtdisc,swap,tr2
            real(qp) :: s
@@ -45869,7 +45869,7 @@ module stdlib_linalg_lapack_w
                     if (h(k,k - 1) == czero) go to 20
                  end do
                  k = ilo
-20               continue
+                 20 continue
                  ktop = k
                  ! ==== select deflation window size:
                  ! .    typical case:
@@ -45965,7 +45965,7 @@ module stdlib_linalg_lapack_w
                           ks = kbot - ns + 1
                           kt = n - ns + 1
                           call stdlib_wlacpy('A',ns,ns,h(ks,ks),ldh,h(kt,1),ldh)
-                                    
+
                           if (ns > nmin) then
                              call stdlib_wlaqr4(.false.,.false.,ns,1,ns,h(kt,1),ldh,w( &
                                        ks),1,1,zdum,1,work,lwork,inf)
@@ -46010,7 +46010,7 @@ module stdlib_linalg_lapack_w
                                 end if
                              end do
                           end do
-60                        continue
+                          60 continue
                        end if
                     end if
                     ! ==== if there are only two shifts, then use
@@ -46062,7 +46062,7 @@ module stdlib_linalg_lapack_w
               ! ==== iteration limit exceeded.  set info to show where
               ! .    the problem occurred and exit. ====
               info = kbot
-80            continue
+              80 continue
            end if
            ! ==== return the optimal value of lwork. ====
            work(1) = cmplx(lwkopt,0,KIND=qp)
@@ -46088,7 +46088,7 @@ module stdlib_linalg_lapack_w
         ! ================================================================
            ! Parameters
            real(qp),parameter :: rzero = 0.0_qp
-           
+
            ! Local Scalars
            complex(qp) :: cdum,h21s,h31s
            real(qp) :: s
@@ -46159,7 +46159,7 @@ module stdlib_linalg_lapack_w
            ! Parameters
            real(qp),parameter :: rzero = 0.0_qp
            real(qp),parameter :: rone = 1.0_qp
-           
+
            ! Local Scalars
            complex(qp) :: beta,cdum,s,tau
            real(qp) :: foo,safmax,safmin,smlnum,ulp
@@ -46182,7 +46182,7 @@ module stdlib_linalg_lapack_w
               lwk1 = int(work(1),KIND=ilp)
               ! ==== workspace query call to stdlib_wunmhr ====
               call stdlib_wunmhr('R','N',jw,jw,1,jw - 1,t,ldt,work,v,ldv,work,-1,info)
-                        
+
               lwk2 = int(work(1),KIND=ilp)
               ! ==== optimal workspace ====
               lwkopt = jw + max(lwk1,lwk2)
@@ -46267,7 +46267,7 @@ module stdlib_linalg_lapack_w
                  end do
                  ilst = i
                  if (ifst /= ilst) call stdlib_wtrexc('V',jw,t,ldt,v,ldv,ifst,ilst,info)
-                           
+
               end do
            end if
            ! ==== restore shift/eigenvalue array from t ====
@@ -46286,11 +46286,11 @@ module stdlib_linalg_lapack_w
                  work(1) = cone
                  call stdlib_wlaset('L',jw - 2,jw - 2,czero,czero,t(3,1),ldt)
                  call stdlib_wlarf('L',ns,jw,work,1,conjg(tau),t,ldt,work(jw + 1))
-                           
+
                  call stdlib_wlarf('R',ns,ns,work,1,tau,t,ldt,work(jw + 1))
                  call stdlib_wlarf('R',jw,ns,work,1,tau,v,ldv,work(jw + 1))
                  call stdlib_wgehrd(jw,1,ns,t,ldt,work,work(jw + 1),lwork - jw,info)
-                           
+
               end if
               ! ==== copy updated reduced window into place ====
               if (kwtop > 1) h(kwtop,kwtop - 1) = s*conjg(v(1,1))
@@ -46370,7 +46370,7 @@ module stdlib_linalg_lapack_w
            ! Parameters
            real(qp),parameter :: rzero = 0.0_qp
            real(qp),parameter :: rone = 1.0_qp
-           
+
            ! Local Scalars
            complex(qp) :: beta,cdum,s,tau
            real(qp) :: foo,safmax,safmin,smlnum,ulp
@@ -46393,7 +46393,7 @@ module stdlib_linalg_lapack_w
               lwk1 = int(work(1),KIND=ilp)
               ! ==== workspace query call to stdlib_wunmhr ====
               call stdlib_wunmhr('R','N',jw,jw,1,jw - 1,t,ldt,work,v,ldv,work,-1,info)
-                        
+
               lwk2 = int(work(1),KIND=ilp)
               ! ==== workspace query call to stdlib_wlaqr4 ====
               call stdlib_wlaqr4(.true.,.true.,jw,1,jw,t,ldt,sh,1,jw,v,ldv,work,-1, &
@@ -46488,7 +46488,7 @@ module stdlib_linalg_lapack_w
                  end do
                  ilst = i
                  if (ifst /= ilst) call stdlib_wtrexc('V',jw,t,ldt,v,ldv,ifst,ilst,info)
-                           
+
               end do
            end if
            ! ==== restore shift/eigenvalue array from t ====
@@ -46507,11 +46507,11 @@ module stdlib_linalg_lapack_w
                  work(1) = cone
                  call stdlib_wlaset('L',jw - 2,jw - 2,czero,czero,t(3,1),ldt)
                  call stdlib_wlarf('L',ns,jw,work,1,conjg(tau),t,ldt,work(jw + 1))
-                           
+
                  call stdlib_wlarf('R',ns,ns,work,1,tau,t,ldt,work(jw + 1))
                  call stdlib_wlarf('R',jw,ns,work,1,tau,v,ldv,work(jw + 1))
                  call stdlib_wgehrd(jw,1,ns,t,ldt,work,work(jw + 1),lwork - jw,info)
-                           
+
               end if
               ! ==== copy updated reduced window into place ====
               if (kwtop > 1) h(kwtop,kwtop - 1) = s*conjg(v(1,1))
@@ -46600,18 +46600,18 @@ module stdlib_linalg_lapack_w
            ! ==== matrices of order ntiny or smaller must be processed by
            ! .    stdlib_wlahqr because of insufficient subdiagonal scratch space.
            ! .    (this is a hard limit.) ====
-           
+
            ! ==== exceptional deflation windows:  try to cure rare
            ! .    slow convergence by varying the size of the
            ! .    deflation window after kexnw iterations. ====
-           
+
            ! ==== exceptional shifts: try to cure rare slow convergence
            ! .    with ad-hoc exceptional shifts every kexsh iterations.
            ! .    ====
-           
+
            ! ==== the constant wilk1 is used to form the exceptional
            ! .    shifts. ====
-           
+
            ! Local Scalars
            complex(qp) :: aa,bb,cc,cdum,dd,det,rtdisc,swap,tr2
            real(qp) :: s
@@ -46716,7 +46716,7 @@ module stdlib_linalg_lapack_w
                     if (h(k,k - 1) == czero) go to 20
                  end do
                  k = ilo
-20               continue
+                 20 continue
                  ktop = k
                  ! ==== select deflation window size:
                  ! .    typical case:
@@ -46812,7 +46812,7 @@ module stdlib_linalg_lapack_w
                           ks = kbot - ns + 1
                           kt = n - ns + 1
                           call stdlib_wlacpy('A',ns,ns,h(ks,ks),ldh,h(kt,1),ldh)
-                                    
+
                           call stdlib_wlahqr(.false.,.false.,ns,1,ns,h(kt,1),ldh,w(ks) &
                                     ,1,1,zdum,1,inf)
                           ks = ks + inf
@@ -46852,7 +46852,7 @@ module stdlib_linalg_lapack_w
                                 end if
                              end do
                           end do
-60                        continue
+                          60 continue
                        end if
                     end if
                     ! ==== if there are only two shifts, then use
@@ -46904,7 +46904,7 @@ module stdlib_linalg_lapack_w
               ! ==== iteration limit exceeded.  set info to show where
               ! .    the problem occurred and exit. ====
               info = kbot
-80            continue
+              80 continue
            end if
            ! ==== return the optimal value of lwork. ====
            work(1) = cmplx(lwkopt,0,KIND=qp)
@@ -46929,7 +46929,7 @@ module stdlib_linalg_lapack_w
            ! Parameters
            real(qp),parameter :: rzero = 0.0_qp
            real(qp),parameter :: rone = 1.0_qp
-           
+
            ! Local Scalars
            complex(qp) :: alpha,beta,cdum,refsum
            real(qp) :: h11,h12,h21,h22,safmax,safmin,scl,smlnum,tst1,tst2,ulp
@@ -47065,9 +47065,9 @@ module stdlib_linalg_lapack_w
                              h12 = max(cabs1(h(k + 1,k)),cabs1(h(k,k + 1)))
                              h21 = min(cabs1(h(k + 1,k)),cabs1(h(k,k + 1)))
                              h11 = max(cabs1(h(k + 1,k + 1)),cabs1(h(k,k) - h(k + 1,k + 1)))
-                                       
+
                              h22 = min(cabs1(h(k + 1,k + 1)),cabs1(h(k,k) - h(k + 1,k + 1)))
-                                       
+
                              scl = h11 + h12
                              tst2 = h22*(h11/scl)
                              if (tst2 == rzero .or. h21*(h12/scl) <= max(smlnum,ulp*tst2)) h( &
@@ -47130,11 +47130,11 @@ module stdlib_linalg_lapack_w
                           ! .    reflector is too large, then abandon it.
                           ! .    otherwise, use the new cone. ====
                           call stdlib_wlaqr1(3,h(k + 1,k + 1),ldh,s(2*m - 1),s(2*m),vt)
-                                    
+
                           alpha = vt(1)
                           call stdlib_wlarfg(3,alpha,vt(2),1,vt(1))
                           refsum = conjg(vt(1))*(h(k + 1,k) + conjg(vt(2))*h(k + 2,k))
-                                    
+
                           if (cabs1(h(k + 2,k) - refsum*vt(2)) + cabs1(refsum*vt(3)) > ulp*( &
                           cabs1(h(k,k)) + cabs1(h(k + 1,k + 1)) + cabs1(h(k + 2,k + 2)))) &
                                     then
@@ -47200,9 +47200,9 @@ module stdlib_linalg_lapack_w
                           h12 = max(cabs1(h(k + 1,k)),cabs1(h(k,k + 1)))
                           h21 = min(cabs1(h(k + 1,k)),cabs1(h(k,k + 1)))
                           h11 = max(cabs1(h(k + 1,k + 1)),cabs1(h(k,k) - h(k + 1,k + 1)))
-                                    
+
                           h22 = min(cabs1(h(k + 1,k + 1)),cabs1(h(k,k) - h(k + 1,k + 1)))
-                                    
+
                           scl = h11 + h12
                           tst2 = h22*(h11/scl)
                           if (tst2 == rzero .or. h21*(h12/scl) <= max(smlnum,ulp*tst2)) h(k + 1, &
@@ -47283,7 +47283,7 @@ module stdlib_linalg_lapack_w
                     call stdlib_wgemm('C','N',nu,jlen,nu,cone,u(k1,k1),ldu,h(incol + k1, &
                                jcol),ldh,czero,wh,ldwh)
                     call stdlib_wlacpy('ALL',nu,jlen,wh,ldwh,h(incol + k1,jcol),ldh)
-                              
+
                  end do
                  ! ==== vertical multiply ====
                  do jrow = jtop,max(ktop,incol) - 1,nv
@@ -47291,7 +47291,7 @@ module stdlib_linalg_lapack_w
                     call stdlib_wgemm('N','N',jlen,nu,nu,cone,h(jrow,incol + k1),ldh,u( &
                               k1,k1),ldu,czero,wv,ldwv)
                     call stdlib_wlacpy('ALL',jlen,nu,wv,ldwv,h(jrow,incol + k1),ldh)
-                              
+
                  end do
                  ! ==== z multiply (also vertical) ====
                  if (wantz) then
@@ -47300,7 +47300,7 @@ module stdlib_linalg_lapack_w
                        call stdlib_wgemm('N','N',jlen,nu,nu,cone,z(jrow,incol + k1),ldz, &
                                  u(k1,k1),ldu,czero,wv,ldwv)
                        call stdlib_wlacpy('ALL',jlen,nu,wv,ldwv,z(jrow,incol + k1),ldz)
-                                 
+
                     end do
                  end if
               end if
@@ -47325,7 +47325,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: thresh = 0.1e+0_qp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(qp) :: cj,large,small
@@ -47385,7 +47385,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: thresh = 0.1e+0_qp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,jc
            real(qp) :: cj,large,small
@@ -47447,7 +47447,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: thresh = 0.1e+0_qp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(qp) :: cj,large,small
@@ -47537,7 +47537,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*),b(ldb,*),q(ldq,*),z(ldz,*), &
                      alpha(*),beta(*),work(*)
            real(qp),intent(out) :: rwork(*)
-           
+
            ! local scalars
            real(qp) :: smlnum,ulp,safmin,safmax,c1,tempr
            complex(qp) :: eshift,s1,temp
@@ -47741,7 +47741,7 @@ module stdlib_linalg_lapack_w
                        end if
                        if (k2 < istop) then
                           call stdlib_wlartg(a(k2,k2 - 1),a(k2 + 1,k2 - 1),c1,s1,temp)
-                                    
+
                           a(k2,k2 - 1) = temp
                           a(k2 + 1,k2 - 1) = czero
                           call stdlib_wrot(istopm - k2 + 1,a(k2,k2),lda,a(k2 + 1,k2),lda,c1, &
@@ -47750,7 +47750,7 @@ module stdlib_linalg_lapack_w
                                     s1)
                           if (ilq) then
                              call stdlib_wrot(n,q(1,k2),1,q(1,k2 + 1),1,c1,conjg(s1))
-                                       
+
                           end if
                        end if
                     end do
@@ -47848,7 +47848,7 @@ module stdlib_linalg_lapack_w
            integer(ilp),intent(in) :: k,lda,ldb,ldq,ldz,istartm,istopm,nq,nz,qstart, &
                      zstart,ihi
            complex(qp),intent(inout) :: a(lda,*),b(ldb,*),q(ldq,*),z(ldz,*)
-           
+
            ! local variables
            real(qp) :: c
            complex(qp) :: s,temp
@@ -47858,12 +47858,12 @@ module stdlib_linalg_lapack_w
               b(ihi,ihi) = temp
               b(ihi,ihi - 1) = czero
               call stdlib_wrot(ihi - istartm,b(istartm,ihi),1,b(istartm,ihi - 1),1,c,s)
-                        
+
               call stdlib_wrot(ihi - istartm + 1,a(istartm,ihi),1,a(istartm,ihi - 1),1,c,s)
-                        
+
               if (ilz) then
                  call stdlib_wrot(nz,z(1,ihi - zstart + 1),1,z(1,ihi - 1 - zstart + 1),1,c,s)
-                           
+
               end if
            else
               ! normal operation, move bulge down
@@ -47872,12 +47872,12 @@ module stdlib_linalg_lapack_w
               b(k + 1,k + 1) = temp
               b(k + 1,k) = czero
               call stdlib_wrot(k + 2 - istartm + 1,a(istartm,k + 1),1,a(istartm,k),1,c,s)
-                        
+
               call stdlib_wrot(k - istartm + 1,b(istartm,k + 1),1,b(istartm,k),1,c,s)
-                        
+
               if (ilz) then
                  call stdlib_wrot(nz,z(1,k + 1 - zstart + 1),1,z(1,k - zstart + 1),1,c,s)
-                           
+
               end if
               ! apply transformation from the left
               call stdlib_wlartg(a(k + 1,k),a(k + 2,k),c,s,temp)
@@ -47906,7 +47906,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: qc(ldqc,*),zc(ldzc,*)
            complex(qp),intent(out) :: work(*)
            real(qp),intent(out) :: rwork(*)
-           
+
            ! local scalars
            integer(ilp) :: jw,kwtop,kwbot,istopm,istartm,k,k2,ztgexc_info,ifst,ilst, &
                      lworkreq,qz_small_info
@@ -47962,7 +47962,7 @@ module stdlib_linalg_lapack_w
            ! store window in case of convergence failure
            call stdlib_wlacpy('ALL',jw,jw,a(kwtop,kwtop),lda,work,jw)
            call stdlib_wlacpy('ALL',jw,jw,b(kwtop,kwtop),ldb,work(jw**2 + 1),jw)
-                     
+
            ! transform window to real schur form
            call stdlib_wlaset('FULL',jw,jw,czero,cone,qc,ldqc)
            call stdlib_wlaset('FULL',jw,jw,czero,cone,zc,ldzc)
@@ -47975,7 +47975,7 @@ module stdlib_linalg_lapack_w
               ns = jw - qz_small_info
               call stdlib_wlacpy('ALL',jw,jw,work,jw,a(kwtop,kwtop),lda)
               call stdlib_wlacpy('ALL',jw,jw,work(jw**2 + 1),jw,b(kwtop,kwtop),ldb)
-                        
+
               return
            end if
            ! deflation detection loop
@@ -48025,7 +48025,7 @@ module stdlib_linalg_lapack_w
                  k2 = max(kwtop,k - 1)
                  call stdlib_wrot(ihi - k2 + 1,a(k,k2),lda,a(k + 1,k2),lda,c1,s1)
                  call stdlib_wrot(ihi - (k - 1) + 1,b(k,k - 1),ldb,b(k + 1,k - 1),ldb,c1,s1)
-                           
+
                  call stdlib_wrot(jw,qc(1,k - kwtop + 1),1,qc(1,k + 1 - kwtop + 1),1,c1,conjg( &
                            s1))
               end do
@@ -48091,7 +48091,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*),b(ldb,*),q(ldq,*),z(ldz,*),qc( &
                      ldqc,*),zc(ldzc,*),work(*),alpha(*),beta(*)
            integer(ilp),intent(out) :: info
-           
+
            ! local scalars
            integer(ilp) :: i,j,ns,istartm,istopm,sheight,swidth,k,np,istartb,istopb, &
                      ishift,nblock,npos
@@ -48167,11 +48167,11 @@ module stdlib_linalg_lapack_w
               call stdlib_wgemm('C','N',sheight,swidth,sheight,cone,qc,ldqc,a(ilo,ilo + &
                         ns),lda,czero,work,sheight)
               call stdlib_wlacpy('ALL',sheight,swidth,work,sheight,a(ilo,ilo + ns),lda)
-                        
+
               call stdlib_wgemm('C','N',sheight,swidth,sheight,cone,qc,ldqc,b(ilo,ilo + &
                         ns),ldb,czero,work,sheight)
               call stdlib_wlacpy('ALL',sheight,swidth,work,sheight,b(ilo,ilo + ns),ldb)
-                        
+
            end if
            if (ilq) then
               call stdlib_wgemm('N','N',n,sheight,sheight,cone,q(1,ilo),ldq,qc,ldqc, &
@@ -48186,11 +48186,11 @@ module stdlib_linalg_lapack_w
               call stdlib_wgemm('N','N',sheight,swidth,swidth,cone,a(istartm,ilo),lda, &
                         zc,ldzc,czero,work,sheight)
               call stdlib_wlacpy('ALL',sheight,swidth,work,sheight,a(istartm,ilo),lda)
-                        
+
               call stdlib_wgemm('N','N',sheight,swidth,swidth,cone,b(istartm,ilo),ldb, &
                         zc,ldzc,czero,work,sheight)
               call stdlib_wlacpy('ALL',sheight,swidth,work,sheight,b(istartm,ilo),ldb)
-                        
+
            end if
            if (ilz) then
               call stdlib_wgemm('N','N',n,swidth,swidth,cone,z(1,ilo),ldz,zc,ldzc, &
@@ -48250,11 +48250,11 @@ module stdlib_linalg_lapack_w
                  call stdlib_wgemm('N','N',sheight,swidth,swidth,cone,a(istartm,k),lda, &
                            zc,ldzc,czero,work,sheight)
                  call stdlib_wlacpy('ALL',sheight,swidth,work,sheight,a(istartm,k),lda)
-                           
+
                  call stdlib_wgemm('N','N',sheight,swidth,swidth,cone,b(istartm,k),ldb, &
                            zc,ldzc,czero,work,sheight)
                  call stdlib_wlacpy('ALL',sheight,swidth,work,sheight,b(istartm,k),ldb)
-                           
+
               end if
               if (ilz) then
                  call stdlib_wgemm('N','N',n,nblock,nblock,cone,z(1,k),ldz,zc,ldzc, &
@@ -48353,7 +48353,7 @@ module stdlib_linalg_lapack_w
            real(qp),intent(out) :: work(*)
            complex(qp),intent(inout) :: z(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: sawnan1,sawnan2
            integer(ilp) :: i,indlpl,indp,inds,indumn,neg1,neg2,r1,r2
@@ -48401,7 +48401,7 @@ module stdlib_linalg_lapack_w
               s = work(inds + i) - lambda
            end do
            sawnan1 = stdlib_qisnan(s)
-60         continue
+           60 continue
            if (sawnan1) then
               ! runs a slower version of the above loop if a nan is detected
               neg1 = 0
@@ -48486,7 +48486,7 @@ module stdlib_linalg_lapack_w
                  end if
                  ztz = ztz + real(z(i)*z(i),KIND=qp)
               end do
-220           continue
+              220 continue
            else
               ! run slower loop if nan occurred.
               do i = r - 1,b1,-1
@@ -48502,7 +48502,7 @@ module stdlib_linalg_lapack_w
                  end if
                  ztz = ztz + real(z(i)*z(i),KIND=qp)
               end do
-240           continue
+              240 continue
            end if
            ! compute the fp vector downwards from r in blocks of size blksiz
            if (.not. sawnan1 .and. .not. sawnan2) then
@@ -48515,7 +48515,7 @@ module stdlib_linalg_lapack_w
                  end if
                  ztz = ztz + real(z(i + 1)*z(i + 1),KIND=qp)
               end do
-260           continue
+              260 continue
            else
               ! run slower loop if nan occurred.
               do i = r,bn - 1
@@ -48531,7 +48531,7 @@ module stdlib_linalg_lapack_w
                  end if
                  ztz = ztz + real(z(i + 1)*z(i + 1),KIND=qp)
               end do
-280           continue
+              280 continue
            end if
            ! compute quantities for convergence test
            tmp = one/ztz
@@ -48612,7 +48612,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: b(ldb,*)
            complex(qp),intent(out) :: c(ldc,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,l
            ! Intrinsic Functions
@@ -48627,7 +48627,7 @@ module stdlib_linalg_lapack_w
            end do
            l = m*n + 1
            call stdlib_qgemm('N','N',m,n,m,one,a,lda,rwork,m,zero,rwork(l),m)
-                     
+
            do j = 1,n
               do i = 1,m
                  c(i,j) = rwork(l + (j - 1)*m + i - 1)
@@ -48639,11 +48639,11 @@ module stdlib_linalg_lapack_w
               end do
            end do
            call stdlib_qgemm('N','N',m,n,m,one,a,lda,rwork,m,zero,rwork(l),m)
-                     
+
            do j = 1,n
               do i = 1,m
                  c(i,j) = cmplx(real(c(i,j),KIND=qp),rwork(l + (j - 1)*m + i - 1),KIND=qp)
-                           
+
               end do
            end do
            return
@@ -48671,7 +48671,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: v(*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: applyleft
            integer(ilp) :: i,lastv,lastc
@@ -48745,7 +48745,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: t(ldt,*),v(ldv,*)
            complex(qp),intent(out) :: work(ldwork,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            character :: transt
            integer(ilp) :: i,j
@@ -49066,7 +49066,7 @@ module stdlib_linalg_lapack_w
      !> arrays A, B and T. See Further Details section.
 
      pure subroutine stdlib_wlarfb_gett(ident,m,n,k,t,ldt,a,lda,b,ldb,work,ldwork)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -49078,7 +49078,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: t(ldt,*)
            complex(qp),intent(out) :: work(ldwork,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lnotident
            integer(ilp) :: i,j
@@ -49102,7 +49102,7 @@ module stdlib_linalg_lapack_w
                  ! v1 is not an identy matrix, but unit lower-triangular
                  ! v1 stored in a1 (diagonal ones are not stored).
                  call stdlib_wtrmm('L','L','C','U',k,n - k,cone,a,lda,work,ldwork)
-                           
+
               end if
               ! col2_(3) compute w2: = w2 + (v2**h) * b2 = w2 + (b1**h) * b2
               ! v2 stored in b1.
@@ -49124,7 +49124,7 @@ module stdlib_linalg_lapack_w
                  ! v1 is not an identity matrix, but unit lower-triangular,
                  ! v1 stored in a1 (diagonal ones are not stored).
                  call stdlib_wtrmm('L','L','N','U',k,n - k,cone,a,lda,work,ldwork)
-                           
+
               end if
               ! col2_(7) compute a2: = a2 - w2 =
                                    ! = a(1:k, k+1:n-k) - work(1:k, 1:n-k),
@@ -49221,7 +49221,7 @@ module stdlib_linalg_lapack_w
            ! Array Arguments
            complex(qp),intent(inout) :: x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j,knt
            real(qp) :: alphi,alphr,beta,rsafmn,safmin,xnorm
@@ -49246,7 +49246,7 @@ module stdlib_linalg_lapack_w
               knt = 0
               if (abs(beta) < safmin) then
                  ! xnorm, beta may be inaccurate; scale x and recompute them
-10   continue
+                 10 continue
                  knt = knt + 1
                  call stdlib_wdscal(n - 1,rsafmn,x,incx)
                  beta = beta*rsafmn
@@ -49294,7 +49294,7 @@ module stdlib_linalg_lapack_w
            ! Array Arguments
            complex(qp),intent(inout) :: x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j,knt
            real(qp) :: alphi,alphr,beta,bignum,smlnum,xnorm
@@ -49343,7 +49343,7 @@ module stdlib_linalg_lapack_w
               knt = 0
               if (abs(beta) < smlnum) then
                  ! xnorm, beta may be inaccurate; scale x and recompute them
-10   continue
+                 10 continue
                  knt = knt + 1
                  call stdlib_wdscal(n - 1,bignum,x,incx)
                  beta = beta*bignum
@@ -49428,7 +49428,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(out) :: t(ldt,*)
            complex(qp),intent(in) :: tau(*),v(ldv,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,prevlastv,lastv
            ! Executable Statements
@@ -49554,7 +49554,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: v(*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j
            complex(qp) :: sum,t1,t10,t2,t3,t4,t5,t6,t7,t8,t9,v1,v10,v2,v3,v4,v5, &
@@ -49569,14 +49569,14 @@ module stdlib_linalg_lapack_w
               ! code for general m
               call stdlib_wlarf(side,m,n,v,1,tau,c,ldc,work)
               go to 410
-10            continue
+              10 continue
               ! special code for 1 x 1 householder
               t1 = cone - tau*v(1)*conjg(v(1))
               do j = 1,n
                  c(1,j) = t1*c(1,j)
               end do
               go to 410
-30            continue
+              30 continue
               ! special code for 2 x 2 householder
               v1 = conjg(v(1))
               t1 = tau*conjg(v1)
@@ -49588,7 +49588,7 @@ module stdlib_linalg_lapack_w
                  c(2,j) = c(2,j) - sum*t2
               end do
               go to 410
-50            continue
+              50 continue
               ! special code for 3 x 3 householder
               v1 = conjg(v(1))
               t1 = tau*conjg(v1)
@@ -49603,7 +49603,7 @@ module stdlib_linalg_lapack_w
                  c(3,j) = c(3,j) - sum*t3
               end do
               go to 410
-70            continue
+              70 continue
               ! special code for 4 x 4 householder
               v1 = conjg(v(1))
               t1 = tau*conjg(v1)
@@ -49621,7 +49621,7 @@ module stdlib_linalg_lapack_w
                  c(4,j) = c(4,j) - sum*t4
               end do
               go to 410
-90            continue
+              90 continue
               ! special code for 5 x 5 householder
               v1 = conjg(v(1))
               t1 = tau*conjg(v1)
@@ -49635,7 +49635,7 @@ module stdlib_linalg_lapack_w
               t5 = tau*conjg(v5)
               do j = 1,n
                  sum = v1*c(1,j) + v2*c(2,j) + v3*c(3,j) + v4*c(4,j) + v5*c(5,j)
-                           
+
                  c(1,j) = c(1,j) - sum*t1
                  c(2,j) = c(2,j) - sum*t2
                  c(3,j) = c(3,j) - sum*t3
@@ -49643,7 +49643,7 @@ module stdlib_linalg_lapack_w
                  c(5,j) = c(5,j) - sum*t5
               end do
               go to 410
-110           continue
+              110 continue
               ! special code for 6 x 6 householder
               v1 = conjg(v(1))
               t1 = tau*conjg(v1)
@@ -49668,7 +49668,7 @@ module stdlib_linalg_lapack_w
                  c(6,j) = c(6,j) - sum*t6
               end do
               go to 410
-130           continue
+              130 continue
               ! special code for 7 x 7 householder
               v1 = conjg(v(1))
               t1 = tau*conjg(v1)
@@ -49696,7 +49696,7 @@ module stdlib_linalg_lapack_w
                  c(7,j) = c(7,j) - sum*t7
               end do
               go to 410
-150           continue
+              150 continue
               ! special code for 8 x 8 householder
               v1 = conjg(v(1))
               t1 = tau*conjg(v1)
@@ -49727,7 +49727,7 @@ module stdlib_linalg_lapack_w
                  c(8,j) = c(8,j) - sum*t8
               end do
               go to 410
-170           continue
+              170 continue
               ! special code for 9 x 9 householder
               v1 = conjg(v(1))
               t1 = tau*conjg(v1)
@@ -49761,7 +49761,7 @@ module stdlib_linalg_lapack_w
                  c(9,j) = c(9,j) - sum*t9
               end do
               go to 410
-190           continue
+              190 continue
               ! special code for 10 x 10 householder
               v1 = conjg(v(1))
               t1 = tau*conjg(v1)
@@ -49804,14 +49804,14 @@ module stdlib_linalg_lapack_w
               ! code for general n
               call stdlib_wlarf(side,m,n,v,1,tau,c,ldc,work)
               go to 410
-210           continue
+              210 continue
               ! special code for 1 x 1 householder
               t1 = cone - tau*v(1)*conjg(v(1))
               do j = 1,m
                  c(j,1) = t1*c(j,1)
               end do
               go to 410
-230           continue
+              230 continue
               ! special code for 2 x 2 householder
               v1 = v(1)
               t1 = tau*conjg(v1)
@@ -49823,7 +49823,7 @@ module stdlib_linalg_lapack_w
                  c(j,2) = c(j,2) - sum*t2
               end do
               go to 410
-250           continue
+              250 continue
               ! special code for 3 x 3 householder
               v1 = v(1)
               t1 = tau*conjg(v1)
@@ -49838,7 +49838,7 @@ module stdlib_linalg_lapack_w
                  c(j,3) = c(j,3) - sum*t3
               end do
               go to 410
-270           continue
+              270 continue
               ! special code for 4 x 4 householder
               v1 = v(1)
               t1 = tau*conjg(v1)
@@ -49856,7 +49856,7 @@ module stdlib_linalg_lapack_w
                  c(j,4) = c(j,4) - sum*t4
               end do
               go to 410
-290           continue
+              290 continue
               ! special code for 5 x 5 householder
               v1 = v(1)
               t1 = tau*conjg(v1)
@@ -49870,7 +49870,7 @@ module stdlib_linalg_lapack_w
               t5 = tau*conjg(v5)
               do j = 1,m
                  sum = v1*c(j,1) + v2*c(j,2) + v3*c(j,3) + v4*c(j,4) + v5*c(j,5)
-                           
+
                  c(j,1) = c(j,1) - sum*t1
                  c(j,2) = c(j,2) - sum*t2
                  c(j,3) = c(j,3) - sum*t3
@@ -49878,7 +49878,7 @@ module stdlib_linalg_lapack_w
                  c(j,5) = c(j,5) - sum*t5
               end do
               go to 410
-310           continue
+              310 continue
               ! special code for 6 x 6 householder
               v1 = v(1)
               t1 = tau*conjg(v1)
@@ -49903,7 +49903,7 @@ module stdlib_linalg_lapack_w
                  c(j,6) = c(j,6) - sum*t6
               end do
               go to 410
-330           continue
+              330 continue
               ! special code for 7 x 7 householder
               v1 = v(1)
               t1 = tau*conjg(v1)
@@ -49931,7 +49931,7 @@ module stdlib_linalg_lapack_w
                  c(j,7) = c(j,7) - sum*t7
               end do
               go to 410
-350           continue
+              350 continue
               ! special code for 8 x 8 householder
               v1 = v(1)
               t1 = tau*conjg(v1)
@@ -49962,7 +49962,7 @@ module stdlib_linalg_lapack_w
                  c(j,8) = c(j,8) - sum*t8
               end do
               go to 410
-370           continue
+              370 continue
               ! special code for 9 x 9 householder
               v1 = v(1)
               t1 = tau*conjg(v1)
@@ -49996,7 +49996,7 @@ module stdlib_linalg_lapack_w
                  c(j,9) = c(j,9) - sum*t9
               end do
               go to 410
-390           continue
+              390 continue
               ! special code for 10 x 10 householder
               v1 = v(1)
               t1 = tau*conjg(v1)
@@ -50034,7 +50034,7 @@ module stdlib_linalg_lapack_w
               end do
               go to 410
            end if
-410        continue
+           410 continue
            return
      end subroutine stdlib_wlarfx
 
@@ -50058,7 +50058,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: v(*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            complex(qp) :: alpha
            ! Executable Statements
@@ -50093,7 +50093,7 @@ module stdlib_linalg_lapack_w
            real(qp),intent(out) :: c(*)
            complex(qp),intent(inout) :: x(*),y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            ! logical            first
            integer(ilp) :: count,i,ic,ix,iy,j
@@ -50131,7 +50131,7 @@ module stdlib_linalg_lapack_w
               gs = g
               count = 0
               if (scale >= safmx2) then
-10            continue
+              10 continue
                  count = count + 1
                  fs = fs*safmn2
                  gs = gs*safmn2
@@ -50144,7 +50144,7 @@ module stdlib_linalg_lapack_w
                     r = f
                     go to 50
                  end if
-20               continue
+                 20 continue
                  count = count - 1
                  fs = fs*safmx2
                  gs = gs*safmx2
@@ -50214,7 +50214,7 @@ module stdlib_linalg_lapack_w
                     end if
                  end if
               end if
-50            continue
+              50 continue
               c(ic) = cs
               y(iy) = sn
               x(ix) = r
@@ -50241,7 +50241,7 @@ module stdlib_linalg_lapack_w
            ! Parameters
            integer(ilp),parameter :: lv = 128
            real(qp),parameter :: twopi = 6.28318530717958647692528676655900576839e+0_qp
-           
+
            ! Local Scalars
            integer(ilp) :: i,il,iv
            ! Local Arrays
@@ -50275,7 +50275,7 @@ module stdlib_linalg_lapack_w
                  ! distributed on the unit disk
                  do i = 1,il
                     x(iv + i - 1) = sqrt(u(2*i - 1))*exp(cmplx(zero,twopi*u(2*i),KIND=qp))
-                              
+
                  end do
               else if (idist == 5) then
                  ! convert generated numbers to complex numbers uniformly
@@ -50284,7 +50284,7 @@ module stdlib_linalg_lapack_w
                     x(iv + i - 1) = exp(cmplx(zero,twopi*u(2*i),KIND=qp))
                  end do
               end if
-60            continue
+              60 continue
            return
      end subroutine stdlib_wlarnv
 
@@ -50312,7 +50312,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: maxitr = 10
-           
+
            ! Local Scalars
            logical(lk) :: eskip,needbs,stp2ii,tryrqc,usedbs,usedrq
            integer(ilp) :: done,i,ibegin,idone,iend,ii,iindc1,iindc2,iindr,iindwk,iinfo, &
@@ -50395,7 +50395,7 @@ module stdlib_linalg_lapack_w
               ! find the eigenvectors of the submatrix indexed ibegin
               ! through iend.
               wend = wbegin - 1
-15            continue
+              15 continue
               if (wend < m) then
                  if (iblock(wend + 1) == jblk) then
                     wend = wend + 1
@@ -50463,7 +50463,7 @@ module stdlib_linalg_lapack_w
               ! loop while( idone<im )
               ! generate the representation tree for the current block and
               ! compute the eigenvectors
-40   continue
+              40 continue
               if (idone < im) then
                  ! this is a crude protection against infinitely deep trees
                  if (ndepth > m) then
@@ -50519,7 +50519,7 @@ module stdlib_linalg_lapack_w
                        sigma = real(z(iend,j + 1),KIND=qp)
                        ! set the corresponding entries in z to zero
                        call stdlib_wlaset('FULL',in,2,czero,czero,z(ibegin,j),ldz)
-                                 
+
                     end if
                     ! compute dl and dll of current rrr
                     do j = ibegin,iend - 1
@@ -50555,7 +50555,7 @@ module stdlib_linalg_lapack_w
                        if (oldfst > 1) then
                           wgap(wbegin + oldfst - 2) = max(wgap(wbegin + oldfst - 2),w(wbegin + oldfst - 1) - &
                           werr(wbegin + oldfst - 1) - w(wbegin + oldfst - 2) - werr(wbegin + oldfst - 2))
-                                    
+
                        end if
                        if (wbegin + oldlst - 1 < wend) then
                           wgap(wbegin + oldlst - 1) = max(wgap(wbegin + oldlst - 1),w(wbegin + oldlst) - &
@@ -50651,15 +50651,15 @@ module stdlib_linalg_lapack_w
                           call stdlib_qlarrf(in,d(ibegin),l(ibegin),work(indld + ibegin - 1), &
                           newfst,newlst,work(wbegin),wgap(wbegin),werr(wbegin),spdiam,lgap, &
                           rgap,pivmin,tau,work(indin1),work(indin2),work(indwrk),iinfo)
-                                    
+
                           ! in the complex case, stdlib_qlarrf cannot write
                           ! the new rrr directly into z and needs an intermediate
                           ! workspace
                           do k = 1,in - 1
                              z(ibegin + k - 1,newftt) = cmplx(work(indin1 + k - 1),zero,KIND=qp)
-                                       
+
                              z(ibegin + k - 1,newftt + 1) = cmplx(work(indin2 + k - 1),zero,KIND=qp)
-                                       
+
                           end do
                           z(iend,newftt) = cmplx(work(indin1 + in - 1),zero,KIND=qp)
                           if (iinfo == 0) then
@@ -50766,7 +50766,7 @@ module stdlib_linalg_lapack_w
                           usedrq = .false.
                           ! bisection is initially turned off unless it is forced
                           needbs = .not. tryrqc
-120                       continue
+                          120 continue
                           ! check if bisection should be used to refine eigenvalue
                           if (needbs) then
                              ! take the bisection as new iterate
@@ -50900,7 +50900,7 @@ module stdlib_linalg_lapack_w
                              end do
                           end if
                           call stdlib_wdscal(zto - zfrom + 1,nrminv,z(zfrom,windex),1)
-125                       continue
+                          125 continue
                           ! update w
                           w(windex) = lambda + sigma
                           ! recompute the gaps on the left and right
@@ -50922,7 +50922,7 @@ module stdlib_linalg_lapack_w
                           idone = idone + 1
                        end if
                        ! here ends the code for the current child
-139  continue
+                       139 continue
                        ! proceed to any remaining child nodes
                        newfst = j + 1
                     end do loop_140
@@ -51116,7 +51116,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: v(*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Executable Statements
            if (stdlib_lsame(side,'L')) then
               ! form  h * c
@@ -51168,7 +51168,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: c(ldc,*),t(ldt,*),v(ldv,*)
            complex(qp),intent(out) :: work(ldwork,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            character :: transt
            integer(ilp) :: i,info,j
@@ -51279,7 +51279,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: tau(*)
            complex(qp),intent(inout) :: v(ldv,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,info,j
            ! Executable Statements
@@ -51336,7 +51336,7 @@ module stdlib_linalg_lapack_w
            ! Array Arguments
            complex(qp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: done
            integer(ilp) :: i,itype,j,k1,k2,k3,k4
@@ -51397,7 +51397,7 @@ module stdlib_linalg_lapack_w
            bignum = one/smlnum
            cfromc = cfrom
            ctoc = cto
-10         continue
+           10 continue
            cfrom1 = cfromc*smlnum
            if (cfrom1 == cfromc) then
               ! cfromc is an inf.  multiply by a correctly signed zero for
@@ -51607,7 +51607,7 @@ module stdlib_linalg_lapack_w
            real(qp),intent(in) :: c(*),s(*)
            complex(qp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,info,j
            real(qp) :: ctemp,stemp
@@ -52110,7 +52110,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: sevten = 17.0e+0_qp
-           
+
            ! Local Scalars
            integer(ilp) :: imax,j,jb,jj,jmax,jp,k,kk,kkw,kp,kstep,kw
            real(qp) :: absakk,alpha,colmax,rowmax
@@ -52132,7 +52132,7 @@ module stdlib_linalg_lapack_w
               ! k is the main loop index, decreasing from n in steps of 1 or 2
               ! kw is the column of w which corresponds to column k of a
               k = n
-10            continue
+              10 continue
               kw = nb + k - n
               ! exit from loop
               if ((k <= n - nb + 1 .and. nb < n) .or. k < 1) go to 30
@@ -52163,7 +52163,7 @@ module stdlib_linalg_lapack_w
                     ! copy column imax to column kw-1 of w and update it
                     call stdlib_wcopy(imax,a(1,imax),1,w(1,kw - 1),1)
                     call stdlib_wcopy(k - imax,a(imax,imax + 1),lda,w(imax + 1,kw - 1),1)
-                              
+
                     if (k < n) call stdlib_wgemv('NO TRANSPOSE',k,n - k,-cone,a(1,k + 1),lda,w( &
                                imax,kw + 1),ldw,cone,w(1,kw - 1),1)
                     ! jmax is the column-index of the largest off-diagonal
@@ -52284,7 +52284,7 @@ module stdlib_linalg_lapack_w
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-30            continue
+              30 continue
               ! update the upper triangle of a11 (= a(1:k,1:k)) as
               ! a11 := a11 - u12*d*u12**t = a11 - u12*w**t
               ! computing blocks of nb columns at a time
@@ -52302,7 +52302,7 @@ module stdlib_linalg_lapack_w
               ! put u12 in standard form by partially undoing the interchanges
               ! in columns k+1:n looping backwards from k+1 to n
               j = k + 1
-60            continue
+              60 continue
                  ! undo the interchanges (if any) of rows jj and jp at each
                  ! step j
                  ! (here, j is a diagonal index)
@@ -52327,7 +52327,7 @@ module stdlib_linalg_lapack_w
               ! for use in updating a22
               ! k is the main loop index, increasing from 1 in steps of 1 or 2
               k = 1
-70            continue
+              70 continue
               ! exit from loop
               if ((k >= nb .and. nb < n) .or. k > n) go to 90
               ! copy column k of a to column k of w and update it
@@ -52396,7 +52396,7 @@ module stdlib_linalg_lapack_w
                     a(kp,kp) = a(kk,kk)
                     call stdlib_wcopy(kp - kk - 1,a(kk + 1,kk),1,a(kp,kk + 1),lda)
                     if (kp < n) call stdlib_wcopy(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     ! interchange rows kk and kp in first k-1 columns of a
                     ! (columns k (or k and k+1 for 2-by-2 pivot) of a will be
                     ! later overwritten). interchange rows kk and kp
@@ -52478,7 +52478,7 @@ module stdlib_linalg_lapack_w
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 70
-90            continue
+              90 continue
               ! update the lower triangle of a22 (= a(k:n,k:n)) as
               ! a22 := a22 - l21*d*l21**t = a22 - l21*w**t
               ! computing blocks of nb columns at a time
@@ -52496,7 +52496,7 @@ module stdlib_linalg_lapack_w
               ! put l21 in standard form by partially undoing the interchanges
               ! of rows in columns 1:k-1 looping backwards from k-1 to 1
               j = k - 1
-120           continue
+              120 continue
                  ! undo the interchanges (if any) of rows jj and jp at each
                  ! step j
                  ! (here, j is a diagonal index)
@@ -52511,7 +52511,7 @@ module stdlib_linalg_lapack_w
                  ! of the rows to swap back doesn't include diagonal element)
                  j = j - 1
                  if (jp /= jj .and. j >= 1) call stdlib_wswap(j,a(jp,1),lda,a(jj,1),lda)
-                           
+
               if (j > 1) go to 120
               ! set kb to the number of columns factorized
               kb = k - 1
@@ -52542,7 +52542,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*),h(ldh,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j,k,k1,i1,i2,mj
            complex(qp) :: piv,alpha
@@ -52557,7 +52557,7 @@ module stdlib_linalg_lapack_w
               ! .....................................................
               ! factorize a as u**t*d*u using the upper triangle of a
               ! .....................................................
-10   continue
+              10 continue
               if (j > min(m,nb)) go to 20
               ! k is the column to be factorized
                ! when being called from stdlib_wsytrf_aa,
@@ -52611,7 +52611,7 @@ module stdlib_linalg_lapack_w
                     i1 = i1 + j - 1
                     i2 = i2 + j - 1
                     call stdlib_wswap(i2 - i1 - 1,a(j1 + i1 - 1,i1 + 1),lda,a(j1 + i1,i2),1)
-                              
+
                     ! swap a(i1, i2+1:m) with a(i2, i2+1:m)
                     if (i2 < m) call stdlib_wswap(m - i2,a(j1 + i1 - 1,i2 + 1),lda,a(j1 + i2 - 1,i2 + 1), &
                                lda)
@@ -52645,18 +52645,18 @@ module stdlib_linalg_lapack_w
                        call stdlib_wscal(m - j - 1,alpha,a(k,j + 2),lda)
                     else
                        call stdlib_wlaset('FULL',1,m - j - 1,czero,czero,a(k,j + 2),lda)
-                                 
+
                     end if
                  end if
               end if
               j = j + 1
               go to 10
-20            continue
+              20 continue
            else
               ! .....................................................
               ! factorize a as l*d*l**t using the lower triangle of a
               ! .....................................................
-30   continue
+              30 continue
               if (j > min(m,nb)) go to 40
               ! k is the column to be factorized
                ! when being called from stdlib_wsytrf_aa,
@@ -52710,7 +52710,7 @@ module stdlib_linalg_lapack_w
                     i1 = i1 + j - 1
                     i2 = i2 + j - 1
                     call stdlib_wswap(i2 - i1 - 1,a(i1 + 1,j1 + i1 - 1),1,a(i2,j1 + i1),lda)
-                              
+
                     ! swap a(i2+1:m, i1) with a(i2+1:m, i2)
                     if (i2 < m) call stdlib_wswap(m - i2,a(i2 + 1,j1 + i1 - 1),1,a(i2 + 1,j1 + i2 - 1), &
                               1)
@@ -52744,13 +52744,13 @@ module stdlib_linalg_lapack_w
                        call stdlib_wscal(m - j - 1,alpha,a(j + 2,k),1)
                     else
                        call stdlib_wlaset('FULL',m - j - 1,1,czero,czero,a(j + 2,k),lda)
-                                 
+
                     end if
                  end if
               end if
               j = j + 1
               go to 30
-40            continue
+              40 continue
            end if
            return
      end subroutine stdlib_wlasyf_aa
@@ -52783,7 +52783,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: sevten = 17.0e+0_qp
-           
+
            ! Local Scalars
            logical(lk) :: done
            integer(ilp) :: imax,itemp,j,jb,jj,jmax,k,kk,kw,kkw,kp,kstep,p,ii
@@ -52810,7 +52810,7 @@ module stdlib_linalg_lapack_w
               e(1) = czero
               ! k is the main loop index, decreasing from n in steps of 1 or 2
               k = n
-10            continue
+              10 continue
               ! kw is the column of w which corresponds to column k of a
               kw = nb + k - n
               ! exit from loop
@@ -52851,12 +52851,12 @@ module stdlib_linalg_lapack_w
                  else
                     done = .false.
                     ! loop until pivot found
-12   continue
+                    12 continue
                        ! begin pivot search loop body
                        ! copy column imax to column kw-1 of w and update it
                        call stdlib_wcopy(imax,a(1,imax),1,w(1,kw - 1),1)
                        call stdlib_wcopy(k - imax,a(imax,imax + 1),lda,w(imax + 1,kw - 1),1)
-                                 
+
                        if (k < n) call stdlib_wgemv('NO TRANSPOSE',k,n - k,-cone,a(1,k + 1),lda, &
                                   w(imax,kw + 1),ldw,cone,w(1,kw - 1),1)
                        ! jmax is the column-index of the largest off-diagonal
@@ -52985,7 +52985,7 @@ module stdlib_linalg_lapack_w
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-30            continue
+              30 continue
               ! update the upper triangle of a11 (= a(1:k,1:k)) as
               ! a11 := a11 - u12*d*u12**t = a11 - u12*w**t
               ! computing blocks of nb columns at a time
@@ -53010,7 +53010,7 @@ module stdlib_linalg_lapack_w
               e(n) = czero
               ! k is the main loop index, increasing from 1 in steps of 1 or 2
               k = 1
-70            continue
+              70 continue
               ! exit from loop
               if ((k >= nb .and. nb < n) .or. k > n) go to 90
               kstep = 1
@@ -53049,7 +53049,7 @@ module stdlib_linalg_lapack_w
                  else
                     done = .false.
                     ! loop until pivot found
-72   continue
+                    72 continue
                        ! begin pivot search loop body
                        ! copy column imax to column k+1 of w and update it
                        call stdlib_wcopy(imax - k,a(imax,k),lda,w(k,k + 1),1)
@@ -53178,7 +53178,7 @@ module stdlib_linalg_lapack_w
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 70
-90            continue
+              90 continue
               ! update the lower triangle of a22 (= a(k:n,k:n)) as
               ! a22 := a22 - l21*d*l21**t = a22 - l21*w**t
               ! computing blocks of nb columns at a time
@@ -53227,7 +53227,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: sevten = 17.0e+0_qp
-           
+
            ! Local Scalars
            logical(lk) :: done
            integer(ilp) :: imax,itemp,j,jb,jj,jmax,jp1,jp2,k,kk,kw,kkw,kp,kstep,p, &
@@ -53252,7 +53252,7 @@ module stdlib_linalg_lapack_w
               ! for use in updating a11
               ! k is the main loop index, decreasing from n in steps of 1 or 2
               k = n
-10            continue
+              10 continue
               ! kw is the column of w which corresponds to column k of a
               kw = nb + k - n
               ! exit from loop
@@ -53291,12 +53291,12 @@ module stdlib_linalg_lapack_w
                  else
                     done = .false.
                     ! loop until pivot found
-12   continue
+                    12 continue
                        ! begin pivot search loop body
                        ! copy column imax to column kw-1 of w and update it
                        call stdlib_wcopy(imax,a(1,imax),1,w(1,kw - 1),1)
                        call stdlib_wcopy(k - imax,a(imax,imax + 1),lda,w(imax + 1,kw - 1),1)
-                                 
+
                        if (k < n) call stdlib_wgemv('NO TRANSPOSE',k,n - k,-cone,a(1,k + 1),lda, &
                                   w(imax,kw + 1),ldw,cone,w(1,kw - 1),1)
                        ! jmax is the column-index of the largest off-diagonal
@@ -53418,7 +53418,7 @@ module stdlib_linalg_lapack_w
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-30            continue
+              30 continue
               ! update the upper triangle of a11 (= a(1:k,1:k)) as
               ! a11 := a11 - u12*d*u12**t = a11 - u12*w**t
               ! computing blocks of nb columns at a time
@@ -53436,7 +53436,7 @@ module stdlib_linalg_lapack_w
               ! put u12 in standard form by partially undoing the interchanges
               ! in columns k+1:n
               j = k + 1
-60            continue
+              60 continue
                  kstep = 1
                  jp1 = 1
                  jj = j
@@ -53462,7 +53462,7 @@ module stdlib_linalg_lapack_w
               ! for use in updating a22
               ! k is the main loop index, increasing from 1 in steps of 1 or 2
               k = 1
-70            continue
+              70 continue
               ! exit from loop
               if ((k >= nb .and. nb < n) .or. k > n) go to 90
               kstep = 1
@@ -53499,7 +53499,7 @@ module stdlib_linalg_lapack_w
                  else
                     done = .false.
                     ! loop until pivot found
-72   continue
+                    72 continue
                        ! begin pivot search loop body
                        ! copy column imax to column k+1 of w and update it
                        call stdlib_wcopy(imax - k,a(imax,k),lda,w(k,k + 1),1)
@@ -53621,7 +53621,7 @@ module stdlib_linalg_lapack_w
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 70
-90            continue
+              90 continue
               ! update the lower triangle of a22 (= a(k:n,k:n)) as
               ! a22 := a22 - l21*d*l21**t = a22 - l21*w**t
               ! computing blocks of nb columns at a time
@@ -53639,7 +53639,7 @@ module stdlib_linalg_lapack_w
               ! put l21 in standard form by partially undoing the interchanges
               ! in columns 1:k-1
               j = k - 1
-120           continue
+              120 continue
                  kstep = 1
                  jp1 = 1
                  jj = j
@@ -53652,7 +53652,7 @@ module stdlib_linalg_lapack_w
                  end if
                  j = j - 1
                  if (jp2 /= jj .and. j >= 1) call stdlib_wswap(j,a(jp2,1),lda,a(jj,1),lda)
-                           
+
                  jj = j + 1
                  if (jp1 /= jj .and. kstep == 2) call stdlib_wswap(j,a(jp1,1),lda,a(jj,1), &
                            lda)
@@ -53716,7 +53716,7 @@ module stdlib_linalg_lapack_w
                  end do
               end do
            end if
-50         continue
+           50 continue
            return
      end subroutine stdlib_wlat2c
 
@@ -53746,7 +53746,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: ab(ldab,*)
            complex(qp),intent(inout) :: x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            integer(ilp) :: i,imax,j,jfirst,jinc,jlast,jlen,maind
@@ -53759,7 +53759,7 @@ module stdlib_linalg_lapack_w
            ! Statement Function Definitions
            cabs1(zdum) = abs(real(zdum,KIND=qp)) + abs(aimag(zdum))
            cabs2(zdum) = abs(real(zdum,KIND=qp)/2._qp) + abs(aimag(zdum)/2._qp)
-                     
+
            ! Executable Statements
            info = 0
            upper = stdlib_lsame(uplo,'U')
@@ -53888,7 +53888,7 @@ module stdlib_linalg_lapack_w
                     grow = grow*(one/(one + cnorm(j)))
                  end do
               end if
-60            continue
+              60 continue
            else
               ! compute the growth in a**t * x = b  or  a**h * x = b.
               if (upper) then
@@ -53941,7 +53941,7 @@ module stdlib_linalg_lapack_w
                     grow = grow/xj
                  end do
               end if
-90            continue
+              90 continue
            end if
            if ((grow*tscal) > smlnum) then
               ! use the level 2 blas solve if the reciprocal of the bound on
@@ -54011,7 +54011,7 @@ module stdlib_linalg_lapack_w
                        scale = zero
                        xmax = zero
                     end if
-110                 continue
+                    110 continue
                     ! scale x if necessary to avoid overflow when adding a
                     ! multiple of column j of a.
                     if (xj > one) then
@@ -54084,11 +54084,11 @@ module stdlib_linalg_lapack_w
                        if (upper) then
                           jlen = min(kd,j - 1)
                           csumj = stdlib_wdotu(jlen,ab(kd + 1 - jlen,j),1,x(j - jlen),1)
-                                    
+
                        else
                           jlen = min(kd,n - j)
                           if (jlen > 1) csumj = stdlib_wdotu(jlen,ab(2,j),1,x(j + 1),1)
-                                    
+
                        end if
                     else
                        ! otherwise, use in-line code for the dot product.
@@ -54149,7 +54149,7 @@ module stdlib_linalg_lapack_w
                           scale = zero
                           xmax = zero
                        end if
-160                    continue
+                       160 continue
                     else
                        ! compute x(j) := x(j) / a(j,j) - csumj if the dot
                        ! product has already been divided by 1/a(j,j).
@@ -54192,11 +54192,11 @@ module stdlib_linalg_lapack_w
                        if (upper) then
                           jlen = min(kd,j - 1)
                           csumj = stdlib_wdotc(jlen,ab(kd + 1 - jlen,j),1,x(j - jlen),1)
-                                    
+
                        else
                           jlen = min(kd,n - j)
                           if (jlen > 1) csumj = stdlib_wdotc(jlen,ab(2,j),1,x(j + 1),1)
-                                    
+
                        end if
                     else
                        ! otherwise, use in-line code for the dot product.
@@ -54204,7 +54204,7 @@ module stdlib_linalg_lapack_w
                           jlen = min(kd,j - 1)
                           do i = 1,jlen
                              csumj = csumj + (conjg(ab(kd + i - jlen,j))*uscal)*x(j - jlen - 1 + i)
-                                       
+
                           end do
                        else
                           jlen = min(kd,n - j)
@@ -54258,7 +54258,7 @@ module stdlib_linalg_lapack_w
                           scale = zero
                           xmax = zero
                        end if
-210                    continue
+                       210 continue
                     else
                        ! compute x(j) := x(j) / a(j,j) - csumj if the dot
                        ! product has already been divided by 1/a(j,j).
@@ -54298,7 +54298,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: maxdim = 2
-           
+
            ! Local Scalars
            integer(ilp) :: i,info,j,k
            real(qp) :: rtemp,scale,sminu,splus
@@ -54321,7 +54321,7 @@ module stdlib_linalg_lapack_w
                  ! lockahead for l- part rhs(1:n-1) = +-1
                  ! splus and smin computed more efficiently than in bsolve[1].
                  splus = splus + real(stdlib_wdotc(n - j,z(j + 1,j),1,z(j + 1,j),1),KIND=qp)
-                           
+
                  sminu = real(stdlib_wdotc(n - j,z(j + 1,j),1,rhs(j + 1),1),KIND=qp)
                  splus = splus*real(rhs(j),KIND=qp)
                  if (splus > sminu) then
@@ -54401,7 +54401,7 @@ module stdlib_linalg_lapack_w
      !> non-trivial solution to A*x = 0 is returned.
 
      pure subroutine stdlib_wlatps(uplo,trans,diag,normin,n,ap,x,scale,cnorm,info)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -54415,7 +54415,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: ap(*)
            complex(qp),intent(inout) :: x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            integer(ilp) :: i,imax,ip,j,jfirst,jinc,jlast,jlen
@@ -54428,7 +54428,7 @@ module stdlib_linalg_lapack_w
            ! Statement Function Definitions
            cabs1(zdum) = abs(real(zdum,KIND=qp)) + abs(aimag(zdum))
            cabs2(zdum) = abs(real(zdum,KIND=qp)/2._qp) + abs(aimag(zdum)/2._qp)
-                     
+
            ! Executable Statements
            info = 0
            upper = stdlib_lsame(uplo,'U')
@@ -54554,7 +54554,7 @@ module stdlib_linalg_lapack_w
                     grow = grow*(one/(one + cnorm(j)))
                  end do
               end if
-60            continue
+              60 continue
            else
               ! compute the growth in a**t * x = b  or  a**h * x = b.
               if (upper) then
@@ -54609,7 +54609,7 @@ module stdlib_linalg_lapack_w
                     grow = grow/xj
                  end do
               end if
-90            continue
+              90 continue
            end if
            if ((grow*tscal) > smlnum) then
               ! use the level 2 blas solve if the reciprocal of the bound on
@@ -54680,7 +54680,7 @@ module stdlib_linalg_lapack_w
                        scale = zero
                        xmax = zero
                     end if
-110                 continue
+                    110 continue
                     ! scale x if necessary to avoid overflow when adding a
                     ! multiple of column j of a.
                     if (xj > one) then
@@ -54710,7 +54710,7 @@ module stdlib_linalg_lapack_w
                           ! compute the update
                              ! x(j+1:n) := x(j+1:n) - x(j) * a(j+1:n,j)
                           call stdlib_waxpy(n - j,-x(j)*tscal,ap(ip + 1),1,x(j + 1),1)
-                                    
+
                           i = j + stdlib_iwamax(n - j,x(j + 1),1)
                           xmax = cabs1(x(i))
                        end if
@@ -54813,7 +54813,7 @@ module stdlib_linalg_lapack_w
                           scale = zero
                           xmax = zero
                        end if
-160                    continue
+                       160 continue
                     else
                        ! compute x(j) := x(j) / a(j,j) - csumj if the dot
                        ! product has already been divided by 1/a(j,j).
@@ -54919,7 +54919,7 @@ module stdlib_linalg_lapack_w
                           scale = zero
                           xmax = zero
                        end if
-210                    continue
+                       210 continue
                     else
                        ! compute x(j) := x(j) / a(j,j) - csumj if the dot
                        ! product has already been divided by 1/a(j,j).
@@ -54961,7 +54961,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: tau(*),w(ldw,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,iw
            complex(qp) :: alpha
@@ -55009,7 +55009,7 @@ module stdlib_linalg_lapack_w
                     end if
                     call stdlib_wscal(i - 1,tau(i - 1),w(1,iw),1)
                     alpha = -chalf*tau(i - 1)*stdlib_wdotc(i - 1,w(1,iw),1,a(1,i),1)
-                              
+
                     call stdlib_waxpy(i - 1,alpha,a(1,i),1,w(1,iw),1)
                  end if
               end do loop_10
@@ -55047,7 +55047,7 @@ module stdlib_linalg_lapack_w
                               ,1,cone,w(i + 1,i),1)
                     call stdlib_wscal(n - i,tau(i),w(i + 1,i),1)
                     alpha = -chalf*tau(i)*stdlib_wdotc(n - i,w(i + 1,i),1,a(i + 1,i),1)
-                              
+
                     call stdlib_waxpy(n - i,alpha,a(i + 1,i),1,w(i + 1,i),1)
                  end if
               end do loop_20
@@ -55067,7 +55067,7 @@ module stdlib_linalg_lapack_w
      !> then s is set to 0 and a non-trivial solution to A*x = 0 is returned.
 
      pure subroutine stdlib_wlatrs(uplo,trans,diag,normin,n,a,lda,x,scale,cnorm,info)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -55081,7 +55081,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: a(lda,*)
            complex(qp),intent(inout) :: x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            integer(ilp) :: i,imax,j,jfirst,jinc,jlast
@@ -55094,7 +55094,7 @@ module stdlib_linalg_lapack_w
            ! Statement Function Definitions
            cabs1(zdum) = abs(real(zdum,KIND=qp)) + abs(aimag(zdum))
            cabs2(zdum) = abs(real(zdum,KIND=qp)/2._qp) + abs(aimag(zdum)/2._qp)
-                     
+
            ! Executable Statements
            info = 0
            upper = stdlib_lsame(uplo,'U')
@@ -55214,7 +55214,7 @@ module stdlib_linalg_lapack_w
                     grow = grow*(one/(one + cnorm(j)))
                  end do
               end if
-60            continue
+              60 continue
            else
               ! compute the growth in a**t * x = b  or  a**h * x = b.
               if (upper) then
@@ -55265,7 +55265,7 @@ module stdlib_linalg_lapack_w
                     grow = grow/xj
                  end do
               end if
-90            continue
+              90 continue
            end if
            if ((grow*tscal) > smlnum) then
               ! use the level 2 blas solve if the reciprocal of the bound on
@@ -55335,7 +55335,7 @@ module stdlib_linalg_lapack_w
                        scale = zero
                        xmax = zero
                     end if
-110                 continue
+                    110 continue
                     ! scale x if necessary to avoid overflow when adding a
                     ! multiple of column j of a.
                     if (xj > one) then
@@ -55364,7 +55364,7 @@ module stdlib_linalg_lapack_w
                           ! compute the update
                              ! x(j+1:n) := x(j+1:n) - x(j) * a(j+1:n,j)
                           call stdlib_waxpy(n - j,-x(j)*tscal,a(j + 1,j),1,x(j + 1),1)
-                                    
+
                           i = j + stdlib_iwamax(n - j,x(j + 1),1)
                           xmax = cabs1(x(i))
                        end if
@@ -55464,7 +55464,7 @@ module stdlib_linalg_lapack_w
                           scale = zero
                           xmax = zero
                        end if
-160                    continue
+                       160 continue
                     else
                        ! compute x(j) := x(j) / a(j,j) - csumj if the dot
                        ! product has already been divided by 1/a(j,j).
@@ -55566,7 +55566,7 @@ module stdlib_linalg_lapack_w
                           scale = zero
                           xmax = zero
                        end if
-210                    continue
+                       210 continue
                     else
                        ! compute x(j) := x(j) / a(j,j) - csumj if the dot
                        ! product has already been divided by 1/a(j,j).
@@ -55599,7 +55599,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            complex(qp) :: alpha
@@ -55760,7 +55760,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: d(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: iinfo,j,jb,nb
            ! Intrinsic Functions
@@ -55792,7 +55792,7 @@ module stdlib_linalg_lapack_w
                  jb = min(min(m,n) - j + 1,nb)
                  ! factor diagonal and subdiagonal blocks.
                  call stdlib_wlaunhr_col_getrfnp2(m - j + 1,jb,a(j,j),lda,d(j),iinfo)
-                           
+
                  if (j + jb <= n) then
                     ! compute block row of u.
                     call stdlib_wtrsm('LEFT','LOWER','NO TRANSPOSE','UNIT',jb,n - j - jb + 1,cone, &
@@ -55801,7 +55801,7 @@ module stdlib_linalg_lapack_w
                        ! update trailing submatrix.
                        call stdlib_wgemm('NO TRANSPOSE','NO TRANSPOSE',m - j - jb + 1,n - j - jb + 1,jb,- &
                        cone,a(j + jb,j),lda,a(j,j + jb),lda,cone,a(j + jb,j + jb),lda)
-                                 
+
                     end if
                  end if
               end do
@@ -55869,7 +55869,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: d(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(qp) :: sfmin
            integer(ilp) :: i,iinfo,n1,n2
@@ -55929,17 +55929,17 @@ module stdlib_linalg_lapack_w
               call stdlib_wlaunhr_col_getrfnp2(n1,n1,a,lda,d,iinfo)
               ! solve for b21
               call stdlib_wtrsm('R','U','N','N',m - n1,n1,cone,a,lda,a(n1 + 1,1),lda)
-                        
+
               ! solve for b12
               call stdlib_wtrsm('L','L','N','U',n1,n2,cone,a,lda,a(1,n1 + 1),lda)
-                        
+
               ! update b22, i.e. compute the schur complement
               ! b22 := b22 - b21*b12
               call stdlib_wgemm('N','N',m - n1,n2,n1,-cone,a(n1 + 1,1),lda,a(1,n1 + 1), &
                         lda,cone,a(n1 + 1,n1 + 1),lda)
               ! factor b22, recursive call
               call stdlib_wlaunhr_col_getrfnp2(m - n1,n2,a(n1 + 1,n1 + 1),lda,d(n1 + 1),iinfo)
-                        
+
            end if
            return
      end subroutine stdlib_wlaunhr_col_getrfnp2
@@ -55964,7 +55964,7 @@ module stdlib_linalg_lapack_w
            ! Array Arguments
            complex(qp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i
@@ -56042,7 +56042,7 @@ module stdlib_linalg_lapack_w
            ! Array Arguments
            complex(qp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,ib,nb
@@ -56113,7 +56113,7 @@ module stdlib_linalg_lapack_w
      !> condition number is computed as RCOND = 1 / (ANORM * norm(inv(A))).
 
      pure subroutine stdlib_wpbcon(uplo,n,kd,ab,ldab,anorm,rcond,work,rwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -56128,7 +56128,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: ab(ldab,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            character :: normin
@@ -56174,7 +56174,7 @@ module stdlib_linalg_lapack_w
            ! estimate the 1-norm of the inverse.
            kase = 0
            normin = 'N'
-10         continue
+           10 continue
            call stdlib_wlacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               if (upper) then
@@ -56205,7 +56205,7 @@ module stdlib_linalg_lapack_w
            end if
            ! compute the estimate of the reciprocal condition number.
            if (ainvnm /= zero) rcond = (one/ainvnm)/anorm
-20         continue
+           20 continue
            return
      end subroutine stdlib_wpbcon
 
@@ -56231,7 +56231,7 @@ module stdlib_linalg_lapack_w
            real(qp),intent(out) :: s(*)
            complex(qp),intent(in) :: ab(ldab,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,j
@@ -56318,7 +56318,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,j,k,kase,l,nz
@@ -56375,12 +56375,12 @@ module stdlib_linalg_lapack_w
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_wcopy(n,b(1,j),1,work,1)
               call stdlib_whbmv(uplo,n,kd,-cone,ab,ldab,x(1,j),1,cone,work,1)
-                        
+
               ! compute componentwise relative backward error from formula
               ! max(i) ( abs(r(i)) / ( abs(a)*abs(x) + abs(b) )(i) )
               ! where abs(z) is the componentwise absolute value of the matrix
@@ -56462,7 +56462,7 @@ module stdlib_linalg_lapack_w
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_wlacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -56511,7 +56511,7 @@ module stdlib_linalg_lapack_w
            ! Array Arguments
            complex(qp),intent(inout) :: ab(ldab,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,kld,km,m
@@ -56556,7 +56556,7 @@ module stdlib_linalg_lapack_w
                  ! the leading submatrix within the band.
                  call stdlib_wdscal(km,one/ajj,ab(kd + 1 - km,j),1)
                  call stdlib_wher('UPPER',km,-one,ab(kd + 1 - km,j),1,ab(kd + 1,j - km),kld)
-                           
+
               end do
               ! factorize the updated submatrix a(1:m,1:m) as u**h*u.
               do j = 1,m
@@ -56575,7 +56575,7 @@ module stdlib_linalg_lapack_w
                     call stdlib_wdscal(km,one/ajj,ab(kd,j + 1),kld)
                     call stdlib_wlacgv(km,ab(kd,j + 1),kld)
                     call stdlib_wher('UPPER',km,-one,ab(kd,j + 1),kld,ab(kd + 1,j + 1),kld)
-                              
+
                     call stdlib_wlacgv(km,ab(kd,j + 1),kld)
                  end if
               end do
@@ -56596,7 +56596,7 @@ module stdlib_linalg_lapack_w
                  call stdlib_wdscal(km,one/ajj,ab(km + 1,j - km),kld)
                  call stdlib_wlacgv(km,ab(km + 1,j - km),kld)
                  call stdlib_wher('LOWER',km,-one,ab(km + 1,j - km),kld,ab(1,j - km),kld)
-                           
+
                  call stdlib_wlacgv(km,ab(km + 1,j - km),kld)
               end do
               ! factorize the updated submatrix a(1:m,1:m) as u**h*u.
@@ -56619,7 +56619,7 @@ module stdlib_linalg_lapack_w
               end do
            end if
            return
-50         continue
+           50 continue
            info = j
            return
      end subroutine stdlib_wpbstf
@@ -56703,7 +56703,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: ab(ldab,*),afb(ldafb,*),b(ldb,*)
            complex(qp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: equil,nofact,rcequ,upper
            integer(ilp) :: i,infequ,j,j1,j2
@@ -56792,7 +56792,7 @@ module stdlib_linalg_lapack_w
                  do j = 1,n
                     j1 = max(j - kd,1)
                     call stdlib_wcopy(j - j1 + 1,ab(kd + 1 - j + j1,j),1,afb(kd + 1 - j + j1,j),1)
-                              
+
                  end do
               else
                  do j = 1,n
@@ -56855,7 +56855,7 @@ module stdlib_linalg_lapack_w
            ! Array Arguments
            complex(qp),intent(inout) :: ab(ldab,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,kld,kn
@@ -56900,7 +56900,7 @@ module stdlib_linalg_lapack_w
                     call stdlib_wdscal(kn,one/ajj,ab(kd,j + 1),kld)
                     call stdlib_wlacgv(kn,ab(kd,j + 1),kld)
                     call stdlib_wher('UPPER',kn,-one,ab(kd,j + 1),kld,ab(kd + 1,j + 1),kld)
-                              
+
                     call stdlib_wlacgv(kn,ab(kd,j + 1),kld)
                  end if
               end do
@@ -56925,7 +56925,7 @@ module stdlib_linalg_lapack_w
               end do
            end if
            return
-30         continue
+           30 continue
            info = j
            return
      end subroutine stdlib_wpbtf2
@@ -56951,7 +56951,7 @@ module stdlib_linalg_lapack_w
            ! Parameters
            integer(ilp),parameter :: nbmax = 32
            integer(ilp),parameter :: ldwork = nbmax + 1
-           
+
            ! Local Scalars
            integer(ilp) :: i,i2,i3,ib,ii,j,jj,nb
            ! Local Arrays
@@ -57124,7 +57124,7 @@ module stdlib_linalg_lapack_w
               end if
            end if
            return
-150        continue
+           150 continue
            return
      end subroutine stdlib_wpbtrf
 
@@ -57215,7 +57215,7 @@ module stdlib_linalg_lapack_w
            ! Array Arguments
            complex(qp),intent(inout) :: a(0:*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,nisodd,normaltransr
            integer(ilp) :: n1,n2,k
@@ -57267,7 +57267,7 @@ module stdlib_linalg_lapack_w
                     call stdlib_wpotrf('L',n1,a(0),n,info)
                     if (info > 0) return
                     call stdlib_wtrsm('R','L','C','N',n2,n1,cone,a(0),n,a(n1),n)
-                              
+
                     call stdlib_wherk('U','N',n2,n1,-one,a(n1),n,one,a(n),n)
                     call stdlib_wpotrf('U',n2,a(n),n,info)
                     if (info > 0) info = info + n1
@@ -57278,7 +57278,7 @@ module stdlib_linalg_lapack_w
                     call stdlib_wpotrf('L',n1,a(n2),n,info)
                     if (info > 0) return
                     call stdlib_wtrsm('L','L','N','N',n1,n2,cone,a(n2),n,a(0),n)
-                              
+
                     call stdlib_wherk('U','C',n2,n1,-one,a(0),n,one,a(n1),n)
                     call stdlib_wpotrf('U',n2,a(n1),n,info)
                     if (info > 0) info = info + n1
@@ -57294,7 +57294,7 @@ module stdlib_linalg_lapack_w
                     call stdlib_wtrsm('L','U','C','N',n1,n2,cone,a(0),n1,a(n1*n1), &
                               n1)
                     call stdlib_wherk('L','C',n2,n1,-one,a(n1*n1),n1,one,a(1),n1)
-                              
+
                     call stdlib_wpotrf('L',n2,a(1),n1,info)
                     if (info > 0) info = info + n1
                  else
@@ -57306,7 +57306,7 @@ module stdlib_linalg_lapack_w
                     call stdlib_wtrsm('R','U','N','N',n2,n1,cone,a(n2*n2),n2,a(0), &
                               n2)
                     call stdlib_wherk('L','N',n2,n1,-one,a(0),n2,one,a(n1*n2),n2)
-                              
+
                     call stdlib_wpotrf('L',n2,a(n1*n2),n2,info)
                     if (info > 0) info = info + n1
                  end if
@@ -57322,9 +57322,9 @@ module stdlib_linalg_lapack_w
                     call stdlib_wpotrf('L',k,a(1),n + 1,info)
                     if (info > 0) return
                     call stdlib_wtrsm('R','L','C','N',k,k,cone,a(1),n + 1,a(k + 1),n + 1)
-                              
+
                     call stdlib_wherk('U','N',k,k,-one,a(k + 1),n + 1,one,a(0),n + 1)
-                              
+
                     call stdlib_wpotrf('U',k,a(0),n + 1,info)
                     if (info > 0) info = info + k
                  else
@@ -57334,9 +57334,9 @@ module stdlib_linalg_lapack_w
                     call stdlib_wpotrf('L',k,a(k + 1),n + 1,info)
                     if (info > 0) return
                     call stdlib_wtrsm('L','L','N','N',k,k,cone,a(k + 1),n + 1,a(0),n + 1)
-                              
+
                     call stdlib_wherk('U','C',k,k,-one,a(0),n + 1,one,a(k),n + 1)
-                              
+
                     call stdlib_wpotrf('U',k,a(k),n + 1,info)
                     if (info > 0) info = info + k
                  end if
@@ -57351,7 +57351,7 @@ module stdlib_linalg_lapack_w
                     call stdlib_wtrsm('L','U','C','N',k,k,cone,a(k),n1,a(k*(k + 1)), &
                               k)
                     call stdlib_wherk('L','C',k,k,-one,a(k*(k + 1)),k,one,a(0),k)
-                              
+
                     call stdlib_wpotrf('L',k,a(0),k,info)
                     if (info > 0) info = info + k
                  else
@@ -57386,7 +57386,7 @@ module stdlib_linalg_lapack_w
            ! Array Arguments
            complex(qp),intent(inout) :: a(0:*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,nisodd,normaltransr
            integer(ilp) :: n1,n2,k
@@ -57442,7 +57442,7 @@ module stdlib_linalg_lapack_w
                     call stdlib_wlauum('L',n1,a(0),n,info)
                     call stdlib_wherk('L','C',n1,n2,one,a(n1),n,one,a(0),n)
                     call stdlib_wtrmm('L','U','N','N',n2,n1,cone,a(n),n,a(n1),n)
-                              
+
                     call stdlib_wlauum('U',n2,a(n),n,info)
                  else
                     ! srpa for upper, normal and n is odd ( a(0:n-1,0:n2-1)
@@ -57451,7 +57451,7 @@ module stdlib_linalg_lapack_w
                     call stdlib_wlauum('L',n1,a(n2),n,info)
                     call stdlib_wherk('L','N',n1,n2,one,a(0),n,one,a(n2),n)
                     call stdlib_wtrmm('R','U','C','N',n1,n2,cone,a(n1),n,a(0),n)
-                              
+
                     call stdlib_wlauum('U',n2,a(n1),n,info)
                  end if
               else
@@ -57461,7 +57461,7 @@ module stdlib_linalg_lapack_w
                     ! t1 -> a(0), t2 -> a(1), s -> a(0+n1*n1)
                     call stdlib_wlauum('U',n1,a(0),n1,info)
                     call stdlib_wherk('U','N',n1,n2,one,a(n1*n1),n1,one,a(0),n1)
-                              
+
                     call stdlib_wtrmm('R','L','N','N',n1,n2,cone,a(1),n1,a(n1*n1), &
                               n1)
                     call stdlib_wlauum('L',n2,a(1),n1,info)
@@ -57470,7 +57470,7 @@ module stdlib_linalg_lapack_w
                     ! t1 -> a(0+n2*n2), t2 -> a(0+n1*n2), s -> a(0)
                     call stdlib_wlauum('U',n1,a(n2*n2),n2,info)
                     call stdlib_wherk('U','C',n1,n2,one,a(0),n2,one,a(n2*n2),n2)
-                              
+
                     call stdlib_wtrmm('L','L','C','N',n2,n1,cone,a(n1*n2),n2,a(0), &
                               n2)
                     call stdlib_wlauum('L',n2,a(n1*n2),n2,info)
@@ -57486,9 +57486,9 @@ module stdlib_linalg_lapack_w
                     ! t1 -> a(1), t2 -> a(0), s -> a(k+1)
                     call stdlib_wlauum('L',k,a(1),n + 1,info)
                     call stdlib_wherk('L','C',k,k,one,a(k + 1),n + 1,one,a(1),n + 1)
-                              
+
                     call stdlib_wtrmm('L','U','N','N',k,k,cone,a(0),n + 1,a(k + 1),n + 1)
-                              
+
                     call stdlib_wlauum('U',k,a(0),n + 1,info)
                  else
                     ! srpa for upper, normal, and n is even ( a(0:n,0:k-1) )
@@ -57496,9 +57496,9 @@ module stdlib_linalg_lapack_w
                     ! t1 -> a(k+1), t2 -> a(k), s -> a(0)
                     call stdlib_wlauum('L',k,a(k + 1),n + 1,info)
                     call stdlib_wherk('L','N',k,k,one,a(0),n + 1,one,a(k + 1),n + 1)
-                              
+
                     call stdlib_wtrmm('R','U','C','N',k,k,cone,a(k),n + 1,a(0),n + 1)
-                              
+
                     call stdlib_wlauum('U',k,a(k),n + 1,info)
                  end if
               else
@@ -57509,7 +57509,7 @@ module stdlib_linalg_lapack_w
                     ! t1 -> a(0+k), t2 -> a(0+0), s -> a(0+k*(k+1)); lda=k
                     call stdlib_wlauum('U',k,a(k),k,info)
                     call stdlib_wherk('U','N',k,k,one,a(k*(k + 1)),k,one,a(k),k)
-                              
+
                     call stdlib_wtrmm('R','L','N','N',k,k,cone,a(0),k,a(k*(k + 1)), &
                               k)
                     call stdlib_wlauum('L',k,a(0),k,info)
@@ -57519,9 +57519,9 @@ module stdlib_linalg_lapack_w
                     ! t1 -> a(0+k*(k+1)), t2 -> a(0+k*k), s -> a(0+0)); lda=k
                     call stdlib_wlauum('U',k,a(k*(k + 1)),k,info)
                     call stdlib_wherk('U','C',k,k,one,a(0),k,one,a(k*(k + 1)),k)
-                              
+
                     call stdlib_wtrmm('L','L','C','N',k,k,cone,a(k*k),k,a(0),k)
-                              
+
                     call stdlib_wlauum('L',k,a(k*k),k,info)
                  end if
               end if
@@ -57545,7 +57545,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: a(0:*)
            complex(qp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,normaltransr
            ! Intrinsic Functions
@@ -57604,7 +57604,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            character :: normin
@@ -57648,7 +57648,7 @@ module stdlib_linalg_lapack_w
            ! estimate the 1-norm of inv(a).
            kase = 0
            normin = 'N'
-10         continue
+           10 continue
            call stdlib_wlacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               if (upper) then
@@ -57679,7 +57679,7 @@ module stdlib_linalg_lapack_w
            end if
            ! compute the estimate of the reciprocal condition number.
            if (ainvnm /= zero) rcond = (one/ainvnm)/anorm
-20         continue
+           20 continue
            return
      end subroutine stdlib_wpocon
 
@@ -57704,7 +57704,7 @@ module stdlib_linalg_lapack_w
            real(qp),intent(out) :: s(*)
            complex(qp),intent(in) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(qp) :: smin
@@ -57783,7 +57783,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: a(lda,*)
            real(qp),intent(out) :: s(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(qp) :: smin,base,tmp
@@ -57861,7 +57861,7 @@ module stdlib_linalg_lapack_w
         ! ====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,j,k,kase,nz
@@ -57916,7 +57916,7 @@ module stdlib_linalg_lapack_w
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_wcopy(n,b(1,j),1,work,1)
@@ -58000,7 +58000,7 @@ module stdlib_linalg_lapack_w
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_wlacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -58104,7 +58104,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*),af(ldaf,*),b(ldb,*)
            complex(qp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: equil,nofact,rcequ
            integer(ilp) :: i,infequ,j
@@ -58242,7 +58242,7 @@ module stdlib_linalg_lapack_w
            ! Array Arguments
            complex(qp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j
@@ -58310,9 +58310,9 @@ module stdlib_linalg_lapack_w
               end do
            end if
            go to 40
-30         continue
+           30 continue
            info = j
-40         continue
+           40 continue
            return
      end subroutine stdlib_wpotf2
 
@@ -58335,7 +58335,7 @@ module stdlib_linalg_lapack_w
            ! Array Arguments
            complex(qp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,jb,nb
@@ -58404,9 +58404,9 @@ module stdlib_linalg_lapack_w
               end if
            end if
            go to 40
-30         continue
+           30 continue
            info = info + j - 1
-40         continue
+           40 continue
            return
      end subroutine stdlib_wpotrf
 
@@ -58435,7 +58435,7 @@ module stdlib_linalg_lapack_w
            ! Array Arguments
            complex(qp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: n1,n2,iinfo
@@ -58567,7 +58567,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: a(lda,*)
            complex(qp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            ! Intrinsic Functions
@@ -58635,7 +58635,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: ap(*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            character :: normin
@@ -58677,7 +58677,7 @@ module stdlib_linalg_lapack_w
            ! estimate the 1-norm of the inverse.
            kase = 0
            normin = 'N'
-10         continue
+           10 continue
            call stdlib_wlacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               if (upper) then
@@ -58708,7 +58708,7 @@ module stdlib_linalg_lapack_w
            end if
            ! compute the estimate of the reciprocal condition number.
            if (ainvnm /= zero) rcond = (one/ainvnm)/anorm
-20         continue
+           20 continue
            return
      end subroutine stdlib_wppcon
 
@@ -58734,7 +58734,7 @@ module stdlib_linalg_lapack_w
            real(qp),intent(out) :: s(*)
            complex(qp),intent(in) :: ap(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,jj
@@ -58827,7 +58827,7 @@ module stdlib_linalg_lapack_w
         ! ====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,ik,j,k,kase,kk,nz
@@ -58878,7 +58878,7 @@ module stdlib_linalg_lapack_w
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_wcopy(n,b(1,j),1,work,1)
@@ -58969,7 +58969,7 @@ module stdlib_linalg_lapack_w
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_wlacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -59071,7 +59071,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: afp(*),ap(*),b(ldb,*)
            complex(qp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: equil,nofact,rcequ
            integer(ilp) :: i,infequ,j
@@ -59204,7 +59204,7 @@ module stdlib_linalg_lapack_w
            ! Array Arguments
            complex(qp),intent(inout) :: ap(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,jc,jj
@@ -59266,9 +59266,9 @@ module stdlib_linalg_lapack_w
               end do
            end if
            go to 40
-30         continue
+           30 continue
            info = j
-40         continue
+           40 continue
            return
      end subroutine stdlib_wpptrf
 
@@ -59287,7 +59287,7 @@ module stdlib_linalg_lapack_w
            ! Array Arguments
            complex(qp),intent(inout) :: ap(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,jc,jj,jjn
@@ -59384,14 +59384,14 @@ module stdlib_linalg_lapack_w
                            1)
                  ! solve u*x = b, overwriting b with x.
                  call stdlib_wtpsv('UPPER','NO TRANSPOSE','NON-UNIT',n,ap,b(1,i),1)
-                           
+
               end do
            else
               ! solve a*x = b where a = l * l**h.
               do i = 1,nrhs
                  ! solve l*y = b, overwriting b with x.
                  call stdlib_wtpsv('LOWER','NO TRANSPOSE','NON-UNIT',n,ap,b(1,i),1)
-                           
+
                  ! solve l**h *x = y, overwriting b with x.
                  call stdlib_wtpsv('LOWER','CONJUGATE TRANSPOSE','NON-UNIT',n,ap,b(1,i), &
                            1)
@@ -59424,7 +59424,7 @@ module stdlib_linalg_lapack_w
            real(qp),intent(out) :: work(2*n)
            integer(ilp),intent(out) :: piv(n)
         ! =====================================================================
-           
+
            ! Local Scalars
            complex(qp) :: ztemp
            real(qp) :: ajj,dstop,dtemp
@@ -59483,7 +59483,7 @@ module stdlib_linalg_lapack_w
                  do i = j,n
                     if (j > 1) then
                        work(i) = work(i) + real(conjg(a(j - 1,i))*a(j - 1,i),KIND=qp)
-                                 
+
                     end if
                     work(n + i) = real(a(i,i),KIND=qp) - work(i)
                  end do
@@ -59501,7 +59501,7 @@ module stdlib_linalg_lapack_w
                     a(pvt,pvt) = a(j,j)
                     call stdlib_wswap(j - 1,a(1,j),1,a(1,pvt),1)
                     if (pvt < n) call stdlib_wswap(n - pvt,a(j,pvt + 1),lda,a(pvt,pvt + 1),lda)
-                              
+
                     do i = j + 1,pvt - 1
                        ztemp = conjg(a(j,i))
                        a(j,i) = conjg(a(i,pvt))
@@ -59536,7 +59536,7 @@ module stdlib_linalg_lapack_w
                  do i = j,n
                     if (j > 1) then
                        work(i) = work(i) + real(conjg(a(i,j - 1))*a(i,j - 1),KIND=qp)
-                                 
+
                     end if
                     work(n + i) = real(a(i,i),KIND=qp) - work(i)
                  end do
@@ -59554,7 +59554,7 @@ module stdlib_linalg_lapack_w
                     a(pvt,pvt) = a(j,j)
                     call stdlib_wswap(j - 1,a(j,1),lda,a(pvt,1),lda)
                     if (pvt < n) call stdlib_wswap(n - pvt,a(pvt + 1,j),1,a(pvt + 1,pvt),1)
-                              
+
                     do i = j + 1,pvt - 1
                        ztemp = conjg(a(i,j))
                        a(i,j) = conjg(a(pvt,i))
@@ -59584,12 +59584,12 @@ module stdlib_linalg_lapack_w
            ! ran to completion, a has full rank
            rank = n
            go to 200
-190        continue
+           190 continue
            ! rank is number of steps completed.  set info = 1 to signal
            ! that the factorization cannot be used to solve a system.
            rank = j - 1
            info = 1
-200        continue
+           200 continue
            return
      end subroutine stdlib_wpstf2
 
@@ -59617,7 +59617,7 @@ module stdlib_linalg_lapack_w
            real(qp),intent(out) :: work(2*n)
            integer(ilp),intent(out) :: piv(n)
         ! =====================================================================
-           
+
            ! Local Scalars
            complex(qp) :: ztemp
            real(qp) :: ajj,dstop,dtemp
@@ -59809,12 +59809,12 @@ module stdlib_linalg_lapack_w
            ! ran to completion, a has full rank
            rank = n
            go to 230
-220        continue
+           220 continue
            ! rank is the number of steps completed.  set info = 1 to signal
            ! that the factorization cannot be used to solve a system.
            rank = j - 1
            info = 1
-230        continue
+           230 continue
            return
      end subroutine stdlib_wpstrf
 
@@ -59840,7 +59840,7 @@ module stdlib_linalg_lapack_w
            real(qp),intent(out) :: rwork(*)
            complex(qp),intent(in) :: e(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,ix
            real(qp) :: ainvnm
@@ -59921,7 +59921,7 @@ module stdlib_linalg_lapack_w
            real(qp),intent(out) :: work(*)
            complex(qp),intent(inout) :: z(ldz,*)
         ! ====================================================================
-           
+
            ! Local Arrays
            complex(qp) :: c(1,1),vt(1,1)
            ! Local Scalars
@@ -59975,7 +59975,7 @@ module stdlib_linalg_lapack_w
               nru = 0
            end if
            call stdlib_wbdsqr('LOWER',n,0,nru,0,d,e,vt,1,z,ldz,c,1,work,info)
-                     
+
            ! square the singular values.
            if (info == 0) then
               do i = 1,n
@@ -60010,7 +60010,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,ix,j,nz
@@ -60059,7 +60059,7 @@ module stdlib_linalg_lapack_w
            loop_100: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x.  also compute
               ! abs(a)*abs(x) + abs(b) for use in the backward error bound.
@@ -60075,7 +60075,7 @@ module stdlib_linalg_lapack_w
                     ex = e(1)*x(2,j)
                     work(1) = bi - dx - ex
                     rwork(1) = cabs1(bi) + cabs1(dx) + cabs1(e(1))*cabs1(x(2,j))
-                              
+
                     do i = 2,n - 1
                        bi = b(i,j)
                        cx = conjg(e(i - 1))*x(i - 1,j)
@@ -60104,7 +60104,7 @@ module stdlib_linalg_lapack_w
                     ex = conjg(e(1))*x(2,j)
                     work(1) = bi - dx - ex
                     rwork(1) = cabs1(bi) + cabs1(dx) + cabs1(e(1))*cabs1(x(2,j))
-                              
+
                     do i = 2,n - 1
                        bi = b(i,j)
                        cx = e(i - 1)*x(i - 1,j)
@@ -60268,7 +60268,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: ef(*)
            complex(qp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nofact
            real(qp) :: anorm
@@ -60335,7 +60335,7 @@ module stdlib_linalg_lapack_w
            real(qp),intent(inout) :: d(*)
            complex(qp),intent(inout) :: e(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,i4
            real(qp) :: eii,eir,f,g
@@ -60415,7 +60415,7 @@ module stdlib_linalg_lapack_w
            end do loop_20
            ! check d(n) for positive definiteness.
            if (d(n) <= zero) info = n
-30         continue
+           30 continue
            return
      end subroutine stdlib_wpttrf
 
@@ -60519,7 +60519,7 @@ module stdlib_linalg_lapack_w
               ! overwriting each right hand side vector with its solution.
               if (nrhs <= 2) then
                  j = 1
-10               continue
+                 10 continue
                  ! solve u**h * x = b.
                  do i = 2,n
                     b(i,j) = b(i,j) - b(i - 1,j)*conjg(e(i - 1))
@@ -60553,7 +60553,7 @@ module stdlib_linalg_lapack_w
               ! overwriting each right hand side vector with its solution.
               if (nrhs <= 2) then
                  j = 1
-80               continue
+                 80 continue
                  ! solve l * x = b.
                  do i = 2,n
                     b(i,j) = b(i,j) - b(i - 1,j)*e(i - 1)
@@ -60622,7 +60622,7 @@ module stdlib_linalg_lapack_w
            end do
            return
            ! code for both increments equal to 1
-20   continue
+           20 continue
            do i = 1,n
               stemp = c*cx(i) + s*cy(i)
               cy(i) = c*cy(i) - conjg(s)*cx(i)
@@ -60652,7 +60652,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: ap(*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,ip,kase
@@ -60700,7 +60700,7 @@ module stdlib_linalg_lapack_w
            end if
            ! estimate the 1-norm of the inverse.
            kase = 0
-30         continue
+           30 continue
            call stdlib_wlacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               ! multiply by inv(l*d*l**t) or inv(u*d*u**t).
@@ -60729,7 +60729,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: ap(*),x(*)
            complex(qp),intent(inout) :: y(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,info,ix,iy,j,jx,jy,k,kk,kx,ky
            complex(qp) :: temp1,temp2
@@ -60886,7 +60886,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: ap(*)
            complex(qp),intent(in) :: x(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,info,ix,j,jx,k,kk,kx
            complex(qp) :: temp
@@ -61012,7 +61012,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,ik,j,k,kase,kk,nz
@@ -61063,7 +61063,7 @@ module stdlib_linalg_lapack_w
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_wcopy(n,b(1,j),1,work,1)
@@ -61154,7 +61154,7 @@ module stdlib_linalg_lapack_w
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_wlacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -61257,7 +61257,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: ap(*),b(ldb,*)
            complex(qp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nofact
            real(qp) :: anorm
@@ -61333,7 +61333,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: sevten = 17.0e+0_qp
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,imax,j,jmax,k,kc,kk,knc,kp,kpc,kstep,kx,npp
@@ -61366,7 +61366,7 @@ module stdlib_linalg_lapack_w
               ! 1 or 2
               k = n
               kc = (n - 1)*n/2 + 1
-10            continue
+              10 continue
               knc = kc
               ! if k < 1, exit from loop
               if (k < 1) go to 110
@@ -61469,9 +61469,9 @@ module stdlib_linalg_lapack_w
                        d12 = t/d12
                        do j = k - 2,1,-1
                           wkm1 = d12*(d11*ap(j + (k - 2)*(k - 1)/2) - ap(j + (k - 1)*k/2))
-                                    
+
                           wk = d12*(d22*ap(j + (k - 1)*k/2) - ap(j + (k - 2)*(k - 1)/2))
-                                    
+
                           do i = j,1,-1
                              ap(i + (j - 1)*j/2) = ap(i + (j - 1)*j/2) - ap(i + (k - 1)*k/2) &
                                        *wk - ap(i + (k - 2)*(k - 1)/2)*wkm1
@@ -61500,7 +61500,7 @@ module stdlib_linalg_lapack_w
               k = 1
               kc = 1
               npp = n*(n + 1)/2
-60            continue
+              60 continue
               knc = kc
               ! if k > n, exit from loop
               if (k > n) go to 110
@@ -61561,7 +61561,7 @@ module stdlib_linalg_lapack_w
                     ! interchange rows and columns kk and kp in the trailing
                     ! submatrix a(k:n,k:n)
                     if (kp < n) call stdlib_wswap(n - kp,ap(knc + kp - kk + 1),1,ap(kpc + 1),1)
-                              
+
                     kx = knc + kp - kk
                     do j = kk + 1,kp - 1
                        kx = kx + n - j + 1
@@ -61609,7 +61609,7 @@ module stdlib_linalg_lapack_w
                        d21 = t/d21
                        do j = k + 2,n
                           wk = d21*(d11*ap(j + (k - 1)*(2*n - k)/2) - ap(j + k*(2*n - k - 1)/2))
-                                    
+
                           wkp1 = d21*(d22*ap(j + k*(2*n - k - 1)/2) - ap(j + (k - 1)*(2*n - k)/2) &
                                      )
                           do i = j,n
@@ -61634,7 +61634,7 @@ module stdlib_linalg_lapack_w
               kc = knc + n - k + 2
               go to 60
            end if
-110        continue
+           110 continue
            return
      end subroutine stdlib_wsptrf
 
@@ -61655,7 +61655,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: ap(*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kc,kcnext,kp,kpc,kstep,kx,npp
@@ -61700,7 +61700,7 @@ module stdlib_linalg_lapack_w
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
               kc = 1
-30            continue
+              30 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               kcnext = kc + k
@@ -61735,9 +61735,9 @@ module stdlib_linalg_lapack_w
                               kcnext),1)
                     call stdlib_wcopy(k - 1,ap(kcnext),1,work,1)
                     call stdlib_wspmv(uplo,k - 1,-cone,ap,work,1,czero,ap(kcnext),1)
-                              
+
                     ap(kcnext + k) = ap(kcnext + k) - stdlib_wdotu(k - 1,work,1,ap(kcnext),1)
-                              
+
                  end if
                  kstep = 2
                  kcnext = kcnext + k + 1
@@ -61767,7 +61767,7 @@ module stdlib_linalg_lapack_w
               k = k + kstep
               kc = kcnext
               go to 30
-50            continue
+              50 continue
            else
               ! compute inv(a) from the factorization a = l*d*l**t.
               ! k is the main loop index, increasing from 1 to n in steps of
@@ -61775,7 +61775,7 @@ module stdlib_linalg_lapack_w
               npp = n*(n + 1)/2
               k = n
               kc = npp
-60            continue
+              60 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 80
               kcnext = kc - (n - k + 2)
@@ -61814,7 +61814,7 @@ module stdlib_linalg_lapack_w
                     call stdlib_wspmv(uplo,n - k,-cone,ap(kc + (n - k + 1)),work,1,czero,ap( &
                               kcnext + 2),1)
                     ap(kcnext) = ap(kcnext) - stdlib_wdotu(n - k,work,1,ap(kcnext + 2),1)
-                              
+
                  end if
                  kstep = 2
                  kcnext = kcnext - (n - k + 3)
@@ -61844,7 +61844,7 @@ module stdlib_linalg_lapack_w
               k = k - kstep
               kc = kcnext
               go to 60
-80            continue
+              80 continue
            end if
            return
      end subroutine stdlib_wsptri
@@ -61866,7 +61866,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: ap(*)
            complex(qp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kc,kp
@@ -61898,7 +61898,7 @@ module stdlib_linalg_lapack_w
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
               kc = n*(n + 1)/2 + 1
-10            continue
+              10 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 30
               kc = kc - k
@@ -61910,7 +61910,7 @@ module stdlib_linalg_lapack_w
                  ! multiply by inv(u(k)), where u(k) is the transformation
                  ! stored in column k of a.
                  call stdlib_wgeru(k - 1,nrhs,-cone,ap(kc),1,b(k,1),ldb,b(1,1),ldb)
-                           
+
                  ! multiply by the inverse of the diagonal block.
                  call stdlib_wscal(nrhs,cone/ap(kc + k - 1),b(k,1),ldb)
                  k = k - 1
@@ -61922,7 +61922,7 @@ module stdlib_linalg_lapack_w
                  ! multiply by inv(u(k)), where u(k) is the transformation
                  ! stored in columns k-1 and k of a.
                  call stdlib_wgeru(k - 2,nrhs,-cone,ap(kc),1,b(k,1),ldb,b(1,1),ldb)
-                           
+
                  call stdlib_wgeru(k - 2,nrhs,-cone,ap(kc - (k - 1)),1,b(k - 1,1),ldb,b(1, &
                            1),ldb)
                  ! multiply by the inverse of the diagonal block.
@@ -61940,13 +61940,13 @@ module stdlib_linalg_lapack_w
                  k = k - 2
               end if
               go to 10
-30            continue
+              30 continue
               ! next solve u**t*x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
               kc = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               if (ipiv(k) > 0) then
@@ -61975,7 +61975,7 @@ module stdlib_linalg_lapack_w
                  k = k + 2
               end if
               go to 40
-50            continue
+              50 continue
            else
               ! solve a*x = b, where a = l*d*l**t.
               ! first solve l*d*x = b, overwriting b with x.
@@ -61983,7 +61983,7 @@ module stdlib_linalg_lapack_w
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
               kc = 1
-60            continue
+              60 continue
               ! if k > n, exit from loop.
               if (k > n) go to 80
               if (ipiv(k) > 0) then
@@ -62027,13 +62027,13 @@ module stdlib_linalg_lapack_w
                  k = k + 2
               end if
               go to 60
-80            continue
+              80 continue
               ! next solve l**t*x = b, overwriting b with x.
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
               kc = n*(n + 1)/2 + 1
-90            continue
+              90 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 100
               kc = kc - (n - k + 1)
@@ -62064,7 +62064,7 @@ module stdlib_linalg_lapack_w
                  k = k - 2
               end if
               go to 90
-100           continue
+              100 continue
            end if
            return
      end subroutine stdlib_wsptrs
@@ -62097,7 +62097,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(out) :: work(*)
            complex(qp),intent(inout) :: z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: finish,i,icompz,ii,j,k,lgn,liwmin,ll,lrwmin,lwmin,m,smlsiz, &
@@ -62210,7 +62210,7 @@ module stdlib_linalg_lapack_w
               eps = stdlib_qlamch('EPSILON')
               start = 1
               ! while ( start <= n )
-30   continue
+              30 continue
               if (start <= n) then
                  ! let finish be the position of the next subdiagonal entry
                  ! such that e( finish ) <= tiny or finish = n if no such
@@ -62218,7 +62218,7 @@ module stdlib_linalg_lapack_w
                  ! between start and finish constitutes an independent
                  ! sub-problem.
                  finish = start
-40               continue
+                 40 continue
                  if (finish < n) then
                     tiny = eps*sqrt(abs(d(finish)))*sqrt(abs(d(finish + 1)))
                     if (abs(e(finish)) > tiny) then
@@ -62233,7 +62233,7 @@ module stdlib_linalg_lapack_w
                     orgnrm = stdlib_qlanst('M',m,d(start),e(start))
                     call stdlib_qlascl('G',0,0,orgnrm,one,m,1,d(start),m,info)
                     call stdlib_qlascl('G',0,0,orgnrm,one,m - 1,1,e(start),m - 1,info)
-                              
+
                     call stdlib_wlaed0(n,m,d(start),e(start),z(1,start),ldz,work,n, &
                               rwork,iwork,info)
                     if (info > 0) then
@@ -62276,7 +62276,7 @@ module stdlib_linalg_lapack_w
                 end if
               end do
            end if
-70         continue
+           70 continue
            work(1) = lwmin
            rwork(1) = lrwmin
            iwork(1) = liwmin
@@ -62355,7 +62355,7 @@ module stdlib_linalg_lapack_w
            real(qp),parameter :: odm1 = 1.0e-1_qp
            integer(ilp),parameter :: maxits = 5
            integer(ilp),parameter :: extra = 2
-           
+
            ! Local Scalars
            integer(ilp) :: b1,blksiz,bn,gpind,i,iinfo,indrv1,indrv2,indrv3,indrv4, &
                      indrv5,its,j,j1,jblk,jmax,jr,nblk,nrmchk
@@ -62388,7 +62388,7 @@ module stdlib_linalg_lapack_w
                     go to 30
                  end if
               end do
-30            continue
+              30 continue
            end if
            if (info /= 0) then
               call stdlib_xerbla('ZSTEIN',-info)
@@ -62435,7 +62435,7 @@ module stdlib_linalg_lapack_w
               ortol = odm3*onenrm
               dtpcrt = sqrt(odm1/blksiz)
               ! loop through eigenvalues of block nblk.
-60   continue
+              60 continue
               jblk = 0
               loop_170: do j = j1,m
                  if (iblock(j) /= nblk) then
@@ -62470,7 +62470,7 @@ module stdlib_linalg_lapack_w
                  call stdlib_qlagtf(blksiz,work(indrv4 + 1),xj,work(indrv2 + 2),work(indrv3 + &
                            1),tol,work(indrv5 + 1),iwork,iinfo)
                  ! update iteration count.
-70   continue
+                 70 continue
                  its = its + 1
                  if (its > maxits) go to 120
                  ! normalize and scale the righthand side vector pb.
@@ -62498,7 +62498,7 @@ module stdlib_linalg_lapack_w
                     end do
                  end if
                  ! check the infinity norm of the iterate.
-110  continue
+                 110 continue
                  jmax = stdlib_iqamax(blksiz,work(indrv1 + 1),1)
                  nrm = abs(work(indrv1 + jmax))
                  ! continue for additional iterations after norm reaches
@@ -62509,16 +62509,16 @@ module stdlib_linalg_lapack_w
                  go to 130
                  ! if stopping criterion was not satisfied, update info and
                  ! store eigenvector number in array ifail.
-120  continue
+                 120 continue
                  info = info + 1
                  ifail(info) = j
                  ! accept iterate as jth eigenvector.
-130  continue
+                 130 continue
                  scl = one/stdlib_qnrm2(blksiz,work(indrv1 + 1),1)
                  jmax = stdlib_iqamax(blksiz,work(indrv1 + 1),1)
                  if (work(indrv1 + jmax) < zero) scl = -scl
                  call stdlib_qscal(blksiz,scl,work(indrv1 + 1),1)
-140              continue
+                 140 continue
                  do i = 1,n
                     z(i,j) = czero
                  end do
@@ -62612,7 +62612,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: minrgp = 1.0e-3_qp
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,lquery,valeig,wantz,zquery
            integer(ilp) :: i,ibegin,iend,ifirst,iil,iindbl,iindw,iindwk,iinfo,iinspl, &
@@ -62691,7 +62691,7 @@ module stdlib_linalg_lapack_w
                  nzcmin = n
               else if (wantz .and. valeig) then
                  call stdlib_qlarrc('T',n,vl,vu,d,e,safmin,nzcmin,itmp,itmp2,info)
-                           
+
               else if (wantz .and. indeig) then
                  nzcmin = iiu - iil + 1
               else
@@ -62861,7 +62861,7 @@ module stdlib_linalg_lapack_w
               call stdlib_qlarre(range,n,wl,wu,iil,iiu,d,e,work(inde2),rtol1,rtol2, &
               thresh,nsplit,iwork(iinspl),m,w,work(inderr),work(indgp),iwork(iindbl), &
               iwork(iindw),work(indgrs),pivmin,work(indwrk),iwork(iindwk),iinfo)
-                        
+
               if (iinfo /= 0) then
                  info = 10 + abs(iinfo)
                  return
@@ -62900,7 +62900,7 @@ module stdlib_linalg_lapack_w
                     in = iend - ibegin + 1
                     wend = wbegin - 1
                     ! check if any eigenvalues have to be refined in this block
-36   continue
+                    36 continue
                     if (wend < m) then
                        if (iwork(iindbl + wend) == jblk) then
                           wend = wend + 1
@@ -62988,7 +62988,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: maxit = 30
-           
+
            ! Local Scalars
            integer(ilp) :: i,icompz,ii,iscale,j,jtot,k,l,l1,lend,lendm1,lendp1,lendsv, &
                       lm1,lsv,m,mm,mm1,nm1,nmaxit
@@ -63042,7 +63042,7 @@ module stdlib_linalg_lapack_w
            ! element is smaller.
            l1 = 1
            nm1 = n - 1
-10         continue
+           10 continue
            if (l1 > n) go to 160
            if (l1 > 1) e(l1 - 1) = zero
            if (l1 <= nm1) then
@@ -63056,7 +63056,7 @@ module stdlib_linalg_lapack_w
               end do
            end if
            m = n
-30         continue
+           30 continue
            l = l1
            lsv = l
            lend = m
@@ -63084,7 +63084,7 @@ module stdlib_linalg_lapack_w
            if (lend > l) then
               ! ql iteration
               ! look for small subdiagonal element.
-40   continue
+              40 continue
               if (l /= lend) then
                  lendm1 = lend - 1
                  do m = l,lendm1
@@ -63093,7 +63093,7 @@ module stdlib_linalg_lapack_w
                  end do
               end if
               m = lend
-60            continue
+              60 continue
               if (m < lend) e(m) = zero
               p = d(l)
               if (m == l) go to 80
@@ -63153,7 +63153,7 @@ module stdlib_linalg_lapack_w
               e(l) = g
               go to 40
               ! eigenvalue found.
-80   continue
+              80 continue
               d(l) = p
               l = l + 1
               if (l <= lend) go to 40
@@ -63161,7 +63161,7 @@ module stdlib_linalg_lapack_w
            else
               ! qr iteration
               ! look for small superdiagonal element.
-90   continue
+              90 continue
               if (l /= lend) then
                  lendp1 = lend + 1
                  do m = l,lendp1,-1
@@ -63170,7 +63170,7 @@ module stdlib_linalg_lapack_w
                  end do
               end if
               m = lend
-110           continue
+              110 continue
               if (m > lend) e(m - 1) = zero
               p = d(l)
               if (m == l) go to 130
@@ -63230,24 +63230,24 @@ module stdlib_linalg_lapack_w
               e(lm1) = g
               go to 90
               ! eigenvalue found.
-130  continue
+              130 continue
               d(l) = p
               l = l - 1
               if (l >= lend) go to 90
               go to 140
            end if
            ! undo scaling if necessary
-140  continue
+           140 continue
            if (iscale == 1) then
               call stdlib_qlascl('G',0,0,ssfmax,anorm,lendsv - lsv + 1,1,d(lsv),n,info)
-                        
+
               call stdlib_qlascl('G',0,0,ssfmax,anorm,lendsv - lsv,1,e(lsv),n,info)
-                        
+
            else if (iscale == 2) then
               call stdlib_qlascl('G',0,0,ssfmin,anorm,lendsv - lsv + 1,1,d(lsv),n,info)
-                        
+
               call stdlib_qlascl('G',0,0,ssfmin,anorm,lendsv - lsv,1,e(lsv),n,info)
-                        
+
            end if
            ! check for no convergence to an eigenvalue after a total
            ! of n*maxit iterations.
@@ -63259,7 +63259,7 @@ module stdlib_linalg_lapack_w
            end if
            go to 10
            ! order eigenvalues and eigenvectors.
-160  continue
+           160 continue
            if (icompz == 0) then
               ! use quick sort
               call stdlib_qlasrt('I',n,d,info)
@@ -63306,7 +63306,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: a(lda,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,kase
@@ -63354,7 +63354,7 @@ module stdlib_linalg_lapack_w
            end if
            ! estimate the 1-norm of the inverse.
            kase = 0
-30         continue
+           30 continue
            call stdlib_wlacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               ! multiply by inv(l*d*l**t) or inv(u*d*u**t).
@@ -63387,7 +63387,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: a(lda,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,kase
@@ -63435,7 +63435,7 @@ module stdlib_linalg_lapack_w
            end if
            ! estimate the 1-norm of the inverse.
            kase = 0
-30         continue
+           30 continue
            call stdlib_wlacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               ! multiply by inv(l*d*l**t) or inv(u*d*u**t).
@@ -63464,7 +63464,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: e(*)
         ! =====================================================================
-           
+
            ! External Subroutines
            logical(lk) :: upper,convert
            integer(ilp) :: i,ip,j
@@ -63682,7 +63682,7 @@ module stdlib_linalg_lapack_w
            integer(ilp),intent(inout) :: ipiv(*)
            complex(qp),intent(inout) :: a(lda,*),e(*)
         ! =====================================================================
-           
+
            ! External Subroutines
            logical(lk) :: upper,convert
            integer(ilp) :: i,ip
@@ -63746,7 +63746,7 @@ module stdlib_linalg_lapack_w
                        if (i < n) then
                           if (ip /= (i - 1)) then
                              call stdlib_wswap(n - i,a(i - 1,i + 1),lda,a(ip,i + 1),lda)
-                                       
+
                           end if
                        end if
                        ! convert ipiv
@@ -63782,7 +63782,7 @@ module stdlib_linalg_lapack_w
                        if (i < n) then
                           if (ip /= (i - 1)) then
                              call stdlib_wswap(n - i,a(ip,i + 1),lda,a(i - 1,i + 1),lda)
-                                       
+
                           end if
                        end if
                        ! convert ipiv
@@ -63937,7 +63937,7 @@ module stdlib_linalg_lapack_w
            integer(ilp),intent(in) :: ipiv(*)
            complex(qp),intent(inout) :: a(lda,*),e(*)
         ! =====================================================================
-           
+
            ! External Subroutines
            logical(lk) :: upper,convert
            integer(ilp) :: i,ip,ip2
@@ -64006,7 +64006,7 @@ module stdlib_linalg_lapack_w
                           end if
                           if (ip2 /= (i - 1)) then
                              call stdlib_wswap(n - i,a(i - 1,i + 1),lda,a(ip2,i + 1),lda)
-                                       
+
                           end if
                        end if
                        i = i - 1
@@ -64039,7 +64039,7 @@ module stdlib_linalg_lapack_w
                        if (i < n) then
                           if (ip2 /= (i - 1)) then
                              call stdlib_wswap(n - i,a(ip2,i + 1),lda,a(i - 1,i + 1),lda)
-                                       
+
                           end if
                           if (ip /= i) then
                              call stdlib_wswap(n - i,a(ip,i + 1),lda,a(i,i + 1),lda)
@@ -64188,7 +64188,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: max_iter = 100
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,iter
            real(qp) :: avg,std,tol,c0,c1,c2,t,u,si,d,base,smin,smax,smlnum,bignum, &
@@ -64329,7 +64329,7 @@ module stdlib_linalg_lapack_w
                  s(i) = si
               end do
            end do
-999        continue
+           999 continue
            smlnum = stdlib_qlamch('SAFEMIN')
            bignum = one/smlnum
            smin = bignum
@@ -64362,7 +64362,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: a(lda,*),x(*)
            complex(qp),intent(inout) :: y(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,info,ix,iy,j,jx,jy,kx,ky
            complex(qp) :: temp1,temp2
@@ -64515,7 +64515,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(in) :: x(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,info,ix,j,jx,kx
            complex(qp) :: temp
@@ -64624,7 +64624,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,j,k,kase,nz
@@ -64679,7 +64679,7 @@ module stdlib_linalg_lapack_w
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_wcopy(n,b(1,j),1,work,1)
@@ -64763,7 +64763,7 @@ module stdlib_linalg_lapack_w
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_wlacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -64881,7 +64881,7 @@ module stdlib_linalg_lapack_w
      !> form of A is then used to solve the system of equations A * X = B.
 
      pure subroutine stdlib_wsysv_aa(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -64935,7 +64935,7 @@ module stdlib_linalg_lapack_w
            if (info == 0) then
               ! solve the system a*x = b, overwriting b with x.
               call stdlib_wsytrs_aa(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-                        
+
            end if
            work(1) = lwkopt
            return
@@ -64957,7 +64957,7 @@ module stdlib_linalg_lapack_w
      !> the system of equations A * X = B by calling BLAS3 routine ZSYTRS_3.
 
      pure subroutine stdlib_wsysv_rk(uplo,n,nrhs,a,lda,e,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -65036,7 +65036,7 @@ module stdlib_linalg_lapack_w
      !> of equations A * X = B by calling ZSYTRS_ROOK.
 
      pure subroutine stdlib_wsysv_rook(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -65121,7 +65121,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: af(ldaf,*)
            complex(qp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,nofact
            integer(ilp) :: lwkopt,nb
@@ -65284,7 +65284,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: sevten = 17.0e+0_qp
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,imax,j,jmax,k,kk,kp,kstep
@@ -65318,7 +65318,7 @@ module stdlib_linalg_lapack_w
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 70
               kstep = 1
@@ -65433,7 +65433,7 @@ module stdlib_linalg_lapack_w
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop
               if (k > n) go to 70
               kstep = 1
@@ -65486,7 +65486,7 @@ module stdlib_linalg_lapack_w
                     ! interchange rows and columns kk and kp in the trailing
                     ! submatrix a(k:n,k:n)
                     if (kp < n) call stdlib_wswap(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     call stdlib_wswap(kp - kk - 1,a(kk + 1,kk),1,a(kp,kk + 1),lda)
                     t = a(kk,kk)
                     a(kk,kk) = a(kp,kp)
@@ -65507,7 +65507,7 @@ module stdlib_linalg_lapack_w
                        ! a := a - l(k)*d(k)*l(k)**t = a - w(k)*(1/d(k))*w(k)**t
                        r1 = cone/a(k,k)
                        call stdlib_wsyr(uplo,n - k,-r1,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                 
+
                        ! store l(k) in column k
                        call stdlib_wscal(n - k,r1,a(k + 1,k),1)
                     end if
@@ -65547,7 +65547,7 @@ module stdlib_linalg_lapack_w
               k = k + kstep
               go to 40
            end if
-70         continue
+           70 continue
            return
      end subroutine stdlib_wsytf2
 
@@ -65576,7 +65576,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: sevten = 17.0e+0_qp
-           
+
            ! Local Scalars
            logical(lk) :: upper,done
            integer(ilp) :: i,imax,j,jmax,itemp,k,kk,kp,kstep,p,ii
@@ -65615,7 +65615,7 @@ module stdlib_linalg_lapack_w
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 34
               kstep = 1
@@ -65649,7 +65649,7 @@ module stdlib_linalg_lapack_w
                  else
                     done = .false.
                     ! loop until pivot found
-12   continue
+                    12 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -65699,7 +65699,7 @@ module stdlib_linalg_lapack_w
                     ! submatrix a(1:k,1:k) if we have a 2-by-2 pivot
                     if (p > 1) call stdlib_wswap(p - 1,a(1,k),1,a(1,p),1)
                     if (p < (k - 1)) call stdlib_wswap(k - p - 1,a(p + 1,k),1,a(p,p + 1),lda)
-                              
+
                     t = a(k,k)
                     a(k,k) = a(p,p)
                     a(p,p) = t
@@ -65802,7 +65802,7 @@ module stdlib_linalg_lapack_w
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-34            continue
+              34 continue
            else
               ! factorize a as l*d*l**t using the lower triangle of a
               ! initialize the unused last entry of the subdiagonal array e.
@@ -65810,7 +65810,7 @@ module stdlib_linalg_lapack_w
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop
               if (k > n) go to 64
               kstep = 1
@@ -65843,7 +65843,7 @@ module stdlib_linalg_lapack_w
                  else
                     done = .false.
                     ! loop until pivot found
-42   continue
+                    42 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -65893,7 +65893,7 @@ module stdlib_linalg_lapack_w
                     ! submatrix a(k:n,k:n) if we have a 2-by-2 pivot
                     if (p < n) call stdlib_wswap(n - p,a(p + 1,k),1,a(p + 1,p),1)
                     if (p > (k + 1)) call stdlib_wswap(p - k - 1,a(k + 1,k),1,a(p,k + 1),lda)
-                              
+
                     t = a(k,k)
                     a(k,k) = a(p,p)
                     a(p,p) = t
@@ -65907,7 +65907,7 @@ module stdlib_linalg_lapack_w
                     ! interchange rows and columns kk and kp in the trailing
                     ! submatrix a(k:n,k:n)
                     if (kp < n) call stdlib_wswap(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     if ((kk < n) .and. (kp > (kk + 1))) call stdlib_wswap(kp - kk - 1,a(kk + 1,kk), &
                               1,a(kp,kk + 1),lda)
                     t = a(kk,kk)
@@ -65936,7 +65936,7 @@ module stdlib_linalg_lapack_w
                              ! = a - w(k)*(1/d(k))*w(k)**t
                           d11 = cone/a(k,k)
                           call stdlib_wsyr(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                           ! store l(k) in column k
                           call stdlib_wscal(n - k,d11,a(k + 1,k),1)
                        else
@@ -65950,7 +65950,7 @@ module stdlib_linalg_lapack_w
                              ! = a - w(k)*(1/d(k))*w(k)**t
                              ! = a - (w(k)/d(k))*(d(k))*(w(k)/d(k))**t
                           call stdlib_wsyr(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                        end if
                        ! store the subdiagonal element of d in array e
                        e(k) = czero
@@ -66001,7 +66001,7 @@ module stdlib_linalg_lapack_w
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 40
-64            continue
+              64 continue
            end if
            return
      end subroutine stdlib_wsytf2_rk
@@ -66028,7 +66028,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            real(qp),parameter :: sevten = 17.0e+0_qp
-           
+
            ! Local Scalars
            logical(lk) :: upper,done
            integer(ilp) :: i,imax,j,jmax,itemp,k,kk,kp,kstep,p,ii
@@ -66064,7 +66064,7 @@ module stdlib_linalg_lapack_w
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 70
               kstep = 1
@@ -66096,7 +66096,7 @@ module stdlib_linalg_lapack_w
                  else
                     done = .false.
                     ! loop until pivot found
-12   continue
+                    12 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -66146,7 +66146,7 @@ module stdlib_linalg_lapack_w
                     ! submatrix a(1:k,1:k) if we have a 2-by-2 pivot
                     if (p > 1) call stdlib_wswap(p - 1,a(1,k),1,a(1,p),1)
                     if (p < (k - 1)) call stdlib_wswap(k - p - 1,a(p + 1,k),1,a(p,p + 1),lda)
-                              
+
                     t = a(k,k)
                     a(k,k) = a(p,p)
                     a(p,p) = t
@@ -66240,7 +66240,7 @@ module stdlib_linalg_lapack_w
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop
               if (k > n) go to 70
               kstep = 1
@@ -66271,7 +66271,7 @@ module stdlib_linalg_lapack_w
                  else
                     done = .false.
                     ! loop until pivot found
-42   continue
+                    42 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -66321,7 +66321,7 @@ module stdlib_linalg_lapack_w
                     ! submatrix a(k:n,k:n) if we have a 2-by-2 pivot
                     if (p < n) call stdlib_wswap(n - p,a(p + 1,k),1,a(p + 1,p),1)
                     if (p > (k + 1)) call stdlib_wswap(p - k - 1,a(k + 1,k),1,a(p,k + 1),lda)
-                              
+
                     t = a(k,k)
                     a(k,k) = a(p,p)
                     a(p,p) = t
@@ -66332,7 +66332,7 @@ module stdlib_linalg_lapack_w
                     ! interchange rows and columns kk and kp in the trailing
                     ! submatrix a(k:n,k:n)
                     if (kp < n) call stdlib_wswap(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     if ((kk < n) .and. (kp > (kk + 1))) call stdlib_wswap(kp - kk - 1,a(kk + 1,kk), &
                               1,a(kp,kk + 1),lda)
                     t = a(kk,kk)
@@ -66358,7 +66358,7 @@ module stdlib_linalg_lapack_w
                              ! = a - w(k)*(1/d(k))*w(k)**t
                           d11 = cone/a(k,k)
                           call stdlib_wsyr(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                           ! store l(k) in column k
                           call stdlib_wscal(n - k,d11,a(k + 1,k),1)
                        else
@@ -66372,7 +66372,7 @@ module stdlib_linalg_lapack_w
                              ! = a - w(k)*(1/d(k))*w(k)**t
                              ! = a - (w(k)/d(k))*(d(k))*(w(k)/d(k))**t
                           call stdlib_wsyr(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                        end if
                     end if
                  else
@@ -66416,7 +66416,7 @@ module stdlib_linalg_lapack_w
               k = k + kstep
               go to 40
            end if
-70         continue
+           70 continue
            return
      end subroutine stdlib_wsytf2_rook
 
@@ -66491,7 +66491,7 @@ module stdlib_linalg_lapack_w
               ! kb, where kb is the number of columns factorized by stdlib_wlasyf;
               ! kb is either nb or nb-1, or k for the last block
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 40
               if (k > nb) then
@@ -66514,7 +66514,7 @@ module stdlib_linalg_lapack_w
               ! kb, where kb is the number of columns factorized by stdlib_wlasyf;
               ! kb is either nb or nb-1, or n-k+1 for the last block
               k = 1
-20            continue
+              20 continue
               ! if k > n, exit from loop
               if (k > n) go to 40
               if (k <= n - nb) then
@@ -66541,7 +66541,7 @@ module stdlib_linalg_lapack_w
               k = k + kb
               go to 20
            end if
-40         continue
+           40 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_wsytrf
@@ -66566,7 +66566,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper
            integer(ilp) :: j,lwkopt
@@ -66622,7 +66622,7 @@ module stdlib_linalg_lapack_w
               ! jb, where jb is the number of columns factorized by stdlib_wlasyf;
               ! jb is either nb, or n-j+1 for the last block
               j = 0
-10            continue
+              10 continue
               if (j >= n) go to 20
               ! each step of the main loop
                ! j is the last column of the previous panel
@@ -66654,7 +66654,7 @@ module stdlib_linalg_lapack_w
                     alpha = a(j,j + 1)
                     a(j,j + 1) = cone
                     call stdlib_wcopy(n - j,a(j - 1,j + 1),lda,work((j + 1 - j1 + 1) + jb*n),1)
-                              
+
                     call stdlib_wscal(n - j,alpha,work((j + 1 - j1 + 1) + jb*n),1)
                     ! k1 identifies if the previous column of the panel has been
                      ! explicitly stored, e.g., k1=1 and k2= 0 for the first panel,
@@ -66699,7 +66699,7 @@ module stdlib_linalg_lapack_w
               ! jb, where jb is the number of columns factorized by stdlib_wlasyf;
               ! jb is either nb, or n-j+1 for the last block
               j = 0
-11            continue
+              11 continue
               if (j >= n) go to 20
               ! each step of the main loop
                ! j is the last column of the previous panel
@@ -66756,7 +66756,7 @@ module stdlib_linalg_lapack_w
                        ! update off-diagonal block in j2-th block column with stdlib_wgemm
                        call stdlib_wgemm('NO TRANSPOSE','TRANSPOSE',n - j3 + 1,nj,jb + 1,-cone, &
                        work(j3 - j1 + 1 + k1*n),n,a(j2,j1 - k2),lda,cone,a(j3,j2),lda)
-                                 
+
                     end do
                     ! recover t( j+1, j )
                     a(j + 1,j) = alpha
@@ -66766,7 +66766,7 @@ module stdlib_linalg_lapack_w
               end if
               go to 11
            end if
-20         continue
+           20 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_wsytrf_aa
@@ -66843,14 +66843,14 @@ module stdlib_linalg_lapack_w
               ! kb, where kb is the number of columns factorized by stdlib_wlasyf_rk;
               ! kb is either nb or nb-1, or k for the last block
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 15
               if (k > nb) then
                  ! factorize columns k-kb+1:k of a and use blocked code to
                  ! update columns 1:k-kb
                  call stdlib_wlasyf_rk(uplo,k,nb,kb,a,lda,e,ipiv,work,ldwork,iinfo)
-                           
+
               else
                  ! use unblocked code to factorize columns 1:k of a
                  call stdlib_wsytf2_rk(uplo,k,a,lda,e,ipiv,iinfo)
@@ -66879,14 +66879,14 @@ module stdlib_linalg_lapack_w
               go to 10
               ! this label is the exit from main loop over k decreasing
               ! from n to 1 in steps of kb
-15   continue
+              15 continue
            else
               ! factorize a as l*d*l**t using the lower triangle of a
               ! k is the main loop index, increasing from 1 to n in steps of
               ! kb, where kb is the number of columns factorized by stdlib_wlasyf_rk;
               ! kb is either nb or nb-1, or n-k+1 for the last block
               k = 1
-20            continue
+              20 continue
               ! if k > n, exit from loop
               if (k > n) go to 35
               if (k <= n - nb) then
@@ -66897,7 +66897,7 @@ module stdlib_linalg_lapack_w
               else
                  ! use unblocked code to factorize columns k:n of a
                  call stdlib_wsytf2_rk(uplo,n - k + 1,a(k,k),lda,e(k),ipiv(k),iinfo)
-                           
+
                  kb = n - k + 1
               end if
               ! set info on the first occurrence of a zero pivot
@@ -66930,7 +66930,7 @@ module stdlib_linalg_lapack_w
               go to 20
               ! this label is the exit from main loop over k increasing
               ! from 1 to n in steps of kb
-35   continue
+              35 continue
            ! end lower
            end if
            work(1) = lwkopt
@@ -67008,14 +67008,14 @@ module stdlib_linalg_lapack_w
               ! kb, where kb is the number of columns factorized by stdlib_wlasyf_rook;
               ! kb is either nb or nb-1, or k for the last block
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 40
               if (k > nb) then
                  ! factorize columns k-kb+1:k of a and use blocked code to
                  ! update columns 1:k-kb
                  call stdlib_wlasyf_rook(uplo,k,nb,kb,a,lda,ipiv,work,ldwork,iinfo)
-                           
+
               else
                  ! use unblocked code to factorize columns 1:k of a
                  call stdlib_wsytf2_rook(uplo,k,a,lda,ipiv,iinfo)
@@ -67033,7 +67033,7 @@ module stdlib_linalg_lapack_w
               ! kb, where kb is the number of columns factorized by stdlib_wlasyf_rook;
               ! kb is either nb or nb-1, or n-k+1 for the last block
               k = 1
-20            continue
+              20 continue
               ! if k > n, exit from loop
               if (k > n) go to 40
               if (k <= n - nb) then
@@ -67060,7 +67060,7 @@ module stdlib_linalg_lapack_w
               k = k + kb
               go to 20
            end if
-40         continue
+           40 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_wsytrf_rook
@@ -67082,7 +67082,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: k,kp,kstep
@@ -67124,7 +67124,7 @@ module stdlib_linalg_lapack_w
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-30            continue
+              30 continue
               ! if k > n, exit from loop.
               if (k > n) go to 40
               if (ipiv(k) > 0) then
@@ -67135,7 +67135,7 @@ module stdlib_linalg_lapack_w
                  if (k > 1) then
                     call stdlib_wcopy(k - 1,a(1,k),1,work,1)
                     call stdlib_wsymv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - stdlib_wdotu(k - 1,work,1,a(1,k),1)
                  end if
                  kstep = 1
@@ -67154,15 +67154,15 @@ module stdlib_linalg_lapack_w
                  if (k > 1) then
                     call stdlib_wcopy(k - 1,a(1,k),1,work,1)
                     call stdlib_wsymv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - stdlib_wdotu(k - 1,work,1,a(1,k),1)
                     a(k,k + 1) = a(k,k + 1) - stdlib_wdotu(k - 1,a(1,k),1,a(1,k + 1),1)
-                              
+
                     call stdlib_wcopy(k - 1,a(1,k + 1),1,work,1)
                     call stdlib_wsymv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k + 1),1)
-                              
+
                     a(k + 1,k + 1) = a(k + 1,k + 1) - stdlib_wdotu(k - 1,work,1,a(1,k + 1),1)
-                              
+
                  end if
                  kstep = 2
               end if
@@ -67183,13 +67183,13 @@ module stdlib_linalg_lapack_w
               end if
               k = k + kstep
               go to 30
-40            continue
+              40 continue
            else
               ! compute inv(a) from the factorization a = l*d*l**t.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-50            continue
+              50 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 60
               if (ipiv(k) > 0) then
@@ -67227,7 +67227,7 @@ module stdlib_linalg_lapack_w
                     call stdlib_wsymv(uplo,n - k,-cone,a(k + 1,k + 1),lda,work,1,czero,a(k + &
                               1,k - 1),1)
                     a(k - 1,k - 1) = a(k - 1,k - 1) - stdlib_wdotu(n - k,work,1,a(k + 1,k - 1),1)
-                              
+
                  end if
                  kstep = 2
               end if
@@ -67248,7 +67248,7 @@ module stdlib_linalg_lapack_w
               end if
               k = k - kstep
               go to 50
-60            continue
+              60 continue
            end if
            return
      end subroutine stdlib_wsytri
@@ -67270,7 +67270,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: k,kp,kstep
@@ -67312,7 +67312,7 @@ module stdlib_linalg_lapack_w
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-30            continue
+              30 continue
               ! if k > n, exit from loop.
               if (k > n) go to 40
               if (ipiv(k) > 0) then
@@ -67323,7 +67323,7 @@ module stdlib_linalg_lapack_w
                  if (k > 1) then
                     call stdlib_wcopy(k - 1,a(1,k),1,work,1)
                     call stdlib_wsymv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - stdlib_wdotu(k - 1,work,1,a(1,k),1)
                  end if
                  kstep = 1
@@ -67342,15 +67342,15 @@ module stdlib_linalg_lapack_w
                  if (k > 1) then
                     call stdlib_wcopy(k - 1,a(1,k),1,work,1)
                     call stdlib_wsymv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - stdlib_wdotu(k - 1,work,1,a(1,k),1)
                     a(k,k + 1) = a(k,k + 1) - stdlib_wdotu(k - 1,a(1,k),1,a(1,k + 1),1)
-                              
+
                     call stdlib_wcopy(k - 1,a(1,k + 1),1,work,1)
                     call stdlib_wsymv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k + 1),1)
-                              
+
                     a(k + 1,k + 1) = a(k + 1,k + 1) - stdlib_wdotu(k - 1,work,1,a(1,k + 1),1)
-                              
+
                  end if
                  kstep = 2
               end if
@@ -67391,13 +67391,13 @@ module stdlib_linalg_lapack_w
               end if
               k = k + 1
               go to 30
-40            continue
+              40 continue
            else
               ! compute inv(a) from the factorization a = l*d*l**t.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-50            continue
+              50 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 60
               if (ipiv(k) > 0) then
@@ -67435,7 +67435,7 @@ module stdlib_linalg_lapack_w
                     call stdlib_wsymv(uplo,n - k,-cone,a(k + 1,k + 1),lda,work,1,czero,a(k + 1, &
                                k - 1),1)
                     a(k - 1,k - 1) = a(k - 1,k - 1) - stdlib_wdotu(n - k,work,1,a(k + 1,k - 1),1)
-                              
+
                  end if
                  kstep = 2
               end if
@@ -67476,7 +67476,7 @@ module stdlib_linalg_lapack_w
               end if
               k = k - 1
               go to 50
-60            continue
+              60 continue
            end if
            return
      end subroutine stdlib_wsytri_rook
@@ -67498,7 +67498,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: a(lda,*)
            complex(qp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kp
@@ -67531,7 +67531,7 @@ module stdlib_linalg_lapack_w
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 30
               if (ipiv(k) > 0) then
@@ -67571,12 +67571,12 @@ module stdlib_linalg_lapack_w
                  k = k - 2
               end if
               go to 10
-30            continue
+              30 continue
               ! next solve u**t *x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               if (ipiv(k) > 0) then
@@ -67603,14 +67603,14 @@ module stdlib_linalg_lapack_w
                  k = k + 2
               end if
               go to 40
-50            continue
+              50 continue
            else
               ! solve a*x = b, where a = l*d*l**t.
               ! first solve l*d*x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-60            continue
+              60 continue
               ! if k > n, exit from loop.
               if (k > n) go to 80
               if (ipiv(k) > 0) then
@@ -67652,12 +67652,12 @@ module stdlib_linalg_lapack_w
                  k = k + 2
               end if
               go to 60
-80            continue
+              80 continue
               ! next solve l**t *x = b, overwriting b with x.
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-90            continue
+              90 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 100
               if (ipiv(k) > 0) then
@@ -67686,7 +67686,7 @@ module stdlib_linalg_lapack_w
                  k = k - 2
               end if
               go to 90
-100           continue
+              100 continue
            end if
            return
      end subroutine stdlib_wsytrs
@@ -67708,7 +67708,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,iinfo,j,k,kp
@@ -67817,7 +67817,7 @@ module stdlib_linalg_lapack_w
                  ! interchange rows k and -ipiv(k+1).
                  kp = -ipiv(k + 1)
                  if (kp == -ipiv(k)) call stdlib_wswap(nrhs,b(k + 1,1),ldb,b(kp,1),ldb)
-                           
+
                  k = k + 2
               end if
              end do
@@ -67892,7 +67892,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: a(lda,*),e(*)
            complex(qp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,j,k,kp
@@ -68031,7 +68031,7 @@ module stdlib_linalg_lapack_w
      !> A = L*T*L**T computed by ZSYTRF_AA.
 
      pure subroutine stdlib_wsytrs_aa(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -68045,7 +68045,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: b(ldb,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            logical(lk) :: lquery,upper
            integer(ilp) :: k,kp,lwkopt
            ! Intrinsic Functions
@@ -68162,7 +68162,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: a(lda,*)
            complex(qp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kp
@@ -68195,7 +68195,7 @@ module stdlib_linalg_lapack_w
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 30
               if (ipiv(k) > 0) then
@@ -68239,12 +68239,12 @@ module stdlib_linalg_lapack_w
                  k = k - 2
               end if
               go to 10
-30            continue
+              30 continue
               ! next solve u**t *x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               if (ipiv(k) > 0) then
@@ -68275,14 +68275,14 @@ module stdlib_linalg_lapack_w
                  k = k + 2
               end if
               go to 40
-50            continue
+              50 continue
            else
               ! solve a*x = b, where a = l*d*l**t.
               ! first solve l*d*x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-60            continue
+              60 continue
               ! if k > n, exit from loop.
               if (k > n) go to 80
               if (ipiv(k) > 0) then
@@ -68326,12 +68326,12 @@ module stdlib_linalg_lapack_w
                  k = k + 2
               end if
               go to 60
-80            continue
+              80 continue
               ! next solve l**t *x = b, overwriting b with x.
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-90            continue
+              90 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 100
               if (ipiv(k) > 0) then
@@ -68362,7 +68362,7 @@ module stdlib_linalg_lapack_w
                  k = k - 2
               end if
               go to 90
-100           continue
+              100 continue
            end if
            return
      end subroutine stdlib_wsytrs_rook
@@ -68375,7 +68375,7 @@ module stdlib_linalg_lapack_w
      !> RCOND = 1 / ( norm(A) * norm(inv(A)) ).
 
      subroutine stdlib_wtbcon(norm,uplo,diag,n,kd,ab,ldab,rcond,work,rwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -68389,7 +68389,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: ab(ldab,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,onenrm,upper
            character :: normin
@@ -68447,7 +68447,7 @@ module stdlib_linalg_lapack_w
                  kase1 = 2
               end if
               kase = 0
-10            continue
+              10 continue
               call stdlib_wlacn2(n,work(n + 1),work,ainvnm,kase,isave)
               if (kase /= 0) then
                  if (kase == kase1) then
@@ -68472,7 +68472,7 @@ module stdlib_linalg_lapack_w
               ! compute the estimate of the reciprocal condition number.
               if (ainvnm /= zero) rcond = (one/anorm)/ainvnm
            end if
-20         continue
+           20 continue
            return
      end subroutine stdlib_wtbcon
 
@@ -68497,7 +68497,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: ab(ldab,*),b(ldb,*),x(ldx,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            character :: transn,transt
@@ -68690,7 +68690,7 @@ module stdlib_linalg_lapack_w
                  end if
               end do
               kase = 0
-210           continue
+              210 continue
               call stdlib_wlacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -68724,7 +68724,7 @@ module stdlib_linalg_lapack_w
      !> N-by-NRHS matrix.  A check is made to verify that A is nonsingular.
 
      pure subroutine stdlib_wtbtrs(uplo,trans,diag,n,kd,nrhs,ab,ldab,b,ldb,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -68736,7 +68736,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: ab(ldab,*)
            complex(qp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,upper
            integer(ilp) :: j
@@ -68801,7 +68801,7 @@ module stdlib_linalg_lapack_w
      !> The matrix X is overwritten on B.
 
      pure subroutine stdlib_wtfsm(transr,side,uplo,trans,diag,m,n,alpha,a,b,ldb)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -68813,7 +68813,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: a(0:*)
            complex(qp),intent(inout) :: b(0:ldb - 1,0:*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,lside,misodd,nisodd,normaltransr,notrans
            integer(ilp) :: m1,m2,n1,n2,k,info,i,j
@@ -68888,7 +68888,7 @@ module stdlib_linalg_lapack_w
                           ! trans = 'n'
                           if (m == 1) then
                              call stdlib_wtrsm('L','L','N',diag,m1,n,alpha,a,m,b,ldb)
-                                       
+
                           else
                              call stdlib_wtrsm('L','L','N',diag,m1,n,alpha,a(0),m,b, &
                                        ldb)
@@ -68931,7 +68931,7 @@ module stdlib_linalg_lapack_w
                           call stdlib_wgemm('N','N',m1,n,m2,-cone,a(0),m,b(m1,0), &
                                     ldb,alpha,b,ldb)
                           call stdlib_wtrsm('L','L','C',diag,m1,n,cone,a(m2),m,b,ldb)
-                                    
+
                        end if
                     end if
                  else
@@ -69013,7 +69013,7 @@ module stdlib_linalg_lapack_w
                           call stdlib_wgemm('C','N',k,n,k,-cone,a(k + 1),m + 1,b(k,0), &
                                     ldb,alpha,b,ldb)
                           call stdlib_wtrsm('L','L','C',diag,k,n,cone,a(1),m + 1,b,ldb)
-                                    
+
                        end if
                     else
                        ! side  ='l', n is even, transr = 'n', and uplo = 'u'
@@ -69045,7 +69045,7 @@ module stdlib_linalg_lapack_w
                           ! side  ='l', n is even, transr = 'c', uplo = 'l',
                           ! and trans = 'n'
                           call stdlib_wtrsm('L','U','C',diag,k,n,alpha,a(k),k,b,ldb)
-                                    
+
                           call stdlib_wgemm('C','N',k,n,k,-cone,a(k*(k + 1)),k,b,ldb, &
                                     alpha,b(k,0),ldb)
                           call stdlib_wtrsm('L','L','N',diag,k,n,cone,a(0),k,b(k,0), &
@@ -69058,7 +69058,7 @@ module stdlib_linalg_lapack_w
                           call stdlib_wgemm('N','N',k,n,k,-cone,a(k*(k + 1)),k,b(k,0) &
                                     ,ldb,alpha,b,ldb)
                           call stdlib_wtrsm('L','U','N',diag,k,n,cone,a(k),k,b,ldb)
-                                    
+
                        end if
                     else
                        ! side  ='l', n is even, transr = 'c', and uplo = 'u'
@@ -69308,7 +69308,7 @@ module stdlib_linalg_lapack_w
            ! Array Arguments
            complex(qp),intent(inout) :: a(0:*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,nisodd,normaltransr
            integer(ilp) :: n1,n2,k
@@ -69363,12 +69363,12 @@ module stdlib_linalg_lapack_w
                     call stdlib_wtrtri('L',diag,n1,a(0),n,info)
                     if (info > 0) return
                     call stdlib_wtrmm('R','L','N',diag,n2,n1,-cone,a(0),n,a(n1),n)
-                              
+
                     call stdlib_wtrtri('U',diag,n2,a(n),n,info)
                     if (info > 0) info = info + n1
                     if (info > 0) return
                     call stdlib_wtrmm('L','U','C',diag,n2,n1,cone,a(n),n,a(n1),n)
-                              
+
                  else
                    ! srpa for upper, normal and n is odd ( a(0:n-1,0:n2-1)
                    ! t1 -> a(n1+1,0), t2 -> a(n1,0), s -> a(0,0)
@@ -69376,12 +69376,12 @@ module stdlib_linalg_lapack_w
                     call stdlib_wtrtri('L',diag,n1,a(n2),n,info)
                     if (info > 0) return
                     call stdlib_wtrmm('L','L','C',diag,n1,n2,-cone,a(n2),n,a(0),n)
-                              
+
                     call stdlib_wtrtri('U',diag,n2,a(n1),n,info)
                     if (info > 0) info = info + n1
                     if (info > 0) return
                     call stdlib_wtrmm('R','U','N',diag,n1,n2,cone,a(n1),n,a(0),n)
-                              
+
                  end if
               else
                  ! n is odd and transr = 'c'
@@ -69440,7 +69440,7 @@ module stdlib_linalg_lapack_w
                     if (info > 0) info = info + k
                     if (info > 0) return
                     call stdlib_wtrmm('R','U','N',diag,k,k,cone,a(k),n + 1,a(0),n + 1)
-                              
+
                  end if
               else
                  ! n is even and transr = 'c'
@@ -69469,7 +69469,7 @@ module stdlib_linalg_lapack_w
                     if (info > 0) info = info + k
                     if (info > 0) return
                     call stdlib_wtrmm('L','L','N',diag,k,k,cone,a(k*k),k,a(0),k)
-                              
+
                  end if
               end if
            end if
@@ -70020,7 +70020,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: vl(ldvl,*),vr(ldvr,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: compl,compr,ilall,ilback,ilbbad,ilcomp,lsa,lsb
            integer(ilp) :: i,ibeg,ieig,iend,ihwmny,im,iside,isrc,j,je,jr
@@ -70175,7 +70175,7 @@ module stdlib_linalg_lapack_w
                     scale = one
                     if (lsa) scale = (small/abs(sbeta))*min(anorm,big)
                     if (lsb) scale = max(scale, (small/abs1(salpha))*min(bnorm,big))
-                              
+
                     if (lsa .or. lsb) then
                        scale = min(scale,one/(safmin*max(one,abs(acoeff),abs1(bcoeff)) &
                                  ))
@@ -70304,7 +70304,7 @@ module stdlib_linalg_lapack_w
                     scale = one
                     if (lsa) scale = (small/abs(sbeta))*min(anorm,big)
                     if (lsb) scale = max(scale, (small/abs1(salpha))*min(bnorm,big))
-                              
+
                     if (lsa .or. lsb) then
                        scale = min(scale,one/(safmin*max(one,abs(acoeff),abs1(bcoeff)) &
                                  ))
@@ -70408,7 +70408,7 @@ module stdlib_linalg_lapack_w
      !> Q(in) * B(in) * Z(in)**H = Q(out) * B(out) * Z(out)**H
 
      pure subroutine stdlib_wtgex2(wantq,wantz,n,a,lda,b,ldb,q,ldq,z,ldz,j1,info)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -70423,7 +70423,7 @@ module stdlib_linalg_lapack_w
            real(qp),parameter :: twenty = 2.0e+1_qp
            integer(ilp),parameter :: ldst = 2
            logical(lk),parameter :: wands = .true.
-           
+
            ! Local Scalars
            logical(lk) :: strong,weak
            integer(ilp) :: i,m
@@ -70525,13 +70525,13 @@ module stdlib_linalg_lapack_w
            b(j1 + 1,j1) = czero
            ! accumulate transformations into q and z if requested.
            if (wantz) call stdlib_wrot(n,z(1,j1),1,z(1,j1 + 1),1,cz,conjg(sz))
-                     
+
            if (wantq) call stdlib_wrot(n,q(1,j1),1,q(1,j1 + 1),1,cq,conjg(sq))
-                     
+
            ! exit with info = 0 if swap was successfully performed.
            return
            ! exit with info = 1 if swap was rejected.
-20   continue
+           20 continue
            info = 1
            return
      end subroutine stdlib_wtgex2
@@ -70591,10 +70591,10 @@ module stdlib_linalg_lapack_w
            if (ifst == ilst) return
            if (ifst < ilst) then
               here = ifst
-10            continue
+              10 continue
               ! swap with next one below
               call stdlib_wtgex2(wantq,wantz,n,a,lda,b,ldb,q,ldq,z,ldz,here,info)
-                        
+
               if (info /= 0) then
                  ilst = here
                  return
@@ -70604,10 +70604,10 @@ module stdlib_linalg_lapack_w
               here = here - 1
            else
               here = ifst - 1
-20            continue
+              20 continue
               ! swap with next one above
               call stdlib_wtgex2(wantq,wantz,n,a,lda,b,ldb,q,ldq,z,ldz,here,info)
-                        
+
               if (info /= 0) then
                  ilst = here
                  return
@@ -70658,7 +70658,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: idifjb = 3
-           
+
            ! Local Scalars
            logical(lk) :: lquery,swap,wantd,wantd1,wantd2,wantp
            integer(ilp) :: i,ierr,ijb,k,kase,ks,liwmin,lwmin,mn2,n1,n2
@@ -70837,7 +70837,7 @@ module stdlib_linalg_lapack_w
                  ijb = 0
                  mn2 = 2*n1*n2
                  ! 1-norm-based estimate of difu.
-40   continue
+                 40 continue
                  call stdlib_wlacn2(mn2,work(mn2 + 1),work,dif(1),kase,isave)
                  if (kase /= 0) then
                     if (kase == 1) then
@@ -70855,7 +70855,7 @@ module stdlib_linalg_lapack_w
                  end if
                  dif(1) = dscale/dif(1)
                  ! 1-norm-based estimate of difl.
-50   continue
+                 50 continue
                  call stdlib_wlacn2(mn2,work(mn2 + 1),work,dif(2),kase,isave)
                  if (kase /= 0) then
                     if (kase == 1) then
@@ -70892,7 +70892,7 @@ module stdlib_linalg_lapack_w
               alpha(k) = a(k,k)
               beta(k) = b(k,k)
            end do
-70         continue
+           70 continue
            work(1) = lwmin
            iwork(1) = liwmin
            return
@@ -70979,7 +70979,7 @@ module stdlib_linalg_lapack_w
            ! Parameters
            integer(ilp),parameter :: maxit = 40
            real(qp),parameter :: hugenum = huge(zero)
-           
+
            ! Local Scalars
            logical(lk) :: initq,initu,initv,upper,wantq,wantu,wantv
            integer(ilp) :: i,j,kcycle
@@ -71058,7 +71058,7 @@ module stdlib_linalg_lapack_w
                     ! update (n-l+i)-th and (n-l+j)-th columns of matrices
                     ! a and b: a*q and b*q
                     call stdlib_wrot(min(k + l,m),a(1,n - l + j),1,a(1,n - l + i),1,csq,snq)
-                              
+
                     call stdlib_wrot(l,b(1,n - l + j),1,b(1,n - l + i),1,csq,snq)
                     if (upper) then
                        if (k + i <= m) a(k + i,n - l + j) = czero
@@ -71077,7 +71077,7 @@ module stdlib_linalg_lapack_w
                               csu,snu)
                     if (wantv) call stdlib_wrot(p,v(1,j),1,v(1,i),1,csv,snv)
                     if (wantq) call stdlib_wrot(n,q(1,n - l + j),1,q(1,n - l + i),1,csq,snq)
-                              
+
                  end do loop_10
               end do loop_20
               if (.not. upper) then
@@ -71099,7 +71099,7 @@ module stdlib_linalg_lapack_w
            ! the algorithm has not converged after maxit cycles.
            info = 1
            go to 100
-50         continue
+           50 continue
            ! if error <= min(tola,tolb), then the algorithm has converged.
            ! compute the generalized singular value pairs (alpha, beta), and
            ! set the triangular matrix r to array a.
@@ -71140,7 +71140,7 @@ module stdlib_linalg_lapack_w
                  beta(i) = zero
               end do
            end if
-100        continue
+           100 continue
            ncycle = kcycle
            return
      end subroutine stdlib_wtgsja
@@ -71168,7 +71168,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: idifjb = 3
-           
+
            ! Local Scalars
            logical(lk) :: lquery,somcon,wantbh,wantdf,wants
            integer(ilp) :: i,ierr,ifst,ilst,k,ks,lwmin,n1,n2
@@ -71344,7 +71344,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: ldz = 2
-           
+
            ! Local Scalars
            logical(lk) :: notran
            integer(ilp) :: i,ierr,j,k
@@ -71415,15 +71415,15 @@ module stdlib_linalg_lapack_w
                        if (scaloc /= one) then
                           do k = 1,n
                              call stdlib_wscal(m,cmplx(scaloc,zero,KIND=qp),c(1,k),1)
-                                       
+
                              call stdlib_wscal(m,cmplx(scaloc,zero,KIND=qp),f(1,k),1)
-                                       
+
                           end do
                           scale = scale*scaloc
                        end if
                     else
                        call stdlib_wlatdf(ijob,ldz,z,ldz,rhs,rdsum,rdscal,ipiv,jpiv)
-                                 
+
                     end if
                     ! unpack solution vector(s)
                     c(i,j) = rhs(1)
@@ -71436,9 +71436,9 @@ module stdlib_linalg_lapack_w
                     end if
                     if (j < n) then
                        call stdlib_waxpy(n - j,rhs(2),b(j,j + 1),ldb,c(i,j + 1),ldc)
-                                 
+
                        call stdlib_waxpy(n - j,rhs(2),e(j,j + 1),lde,f(i,j + 1),ldf)
-                                 
+
                     end if
                  end do loop_20
               end do loop_30
@@ -71466,9 +71466,9 @@ module stdlib_linalg_lapack_w
                     if (scaloc /= one) then
                        do k = 1,n
                           call stdlib_wscal(m,cmplx(scaloc,zero,KIND=qp),c(1,k),1)
-                                    
+
                           call stdlib_wscal(m,cmplx(scaloc,zero,KIND=qp),f(1,k),1)
-                                    
+
                        end do
                        scale = scale*scaloc
                     end if
@@ -71536,7 +71536,7 @@ module stdlib_linalg_lapack_w
         ! =====================================================================
         ! replaced various illegal calls to stdlib_zcopy by calls to stdlib_zlaset.
         ! sven hammarling, 1/5/02.
-           
+
            ! Local Scalars
            logical(lk) :: lquery,notran
            integer(ilp) :: i,ie,ifunc,iround,is,isolve,j,je,js,k,linfo,lwmin,mb,nb, &
@@ -71656,27 +71656,27 @@ module stdlib_linalg_lapack_w
            ! determine block structure of a
            p = 0
            i = 1
-40         continue
+           40 continue
            if (i > m) go to 50
            p = p + 1
            iwork(p) = i
            i = i + mb
            if (i >= m) go to 50
            go to 40
-50         continue
+           50 continue
            iwork(p + 1) = m + 1
            if (iwork(p) == iwork(p + 1)) p = p - 1
            ! determine block structure of b
            q = p + 1
            j = 1
-60         continue
+           60 continue
            if (j > n) go to 70
            q = q + 1
            iwork(q) = j
            j = j + nb
            if (j >= n) go to 70
            go to 60
-70         continue
+           70 continue
            iwork(q + 1) = n + 1
            if (iwork(q) == iwork(q + 1)) q = q - 1
            if (notran) then
@@ -71705,15 +71705,15 @@ module stdlib_linalg_lapack_w
                        if (scaloc /= one) then
                           do k = 1,js - 1
                              call stdlib_wscal(m,cmplx(scaloc,zero,KIND=qp),c(1,k),1)
-                                       
+
                              call stdlib_wscal(m,cmplx(scaloc,zero,KIND=qp),f(1,k),1)
-                                       
+
                           end do
                           do k = js,je
                              call stdlib_wscal(is - 1,cmplx(scaloc,zero,KIND=qp),c(1,k),1)
-                                       
+
                              call stdlib_wscal(is - 1,cmplx(scaloc,zero,KIND=qp),f(1,k),1)
-                                       
+
                           end do
                           do k = js,je
                              call stdlib_wscal(m - ie,cmplx(scaloc,zero,KIND=qp),c(ie + 1,k), &
@@ -71723,9 +71723,9 @@ module stdlib_linalg_lapack_w
                           end do
                           do k = je + 1,n
                              call stdlib_wscal(m,cmplx(scaloc,zero,KIND=qp),c(1,k),1)
-                                       
+
                              call stdlib_wscal(m,cmplx(scaloc,zero,KIND=qp),f(1,k),1)
-                                       
+
                           end do
                           scale = scale*scaloc
                        end if
@@ -71791,27 +71791,27 @@ module stdlib_linalg_lapack_w
                     if (scaloc /= one) then
                        do k = 1,js - 1
                           call stdlib_wscal(m,cmplx(scaloc,zero,KIND=qp),c(1,k),1)
-                                    
+
                           call stdlib_wscal(m,cmplx(scaloc,zero,KIND=qp),f(1,k),1)
-                                    
+
                        end do
                        do k = js,je
                           call stdlib_wscal(is - 1,cmplx(scaloc,zero,KIND=qp),c(1,k),1)
-                                    
+
                           call stdlib_wscal(is - 1,cmplx(scaloc,zero,KIND=qp),f(1,k),1)
-                                    
+
                        end do
                        do k = js,je
                           call stdlib_wscal(m - ie,cmplx(scaloc,zero,KIND=qp),c(ie + 1,k),1)
-                                    
+
                           call stdlib_wscal(m - ie,cmplx(scaloc,zero,KIND=qp),f(ie + 1,k),1)
-                                    
+
                        end do
                        do k = je + 1,n
                           call stdlib_wscal(m,cmplx(scaloc,zero,KIND=qp),c(1,k),1)
-                                    
+
                           call stdlib_wscal(m,cmplx(scaloc,zero,KIND=qp),f(1,k),1)
-                                    
+
                        end do
                        scale = scale*scaloc
                     end if
@@ -71819,10 +71819,10 @@ module stdlib_linalg_lapack_w
                     if (j > p + 2) then
                        call stdlib_wgemm('N','C',mb,js - 1,nb,cmplx(one,zero,KIND=qp),c(is, &
                         js),ldc,b(1,js),ldb,cmplx(one,zero,KIND=qp),f(is,1),ldf)
-                                  
+
                        call stdlib_wgemm('N','C',mb,js - 1,nb,cmplx(one,zero,KIND=qp),f(is, &
                         js),ldf,e(1,js),lde,cmplx(one,zero,KIND=qp),f(is,1),ldf)
-                                  
+
                     end if
                     if (i < p) then
                        call stdlib_wgemm('C','N',m - ie,nb,mb,cmplx(-one,zero,KIND=qp),a( &
@@ -71860,7 +71860,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: ap(*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,onenrm,upper
            character :: normin
@@ -71914,7 +71914,7 @@ module stdlib_linalg_lapack_w
                  kase1 = 2
               end if
               kase = 0
-10            continue
+              10 continue
               call stdlib_wlacn2(n,work(n + 1),work,ainvnm,kase,isave)
               if (kase /= 0) then
                  if (kase == kase1) then
@@ -71939,7 +71939,7 @@ module stdlib_linalg_lapack_w
               ! compute the estimate of the reciprocal condition number.
               if (ainvnm /= zero) rcond = (one/anorm)/ainvnm
            end if
-20         continue
+           20 continue
            return
      end subroutine stdlib_wtpcon
 
@@ -71995,7 +71995,7 @@ module stdlib_linalg_lapack_w
                  lb = nb - n + l - i + 1
               end if
               call stdlib_wtplqt2(ib,nb,lb,a(i,i),lda,b(i,1),ldb,t(1,i),ldt,iinfo)
-                        
+
            ! update by applying h**t to b(i+ib:m,:) from the right
               if (i + ib <= m) then
                  call stdlib_wtprfb('R','N','F','R',m - i - ib + 1,nb,ib,lb,b(i,1),ldb,t( &
@@ -72020,7 +72020,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(qp),intent(out) :: t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,p,mp,np
            complex(qp) :: alpha
@@ -72411,7 +72411,7 @@ module stdlib_linalg_lapack_w
                  lb = mb - m + l - i + 1
               end if
               call stdlib_wtpqrt2(mb,ib,lb,a(i,i),lda,b(1,i),ldb,t(1,i),ldt,iinfo)
-                        
+
            ! update by applying h**h to b(:,i+ib:n) from the left
               if (i + ib <= n) then
                  call stdlib_wtprfb('L','C','F','C',mb,n - i - ib + 1,ib,lb,b(1,i),ldb,t( &
@@ -72436,7 +72436,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(qp),intent(out) :: t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,p,mp,np
            complex(qp) :: alpha
@@ -72481,7 +72481,7 @@ module stdlib_linalg_lapack_w
                     a(i,i + j) = a(i,i + j) + alpha*conjg(t(j,n))
                  end do
                  call stdlib_wgerc(p,n - i,alpha,b(1,i),1,t(1,n),1,b(1,i + 1),ldb)
-                           
+
               end if
            end do
            do i = 2,n
@@ -72503,7 +72503,7 @@ module stdlib_linalg_lapack_w
                         np,i),1)
               ! b1
               call stdlib_wgemv('C',m - l,i - 1,alpha,b,ldb,b(1,i),1,cone,t(1,i),1)
-                        
+
               ! t(1:i-1,i) := t(1:i-1,1:i-1) * t(1:i-1,i)
               call stdlib_wtrmv('U','N','N',i - 1,t,ldt,t(1,i),1)
               ! t(i,i) = tau(i)
@@ -72529,7 +72529,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: t(ldt,*),v(ldv,*)
            complex(qp),intent(out) :: work(ldwork,*)
         ! ==========================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,mp,np,kp
            logical(lk) :: left,forward,column,right,backward,row
@@ -72587,9 +72587,9 @@ module stdlib_linalg_lapack_w
                  end do
               end do
               call stdlib_wtrmm('L','U','C','N',l,n,cone,v(mp,1),ldv,work,ldwork)
-                        
+
               call stdlib_wgemm('C','N',l,n,m - l,cone,v,ldv,b,ldb,cone,work,ldwork)
-                        
+
               call stdlib_wgemm('C','N',k - l,n,m,cone,v(1,kp),ldv,b,ldb,czero,work( &
                         kp,1),ldwork)
               do j = 1,n
@@ -72604,11 +72604,11 @@ module stdlib_linalg_lapack_w
                  end do
               end do
               call stdlib_wgemm('N','N',m - l,n,k,-cone,v,ldv,work,ldwork,cone,b,ldb)
-                        
+
               call stdlib_wgemm('N','N',l,n,k - l,-cone,v(mp,kp),ldv,work(kp,1), &
                         ldwork,cone,b(mp,1),ldb)
               call stdlib_wtrmm('L','U','N','N',l,n,cone,v(mp,1),ldv,work,ldwork)
-                        
+
               do j = 1,n
                  do i = 1,l
                     b(m - l + i,j) = b(m - l + i,j) - work(i,j)
@@ -72632,9 +72632,9 @@ module stdlib_linalg_lapack_w
                  end do
               end do
               call stdlib_wtrmm('R','U','N','N',m,l,cone,v(np,1),ldv,work,ldwork)
-                        
+
               call stdlib_wgemm('N','N',m,l,n - l,cone,b,ldb,v,ldv,cone,work,ldwork)
-                        
+
               call stdlib_wgemm('N','N',m,k - l,n,cone,b,ldb,v(1,kp),ldv,czero,work( &
                         1,kp),ldwork)
               do j = 1,k
@@ -72649,11 +72649,11 @@ module stdlib_linalg_lapack_w
                  end do
               end do
               call stdlib_wgemm('N','C',m,n - l,k,-cone,work,ldwork,v,ldv,cone,b,ldb)
-                        
+
               call stdlib_wgemm('N','C',m,l,k - l,-cone,work(1,kp),ldwork,v(np,kp), &
                         ldv,cone,b(1,np),ldb)
               call stdlib_wtrmm('R','U','C','N',m,l,cone,v(np,1),ldv,work,ldwork)
-                        
+
               do j = 1,l
                  do i = 1,m
                     b(i,n - l + j) = b(i,n - l + j) - work(i,j)
@@ -72682,7 +72682,7 @@ module stdlib_linalg_lapack_w
               call stdlib_wgemm('C','N',l,n,m - l,cone,v(mp,kp),ldv,b(mp,1),ldb, &
                         cone,work(kp,1),ldwork)
               call stdlib_wgemm('C','N',k - l,n,m,cone,v,ldv,b,ldb,czero,work,ldwork)
-                        
+
               do j = 1,n
                  do i = 1,k
                     work(i,j) = work(i,j) + a(i,j)
@@ -72697,7 +72697,7 @@ module stdlib_linalg_lapack_w
               call stdlib_wgemm('N','N',m - l,n,k,-cone,v(mp,1),ldv,work,ldwork,cone, &
                         b(mp,1),ldb)
               call stdlib_wgemm('N','N',l,n,k - l,-cone,v,ldv,work,ldwork,cone,b,ldb)
-                        
+
               call stdlib_wtrmm('L','L','N','N',l,n,cone,v(1,kp),ldv,work(kp,1), &
                         ldwork)
               do j = 1,n
@@ -72727,7 +72727,7 @@ module stdlib_linalg_lapack_w
               call stdlib_wgemm('N','N',m,l,n - l,cone,b(1,np),ldb,v(np,kp),ldv, &
                         cone,work(1,kp),ldwork)
               call stdlib_wgemm('N','N',m,k - l,n,cone,b,ldb,v,ldv,czero,work,ldwork)
-                        
+
               do j = 1,k
                  do i = 1,m
                     work(i,j) = work(i,j) + a(i,j)
@@ -72742,7 +72742,7 @@ module stdlib_linalg_lapack_w
               call stdlib_wgemm('N','C',m,n - l,k,-cone,work,ldwork,v(np,1),ldv,cone, &
                         b(1,np),ldb)
               call stdlib_wgemm('N','C',m,l,k - l,-cone,work,ldwork,v,ldv,cone,b,ldb)
-                        
+
               call stdlib_wtrmm('R','L','C','N',m,l,cone,v(1,kp),ldv,work(1,kp), &
                         ldwork)
               do j = 1,l
@@ -72768,9 +72768,9 @@ module stdlib_linalg_lapack_w
                  end do
               end do
               call stdlib_wtrmm('L','L','N','N',l,n,cone,v(1,mp),ldv,work,ldb)
-                        
+
               call stdlib_wgemm('N','N',l,n,m - l,cone,v,ldv,b,ldb,cone,work,ldwork)
-                        
+
               call stdlib_wgemm('N','N',k - l,n,m,cone,v(kp,1),ldv,b,ldb,czero,work( &
                         kp,1),ldwork)
               do j = 1,n
@@ -72785,11 +72785,11 @@ module stdlib_linalg_lapack_w
                  end do
               end do
               call stdlib_wgemm('C','N',m - l,n,k,-cone,v,ldv,work,ldwork,cone,b,ldb)
-                        
+
               call stdlib_wgemm('C','N',l,n,k - l,-cone,v(kp,mp),ldv,work(kp,1), &
                         ldwork,cone,b(mp,1),ldb)
               call stdlib_wtrmm('L','L','C','N',l,n,cone,v(1,mp),ldv,work,ldwork)
-                        
+
               do j = 1,n
                  do i = 1,l
                     b(m - l + i,j) = b(m - l + i,j) - work(i,j)
@@ -72812,9 +72812,9 @@ module stdlib_linalg_lapack_w
                  end do
               end do
               call stdlib_wtrmm('R','L','C','N',m,l,cone,v(1,np),ldv,work,ldwork)
-                        
+
               call stdlib_wgemm('N','C',m,l,n - l,cone,b,ldb,v,ldv,cone,work,ldwork)
-                        
+
               call stdlib_wgemm('N','C',m,k - l,n,cone,b,ldb,v(kp,1),ldv,czero,work( &
                         1,kp),ldwork)
               do j = 1,k
@@ -72829,11 +72829,11 @@ module stdlib_linalg_lapack_w
                  end do
               end do
               call stdlib_wgemm('N','N',m,n - l,k,-cone,work,ldwork,v,ldv,cone,b,ldb)
-                        
+
               call stdlib_wgemm('N','N',m,l,k - l,-cone,work(1,kp),ldwork,v(kp,np), &
                         ldv,cone,b(1,np),ldb)
               call stdlib_wtrmm('R','L','N','N',m,l,cone,v(1,np),ldv,work,ldwork)
-                        
+
               do j = 1,l
                  do i = 1,m
                     b(i,n - l + j) = b(i,n - l + j) - work(i,j)
@@ -72861,7 +72861,7 @@ module stdlib_linalg_lapack_w
               call stdlib_wgemm('N','N',l,n,m - l,cone,v(kp,mp),ldv,b(mp,1),ldb, &
                         cone,work(kp,1),ldwork)
               call stdlib_wgemm('N','N',k - l,n,m,cone,v,ldv,b,ldb,czero,work,ldwork)
-                        
+
               do j = 1,n
                  do i = 1,k
                     work(i,j) = work(i,j) + a(i,j)
@@ -72876,7 +72876,7 @@ module stdlib_linalg_lapack_w
               call stdlib_wgemm('C','N',m - l,n,k,-cone,v(1,mp),ldv,work,ldwork,cone, &
                         b(mp,1),ldb)
               call stdlib_wgemm('C','N',l,n,k - l,-cone,v,ldv,work,ldwork,cone,b,ldb)
-                        
+
               call stdlib_wtrmm('L','U','C','N',l,n,cone,v(kp,1),ldv,work(kp,1), &
                         ldwork)
               do j = 1,n
@@ -72905,7 +72905,7 @@ module stdlib_linalg_lapack_w
               call stdlib_wgemm('N','C',m,l,n - l,cone,b(1,np),ldb,v(kp,np),ldv, &
                         cone,work(1,kp),ldwork)
               call stdlib_wgemm('N','C',m,k - l,n,cone,b,ldb,v,ldv,czero,work,ldwork)
-                        
+
               do j = 1,k
                  do i = 1,m
                     work(i,j) = work(i,j) + a(i,j)
@@ -72920,7 +72920,7 @@ module stdlib_linalg_lapack_w
               call stdlib_wgemm('N','N',m,n - l,k,-cone,work,ldwork,v(1,np),ldv,cone, &
                         b(1,np),ldb)
               call stdlib_wgemm('N','N',m,l,k - l,-cone,work,ldwork,v,ldv,cone,b,ldb)
-                        
+
               call stdlib_wtrmm('R','U','N','N',m,l,cone,v(kp,1),ldv,work(1,kp), &
                         ldwork)
               do j = 1,l
@@ -72953,7 +72953,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: ap(*),b(ldb,*),x(ldx,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            character :: transn,transt
@@ -73154,7 +73154,7 @@ module stdlib_linalg_lapack_w
                  end if
               end do
               kase = 0
-210           continue
+              210 continue
               call stdlib_wlacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -73196,7 +73196,7 @@ module stdlib_linalg_lapack_w
            ! Array Arguments
            complex(qp),intent(inout) :: ap(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,upper
            integer(ilp) :: j,jc,jclast,jj
@@ -73290,7 +73290,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: ap(*)
            complex(qp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,upper
            integer(ilp) :: j,jc
@@ -73678,7 +73678,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: a(lda,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,onenrm,upper
            character :: normin
@@ -73734,7 +73734,7 @@ module stdlib_linalg_lapack_w
                  kase1 = 2
               end if
               kase = 0
-10            continue
+              10 continue
               call stdlib_wlacn2(n,work(n + 1),work,ainvnm,kase,isave)
               if (kase /= 0) then
                  if (kase == kase1) then
@@ -73759,7 +73759,7 @@ module stdlib_linalg_lapack_w
               ! compute the estimate of the reciprocal condition number.
               if (ainvnm /= zero) rcond = (one/anorm)/ainvnm
            end if
-20         continue
+           20 continue
            return
      end subroutine stdlib_wtrcon
 
@@ -73797,7 +73797,7 @@ module stdlib_linalg_lapack_w
            ! Parameters
            complex(qp),parameter :: cmzero = (0.0e+0_qp,0.0e+0_qp)
            complex(qp),parameter :: cmone = (1.0e+0_qp,0.0e+0_qp)
-           
+
            ! Local Scalars
            logical(lk) :: allv,bothv,leftv,over,rightv,somev
            integer(ilp) :: i,ii,is,j,k,ki
@@ -73997,7 +73997,7 @@ module stdlib_linalg_lapack_w
            ! Parameters
            integer(ilp),parameter :: nbmin = 8
            integer(ilp),parameter :: nbmax = 128
-           
+
            ! Local Scalars
            logical(lk) :: allv,bothv,leftv,lquery,over,rightv,somev
            integer(ilp) :: i,ii,is,j,k,ki,iv,maxwrk,nb
@@ -74324,7 +74324,7 @@ module stdlib_linalg_lapack_w
               call stdlib_wlartg(t(k,k + 1),t22 - t11,cs,sn,temp)
               ! apply transformation to the matrix t.
               if (k + 2 <= n) call stdlib_wrot(n - k - 1,t(k,k + 2),ldt,t(k + 1,k + 2),ldt,cs,sn)
-                        
+
               call stdlib_wrot(k - 1,t(1,k),1,t(1,k + 1),1,cs,conjg(sn))
               t(k,k) = t22
               t(k + 1,k + 1) = t11
@@ -74357,7 +74357,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: a(lda,*),b(ldb,*),x(ldx,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            character :: transn,transt
@@ -74548,7 +74548,7 @@ module stdlib_linalg_lapack_w
                  end if
               end do
               kase = 0
-210           continue
+              210 continue
               call stdlib_wlacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -74599,7 +74599,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: q(ldq,*),t(ldt,*)
            complex(qp),intent(out) :: w(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wantbh,wantq,wants,wantsp
            integer(ilp) :: ierr,k,kase,ks,lwmin,n1,n2,nn
@@ -74688,7 +74688,7 @@ module stdlib_linalg_lapack_w
               ! estimate sep(t11,t22).
               est = zero
               kase = 0
-30            continue
+              30 continue
               call stdlib_wlacn2(nn,work(nn + 1),work,est,kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -74704,7 +74704,7 @@ module stdlib_linalg_lapack_w
               end if
               sep = scale/est
            end if
-40         continue
+           40 continue
            ! copy reordered eigenvalues to w.
            do k = 1,n
               w(k) = t(k,k)
@@ -74732,7 +74732,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: t(ldt,*),vl(ldvl,*),vr(ldvr,*)
            complex(qp),intent(out) :: work(ldwork,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: somcon,wantbh,wants,wantsp
            character :: normin
@@ -74831,7 +74831,7 @@ module stdlib_linalg_lapack_w
                  est = zero
                  kase = 0
                  normin = 'N'
-30               continue
+                 30 continue
                  call stdlib_wlacn2(n - 1,work(1,n + 1),work,est,kase,isave)
                  if (kase /= 0) then
                     if (kase == 1) then
@@ -74856,7 +74856,7 @@ module stdlib_linalg_lapack_w
                  end if
                  sep(ks) = one/max(est,smlnum)
               end if
-40            continue
+              40 continue
               ks = ks + 1
            end do loop_50
            return
@@ -74871,7 +74871,7 @@ module stdlib_linalg_lapack_w
      !> overflow in X.
 
      subroutine stdlib_wtrsyl(trana,tranb,isgn,m,n,a,lda,b,ldb,c,ldc,scale,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -74884,7 +74884,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: a(lda,*),b(ldb,*)
            complex(qp),intent(inout) :: c(ldc,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notrna,notrnb
            integer(ilp) :: j,k,l
@@ -75103,7 +75103,7 @@ module stdlib_linalg_lapack_w
            ! Array Arguments
            complex(qp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,upper
            integer(ilp) :: j
@@ -75139,7 +75139,7 @@ module stdlib_linalg_lapack_w
                  end if
                  ! compute elements 1:j-1 of j-th column.
                  call stdlib_wtrmv('UPPER','NO TRANSPOSE',diag,j - 1,a,lda,a(1,j),1)
-                           
+
                  call stdlib_wscal(j - 1,ajj,a(1,j),1)
               end do
            else
@@ -75177,7 +75177,7 @@ module stdlib_linalg_lapack_w
            ! Array Arguments
            complex(qp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,upper
            integer(ilp) :: j,jb,nb,nn
@@ -75266,7 +75266,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: a(lda,*)
            complex(qp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit
            ! Intrinsic Functions
@@ -75630,7 +75630,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,iws,ki,kk,ldwork,lwkmin,lwkopt,m1,mu,nb,nbmin, &
@@ -75715,7 +75715,7 @@ module stdlib_linalg_lapack_w
                     ! apply h to a(1:i-1,i:n) from the right
                     call stdlib_wlarzb('RIGHT','NO TRANSPOSE','BACKWARD','ROWWISE',i - 1,n - i + 1, &
                      ib,n - m,a(i,m1),lda,work,ldwork,a(1,i),lda,work(ib + 1),ldwork)
-                               
+
                  end if
               end do
               mu = i + nb - 1
@@ -75758,11 +75758,11 @@ module stdlib_linalg_lapack_w
            real(qp),intent(out) :: phi(*),theta(*)
            complex(qp),intent(out) :: taup1(*),taup2(*),tauq1(*),tauq2(*),work(*)
            complex(qp),intent(inout) :: x11(ldx11,*),x12(ldx12,*),x21(ldx21,*),x22(ldx22,*)
-                     
+
         ! ====================================================================
            ! Parameters
            real(qp),parameter :: realone = 1.0_qp
-           
+
            ! Local Scalars
            logical(lk) :: colmajor,lquery
            integer(ilp) :: i,lworkmin,lworkopt
@@ -75897,7 +75897,7 @@ module stdlib_linalg_lapack_w
                        call stdlib_wlarfgp(m - q - i + 1,x12(i,i),x12(i,i),ldx12,tauq2(i))
                     else
                        call stdlib_wlarfgp(m - q - i + 1,x12(i,i),x12(i,i + 1),ldx12,tauq2(i))
-                                 
+
                     end if
                  end if
                  x12(i,i) = cone
@@ -75921,7 +75921,7 @@ module stdlib_linalg_lapack_w
               ! reduce columns q + 1, ..., p of x12, x22
               do i = q + 1,p
                  call stdlib_wscal(m - q - i + 1,cmplx(-z1*z4,0.0_qp,KIND=qp),x12(i,i),ldx12)
-                           
+
                  call stdlib_wlacgv(m - q - i + 1,x12(i,i),ldx12)
                  if (i >= m - q) then
                     call stdlib_wlarfgp(m - q - i + 1,x12(i,i),x12(i,i),ldx12,tauq2(i))
@@ -75940,10 +75940,10 @@ module stdlib_linalg_lapack_w
               ! reduce columns p + 1, ..., m - q of x12, x22
               do i = 1,m - p - q
                  call stdlib_wscal(m - p - q - i + 1,cmplx(z2*z4,0.0_qp,KIND=qp),x22(q + i,p + i),ldx22)
-                           
+
                  call stdlib_wlacgv(m - p - q - i + 1,x22(q + i,p + i),ldx22)
                  call stdlib_wlarfgp(m - p - q - i + 1,x22(q + i,p + i),x22(q + i,p + i + 1),ldx22,tauq2(p + i))
-                           
+
                  x22(q + i,p + i) = cone
                  call stdlib_wlarf('R',m - p - q - i,m - p - q - i + 1,x22(q + i,p + i),ldx22,tauq2(p + i),x22( &
                            q + i + 1,p + i),ldx22,work)
@@ -75962,7 +75962,7 @@ module stdlib_linalg_lapack_w
                  end if
                  if (i == 1) then
                     call stdlib_wscal(m - p - i + 1,cmplx(z2,0.0_qp,KIND=qp),x21(i,i),ldx21)
-                              
+
                  else
                     call stdlib_wscal(m - p - i + 1,cmplx(z2*cos(phi(i - 1)),0.0_qp,KIND=qp),x21(i,i), &
                                ldx21)
@@ -76037,9 +76037,9 @@ module stdlib_linalg_lapack_w
               ! reduce columns p + 1, ..., m - q of x12, x22
               do i = 1,m - p - q
                  call stdlib_wscal(m - p - q - i + 1,cmplx(z2*z4,0.0_qp,KIND=qp),x22(p + i,q + i),1)
-                           
+
                  call stdlib_wlarfgp(m - p - q - i + 1,x22(p + i,q + i),x22(p + i + 1,q + i),1,tauq2(p + i))
-                           
+
                  x22(p + i,q + i) = cone
                  if (m - p - q /= i) then
                     call stdlib_wlarf('L',m - p - q - i + 1,m - p - q - i,x22(p + i,q + i),1,conjg(tauq2(p + i)), &
@@ -76079,7 +76079,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(out) :: taup1(*),taup2(*),tauq1(*),work(*)
            complex(qp),intent(inout) :: x11(ldx11,*),x21(ldx21,*)
         ! ====================================================================
-           
+
            ! Local Scalars
            real(qp) :: c,s
            integer(ilp) :: childinfo,i,ilarf,iorbdb5,llarf,lorbdb5,lworkmin, &
@@ -76184,7 +76184,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(out) :: taup1(*),taup2(*),tauq1(*),work(*)
            complex(qp),intent(inout) :: x11(ldx11,*),x21(ldx21,*)
         ! ====================================================================
-           
+
            ! Local Scalars
            real(qp) :: c,s
            integer(ilp) :: childinfo,i,ilarf,iorbdb5,llarf,lorbdb5,lworkmin, &
@@ -76299,7 +76299,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(out) :: taup1(*),taup2(*),tauq1(*),work(*)
            complex(qp),intent(inout) :: x11(ldx11,*),x21(ldx21,*)
         ! ====================================================================
-           
+
            ! Local Scalars
            real(qp) :: c,s
            integer(ilp) :: childinfo,i,ilarf,iorbdb5,llarf,lorbdb5,lworkmin, &
@@ -76413,7 +76413,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(out) :: phantom(*),taup1(*),taup2(*),tauq1(*),work(*)
            complex(qp),intent(inout) :: x11(ldx11,*),x21(ldx21,*)
         ! ====================================================================
-           
+
            ! Local Scalars
            real(qp) :: c,s
            integer(ilp) :: childinfo,i,ilarf,iorbdb5,j,llarf,lorbdb5,lworkmin, &
@@ -76468,7 +76468,7 @@ module stdlib_linalg_lapack_w
                  call stdlib_wlarfgp(p,phantom(1),phantom(2),1,taup1(1))
                  call stdlib_wlarfgp(m - p,phantom(p + 1),phantom(p + 2),1,taup2(1))
                  theta(i) = atan2(real(phantom(1),KIND=qp),real(phantom(p + 1),KIND=qp))
-                           
+
                  c = cos(theta(i))
                  s = sin(theta(i))
                  phantom(1) = cone
@@ -76524,7 +76524,7 @@ module stdlib_linalg_lapack_w
            do i = p + 1,q
               call stdlib_wlacgv(q - i + 1,x21(m - q + i - p,i),ldx21)
               call stdlib_wlarfgp(q - i + 1,x21(m - q + i - p,i),x21(m - q + i - p,i + 1),ldx21,tauq1(i))
-                        
+
               x21(m - q + i - p,i) = cone
               call stdlib_wlarf('R',q - i,q - i + 1,x21(m - q + i - p,i),ldx21,tauq1(i),x21(m - q + i - p + 1,i) &
                         ,ldx21,work(ilarf))
@@ -76558,7 +76558,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(out) :: work(*)
            complex(qp),intent(inout) :: x1(*),x2(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: childinfo,i,j
            ! Intrinsic Function
@@ -76659,7 +76659,7 @@ module stdlib_linalg_lapack_w
            real(qp),parameter :: alphasq = 0.01_qp
            real(qp),parameter :: realone = 1.0_qp
            real(qp),parameter :: realzero = 0.0_qp
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(qp) :: normsq1,normsq2,scl1,scl2,ssq1,ssq2
@@ -76789,11 +76789,11 @@ module stdlib_linalg_lapack_w
            real(qp),intent(out) :: theta(*)
            real(qp),intent(out) :: rwork(*)
            complex(qp),intent(out) :: u1(ldu1,*),u2(ldu2,*),v1t(ldv1t,*),v2t(ldv2t,*),work(*)
-                     
+
            complex(qp),intent(inout) :: x11(ldx11,*),x12(ldx12,*),x21(ldx21,*),x22(ldx22,*)
-                     
+
         ! ===================================================================
-           
+
            ! Local Scalars
            character :: transt,signst
            integer(ilp) :: childinfo,i,ib11d,ib11e,ib12d,ib12e,ib21d,ib21e,ib22d,ib22e, &
@@ -77004,7 +77004,7 @@ module stdlib_linalg_lapack_w
                  call stdlib_wlacpy('L',m - q,p,x12,ldx12,v2t,ldv2t)
                  if (m > p + q) then
                     call stdlib_wlacpy('L',m - p - q,m - p - q,x22(p1,q1),ldx22,v2t(p + 1,p + 1),ldv2t)
-                              
+
                  end if
                  call stdlib_wungqr(m - q,m - q,m - q,v2t,ldv2t,work(itauq2),work(iorgqr), &
                            lorgqrwork,info)
@@ -77083,7 +77083,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: x11(ldx11,*),x21(ldx21,*)
            integer(ilp),intent(out) :: iwork(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: childinfo,i,ib11d,ib11e,ib12d,ib12e,ib21d,ib21e,ib22d,ib22e, &
            ibbcsd,iorbdb,iorglq,iorgqr,iphi,itaup1,itaup2,itauq1,j,lbbcsd,lorbdb, &
@@ -77183,13 +77183,13 @@ module stdlib_linalg_lapack_w
                  end if
                  if (wantu2 .and. m - p > 0) then
                     call stdlib_wungqr(m - p,m - p,q,u2,ldu2,cdum,work(1),-1,childinfo)
-                              
+
                     lorgqrmin = max(lorgqrmin,m - p)
                     lorgqropt = max(lorgqropt,int(work(1),KIND=ilp))
                  end if
                  if (wantv1t .and. q > 0) then
                     call stdlib_wunglq(q - 1,q - 1,q - 1,v1t,ldv1t,cdum,work(1),-1,childinfo)
-                              
+
                     lorglqmin = max(lorglqmin,q - 1)
                     lorglqopt = max(lorglqopt,int(work(1),KIND=ilp))
                  end if
@@ -77209,7 +77209,7 @@ module stdlib_linalg_lapack_w
                  end if
                  if (wantu2 .and. m - p > 0) then
                     call stdlib_wungqr(m - p,m - p,q,u2,ldu2,cdum,work(1),-1,childinfo)
-                              
+
                     lorgqrmin = max(lorgqrmin,m - p)
                     lorgqropt = max(lorgqropt,int(work(1),KIND=ilp))
                  end if
@@ -77257,7 +77257,7 @@ module stdlib_linalg_lapack_w
                  end if
                  if (wantu2 .and. m - p > 0) then
                     call stdlib_wungqr(m - p,m - p,m - q,u2,ldu2,cdum,work(1),-1,childinfo)
-                              
+
                     lorgqrmin = max(lorgqrmin,m - p)
                     lorgqropt = max(lorgqropt,int(work(1),KIND=ilp))
                  end if
@@ -77457,7 +77457,7 @@ module stdlib_linalg_lapack_w
                  call stdlib_wlacpy('U',p - (m - q),q - (m - q),x11(m - q + 1,m - q + 1),ldx11,v1t(m - q + 1,m - q + &
                            1),ldv1t)
                  call stdlib_wlacpy('U',-p + q,q - p,x21(m - q + 1,p + 1),ldx21,v1t(p + 1,p + 1),ldv1t)
-                           
+
                  call stdlib_wunglq(q,q,q,v1t,ldv1t,work(itauq1),work(iorglq),lorglq, &
                            childinfo)
               end if
@@ -77504,7 +77504,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: tau(*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,ii,j,l
            ! Intrinsic Functions
@@ -77539,7 +77539,7 @@ module stdlib_linalg_lapack_w
               ! apply h(i) to a(1:m-k+i,1:n-k+i) from the left
               a(m - n + ii,ii) = cone
               call stdlib_wlarf('LEFT',m - n + ii,ii - 1,a(1,ii),1,tau(i),a,lda,work)
-                        
+
               call stdlib_wscal(m - n + ii - 1,-tau(i),a(1,ii),1)
               a(m - n + ii,ii) = cone - tau(i)
               ! set a(m-k+i+1:m,n-k+i) to czero
@@ -77568,7 +77568,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: tau(*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,l
            ! Intrinsic Functions
@@ -77645,7 +77645,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: tau(*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wantq
            integer(ilp) :: i,iinfo,j,lwkopt,mn
@@ -77729,7 +77729,7 @@ module stdlib_linalg_lapack_w
                  if (m > 1) then
                     ! form q(2:m,2:m)
                     call stdlib_wungqr(m - 1,m - 1,m - 1,a(2,2),lda,tau,work,lwork,iinfo)
-                              
+
                  end if
               end if
            else
@@ -77756,7 +77756,7 @@ module stdlib_linalg_lapack_w
                  if (n > 1) then
                     ! form p**h(2:n,2:n)
                     call stdlib_wunglq(n - 1,n - 1,n - 1,a(2,2),lda,tau,work,lwork,iinfo)
-                              
+
                  end if
               end if
            end if
@@ -77781,7 +77781,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: tau(*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,iinfo,j,lwkopt,nb,nh
@@ -77872,7 +77872,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: tau(*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,l
            ! Intrinsic Functions
@@ -77943,7 +77943,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: tau(*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,iinfo,iws,j,ki,kk,l,ldwork,lwkopt,nb,nbmin,nx
@@ -78059,7 +78059,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: tau(*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,iinfo,iws,j,kk,l,ldwork,lwkopt,nb,nbmin,nx
@@ -78145,7 +78145,7 @@ module stdlib_linalg_lapack_w
                     ! apply h to a(1:m-k+i+ib-1,1:n-k+i-1) from the left
                     call stdlib_wlarfb('LEFT','NO TRANSPOSE','BACKWARD','COLUMNWISE',m - k + i + ib - &
                     1,n - k + i - 1,ib,a(1,n - k + i),lda,work,ldwork,a,lda,work(ib + 1),ldwork)
-                              
+
                  end if
                  ! apply h to rows 1:m-k+i+ib-1 of current block
                  call stdlib_wung2l(m - k + i + ib - 1,ib,ib,a(1,n - k + i),lda,tau(i),work,iinfo &
@@ -78180,7 +78180,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: tau(*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,iinfo,iws,j,ki,kk,l,ldwork,lwkopt,nb,nbmin,nx
@@ -78296,7 +78296,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: tau(*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,ii,j,l
            ! Intrinsic Functions
@@ -78364,7 +78364,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: tau(*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,ii,iinfo,iws,j,kk,l,ldwork,lwkopt,nb,nbmin,nx
@@ -78451,11 +78451,11 @@ module stdlib_linalg_lapack_w
                     ! apply h**h to a(1:m-k+i-1,1:n-k+i+ib-1) from the right
                     call stdlib_wlarfb('RIGHT','CONJUGATE TRANSPOSE','BACKWARD','ROWWISE',ii - &
                     1,n - k + i + ib - 1,ib,a(ii,1),lda,work,ldwork,a,lda,work(ib + 1),ldwork)
-                              
+
                  end if
                  ! apply h**h to columns 1:n-k+i+ib-1 of current block
                  call stdlib_wungr2(ib,n - k + i + ib - 1,ib,a(ii,1),lda,tau(i),work,iinfo)
-                           
+
                  ! set columns n-k+i+ib:n of current block to czero
                  do l = n - k + i + ib,n
                     do j = ii,ii + ib - 1
@@ -78487,7 +78487,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: tau(*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper
            integer(ilp) :: i,iinfo,j,lwkopt,nb
@@ -78562,7 +78562,7 @@ module stdlib_linalg_lapack_w
               if (n > 1) then
                  ! generate q(2:n,2:n)
                  call stdlib_wungqr(n - 1,n - 1,n - 1,a(2,2),lda,tau,work,lwork,iinfo)
-                           
+
               end if
            end if
            work(1) = lwkopt
@@ -78587,7 +78587,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: t(ldt,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: iinfo,ldc,lworkopt,lc,lw,nblocal,j
@@ -78695,7 +78695,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: t(ldt,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: nblocal,mb2,m_plus_one,itmp,ib_bottom,lworkopt, &
@@ -78831,7 +78831,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: a(lda,*)
            complex(qp),intent(out) :: d(*),t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,iinfo,j,jb,jbtemp1,jbtemp2,jnb,nplusone
            ! Intrinsic Functions
@@ -78871,7 +78871,7 @@ module stdlib_linalg_lapack_w
            ! (1-2) solve for v2.
            if (m > n) then
               call stdlib_wtrsm('R','U','N','N',m - n,n,cone,a,lda,a(n + 1,1),lda)
-                        
+
            end if
            ! (2) reconstruct the block reflector t stored in t(1:nb, 1:n)
            ! as a sequence of upper-triangular blocks with nb-size column
@@ -78948,7 +78948,7 @@ module stdlib_linalg_lapack_w
      end subroutine stdlib_wunhr_col
 
      pure subroutine stdlib_wunm22(side,trans,m,n,n1,n2,q,ldq,c,ldc,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -78961,7 +78961,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(inout) :: c(ldc,*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            integer(ilp) :: i,ldwork,len,lwkopt,nb,nq,nw
@@ -79020,12 +79020,12 @@ module stdlib_linalg_lapack_w
            ! degenerate cases (n1 = 0 or n2 = 0) are handled using stdlib_wtrmm.
            if (n1 == 0) then
               call stdlib_wtrmm(side,'UPPER',trans,'NON-UNIT',m,n,cone,q,ldq,c,ldc)
-                        
+
               work(1) = cone
               return
            else if (n2 == 0) then
               call stdlib_wtrmm(side,'LOWER',trans,'NON-UNIT',m,n,cone,q,ldq,c,ldc)
-                        
+
               work(1) = cone
               return
            end if
@@ -79045,7 +79045,7 @@ module stdlib_linalg_lapack_w
                               c(1,i),ldc,cone,work,ldwork)
                     ! multiply top part of c by q21.
                     call stdlib_wlacpy('ALL',n2,len,c(1,i),ldc,work(n1 + 1),ldwork)
-                              
+
                     call stdlib_wtrmm('LEFT','UPPER','NO TRANSPOSE','NON-UNIT',n2,len,cone, &
                               q(n1 + 1,1),ldq,work(n1 + 1),ldwork)
                     ! multiply bottom part of c by q22.
@@ -79067,7 +79067,7 @@ module stdlib_linalg_lapack_w
                               1,i),ldc,cone,work,ldwork)
                     ! multiply top part of c by q12**h.
                     call stdlib_wlacpy('ALL',n1,len,c(1,i),ldc,work(n2 + 1),ldwork)
-                              
+
                     call stdlib_wtrmm('LEFT','LOWER','CONJUGATE','NON-UNIT',n1,len,cone,q( &
                               1,n2 + 1),ldq,work(n2 + 1),ldwork)
                     ! multiply bottom part of c by q22**h.
@@ -79152,7 +79152,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: tau(*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: left,notran
            integer(ilp) :: i,i1,i2,i3,mi,ni,nq
@@ -79251,7 +79251,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: tau(*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: left,notran
            integer(ilp) :: i,i1,i2,i3,ic,jc,mi,ni,nq
@@ -79614,7 +79614,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: tau(*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: left,notran
            integer(ilp) :: i,i1,i2,i3,ic,jc,mi,ni,nq
@@ -79689,7 +79689,7 @@ module stdlib_linalg_lapack_w
               aii = a(i,i)
               a(i,i) = cone
               call stdlib_wlarf(side,mi,ni,a(i,i),lda,taui,c(ic,jc),ldc,work)
-                        
+
               a(i,i) = aii
               if (i < nq) call stdlib_wlacgv(nq - i,a(i,i + 1),lda)
            end do
@@ -79707,7 +79707,7 @@ module stdlib_linalg_lapack_w
      !> if SIDE = 'R'.
 
      pure subroutine stdlib_wunmlq(side,trans,m,n,k,a,lda,tau,c,ldc,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -79724,7 +79724,7 @@ module stdlib_linalg_lapack_w
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            character :: transt
@@ -79850,7 +79850,7 @@ module stdlib_linalg_lapack_w
      !> if SIDE = 'R'.
 
      pure subroutine stdlib_wunmql(side,trans,m,n,k,a,lda,tau,c,ldc,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -79867,7 +79867,7 @@ module stdlib_linalg_lapack_w
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            integer(ilp) :: i,i1,i2,i3,ib,iinfo,iwt,ldwork,lwkopt,mi,nb,nbmin,ni,nq, &
@@ -79911,7 +79911,7 @@ module stdlib_linalg_lapack_w
                  lwkopt = 1
               else
                  nb = min(nbmax,stdlib_ilaenv(1,'ZUNMQL',side//trans,m,n,k,-1))
-                           
+
                  lwkopt = nw*nb + tsize
               end if
               work(1) = lwkopt
@@ -79987,7 +79987,7 @@ module stdlib_linalg_lapack_w
      !> if SIDE = 'R'.
 
      pure subroutine stdlib_wunmqr(side,trans,m,n,k,a,lda,tau,c,ldc,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -80004,7 +80004,7 @@ module stdlib_linalg_lapack_w
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            integer(ilp) :: i,i1,i2,i3,ib,ic,iinfo,iwt,jc,ldwork,lwkopt,mi,nb,nbmin, &
@@ -80137,7 +80137,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: tau(*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: left,notran
            integer(ilp) :: i,i1,i2,i3,mi,ni,nq
@@ -80226,7 +80226,7 @@ module stdlib_linalg_lapack_w
      !> if SIDE = 'R'.
 
      pure subroutine stdlib_wunmr3(side,trans,m,n,k,l,a,lda,tau,c,ldc,work,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -80314,7 +80314,7 @@ module stdlib_linalg_lapack_w
                  taui = conjg(tau(i))
               end if
               call stdlib_wlarz(side,mi,ni,l,a(i,ja),lda,taui,c(ic,jc),ldc,work)
-                        
+
            end do
            return
      end subroutine stdlib_wunmr3
@@ -80330,7 +80330,7 @@ module stdlib_linalg_lapack_w
      !> if SIDE = 'R'.
 
      pure subroutine stdlib_wunmrq(side,trans,m,n,k,a,lda,tau,c,ldc,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -80347,7 +80347,7 @@ module stdlib_linalg_lapack_w
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            character :: transt
@@ -80392,7 +80392,7 @@ module stdlib_linalg_lapack_w
                  lwkopt = 1
               else
                  nb = min(nbmax,stdlib_ilaenv(1,'ZUNMRQ',side//trans,m,n,k,-1))
-                           
+
                  lwkopt = nw*nb + tsize
               end if
               work(1) = lwkopt
@@ -80490,7 +80490,7 @@ module stdlib_linalg_lapack_w
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            character :: transt
@@ -80537,7 +80537,7 @@ module stdlib_linalg_lapack_w
                  lwkopt = 1
               else
                  nb = min(nbmax,stdlib_ilaenv(1,'ZUNMRQ',side//trans,m,n,k,-1))
-                           
+
                  lwkopt = nw*nb + tsize
               end if
               work(1) = lwkopt
@@ -80566,7 +80566,7 @@ module stdlib_linalg_lapack_w
            if (nb < nbmin .or. nb >= k) then
               ! use unblocked code
               call stdlib_wunmr3(side,trans,m,n,k,l,a,lda,tau,c,ldc,work,iinfo)
-                        
+
            else
               ! use blocked code
               iwt = 1 + nw*nb
@@ -80751,7 +80751,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: ap(*),tau(*)
            complex(qp),intent(out) :: q(ldq,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,iinfo,ij,j
@@ -80844,7 +80844,7 @@ module stdlib_linalg_lapack_w
            complex(qp),intent(in) :: tau(*)
            complex(qp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: forwrd,left,notran,upper
            integer(ilp) :: i,i1,i2,i3,ic,ii,jc,mi,ni,nq
@@ -80965,7 +80965,7 @@ module stdlib_linalg_lapack_w
                     taui = conjg(tau(i))
                  end if
                  call stdlib_wlarf(side,mi,ni,ap(ii),1,taui,c(ic,jc),ldc,work)
-                           
+
                  ap(ii) = aii
                  if (forwrd) then
                     ii = ii + nq - i + 1

--- a/src/stdlib_linalg_lapack_w.f90
+++ b/src/stdlib_linalg_lapack_w.f90
@@ -11,6 +11,7 @@ module stdlib_linalg_lapack_w
      private
 
      public :: sp,dp,qp,lk,ilp
+     public :: stdlib_wlag2w
      public :: stdlib_wbbcsd
      public :: stdlib_wbdsqr
      public :: stdlib_wcgesv
@@ -500,6 +501,35 @@ module stdlib_linalg_lapack_w
      real(qp),parameter,private :: sbig = rradix**(-ceiling((maxexp + digits(zero) - 1)*half))
 
      contains
+
+     !> ZLAG2W: converts a COMPLEX matrix, SA, to a COMPLEX*16 matrix, A.
+     !> Note that while it is possible to overflow while converting
+     !> from double to single, it is not possible to overflow when
+     !> converting from single to double.
+     !> This is an auxiliary routine so there is no argument checking.
+
+     pure subroutine stdlib_wlag2w(m,n,sa,ldsa,a,lda,info)
+        ! -- lapack auxiliary routine --
+        ! -- lapack is a software package provided by univ. of tennessee,    --
+        ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
+           ! Scalar Arguments
+           integer(ilp),intent(out) :: info
+           integer(ilp),intent(in) :: lda,ldsa,m,n
+           ! Array Arguments
+           complex(qp),intent(in) :: sa(ldsa,*)
+           complex(qp),intent(out) :: a(lda,*)
+        ! =====================================================================
+           ! Local Scalars
+           integer(ilp) :: i,j
+           ! Executable Statements
+           info = 0
+           do j = 1,n
+              do i = 1,m
+                 a(i,j) = sa(i,j)
+              end do
+           end do
+           return
+     end subroutine stdlib_wlag2w
 
      !> ZBBCSD: computes the CS decomposition of a unitary matrix in
      !> bidiagonal-block form,

--- a/src/stdlib_linalg_lapack_z.f90
+++ b/src/stdlib_linalg_lapack_z.f90
@@ -500,7 +500,7 @@ module stdlib_linalg_lapack_z
 
      contains
 
-     !> ZLAG2W: converts a COMPLEX*16 matrix, SA, to a QUAD-COMPLEX matrix, A.
+     !> ZLAG2W: converts a COMPLEX matrix, SA, to a COMPLEX*16 matrix, A.
      !> Note that while it is possible to overflow while converting
      !> from double to single, it is not possible to overflow when
      !> converting from single to double.

--- a/src/stdlib_linalg_lapack_z.f90
+++ b/src/stdlib_linalg_lapack_z.f90
@@ -543,7 +543,7 @@ module stdlib_linalg_lapack_z
            ! Array Arguments
            complex(dp),intent(inout) :: sx(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: done
            real(dp) :: bignum,cden,cden1,cnum,cnum1,mul,smlnum
@@ -559,7 +559,7 @@ module stdlib_linalg_lapack_z
            ! initialize the denominator to sa and the numerator to 1.
            cden = sa
            cnum = one
-10         continue
+           10 continue
            cden1 = cden*smlnum
            cnum1 = cnum/bignum
            if (abs(cden1) > abs(cnum) .and. cnum /= zero) then
@@ -594,7 +594,7 @@ module stdlib_linalg_lapack_z
      !> works well in practice.
 
      pure subroutine stdlib_zgbequ(m,n,kl,ku,ab,ldab,r,c,rowcnd,colcnd,amax,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -606,7 +606,7 @@ module stdlib_linalg_lapack_z
            real(dp),intent(out) :: c(*),r(*)
            complex(dp),intent(in) :: ab(ldab,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,kd
            real(dp) :: bignum,rcmax,rcmin,smlnum
@@ -735,7 +735,7 @@ module stdlib_linalg_lapack_z
      !> between sqrt(radix) and 1/sqrt(radix).
 
      pure subroutine stdlib_zgbequb(m,n,kl,ku,ab,ldab,r,c,rowcnd,colcnd,amax,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -747,7 +747,7 @@ module stdlib_linalg_lapack_z
            real(dp),intent(out) :: c(*),r(*)
            complex(dp),intent(in) :: ab(ldab,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,kd
            real(dp) :: bignum,rcmax,rcmin,smlnum,radix,logrdx
@@ -883,7 +883,7 @@ module stdlib_linalg_lapack_z
            integer(ilp),intent(out) :: ipiv(*)
            complex(dp),intent(inout) :: ab(ldab,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,jp,ju,km,kv
            ! Intrinsic Functions
@@ -970,7 +970,7 @@ module stdlib_linalg_lapack_z
            real(dp),intent(in) :: scale(*)
            complex(dp),intent(inout) :: v(ldv,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: leftv,rightv
            integer(ilp) :: i,ii,k
@@ -1025,7 +1025,7 @@ module stdlib_linalg_lapack_z
            ! backward permutation
            ! for  i = ilo-1 step -1 until 1,
                     ! ihi+1 step 1 until n do --
-30   continue
+                    30 continue
            if (stdlib_lsame(job,'P') .or. stdlib_lsame(job,'B')) then
               if (rightv) then
                  loop_40: do ii = 1,n
@@ -1075,7 +1075,7 @@ module stdlib_linalg_lapack_z
            ! Parameters
            real(dp),parameter :: sclfac = 2.0e+0_dp
            real(dp),parameter :: factor = 0.95e+0_dp
-           
+
            ! Local Scalars
            logical(lk) :: noconv
            integer(ilp) :: i,ica,iexc,ira,j,k,l,m
@@ -1109,18 +1109,18 @@ module stdlib_linalg_lapack_z
            ! permutation to isolate eigenvalues if possible
            go to 50
            ! row and column exchange.
-20   continue
+           20 continue
            scale(m) = j
            if (j == m) go to 30
            call stdlib_zswap(l,a(1,j),1,a(1,m),1)
            call stdlib_zswap(n - k + 1,a(j,k),lda,a(m,k),lda)
-30         continue
+           30 continue
            go to(40,80) iexc
            ! search for rows isolating an eigenvalue and push them down.
-40   continue
+           40 continue
            if (l == 1) go to 210
            l = l - 1
-50         continue
+           50 continue
            loop_70: do j = l,1,-1
               loop_60: do i = 1,l
                  if (i == j) cycle loop_60
@@ -1133,9 +1133,9 @@ module stdlib_linalg_lapack_z
            end do loop_70
            go to 90
            ! search for columns isolating an eigenvalue and push them left.
-80   continue
+           80 continue
            k = k + 1
-90         continue
+           90 continue
            loop_110: do j = k,l
               loop_100: do i = k,l
                  if (i == j) cycle loop_100
@@ -1146,7 +1146,7 @@ module stdlib_linalg_lapack_z
               iexc = 2
               go to 20
            end do loop_110
-120        continue
+           120 continue
            do i = k,l
               scale(i) = one
            end do
@@ -1157,7 +1157,7 @@ module stdlib_linalg_lapack_z
            sfmax1 = one/sfmin1
            sfmin2 = sfmin1*sclfac
            sfmax2 = one/sfmin2
-140        continue
+           140 continue
            noconv = .false.
            loop_200: do i = k,l
               c = stdlib_dznrm2(l - k + 1,a(k,i),1)
@@ -1171,7 +1171,7 @@ module stdlib_linalg_lapack_z
               g = r/sclfac
               f = one
               s = c + r
-160           continue
+              160 continue
               if (c >= g .or. max(f,c,ca) >= sfmax2 .or. min(r,g,ra) <= sfmin2) go to 170
                  if (stdlib_disnan(c + f + ca + r + g + ra)) then
                  ! exit if nan to avoid infinite loop
@@ -1186,9 +1186,9 @@ module stdlib_linalg_lapack_z
               g = g/sclfac
               ra = ra/sclfac
               go to 160
-170           continue
+              170 continue
               g = c/sclfac
-180           continue
+              180 continue
               if (g < r .or. max(r,ra) >= sfmax2 .or. min(f,c,g,ca) <= sfmin2) go to 190
               f = f/sclfac
               c = c/sclfac
@@ -1198,7 +1198,7 @@ module stdlib_linalg_lapack_z
               ra = ra*sclfac
               go to 180
               ! now balance.
-190  continue
+              190 continue
               if ((c + r) >= factor*s) cycle loop_200
               if (f < one .and. scale(i) < one) then
                  if (f*scale(i) <= sfmin1) cycle loop_200
@@ -1213,7 +1213,7 @@ module stdlib_linalg_lapack_z
               call stdlib_zdscal(l,f,a(1,i),1)
            end do loop_200
            if (noconv) go to 140
-210        continue
+           210 continue
            ilo = k
            ihi = l
            return
@@ -1241,7 +1241,7 @@ module stdlib_linalg_lapack_z
            real(dp),intent(out) :: c(*),r(*)
            complex(dp),intent(in) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(dp) :: bignum,rcmax,rcmin,smlnum
@@ -1375,7 +1375,7 @@ module stdlib_linalg_lapack_z
            real(dp),intent(out) :: c(*),r(*)
            complex(dp),intent(in) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(dp) :: bignum,rcmax,rcmin,smlnum,radix,logrdx
@@ -1508,7 +1508,7 @@ module stdlib_linalg_lapack_z
            integer(ilp),intent(out) :: ipiv(*),jpiv(*)
            complex(dp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,ip,ipv,j,jp,jpv
            real(dp) :: bignum,eps,smin,smlnum,xmax
@@ -1595,7 +1595,7 @@ module stdlib_linalg_lapack_z
            integer(ilp),intent(out) :: ipiv(*)
            complex(dp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(dp) :: sfmin
            integer(ilp) :: i,j,jp
@@ -1654,7 +1654,7 @@ module stdlib_linalg_lapack_z
      !> ZGGBAL.
 
      pure subroutine stdlib_zggbak(job,side,n,ilo,ihi,lscale,rscale,m,v,ldv,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -1721,7 +1721,7 @@ module stdlib_linalg_lapack_z
               end if
            end if
            ! backward permutation
-30   continue
+           30 continue
            if (stdlib_lsame(job,'P') .or. stdlib_lsame(job,'B')) then
               ! backward permutation on right eigenvectors
               if (rightv) then
@@ -1731,7 +1731,7 @@ module stdlib_linalg_lapack_z
                     if (k == i) cycle loop_40
                     call stdlib_zswap(m,v(i,1),ldv,v(k,1),ldv)
                  end do loop_40
-50               continue
+                 50 continue
                  if (ihi == n) go to 70
                  loop_60: do i = ihi + 1,n
                     k = int(rscale(i),KIND=ilp)
@@ -1740,7 +1740,7 @@ module stdlib_linalg_lapack_z
                  end do loop_60
               end if
               ! backward permutation on left eigenvectors
-70   continue
+              70 continue
               if (leftv) then
                  if (ilo == 1) go to 90
                  loop_80: do i = ilo - 1,1,-1
@@ -1748,7 +1748,7 @@ module stdlib_linalg_lapack_z
                     if (k == i) cycle loop_80
                     call stdlib_zswap(m,v(i,1),ldv,v(k,1),ldv)
                  end do loop_80
-90               continue
+                 90 continue
                  if (ihi == n) go to 110
                  loop_100: do i = ihi + 1,n
                     k = int(lscale(i),KIND=ilp)
@@ -1757,7 +1757,7 @@ module stdlib_linalg_lapack_z
                  end do loop_100
               end if
            end if
-110        continue
+           110 continue
            return
      end subroutine stdlib_zggbak
 
@@ -1772,7 +1772,7 @@ module stdlib_linalg_lapack_z
      !> generalized eigenvalue problem A*x = lambda*B*x.
 
      pure subroutine stdlib_zggbal(job,n,a,lda,b,ldb,ilo,ihi,lscale,rscale,work,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -1786,7 +1786,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: sclfac = 1.0e+1_dp
-           
+
            ! Local Scalars
            integer(ilp) :: i,icab,iflow,ip1,ir,irab,it,j,jc,jp1,k,kount,l,lcab,lm1, &
                      lrab,lsfmax,lsfmin,m,nr,nrp2
@@ -1844,13 +1844,13 @@ module stdlib_linalg_lapack_z
            go to 30
            ! permute the matrices a and b to isolate the eigenvalues.
            ! find row with one nonzero in columns 1 through l
-20   continue
+           20 continue
            l = lm1
            if (l /= 1) go to 30
            rscale(1) = 1
            lscale(1) = 1
            go to 190
-30         continue
+           30 continue
            lm1 = l - 1
            loop_80: do i = l,1,-1
               do j = 1,lm1
@@ -1859,21 +1859,21 @@ module stdlib_linalg_lapack_z
               end do
               j = l
               go to 70
-50            continue
+              50 continue
               do j = jp1,l
                  if (a(i,j) /= czero .or. b(i,j) /= czero) cycle loop_80
               end do
               j = jp1 - 1
-70            continue
+              70 continue
               m = l
               iflow = 1
               go to 160
            end do loop_80
            go to 100
            ! find column with one nonzero in rows k through n
-90   continue
+           90 continue
            k = k + 1
-100        continue
+           100 continue
            loop_150: do j = k,l
               do i = k,lm1
                  ip1 = i + 1
@@ -1881,32 +1881,32 @@ module stdlib_linalg_lapack_z
               end do
               i = l
               go to 140
-120           continue
+              120 continue
               do i = ip1,l
                  if (a(i,j) /= czero .or. b(i,j) /= czero) cycle loop_150
               end do
               i = ip1 - 1
-140           continue
+              140 continue
               m = k
               iflow = 2
               go to 160
            end do loop_150
            go to 190
            ! permute rows m and i
-160  continue
+           160 continue
            lscale(m) = i
            if (i == m) go to 170
            call stdlib_zswap(n - k + 1,a(i,k),lda,a(m,k),lda)
            call stdlib_zswap(n - k + 1,b(i,k),ldb,b(m,k),ldb)
            ! permute columns m and j
-170  continue
+           170 continue
            rscale(m) = j
            if (j == m) go to 180
            call stdlib_zswap(l,a(1,j),1,a(1,m),1)
            call stdlib_zswap(l,b(1,j),1,b(1,m),1)
-180        continue
+           180 continue
            go to(20,90) iflow
-190        continue
+           190 continue
            ilo = k
            ihi = l
            if (stdlib_lsame(job,'P')) then
@@ -1938,13 +1938,13 @@ module stdlib_linalg_lapack_z
                     go to 210
                  end if
                  ta = log10(cabs1(a(i,j)))/basl
-210              continue
+                 210 continue
                  if (b(i,j) == czero) then
                     tb = zero
                     go to 220
                  end if
                  tb = log10(cabs1(b(i,j)))/basl
-220              continue
+                 220 continue
                  work(i + 4*n) = work(i + 4*n) - ta - tb
                  work(j + 5*n) = work(j + 5*n) - ta - tb
               end do
@@ -1956,7 +1956,7 @@ module stdlib_linalg_lapack_z
            beta = zero
            it = 1
            ! start generalized conjugate gradient iteration
-250  continue
+           250 continue
            gamma = stdlib_ddot(nr,work(ilo + 4*n),1,work(ilo + 4*n),1) + stdlib_ddot(nr, &
                      work(ilo + 5*n),1,work(ilo + 5*n),1)
            ew = zero
@@ -1986,7 +1986,7 @@ module stdlib_linalg_lapack_z
                  if (a(i,j) == czero) go to 280
                  kount = kount + 1
                  sum = sum + work(j)
-280              continue
+                 280 continue
                  if (b(i,j) == czero) cycle loop_290
                  kount = kount + 1
                  sum = sum + work(j)
@@ -2000,7 +2000,7 @@ module stdlib_linalg_lapack_z
                  if (a(i,j) == czero) go to 310
                  kount = kount + 1
                  sum = sum + work(i + n)
-310              continue
+                 310 continue
                  if (b(i,j) == czero) cycle loop_320
                  kount = kount + 1
                  sum = sum + work(i + n)
@@ -2027,7 +2027,7 @@ module stdlib_linalg_lapack_z
            it = it + 1
            if (it <= nrp2) go to 250
            ! end generalized conjugate gradient iteration
-350  continue
+           350 continue
            sfmin = stdlib_dlamch('S')
            sfmax = one/sfmin
            lsfmin = int(log10(sfmin)/basl + one,KIND=ilp)
@@ -2080,7 +2080,7 @@ module stdlib_linalg_lapack_z
            ! Array Arguments
            complex(dp),intent(inout) :: b(ldb,*),d(*),dl(*),du(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j,k
            complex(dp) :: mult,temp,zdum
@@ -2149,7 +2149,7 @@ module stdlib_linalg_lapack_z
               if (n > 1) b(n - 1,j) = (b(n - 1,j) - du(n - 1)*b(n,j))/d(n - 1)
               do k = n - 2,1,-1
                  b(k,j) = (b(k,j) - du(k)*b(k + 1,j) - dl(k)*b(k + 2,j))/d(k)
-                           
+
               end do
            end do
            return
@@ -2175,7 +2175,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: d(*),dl(*),du(*)
            complex(dp),intent(out) :: du2(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            complex(dp) :: fact,temp,zdum
@@ -2247,7 +2247,7 @@ module stdlib_linalg_lapack_z
                  go to 50
               end if
            end do
-50         continue
+           50 continue
            return
      end subroutine stdlib_zgttrf
 
@@ -2280,7 +2280,7 @@ module stdlib_linalg_lapack_z
               ! overwriting each right hand side vector with its solution.
               if (nrhs <= 1) then
                  j = 1
-10               continue
+                 10 continue
                  ! solve l*x = b.
                  do i = 1,n - 1
                     if (ipiv(i) == i) then
@@ -2296,7 +2296,7 @@ module stdlib_linalg_lapack_z
                  if (n > 1) b(n - 1,j) = (b(n - 1,j) - du(n - 1)*b(n,j))/d(n - 1)
                  do i = n - 2,1,-1
                     b(i,j) = (b(i,j) - du(i)*b(i + 1,j) - du2(i)*b(i + 2,j))/d(i)
-                              
+
                  end do
                  if (j < nrhs) then
                     j = j + 1
@@ -2319,7 +2319,7 @@ module stdlib_linalg_lapack_z
                     if (n > 1) b(n - 1,j) = (b(n - 1,j) - du(n - 1)*b(n,j))/d(n - 1)
                     do i = n - 2,1,-1
                        b(i,j) = (b(i,j) - du(i)*b(i + 1,j) - du2(i)*b(i + 2,j))/d(i)
-                                 
+
                     end do
                  end do
               end if
@@ -2327,7 +2327,7 @@ module stdlib_linalg_lapack_z
               ! solve a**t * x = b.
               if (nrhs <= 1) then
                  j = 1
-70               continue
+                 70 continue
                  ! solve u**t * x = b.
                  b(1,j) = b(1,j)/d(1)
                  if (n > 1) b(2,j) = (b(2,j) - du(1)*b(1,j))/d(2)
@@ -2374,11 +2374,11 @@ module stdlib_linalg_lapack_z
               ! solve a**h * x = b.
               if (nrhs <= 1) then
                  j = 1
-130              continue
+                 130 continue
                  ! solve u**h * x = b.
                  b(1,j) = b(1,j)/conjg(d(1))
                  if (n > 1) b(2,j) = (b(2,j) - conjg(du(1))*b(1,j))/conjg(d(2))
-                           
+
                  do i = 3,n
                     b(i,j) = (b(i,j) - conjg(du(i - 1))*b(i - 1,j) - conjg(du2(i - 2))*b( &
                               i - 2,j))/conjg(d(i))
@@ -2402,7 +2402,7 @@ module stdlib_linalg_lapack_z
                  ! solve u**h * x = b.
                     b(1,j) = b(1,j)/conjg(d(1))
                     if (n > 1) b(2,j) = (b(2,j) - conjg(du(1))*b(1,j))/conjg(d(2))
-                              
+
                     do i = 3,n
                        b(i,j) = (b(i,j) - conjg(du(i - 1))*b(i - 1,j) - conjg(du2(i - 2)) &
                                  *b(i - 2,j))/conjg(d(i))
@@ -2516,7 +2516,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: sevten = 17.0e+0_dp
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,imax,j,jmax,k,kk,kp,kstep
@@ -2550,7 +2550,7 @@ module stdlib_linalg_lapack_z
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 90
               kstep = 1
@@ -2648,7 +2648,7 @@ module stdlib_linalg_lapack_z
                        ! = a - ( w(k-1) w(k) )*inv(d(k))*( w(k-1) w(k) )**h
                     if (k > 2) then
                        d = stdlib_dlapy2(real(a(k - 1,k),KIND=dp),aimag(a(k - 1,k)))
-                                 
+
                        d22 = real(a(k - 1,k - 1),KIND=dp)/d
                        d11 = real(a(k,k),KIND=dp)/d
                        tt = one/(d11*d22 - one)
@@ -2683,7 +2683,7 @@ module stdlib_linalg_lapack_z
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2
               k = 1
-50            continue
+              50 continue
               ! if k > n, exit from loop
               if (k > n) go to 90
               kstep = 1
@@ -2741,7 +2741,7 @@ module stdlib_linalg_lapack_z
                     ! interchange rows and columns kk and kp in the trailing
                     ! submatrix a(k:n,k:n)
                     if (kp < n) call stdlib_zswap(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     do j = kk + 1,kp - 1
                        t = conjg(a(j,kk))
                        a(j,kk) = conjg(a(kp,j))
@@ -2771,7 +2771,7 @@ module stdlib_linalg_lapack_z
                        ! a := a - l(k)*d(k)*l(k)**h = a - w(k)*(1/d(k))*w(k)**h
                        r1 = one/real(a(k,k),KIND=dp)
                        call stdlib_zher(uplo,n - k,-r1,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                 
+
                        ! store l(k) in column k
                        call stdlib_zdscal(n - k,r1,a(k + 1,k),1)
                     end if
@@ -2784,7 +2784,7 @@ module stdlib_linalg_lapack_z
                        ! where l(k) and l(k+1) are the k-th and (k+1)-th
                        ! columns of l
                        d = stdlib_dlapy2(real(a(k + 1,k),KIND=dp),aimag(a(k + 1,k)))
-                                 
+
                        d11 = real(a(k + 1,k + 1),KIND=dp)/d
                        d22 = real(a(k,k),KIND=dp)/d
                        tt = one/(d11*d22 - one)
@@ -2815,7 +2815,7 @@ module stdlib_linalg_lapack_z
               k = k + kstep
               go to 50
            end if
-90         continue
+           90 continue
            return
      end subroutine stdlib_zhetf2
 
@@ -2844,7 +2844,7 @@ module stdlib_linalg_lapack_z
         ! ======================================================================
            ! Parameters
            real(dp),parameter :: sevten = 17.0e+0_dp
-           
+
            ! Local Scalars
            logical(lk) :: done,upper
            integer(ilp) :: i,ii,imax,itemp,j,jmax,k,kk,kp,kstep,p
@@ -2883,7 +2883,7 @@ module stdlib_linalg_lapack_z
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 34
               kstep = 1
@@ -2919,7 +2919,7 @@ module stdlib_linalg_lapack_z
                  else
                     done = .false.
                     ! loop until pivot found
-12   continue
+                    12 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -3068,7 +3068,7 @@ module stdlib_linalg_lapack_z
                     if (k > 2) then
                        ! d = |a12|
                        d = stdlib_dlapy2(real(a(k - 1,k),KIND=dp),aimag(a(k - 1,k)))
-                                 
+
                        d11 = real(a(k,k)/d,KIND=dp)
                        d22 = real(a(k - 1,k - 1)/d,KIND=dp)
                        d12 = a(k - 1,k)/d
@@ -3107,7 +3107,7 @@ module stdlib_linalg_lapack_z
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-34            continue
+              34 continue
            else
               ! factorize a as l*d*l**h using the lower triangle of a
               ! initialize the unused last entry of the subdiagonal array e.
@@ -3115,7 +3115,7 @@ module stdlib_linalg_lapack_z
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop
               if (k > n) go to 64
               kstep = 1
@@ -3151,7 +3151,7 @@ module stdlib_linalg_lapack_z
                  else
                     done = .false.
                     ! loop until pivot found
-42   continue
+                    42 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -3229,7 +3229,7 @@ module stdlib_linalg_lapack_z
                  if (kp /= kk) then
                     ! (1) swap columnar parts
                     if (kp < n) call stdlib_zswap(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     ! (2) swap and conjugate middle parts
                     do j = kk + 1,kp - 1
                        t = conjg(a(j,kk))
@@ -3273,7 +3273,7 @@ module stdlib_linalg_lapack_z
                              ! = a - w(k)*(1/d(k))*w(k)**t
                           d11 = one/real(a(k,k),KIND=dp)
                           call stdlib_zher(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                           ! store l(k) in column k
                           call stdlib_zdscal(n - k,d11,a(k + 1,k),1)
                        else
@@ -3287,7 +3287,7 @@ module stdlib_linalg_lapack_z
                              ! = a - w(k)*(1/d(k))*w(k)**t
                              ! = a - (w(k)/d(k))*(d(k))*(w(k)/d(k))**t
                           call stdlib_zher(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                        end if
                        ! store the subdiagonal element of d in array e
                        e(k) = czero
@@ -3304,7 +3304,7 @@ module stdlib_linalg_lapack_z
                     if (k < n - 1) then
                        ! d = |a21|
                        d = stdlib_dlapy2(real(a(k + 1,k),KIND=dp),aimag(a(k + 1,k)))
-                                 
+
                        d11 = real(a(k + 1,k + 1),KIND=dp)/d
                        d22 = real(a(k,k),KIND=dp)/d
                        d21 = a(k + 1,k)/d
@@ -3343,7 +3343,7 @@ module stdlib_linalg_lapack_z
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 40
-64            continue
+              64 continue
            end if
            return
      end subroutine stdlib_zhetf2_rk
@@ -3370,7 +3370,7 @@ module stdlib_linalg_lapack_z
         ! ======================================================================
            ! Parameters
            real(dp),parameter :: sevten = 17.0e+0_dp
-           
+
            ! Local Scalars
            logical(lk) :: done,upper
            integer(ilp) :: i,ii,imax,itemp,j,jmax,k,kk,kp,kstep,p
@@ -3406,7 +3406,7 @@ module stdlib_linalg_lapack_z
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 70
               kstep = 1
@@ -3440,7 +3440,7 @@ module stdlib_linalg_lapack_z
                  else
                     done = .false.
                     ! loop until pivot found
-12   continue
+                    12 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -3581,7 +3581,7 @@ module stdlib_linalg_lapack_z
                     if (k > 2) then
                        ! d = |a12|
                        d = stdlib_dlapy2(real(a(k - 1,k),KIND=dp),aimag(a(k - 1,k)))
-                                 
+
                        d11 = real(a(k,k)/d,KIND=dp)
                        d22 = real(a(k - 1,k - 1)/d,KIND=dp)
                        d12 = a(k - 1,k)/d
@@ -3619,7 +3619,7 @@ module stdlib_linalg_lapack_z
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop
               if (k > n) go to 70
               kstep = 1
@@ -3653,7 +3653,7 @@ module stdlib_linalg_lapack_z
                  else
                     done = .false.
                     ! loop until pivot found
-42   continue
+                    42 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -3728,7 +3728,7 @@ module stdlib_linalg_lapack_z
                  if (kp /= kk) then
                     ! (1) swap columnar parts
                     if (kp < n) call stdlib_zswap(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     ! (2) swap and conjugate middle parts
                     do j = kk + 1,kp - 1
                        t = conjg(a(j,kk))
@@ -3769,7 +3769,7 @@ module stdlib_linalg_lapack_z
                              ! = a - w(k)*(1/d(k))*w(k)**t
                           d11 = one/real(a(k,k),KIND=dp)
                           call stdlib_zher(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                           ! store l(k) in column k
                           call stdlib_zdscal(n - k,d11,a(k + 1,k),1)
                        else
@@ -3783,7 +3783,7 @@ module stdlib_linalg_lapack_z
                              ! = a - w(k)*(1/d(k))*w(k)**t
                              ! = a - (w(k)/d(k))*(d(k))*(w(k)/d(k))**t
                           call stdlib_zher(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                        end if
                     end if
                  else
@@ -3798,7 +3798,7 @@ module stdlib_linalg_lapack_z
                     if (k < n - 1) then
                        ! d = |a21|
                        d = stdlib_dlapy2(real(a(k + 1,k),KIND=dp),aimag(a(k + 1,k)))
-                                 
+
                        d11 = real(a(k + 1,k + 1),KIND=dp)/d
                        d22 = real(a(k,k),KIND=dp)/d
                        d21 = a(k + 1,k)/d
@@ -3832,7 +3832,7 @@ module stdlib_linalg_lapack_z
               k = k + kstep
               go to 40
            end if
-70         continue
+           70 continue
            return
      end subroutine stdlib_zhetf2_rook
 
@@ -3853,7 +3853,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kp,kstep
@@ -3896,7 +3896,7 @@ module stdlib_linalg_lapack_z
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-30            continue
+              30 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               if (ipiv(k) > 0) then
@@ -3907,7 +3907,7 @@ module stdlib_linalg_lapack_z
                  if (k > 1) then
                     call stdlib_zcopy(k - 1,a(1,k),1,work,1)
                     call stdlib_zhemv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - real(stdlib_zdotc(k - 1,work,1,a(1,k),1), &
                               KIND=dp)
                  end if
@@ -3927,14 +3927,14 @@ module stdlib_linalg_lapack_z
                  if (k > 1) then
                     call stdlib_zcopy(k - 1,a(1,k),1,work,1)
                     call stdlib_zhemv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - real(stdlib_zdotc(k - 1,work,1,a(1,k),1), &
                               KIND=dp)
                     a(k,k + 1) = a(k,k + 1) - stdlib_zdotc(k - 1,a(1,k),1,a(1,k + 1),1)
-                              
+
                     call stdlib_zcopy(k - 1,a(1,k + 1),1,work,1)
                     call stdlib_zhemv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k + 1),1)
-                              
+
                     a(k + 1,k + 1) = a(k + 1,k + 1) - real(stdlib_zdotc(k - 1,work,1,a(1,k + 1), &
                               1),KIND=dp)
                  end if
@@ -3962,13 +3962,13 @@ module stdlib_linalg_lapack_z
               end if
               k = k + kstep
               go to 30
-50            continue
+              50 continue
            else
               ! compute inv(a) from the factorization a = l*d*l**h.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-60            continue
+              60 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 80
               if (ipiv(k) > 0) then
@@ -4034,7 +4034,7 @@ module stdlib_linalg_lapack_z
               end if
               k = k - kstep
               go to 60
-80            continue
+              80 continue
            end if
            return
      end subroutine stdlib_zhetri
@@ -4056,7 +4056,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kp,kstep
@@ -4099,7 +4099,7 @@ module stdlib_linalg_lapack_z
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-30            continue
+              30 continue
               ! if k > n, exit from loop.
               if (k > n) go to 70
               if (ipiv(k) > 0) then
@@ -4110,7 +4110,7 @@ module stdlib_linalg_lapack_z
                  if (k > 1) then
                     call stdlib_zcopy(k - 1,a(1,k),1,work,1)
                     call stdlib_zhemv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - real(stdlib_zdotc(k - 1,work,1,a(1,k),1), &
                               KIND=dp)
                  end if
@@ -4130,14 +4130,14 @@ module stdlib_linalg_lapack_z
                  if (k > 1) then
                     call stdlib_zcopy(k - 1,a(1,k),1,work,1)
                     call stdlib_zhemv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - real(stdlib_zdotc(k - 1,work,1,a(1,k),1), &
                               KIND=dp)
                     a(k,k + 1) = a(k,k + 1) - stdlib_zdotc(k - 1,a(1,k),1,a(1,k + 1),1)
-                              
+
                     call stdlib_zcopy(k - 1,a(1,k + 1),1,work,1)
                     call stdlib_zhemv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k + 1),1)
-                              
+
                     a(k + 1,k + 1) = a(k + 1,k + 1) - real(stdlib_zdotc(k - 1,work,1,a(1,k + 1), &
                               1),KIND=dp)
                  end if
@@ -4197,13 +4197,13 @@ module stdlib_linalg_lapack_z
               end if
               k = k + 1
               go to 30
-70            continue
+              70 continue
            else
               ! compute inv(a) from the factorization a = l*d*l**h.
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-80            continue
+              80 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 120
               if (ipiv(k) > 0) then
@@ -4301,7 +4301,7 @@ module stdlib_linalg_lapack_z
               end if
               k = k - 1
               go to 80
-120           continue
+              120 continue
            end if
            return
      end subroutine stdlib_zhetri_rook
@@ -4329,7 +4329,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: a(lda,*),e(*)
            complex(dp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,j,k,kp
@@ -4487,7 +4487,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: a(lda,*)
            complex(dp),intent(inout) :: c(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,normaltransr,nisodd,notrans
            integer(ilp) :: info,nrowa,j,nk,n1,n2
@@ -4560,7 +4560,7 @@ module stdlib_linalg_lapack_z
                     if (notrans) then
                        ! n is odd, transr = 'n', uplo = 'l', and trans = 'n'
                        call stdlib_zherk('L','N',n1,k,alpha,a(1,1),lda,beta,c(1),n)
-                                 
+
                        call stdlib_zherk('U','N',n2,k,alpha,a(n1 + 1,1),lda,beta,c(n + 1) &
                                  ,n)
                        call stdlib_zgemm('N','C',n2,n1,k,calpha,a(n1 + 1,1),lda,a(1,1) &
@@ -4568,7 +4568,7 @@ module stdlib_linalg_lapack_z
                     else
                        ! n is odd, transr = 'n', uplo = 'l', and trans = 'c'
                        call stdlib_zherk('L','C',n1,k,alpha,a(1,1),lda,beta,c(1),n)
-                                 
+
                        call stdlib_zherk('U','C',n2,k,alpha,a(1,n1 + 1),lda,beta,c(n + 1) &
                                  ,n)
                        call stdlib_zgemm('C','N',n2,n1,k,calpha,a(1,n1 + 1),lda,a(1,1) &
@@ -4745,7 +4745,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: ap(*)
            complex(dp),intent(in) :: bp(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,j1,j1j1,jj,k,k1,k1k1,kk
@@ -4782,7 +4782,7 @@ module stdlib_linalg_lapack_z
                     call stdlib_ztpsv(uplo,'CONJUGATE TRANSPOSE','NON-UNIT',j,bp,ap(j1),1 &
                               )
                     call stdlib_zhpmv(uplo,j - 1,-cone,ap,bp(j1),1,cone,ap(j1),1)
-                              
+
                     call stdlib_zdscal(j - 1,one/bjj,ap(j1),1)
                     ap(jj) = (ap(jj) - stdlib_zdotc(j - 1,ap(j1),1,bp(j1),1))/ &
                               bjj
@@ -4823,7 +4823,7 @@ module stdlib_linalg_lapack_z
                     akk = real(ap(kk),KIND=dp)
                     bkk = real(bp(kk),KIND=dp)
                     call stdlib_ztpmv(uplo,'NO TRANSPOSE','NON-UNIT',k - 1,bp,ap(k1),1)
-                              
+
                     ct = half*akk
                     call stdlib_zaxpy(k - 1,ct,bp(k1),1,ap(k1),1)
                     call stdlib_zhpr2(uplo,k - 1,cone,ap(k1),1,bp(k1),1,ap)
@@ -4874,7 +4874,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: sevten = 17.0e+0_dp
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,imax,j,jmax,k,kc,kk,knc,kp,kpc,kstep,kx,npp
@@ -4907,7 +4907,7 @@ module stdlib_linalg_lapack_z
               ! 1 or 2
               k = n
               kc = (n - 1)*n/2 + 1
-10            continue
+              10 continue
               knc = kc
               ! if k < 1, exit from loop
               if (k < 1) go to 110
@@ -5022,7 +5022,7 @@ module stdlib_linalg_lapack_z
                           wkm1 = d*(d11*ap(j + (k - 2)*(k - 1)/2) - conjg(d12)*ap(j + (k - 1)*k &
                                     /2))
                           wk = d*(d22*ap(j + (k - 1)*k/2) - d12*ap(j + (k - 2)*(k - 1)/2))
-                                    
+
                           do i = j,1,-1
                              ap(i + (j - 1)*j/2) = ap(i + (j - 1)*j/2) - ap(i + (k - 1)*k/2) &
                                        *conjg(wk) - ap(i + (k - 2)*(k - 1)/2)*conjg(wkm1)
@@ -5053,7 +5053,7 @@ module stdlib_linalg_lapack_z
               k = 1
               kc = 1
               npp = n*(n + 1)/2
-60            continue
+              60 continue
               knc = kc
               ! if k > n, exit from loop
               if (k > n) go to 110
@@ -5115,7 +5115,7 @@ module stdlib_linalg_lapack_z
                     ! interchange rows and columns kk and kp in the trailing
                     ! submatrix a(k:n,k:n)
                     if (kp < n) call stdlib_zswap(n - kp,ap(knc + kp - kk + 1),1,ap(kpc + 1),1)
-                              
+
                     kx = knc + kp - kk
                     do j = kk + 1,kp - 1
                        kx = kx + n - j + 1
@@ -5198,7 +5198,7 @@ module stdlib_linalg_lapack_z
               kc = knc + n - k + 2
               go to 60
            end if
-110        continue
+           110 continue
            return
      end subroutine stdlib_zhptrf
 
@@ -5219,7 +5219,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: ap(*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kc,kcnext,kp,kpc,kstep,kx,npp
@@ -5265,7 +5265,7 @@ module stdlib_linalg_lapack_z
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
               kc = 1
-30            continue
+              30 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               kcnext = kc + k
@@ -5302,7 +5302,7 @@ module stdlib_linalg_lapack_z
                               kcnext),1)
                     call stdlib_zcopy(k - 1,ap(kcnext),1,work,1)
                     call stdlib_zhpmv(uplo,k - 1,-cone,ap,work,1,czero,ap(kcnext),1)
-                              
+
                     ap(kcnext + k) = ap(kcnext + k) - real(stdlib_zdotc(k - 1,work,1,ap(kcnext &
                               ),1),KIND=dp)
                  end if
@@ -5335,7 +5335,7 @@ module stdlib_linalg_lapack_z
               k = k + kstep
               kc = kcnext
               go to 30
-50            continue
+              50 continue
            else
               ! compute inv(a) from the factorization a = l*d*l**h.
               ! k is the main loop index, increasing from 1 to n in steps of
@@ -5343,7 +5343,7 @@ module stdlib_linalg_lapack_z
               npp = n*(n + 1)/2
               k = n
               kc = npp
-60            continue
+              60 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 80
               kcnext = kc - (n - k + 2)
@@ -5415,7 +5415,7 @@ module stdlib_linalg_lapack_z
               k = k - kstep
               kc = kcnext
               go to 60
-80            continue
+              80 continue
            end if
            return
      end subroutine stdlib_zhptri
@@ -5435,7 +5435,7 @@ module stdlib_linalg_lapack_z
      !> in computing that entry have at least one zero multiplicand.
 
      subroutine stdlib_zla_gbamv(trans,m,n,kl,ku,alpha,ab,ldab,x,incx,beta,y,incy)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -5446,7 +5446,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: ab(ldab,*),x(*)
            real(dp),intent(inout) :: y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: symb_zero
            real(dp) :: temp,safe1
@@ -5531,7 +5531,7 @@ module stdlib_linalg_lapack_z
                        do j = max(i - kl,1),min(i + ku,lenx)
                           temp = cabs1(ab(kd + i - j,j))
                           symb_zero = symb_zero .and. (x(j) == czero .or. temp == czero)
-                                    
+
                           y(iy) = y(iy) + alpha*cabs1(x(j))*temp
                        end do
                     end if
@@ -5553,7 +5553,7 @@ module stdlib_linalg_lapack_z
                        do j = max(i - kl,1),min(i + ku,lenx)
                           temp = cabs1(ab(ke - i + j,i))
                           symb_zero = symb_zero .and. (x(j) == czero .or. temp == czero)
-                                    
+
                           y(iy) = y(iy) + alpha*cabs1(x(j))*temp
                        end do
                     end if
@@ -5578,7 +5578,7 @@ module stdlib_linalg_lapack_z
                        do j = max(i - kl,1),min(i + ku,lenx)
                           temp = cabs1(ab(kd + i - j,j))
                           symb_zero = symb_zero .and. (x(jx) == czero .or. temp == czero)
-                                    
+
                           y(iy) = y(iy) + alpha*cabs1(x(jx))*temp
                           jx = jx + incx
                        end do
@@ -5602,7 +5602,7 @@ module stdlib_linalg_lapack_z
                        do j = max(i - kl,1),min(i + ku,lenx)
                           temp = cabs1(ab(ke - i + j,i))
                           symb_zero = symb_zero .and. (x(jx) == czero .or. temp == czero)
-                                    
+
                           y(iy) = y(iy) + alpha*cabs1(x(jx))*temp
                           jx = jx + incx
                        end do
@@ -5686,7 +5686,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: a(lda,*),x(*)
            real(dp),intent(inout) :: y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: symb_zero
            real(dp) :: temp,safe1
@@ -5765,7 +5765,7 @@ module stdlib_linalg_lapack_z
                        do j = 1,lenx
                           temp = cabs1(a(i,j))
                           symb_zero = symb_zero .and. (x(j) == czero .or. temp == czero)
-                                    
+
                           y(iy) = y(iy) + alpha*cabs1(x(j))*temp
                        end do
                     end if
@@ -5787,7 +5787,7 @@ module stdlib_linalg_lapack_z
                        do j = 1,lenx
                           temp = cabs1(a(j,i))
                           symb_zero = symb_zero .and. (x(j) == czero .or. temp == czero)
-                                    
+
                           y(iy) = y(iy) + alpha*cabs1(x(j))*temp
                        end do
                     end if
@@ -5812,7 +5812,7 @@ module stdlib_linalg_lapack_z
                        do j = 1,lenx
                           temp = cabs1(a(i,j))
                           symb_zero = symb_zero .and. (x(jx) == czero .or. temp == czero)
-                                    
+
                           y(iy) = y(iy) + alpha*cabs1(x(jx))*temp
                           jx = jx + incx
                        end do
@@ -5836,7 +5836,7 @@ module stdlib_linalg_lapack_z
                        do j = 1,lenx
                           temp = cabs1(a(j,i))
                           symb_zero = symb_zero .and. (x(jx) == czero .or. temp == czero)
-                                    
+
                           y(iy) = y(iy) + alpha*cabs1(x(jx))*temp
                           jx = jx + incx
                        end do
@@ -5917,7 +5917,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: a(lda,*),x(*)
            real(dp),intent(inout) :: y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: symb_zero
            real(dp) :: temp,safe1
@@ -6251,7 +6251,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: a(lda,*),x(*)
            real(dp),intent(inout) :: y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: symb_zero
            real(dp) :: temp,safe1
@@ -6444,7 +6444,7 @@ module stdlib_linalg_lapack_z
              s = (s + s) - s
              y(i) = ((x(i) - s) + w(i)) + y(i)
              x(i) = s
-10           continue
+             10 continue
            return
      end subroutine stdlib_zla_wwaddw
 
@@ -6497,7 +6497,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            integer(ilp) :: i,jlast
            real(dp) :: absxi,altsgn,estold,safmin,temp
@@ -6516,7 +6516,7 @@ module stdlib_linalg_lapack_z
            go to(20,40,70,90,120) isave(1)
            ! ................ entry   (isave( 1 ) = 1)
            ! first iteration.  x has been overwritten by a*x.
-20   continue
+           20 continue
            if (n == 1) then
               v(1) = x(1)
               est = abs(v(1))
@@ -6528,7 +6528,7 @@ module stdlib_linalg_lapack_z
               absxi = abs(x(i))
               if (absxi > safmin) then
                  x(i) = cmplx(real(x(i),KIND=dp)/absxi,aimag(x(i))/absxi,KIND=dp)
-                           
+
               else
                  x(i) = cone
               end if
@@ -6538,11 +6538,11 @@ module stdlib_linalg_lapack_z
            return
            ! ................ entry   (isave( 1 ) = 2)
            ! first iteration.  x has been overwritten by ctrans(a)*x.
-40   continue
+           40 continue
            isave(2) = stdlib_izmax1(n,x,1)
            isave(3) = 2
            ! main loop - iterations 2,3,...,itmax.
-50   continue
+           50 continue
            do i = 1,n
               x(i) = czero
            end do
@@ -6552,7 +6552,7 @@ module stdlib_linalg_lapack_z
            return
            ! ................ entry   (isave( 1 ) = 3)
            ! x has been overwritten by a*x.
-70   continue
+           70 continue
            call stdlib_zcopy(n,x,1,v,1)
            estold = est
            est = stdlib_dzsum1(n,v,1)
@@ -6562,7 +6562,7 @@ module stdlib_linalg_lapack_z
               absxi = abs(x(i))
               if (absxi > safmin) then
                  x(i) = cmplx(real(x(i),KIND=dp)/absxi,aimag(x(i))/absxi,KIND=dp)
-                           
+
               else
                  x(i) = cone
               end if
@@ -6572,7 +6572,7 @@ module stdlib_linalg_lapack_z
            return
            ! ................ entry   (isave( 1 ) = 4)
            ! x has been overwritten by ctrans(a)*x.
-90   continue
+           90 continue
            jlast = isave(2)
            isave(2) = stdlib_izmax1(n,x,1)
            if ((abs(x(jlast)) /= abs(x(isave(2)))) .and. (isave(3) < itmax)) &
@@ -6581,11 +6581,11 @@ module stdlib_linalg_lapack_z
               go to 50
            end if
            ! iteration complete.  final stage.
-100  continue
+           100 continue
            altsgn = one
            do i = 1,n
               x(i) = cmplx(altsgn*(one + real(i - 1,KIND=dp)/real(n - 1,KIND=dp)),KIND=dp)
-                        
+
               altsgn = -altsgn
            end do
            kase = 1
@@ -6593,13 +6593,13 @@ module stdlib_linalg_lapack_z
            return
            ! ................ entry   (isave( 1 ) = 5)
            ! x has been overwritten by a*x.
-120  continue
+           120 continue
            temp = two*(stdlib_dzsum1(n,x,1)/real(3*n,KIND=dp))
            if (temp > est) then
               call stdlib_zcopy(n,x,1,v,1)
               est = temp
            end if
-130        continue
+           130 continue
            kase = 0
            return
      end subroutine stdlib_zlacn2
@@ -6621,7 +6621,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            integer(ilp) :: i,iter,j,jlast,jump
            real(dp) :: absxi,altsgn,estold,safmin,temp
@@ -6642,7 +6642,7 @@ module stdlib_linalg_lapack_z
            go to(20,40,70,90,120) jump
            ! ................ entry   (jump = 1)
            ! first iteration.  x has been overwritten by a*x.
-20   continue
+           20 continue
            if (n == 1) then
               v(1) = x(1)
               est = abs(v(1))
@@ -6654,7 +6654,7 @@ module stdlib_linalg_lapack_z
               absxi = abs(x(i))
               if (absxi > safmin) then
                  x(i) = cmplx(real(x(i),KIND=dp)/absxi,aimag(x(i))/absxi,KIND=dp)
-                           
+
               else
                  x(i) = cone
               end if
@@ -6664,11 +6664,11 @@ module stdlib_linalg_lapack_z
            return
            ! ................ entry   (jump = 2)
            ! first iteration.  x has been overwritten by ctrans(a)*x.
-40   continue
+           40 continue
            j = stdlib_izmax1(n,x,1)
            iter = 2
            ! main loop - iterations 2,3,...,itmax.
-50   continue
+           50 continue
            do i = 1,n
               x(i) = czero
            end do
@@ -6678,7 +6678,7 @@ module stdlib_linalg_lapack_z
            return
            ! ................ entry   (jump = 3)
            ! x has been overwritten by a*x.
-70   continue
+           70 continue
            call stdlib_zcopy(n,x,1,v,1)
            estold = est
            est = stdlib_dzsum1(n,v,1)
@@ -6688,7 +6688,7 @@ module stdlib_linalg_lapack_z
               absxi = abs(x(i))
               if (absxi > safmin) then
                  x(i) = cmplx(real(x(i),KIND=dp)/absxi,aimag(x(i))/absxi,KIND=dp)
-                           
+
               else
                  x(i) = cone
               end if
@@ -6698,7 +6698,7 @@ module stdlib_linalg_lapack_z
            return
            ! ................ entry   (jump = 4)
            ! x has been overwritten by ctrans(a)*x.
-90   continue
+           90 continue
            jlast = j
            j = stdlib_izmax1(n,x,1)
            if ((abs(x(jlast)) /= abs(x(j))) .and. (iter < itmax)) then
@@ -6706,11 +6706,11 @@ module stdlib_linalg_lapack_z
               go to 50
            end if
            ! iteration complete.  final stage.
-100  continue
+           100 continue
            altsgn = one
            do i = 1,n
               x(i) = cmplx(altsgn*(one + real(i - 1,KIND=dp)/real(n - 1,KIND=dp)),KIND=dp)
-                        
+
               altsgn = -altsgn
            end do
            kase = 1
@@ -6718,13 +6718,13 @@ module stdlib_linalg_lapack_z
            return
            ! ................ entry   (jump = 5)
            ! x has been overwritten by a*x.
-120  continue
+           120 continue
            temp = two*(stdlib_dzsum1(n,x,1)/real(3*n,KIND=dp))
            if (temp > est) then
               call stdlib_zcopy(n,x,1,v,1)
               est = temp
            end if
-130        continue
+           130 continue
            kase = 0
            return
      end subroutine stdlib_zlacon
@@ -6828,7 +6828,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: a(lda,*)
            complex(dp),intent(out) :: c(ldc,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,l
            ! Intrinsic Functions
@@ -6843,7 +6843,7 @@ module stdlib_linalg_lapack_z
            end do
            l = m*n + 1
            call stdlib_dgemm('N','N',m,n,n,one,rwork,m,b,ldb,zero,rwork(l),m)
-                     
+
            do j = 1,n
               do i = 1,m
                  c(i,j) = rwork(l + (j - 1)*m + i - 1)
@@ -6855,11 +6855,11 @@ module stdlib_linalg_lapack_z
               end do
            end do
            call stdlib_dgemm('N','N',m,n,n,one,rwork,m,b,ldb,zero,rwork(l),m)
-                     
+
            do j = 1,n
               do i = 1,m
                  c(i,j) = cmplx(real(c(i,j),KIND=dp),rwork(l + (j - 1)*m + i - 1),KIND=dp)
-                           
+
               end do
            end do
            return
@@ -6900,7 +6900,7 @@ module stdlib_linalg_lapack_z
            end do
            return
            ! code for both increments equal to 1
-20   continue
+           20 continue
            do i = 1,n
               ctemp = c*cx(i) + s*cy(i)
               cy(i) = c*cy(i) - s*cx(i)
@@ -6926,7 +6926,7 @@ module stdlib_linalg_lapack_z
            intrinsic :: real,cmplx,aimag
            ! Executable Statements
            call stdlib_dladiv(real(x,KIND=dp),aimag(x),real(y,KIND=dp),aimag(y),zr,zi)
-                     
+
            stdlib_zladiv = cmplx(zr,zi,KIND=dp)
            return
      end function stdlib_zladiv
@@ -6957,7 +6957,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: mone = -1.0_dp
-           
+
            ! Local Scalars
            integer(ilp) :: i,imax,j,jlam,jmax,jp,k2,n1,n1p1,n2
            real(dp) :: c,eps,s,t,tau,tol
@@ -7051,7 +7051,7 @@ module stdlib_linalg_lapack_z
                  go to 70
               end if
            end do
-70         continue
+           70 continue
            j = j + 1
            if (j > n) go to 90
            if (rho*abs(z(j)) <= tol) then
@@ -7085,7 +7085,7 @@ module stdlib_linalg_lapack_z
                  d(jlam) = t
                  k2 = k2 - 1
                  i = 1
-80               continue
+                 80 continue
                  if (k2 + i <= n) then
                     if (d(jlam) < d(indxp(k2 + i))) then
                        indxp(k2 + i - 1) = indxp(k2 + i)
@@ -7108,13 +7108,13 @@ module stdlib_linalg_lapack_z
               end if
            end if
            go to 70
-90         continue
+           90 continue
            ! record the last eigenvalue.
            k = k + 1
            w(k) = z(jlam)
            dlamda(k) = d(jlam)
            indxp(k) = jlam
-100        continue
+           100 continue
            ! sort the eigenvalues and corresponding eigenvectors into dlamda
            ! and q2 respectively.  the eigenvalues/vectors which were not
            ! deflated go into the first k slots of dlamda and q2 respectively,
@@ -7154,7 +7154,7 @@ module stdlib_linalg_lapack_z
        ! =====================================================================
            ! Parameters
            real(dp),parameter :: thresh = 0.1_dp
-           
+
            ! Local Scalars
            real(dp) :: babs,evnorm,tabs,z
            complex(dp) :: s,t,tmp
@@ -7238,7 +7238,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: a,b,c
            complex(dp),intent(out) :: sn1
        ! =====================================================================
-           
+
            ! Local Scalars
            real(dp) :: t
            complex(dp) :: w
@@ -7251,7 +7251,7 @@ module stdlib_linalg_lapack_z
               w = conjg(b)/abs(b)
            end if
            call stdlib_dlaev2(real(a,KIND=dp),abs(b),real(c,KIND=dp),rt1,rt2,cs1,t)
-                     
+
            sn1 = w*t
            return
      end subroutine stdlib_zlaev2
@@ -7291,7 +7291,7 @@ module stdlib_linalg_lapack_z
               end do
            end do
            info = 0
-30         continue
+           30 continue
            return
      end subroutine stdlib_zlag2c
 
@@ -7302,7 +7302,7 @@ module stdlib_linalg_lapack_z
      !> 0., 1., or -1.
 
      pure subroutine stdlib_zlagtm(trans,n,nrhs,alpha,dl,d,du,x,ldx,beta,b,ldb)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -7314,7 +7314,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: b(ldb,*)
            complex(dp),intent(in) :: d(*),dl(*),du(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            ! Intrinsic Functions
@@ -7460,7 +7460,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: sevten = 17.0e+0_dp
-           
+
            ! Local Scalars
            integer(ilp) :: imax,j,jb,jj,jmax,jp,k,kk,kkw,kp,kstep,kw
            real(dp) :: absakk,alpha,colmax,r1,rowmax,t
@@ -7482,7 +7482,7 @@ module stdlib_linalg_lapack_z
               ! k is the main loop index, decreasing from n in steps of 1 or 2
               ! kw is the column of w which corresponds to column k of a
               k = n
-10            continue
+              10 continue
               kw = nb + k - n
               ! exit from loop
               if ((k <= n - nb + 1 .and. nb < n) .or. k < 1) go to 30
@@ -7525,7 +7525,7 @@ module stdlib_linalg_lapack_z
                     call stdlib_zcopy(imax - 1,a(1,imax),1,w(1,kw - 1),1)
                     w(imax,kw - 1) = real(a(imax,imax),KIND=dp)
                     call stdlib_zcopy(k - imax,a(imax,imax + 1),lda,w(imax + 1,kw - 1),1)
-                              
+
                     call stdlib_zlacgv(k - imax,w(imax + 1,kw - 1),1)
                     if (k < n) then
                        call stdlib_zgemv('NO TRANSPOSE',k,n - k,-cone,a(1,k + 1),lda,w(imax, &
@@ -7683,7 +7683,7 @@ module stdlib_linalg_lapack_z
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-30            continue
+              30 continue
               ! update the upper triangle of a11 (= a(1:k,1:k)) as
               ! a11 := a11 - u12*d*u12**h = a11 - u12*w**h
               ! computing blocks of nb columns at a time (note that conjg(w) is
@@ -7704,7 +7704,7 @@ module stdlib_linalg_lapack_z
               ! put u12 in standard form by partially undoing the interchanges
               ! in columns k+1:n looping backwards from k+1 to n
               j = k + 1
-60            continue
+              60 continue
                  ! undo the interchanges (if any) of rows jj and jp at each
                  ! step j
                  ! (here, j is a diagonal index)
@@ -7729,7 +7729,7 @@ module stdlib_linalg_lapack_z
               ! for use in updating a22 (note that conjg(w) is actually stored)
               ! k is the main loop index, increasing from 1 in steps of 1 or 2
               k = 1
-70            continue
+              70 continue
               ! exit from loop
               if ((k >= nb .and. nb < n) .or. k > n) go to 90
               kstep = 1
@@ -7818,7 +7818,7 @@ module stdlib_linalg_lapack_z
                     call stdlib_zcopy(kp - kk - 1,a(kk + 1,kk),1,a(kp,kk + 1),lda)
                     call stdlib_zlacgv(kp - kk - 1,a(kp,kk + 1),lda)
                     if (kp < n) call stdlib_zcopy(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     ! interchange rows kk and kp in first k-1 columns of a
                     ! (columns k (or k and k+1 for 2-by-2 pivot) of a will be
                     ! later overwritten). interchange rows kk and kp
@@ -7924,7 +7924,7 @@ module stdlib_linalg_lapack_z
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 70
-90            continue
+              90 continue
               ! update the lower triangle of a22 (= a(k:n,k:n)) as
               ! a22 := a22 - l21*d*l21**h = a22 - l21*w**h
               ! computing blocks of nb columns at a time (note that conjg(w) is
@@ -7945,7 +7945,7 @@ module stdlib_linalg_lapack_z
               ! put l21 in standard form by partially undoing the interchanges
               ! of rows in columns 1:k-1 looping backwards from k-1 to 1
               j = k - 1
-120           continue
+              120 continue
                  ! undo the interchanges (if any) of rows jj and jp at each
                  ! step j
                  ! (here, j is a diagonal index)
@@ -7960,7 +7960,7 @@ module stdlib_linalg_lapack_z
                  ! of the rows to swap back doesn't include diagonal element)
                  j = j - 1
                  if (jp /= jj .and. j >= 1) call stdlib_zswap(j,a(jp,1),lda,a(jj,1),lda)
-                           
+
               if (j > 1) go to 120
               ! set kb to the number of columns factorized
               kb = k - 1
@@ -7996,7 +7996,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: sevten = 17.0e+0_dp
-           
+
            ! Local Scalars
            logical(lk) :: done
            integer(ilp) :: imax,itemp,ii,j,jb,jj,jmax,k,kk,kkw,kp,kstep,kw,p
@@ -8023,7 +8023,7 @@ module stdlib_linalg_lapack_z
               e(1) = czero
               ! k is the main loop index, decreasing from n in steps of 1 or 2
               k = n
-10            continue
+              10 continue
               ! kw is the column of w which corresponds to column k of a
               kw = nb + k - n
               ! exit from loop
@@ -8070,14 +8070,14 @@ module stdlib_linalg_lapack_z
                  else
                     ! lop until pivot found
                     done = .false.
-12                  continue
+                    12 continue
                        ! begin pivot search loop body
                        ! copy column imax to column kw-1 of w and update it
                        if (imax > 1) call stdlib_zcopy(imax - 1,a(1,imax),1,w(1,kw - 1),1)
-                                 
+
                        w(imax,kw - 1) = real(a(imax,imax),KIND=dp)
                        call stdlib_zcopy(k - imax,a(imax,imax + 1),lda,w(imax + 1,kw - 1),1)
-                                 
+
                        call stdlib_zlacgv(k - imax,w(imax + 1,kw - 1),1)
                        if (k < n) then
                           call stdlib_zgemv('NO TRANSPOSE',k,n - k,-cone,a(1,k + 1),lda,w( &
@@ -8290,7 +8290,7 @@ module stdlib_linalg_lapack_z
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-30            continue
+              30 continue
               ! update the upper triangle of a11 (= a(1:k,1:k)) as
               ! a11 := a11 - u12*d*u12**h = a11 - u12*w**h
               ! computing blocks of nb columns at a time (note that conjg(w) is
@@ -8318,7 +8318,7 @@ module stdlib_linalg_lapack_z
               e(n) = czero
               ! k is the main loop index, increasing from 1 in steps of 1 or 2
               k = 1
-70            continue
+              70 continue
               ! exit from loop
               if ((k >= nb .and. nb < n) .or. k > n) go to 90
               kstep = 1
@@ -8363,7 +8363,7 @@ module stdlib_linalg_lapack_z
                  else
                     done = .false.
                     ! loop until pivot found
-72   continue
+                    72 continue
                        ! begin pivot search loop body
                        ! copy column imax to column k+1 of w and update it
                        call stdlib_zcopy(imax - k,a(imax,k),lda,w(k,k + 1),1)
@@ -8459,7 +8459,7 @@ module stdlib_linalg_lapack_z
                     call stdlib_zcopy(kp - kk - 1,a(kk + 1,kk),1,a(kp,kk + 1),lda)
                     call stdlib_zlacgv(kp - kk - 1,a(kp,kk + 1),lda)
                     if (kp < n) call stdlib_zcopy(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     ! interchange rows kk and kp in first k-1 columns of a
                     ! (column k (or k and k+1 for 2-by-2 pivot) of a will be
                     ! later overwritten). interchange rows kk and kp
@@ -8581,7 +8581,7 @@ module stdlib_linalg_lapack_z
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 70
-90            continue
+              90 continue
               ! update the lower triangle of a22 (= a(k:n,k:n)) as
               ! a22 := a22 - l21*d*l21**h = a22 - l21*w**h
               ! computing blocks of nb columns at a time (note that conjg(w) is
@@ -8634,7 +8634,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: sevten = 17.0e+0_dp
-           
+
            ! Local Scalars
            logical(lk) :: done
            integer(ilp) :: imax,itemp,ii,j,jb,jj,jmax,jp1,jp2,k,kk,kkw,kp,kstep,kw, &
@@ -8659,7 +8659,7 @@ module stdlib_linalg_lapack_z
               ! for use in updating a11 (note that conjg(w) is actually stored)
               ! k is the main loop index, decreasing from n in steps of 1 or 2
               k = n
-10            continue
+              10 continue
               ! kw is the column of w which corresponds to column k of a
               kw = nb + k - n
               ! exit from loop
@@ -8704,14 +8704,14 @@ module stdlib_linalg_lapack_z
                  else
                     ! lop until pivot found
                     done = .false.
-12                  continue
+                    12 continue
                        ! begin pivot search loop body
                        ! copy column imax to column kw-1 of w and update it
                        if (imax > 1) call stdlib_zcopy(imax - 1,a(1,imax),1,w(1,kw - 1),1)
-                                 
+
                        w(imax,kw - 1) = real(a(imax,imax),KIND=dp)
                        call stdlib_zcopy(k - imax,a(imax,imax + 1),lda,w(imax + 1,kw - 1),1)
-                                 
+
                        call stdlib_zlacgv(k - imax,w(imax + 1,kw - 1),1)
                        if (k < n) then
                           call stdlib_zgemv('NO TRANSPOSE',k,n - k,-cone,a(1,k + 1),lda,w( &
@@ -8917,7 +8917,7 @@ module stdlib_linalg_lapack_z
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-30            continue
+              30 continue
               ! update the upper triangle of a11 (= a(1:k,1:k)) as
               ! a11 := a11 - u12*d*u12**h = a11 - u12*w**h
               ! computing blocks of nb columns at a time (note that conjg(w) is
@@ -8938,7 +8938,7 @@ module stdlib_linalg_lapack_z
               ! put u12 in standard form by partially undoing the interchanges
               ! in of rows in columns k+1:n looping backwards from k+1 to n
               j = k + 1
-60            continue
+              60 continue
                  ! undo the interchanges (if any) of rows j and jp2
                  ! (or j and jp2, and j+1 and jp1) at each step j
                  kstep = 1
@@ -8970,7 +8970,7 @@ module stdlib_linalg_lapack_z
               ! for use in updating a22 (note that conjg(w) is actually stored)
               ! k is the main loop index, increasing from 1 in steps of 1 or 2
               k = 1
-70            continue
+              70 continue
               ! exit from loop
               if ((k >= nb .and. nb < n) .or. k > n) go to 90
               kstep = 1
@@ -9013,7 +9013,7 @@ module stdlib_linalg_lapack_z
                  else
                     done = .false.
                     ! loop until pivot found
-72   continue
+                    72 continue
                        ! begin pivot search loop body
                        ! copy column imax to column k+1 of w and update it
                        call stdlib_zcopy(imax - k,a(imax,k),lda,w(k,k + 1),1)
@@ -9109,7 +9109,7 @@ module stdlib_linalg_lapack_z
                     call stdlib_zcopy(kp - kk - 1,a(kk + 1,kk),1,a(kp,kk + 1),lda)
                     call stdlib_zlacgv(kp - kk - 1,a(kp,kk + 1),lda)
                     if (kp < n) call stdlib_zcopy(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     ! interchange rows kk and kp in first k-1 columns of a
                     ! (column k (or k and k+1 for 2-by-2 pivot) of a will be
                     ! later overwritten). interchange rows kk and kp
@@ -9224,7 +9224,7 @@ module stdlib_linalg_lapack_z
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 70
-90            continue
+              90 continue
               ! update the lower triangle of a22 (= a(k:n,k:n)) as
               ! a22 := a22 - l21*d*l21**h = a22 - l21*w**h
               ! computing blocks of nb columns at a time (note that conjg(w) is
@@ -9245,7 +9245,7 @@ module stdlib_linalg_lapack_z
               ! put l21 in standard form by partially undoing the interchanges
               ! of rows in columns 1:k-1 looping backwards from k-1 to 1
               j = k - 1
-120           continue
+              120 continue
                  ! undo the interchanges (if any) of rows j and jp2
                  ! (or j and jp2, and j-1 and jp1) at each step j
                  kstep = 1
@@ -9264,7 +9264,7 @@ module stdlib_linalg_lapack_z
                  ! of the rows to swap back doesn't include diagonal element)
                  j = j - 1
                  if (jp2 /= jj .and. j >= 1) call stdlib_zswap(j,a(jp2,1),lda,a(jj,1),lda)
-                           
+
                  jj = jj - 1
                  if (kstep == 2 .and. jp1 /= jj .and. j >= 1) call stdlib_zswap(j,a(jp1,1),lda,a( &
                             jj,1),lda)
@@ -9309,7 +9309,7 @@ module stdlib_linalg_lapack_z
            ! Array Arguments
            complex(dp),intent(in) :: w(j),x(j)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(dp) :: absalp,absest,absgam,b,eps,norma,s1,s2,scl,t,test,tmp,zeta1, &
                      zeta2
@@ -9392,7 +9392,7 @@ module stdlib_linalg_lapack_z
                  sine = -(alpha/absest)/t
                  cosine = -(gamma/absest)/(one + t)
                  tmp = real(sqrt(sine*conjg(sine) + cosine*conjg(cosine)),KIND=dp)
-                           
+
                  s = sine/tmp
                  c = cosine/tmp
                  sestpr = sqrt(t + one)*absest
@@ -9481,7 +9481,7 @@ module stdlib_linalg_lapack_z
                     sestpr = sqrt(one + t + four*eps*eps*norma)*absest
                  end if
                  tmp = real(sqrt(sine*conjg(sine) + cosine*conjg(cosine)),KIND=dp)
-                           
+
                  s = sine/tmp
                  c = cosine/tmp
                  return
@@ -9523,7 +9523,7 @@ module stdlib_linalg_lapack_z
                  j = i
                  k(j) = -k(j)
                  in = k(j)
-20               continue
+                 20 continue
                  if (k(in) > 0) go to 40
                  do jj = 1,n
                     temp = x(j,jj)
@@ -9534,7 +9534,7 @@ module stdlib_linalg_lapack_z
                  j = in
                  in = k(in)
                  go to 20
-40               continue
+                 40 continue
               end do
            else
               ! backward permutation
@@ -9542,7 +9542,7 @@ module stdlib_linalg_lapack_z
                  if (k(i) > 0) go to 80
                  k(i) = -k(i)
                  j = k(i)
-60               continue
+                 60 continue
                  if (j == i) go to 80
                  do jj = 1,n
                     temp = x(i,jj)
@@ -9552,7 +9552,7 @@ module stdlib_linalg_lapack_z
                  k(j) = -k(j)
                  j = k(j)
                  go to 60
-80               continue
+                 80 continue
               end do
            end if
            return
@@ -9591,7 +9591,7 @@ module stdlib_linalg_lapack_z
                  j = i
                  k(j) = -k(j)
                  in = k(j)
-20               continue
+                 20 continue
                  if (k(in) > 0) go to 40
                  do ii = 1,m
                     temp = x(ii,j)
@@ -9602,7 +9602,7 @@ module stdlib_linalg_lapack_z
                  j = in
                  in = k(in)
                  go to 20
-40               continue
+                 40 continue
               end do
            else
               ! backward permutation
@@ -9610,7 +9610,7 @@ module stdlib_linalg_lapack_z
                  if (k(i) > 0) go to 80
                  k(i) = -k(i)
                  j = k(i)
-60               continue
+                 60 continue
                  if (j == i) go to 80
                  do ii = 1,m
                     temp = x(ii,i)
@@ -9620,7 +9620,7 @@ module stdlib_linalg_lapack_z
                  k(j) = -k(j)
                  j = k(j)
                  go to 60
-80               continue
+                 80 continue
               end do
            end if
            return
@@ -9631,7 +9631,7 @@ module stdlib_linalg_lapack_z
      !> in the vectors R and C.
 
      pure subroutine stdlib_zlaqgb(m,n,kl,ku,ab,ldab,r,c,rowcnd,colcnd,amax,equed)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -9645,7 +9645,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: thresh = 0.1e+0_dp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(dp) :: cj,large,small
@@ -9713,7 +9713,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: thresh = 0.1e+0_dp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(dp) :: cj,large,small
@@ -9780,7 +9780,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: thresh = 0.1e+0_dp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(dp) :: cj,large,small
@@ -9842,7 +9842,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: thresh = 0.1e+0_dp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(dp) :: cj,large,small
@@ -9904,7 +9904,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: thresh = 0.1e+0_dp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,jc
            real(dp) :: cj,large,small
@@ -9972,7 +9972,7 @@ module stdlib_linalg_lapack_z
         ! ================================================================
            ! Parameters
            real(dp),parameter :: rzero = 0.0_dp
-           
+
            ! Local Scalars
            complex(dp) :: cdum,h21s,h31s
            real(dp) :: s
@@ -10032,7 +10032,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: thresh = 0.1e+0_dp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(dp) :: cj,large,small
@@ -10092,7 +10092,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: thresh = 0.1e+0_dp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,jc
            real(dp) :: cj,large,small
@@ -10154,7 +10154,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: thresh = 0.1e+0_dp
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(dp) :: cj,large,small
@@ -10228,7 +10228,7 @@ module stdlib_linalg_lapack_z
            real(dp),intent(out) :: work(*)
            complex(dp),intent(inout) :: z(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: sawnan1,sawnan2
            integer(ilp) :: i,indlpl,indp,inds,indumn,neg1,neg2,r1,r2
@@ -10276,7 +10276,7 @@ module stdlib_linalg_lapack_z
               s = work(inds + i) - lambda
            end do
            sawnan1 = stdlib_disnan(s)
-60         continue
+           60 continue
            if (sawnan1) then
               ! runs a slower version of the above loop if a nan is detected
               neg1 = 0
@@ -10361,7 +10361,7 @@ module stdlib_linalg_lapack_z
                  end if
                  ztz = ztz + real(z(i)*z(i),KIND=dp)
               end do
-220           continue
+              220 continue
            else
               ! run slower loop if nan occurred.
               do i = r - 1,b1,-1
@@ -10377,7 +10377,7 @@ module stdlib_linalg_lapack_z
                  end if
                  ztz = ztz + real(z(i)*z(i),KIND=dp)
               end do
-240           continue
+              240 continue
            end if
            ! compute the fp vector downwards from r in blocks of size blksiz
            if (.not. sawnan1 .and. .not. sawnan2) then
@@ -10390,7 +10390,7 @@ module stdlib_linalg_lapack_z
                  end if
                  ztz = ztz + real(z(i + 1)*z(i + 1),KIND=dp)
               end do
-260           continue
+              260 continue
            else
               ! run slower loop if nan occurred.
               do i = r,bn - 1
@@ -10406,7 +10406,7 @@ module stdlib_linalg_lapack_z
                  end if
                  ztz = ztz + real(z(i + 1)*z(i + 1),KIND=dp)
               end do
-280           continue
+              280 continue
            end if
            ! compute quantities for convergence test
            tmp = one/ztz
@@ -10487,7 +10487,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: b(ldb,*)
            complex(dp),intent(out) :: c(ldc,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,l
            ! Intrinsic Functions
@@ -10502,7 +10502,7 @@ module stdlib_linalg_lapack_z
            end do
            l = m*n + 1
            call stdlib_dgemm('N','N',m,n,m,one,a,lda,rwork,m,zero,rwork(l),m)
-                     
+
            do j = 1,n
               do i = 1,m
                  c(i,j) = rwork(l + (j - 1)*m + i - 1)
@@ -10514,11 +10514,11 @@ module stdlib_linalg_lapack_z
               end do
            end do
            call stdlib_dgemm('N','N',m,n,m,one,a,lda,rwork,m,zero,rwork(l),m)
-                     
+
            do j = 1,n
               do i = 1,m
                  c(i,j) = cmplx(real(c(i,j),KIND=dp),rwork(l + (j - 1)*m + i - 1),KIND=dp)
-                           
+
               end do
            end do
            return
@@ -10546,7 +10546,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: v(*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: applyleft
            integer(ilp) :: i,lastv,lastc
@@ -10620,7 +10620,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: t(ldt,*),v(ldv,*)
            complex(dp),intent(out) :: work(ldwork,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            character :: transt
            integer(ilp) :: i,j
@@ -10941,7 +10941,7 @@ module stdlib_linalg_lapack_z
      !> arrays A, B and T. See Further Details section.
 
      pure subroutine stdlib_zlarfb_gett(ident,m,n,k,t,ldt,a,lda,b,ldb,work,ldwork)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -10953,7 +10953,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: t(ldt,*)
            complex(dp),intent(out) :: work(ldwork,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lnotident
            integer(ilp) :: i,j
@@ -10977,7 +10977,7 @@ module stdlib_linalg_lapack_z
                  ! v1 is not an identy matrix, but unit lower-triangular
                  ! v1 stored in a1 (diagonal ones are not stored).
                  call stdlib_ztrmm('L','L','C','U',k,n - k,cone,a,lda,work,ldwork)
-                           
+
               end if
               ! col2_(3) compute w2: = w2 + (v2**h) * b2 = w2 + (b1**h) * b2
               ! v2 stored in b1.
@@ -10999,7 +10999,7 @@ module stdlib_linalg_lapack_z
                  ! v1 is not an identity matrix, but unit lower-triangular,
                  ! v1 stored in a1 (diagonal ones are not stored).
                  call stdlib_ztrmm('L','L','N','U',k,n - k,cone,a,lda,work,ldwork)
-                           
+
               end if
               ! col2_(7) compute a2: = a2 - w2 =
                                    ! = a(1:k, k+1:n-k) - work(1:k, 1:n-k),
@@ -11096,7 +11096,7 @@ module stdlib_linalg_lapack_z
            ! Array Arguments
            complex(dp),intent(inout) :: x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j,knt
            real(dp) :: alphi,alphr,beta,rsafmn,safmin,xnorm
@@ -11121,7 +11121,7 @@ module stdlib_linalg_lapack_z
               knt = 0
               if (abs(beta) < safmin) then
                  ! xnorm, beta may be inaccurate; scale x and recompute them
-10   continue
+                 10 continue
                  knt = knt + 1
                  call stdlib_zdscal(n - 1,rsafmn,x,incx)
                  beta = beta*rsafmn
@@ -11169,7 +11169,7 @@ module stdlib_linalg_lapack_z
            ! Array Arguments
            complex(dp),intent(inout) :: x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j,knt
            real(dp) :: alphi,alphr,beta,bignum,smlnum,xnorm
@@ -11218,7 +11218,7 @@ module stdlib_linalg_lapack_z
               knt = 0
               if (abs(beta) < smlnum) then
                  ! xnorm, beta may be inaccurate; scale x and recompute them
-10   continue
+                 10 continue
                  knt = knt + 1
                  call stdlib_zdscal(n - 1,bignum,x,incx)
                  beta = beta*bignum
@@ -11303,7 +11303,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(out) :: t(ldt,*)
            complex(dp),intent(in) :: tau(*),v(ldv,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,prevlastv,lastv
            ! Executable Statements
@@ -11429,7 +11429,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: v(*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j
            complex(dp) :: sum,t1,t10,t2,t3,t4,t5,t6,t7,t8,t9,v1,v10,v2,v3,v4,v5, &
@@ -11444,14 +11444,14 @@ module stdlib_linalg_lapack_z
               ! code for general m
               call stdlib_zlarf(side,m,n,v,1,tau,c,ldc,work)
               go to 410
-10            continue
+              10 continue
               ! special code for 1 x 1 householder
               t1 = cone - tau*v(1)*conjg(v(1))
               do j = 1,n
                  c(1,j) = t1*c(1,j)
               end do
               go to 410
-30            continue
+              30 continue
               ! special code for 2 x 2 householder
               v1 = conjg(v(1))
               t1 = tau*conjg(v1)
@@ -11463,7 +11463,7 @@ module stdlib_linalg_lapack_z
                  c(2,j) = c(2,j) - sum*t2
               end do
               go to 410
-50            continue
+              50 continue
               ! special code for 3 x 3 householder
               v1 = conjg(v(1))
               t1 = tau*conjg(v1)
@@ -11478,7 +11478,7 @@ module stdlib_linalg_lapack_z
                  c(3,j) = c(3,j) - sum*t3
               end do
               go to 410
-70            continue
+              70 continue
               ! special code for 4 x 4 householder
               v1 = conjg(v(1))
               t1 = tau*conjg(v1)
@@ -11496,7 +11496,7 @@ module stdlib_linalg_lapack_z
                  c(4,j) = c(4,j) - sum*t4
               end do
               go to 410
-90            continue
+              90 continue
               ! special code for 5 x 5 householder
               v1 = conjg(v(1))
               t1 = tau*conjg(v1)
@@ -11510,7 +11510,7 @@ module stdlib_linalg_lapack_z
               t5 = tau*conjg(v5)
               do j = 1,n
                  sum = v1*c(1,j) + v2*c(2,j) + v3*c(3,j) + v4*c(4,j) + v5*c(5,j)
-                           
+
                  c(1,j) = c(1,j) - sum*t1
                  c(2,j) = c(2,j) - sum*t2
                  c(3,j) = c(3,j) - sum*t3
@@ -11518,7 +11518,7 @@ module stdlib_linalg_lapack_z
                  c(5,j) = c(5,j) - sum*t5
               end do
               go to 410
-110           continue
+              110 continue
               ! special code for 6 x 6 householder
               v1 = conjg(v(1))
               t1 = tau*conjg(v1)
@@ -11543,7 +11543,7 @@ module stdlib_linalg_lapack_z
                  c(6,j) = c(6,j) - sum*t6
               end do
               go to 410
-130           continue
+              130 continue
               ! special code for 7 x 7 householder
               v1 = conjg(v(1))
               t1 = tau*conjg(v1)
@@ -11571,7 +11571,7 @@ module stdlib_linalg_lapack_z
                  c(7,j) = c(7,j) - sum*t7
               end do
               go to 410
-150           continue
+              150 continue
               ! special code for 8 x 8 householder
               v1 = conjg(v(1))
               t1 = tau*conjg(v1)
@@ -11602,7 +11602,7 @@ module stdlib_linalg_lapack_z
                  c(8,j) = c(8,j) - sum*t8
               end do
               go to 410
-170           continue
+              170 continue
               ! special code for 9 x 9 householder
               v1 = conjg(v(1))
               t1 = tau*conjg(v1)
@@ -11636,7 +11636,7 @@ module stdlib_linalg_lapack_z
                  c(9,j) = c(9,j) - sum*t9
               end do
               go to 410
-190           continue
+              190 continue
               ! special code for 10 x 10 householder
               v1 = conjg(v(1))
               t1 = tau*conjg(v1)
@@ -11679,14 +11679,14 @@ module stdlib_linalg_lapack_z
               ! code for general n
               call stdlib_zlarf(side,m,n,v,1,tau,c,ldc,work)
               go to 410
-210           continue
+              210 continue
               ! special code for 1 x 1 householder
               t1 = cone - tau*v(1)*conjg(v(1))
               do j = 1,m
                  c(j,1) = t1*c(j,1)
               end do
               go to 410
-230           continue
+              230 continue
               ! special code for 2 x 2 householder
               v1 = v(1)
               t1 = tau*conjg(v1)
@@ -11698,7 +11698,7 @@ module stdlib_linalg_lapack_z
                  c(j,2) = c(j,2) - sum*t2
               end do
               go to 410
-250           continue
+              250 continue
               ! special code for 3 x 3 householder
               v1 = v(1)
               t1 = tau*conjg(v1)
@@ -11713,7 +11713,7 @@ module stdlib_linalg_lapack_z
                  c(j,3) = c(j,3) - sum*t3
               end do
               go to 410
-270           continue
+              270 continue
               ! special code for 4 x 4 householder
               v1 = v(1)
               t1 = tau*conjg(v1)
@@ -11731,7 +11731,7 @@ module stdlib_linalg_lapack_z
                  c(j,4) = c(j,4) - sum*t4
               end do
               go to 410
-290           continue
+              290 continue
               ! special code for 5 x 5 householder
               v1 = v(1)
               t1 = tau*conjg(v1)
@@ -11745,7 +11745,7 @@ module stdlib_linalg_lapack_z
               t5 = tau*conjg(v5)
               do j = 1,m
                  sum = v1*c(j,1) + v2*c(j,2) + v3*c(j,3) + v4*c(j,4) + v5*c(j,5)
-                           
+
                  c(j,1) = c(j,1) - sum*t1
                  c(j,2) = c(j,2) - sum*t2
                  c(j,3) = c(j,3) - sum*t3
@@ -11753,7 +11753,7 @@ module stdlib_linalg_lapack_z
                  c(j,5) = c(j,5) - sum*t5
               end do
               go to 410
-310           continue
+              310 continue
               ! special code for 6 x 6 householder
               v1 = v(1)
               t1 = tau*conjg(v1)
@@ -11778,7 +11778,7 @@ module stdlib_linalg_lapack_z
                  c(j,6) = c(j,6) - sum*t6
               end do
               go to 410
-330           continue
+              330 continue
               ! special code for 7 x 7 householder
               v1 = v(1)
               t1 = tau*conjg(v1)
@@ -11806,7 +11806,7 @@ module stdlib_linalg_lapack_z
                  c(j,7) = c(j,7) - sum*t7
               end do
               go to 410
-350           continue
+              350 continue
               ! special code for 8 x 8 householder
               v1 = v(1)
               t1 = tau*conjg(v1)
@@ -11837,7 +11837,7 @@ module stdlib_linalg_lapack_z
                  c(j,8) = c(j,8) - sum*t8
               end do
               go to 410
-370           continue
+              370 continue
               ! special code for 9 x 9 householder
               v1 = v(1)
               t1 = tau*conjg(v1)
@@ -11871,7 +11871,7 @@ module stdlib_linalg_lapack_z
                  c(j,9) = c(j,9) - sum*t9
               end do
               go to 410
-390           continue
+              390 continue
               ! special code for 10 x 10 householder
               v1 = v(1)
               t1 = tau*conjg(v1)
@@ -11909,7 +11909,7 @@ module stdlib_linalg_lapack_z
               end do
               go to 410
            end if
-410        continue
+           410 continue
            return
      end subroutine stdlib_zlarfx
 
@@ -11933,7 +11933,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: v(*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            complex(dp) :: alpha
            ! Executable Statements
@@ -11963,7 +11963,7 @@ module stdlib_linalg_lapack_z
            ! Parameters
            integer(ilp),parameter :: lv = 128
            real(dp),parameter :: twopi = 6.28318530717958647692528676655900576839e+0_dp
-           
+
            ! Local Scalars
            integer(ilp) :: i,il,iv
            ! Local Arrays
@@ -11997,7 +11997,7 @@ module stdlib_linalg_lapack_z
                  ! distributed on the unit disk
                  do i = 1,il
                     x(iv + i - 1) = sqrt(u(2*i - 1))*exp(cmplx(zero,twopi*u(2*i),KIND=dp))
-                              
+
                  end do
               else if (idist == 5) then
                  ! convert generated numbers to complex numbers uniformly
@@ -12006,7 +12006,7 @@ module stdlib_linalg_lapack_z
                     x(iv + i - 1) = exp(cmplx(zero,twopi*u(2*i),KIND=dp))
                  end do
               end if
-60            continue
+              60 continue
            return
      end subroutine stdlib_zlarnv
 
@@ -12190,7 +12190,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: v(*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Executable Statements
            if (stdlib_lsame(side,'L')) then
               ! form  h * c
@@ -12242,7 +12242,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: c(ldc,*),t(ldt,*),v(ldv,*)
            complex(dp),intent(out) :: work(ldwork,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            character :: transt
            integer(ilp) :: i,info,j
@@ -12353,7 +12353,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: tau(*)
            complex(dp),intent(inout) :: v(ldv,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,info,j
            ! Executable Statements
@@ -12410,7 +12410,7 @@ module stdlib_linalg_lapack_z
            ! Array Arguments
            complex(dp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: done
            integer(ilp) :: i,itype,j,k1,k2,k3,k4
@@ -12471,7 +12471,7 @@ module stdlib_linalg_lapack_z
            bignum = one/smlnum
            cfromc = cfrom
            ctoc = cto
-10         continue
+           10 continue
            cfrom1 = cfromc*smlnum
            if (cfrom1 == cfromc) then
               ! cfromc is an inf.  multiply by a correctly signed zero for
@@ -12681,7 +12681,7 @@ module stdlib_linalg_lapack_z
            real(dp),intent(in) :: c(*),s(*)
            complex(dp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,info,j
            real(dp) :: ctemp,stemp
@@ -13100,7 +13100,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: sevten = 17.0e+0_dp
-           
+
            ! Local Scalars
            integer(ilp) :: imax,j,jb,jj,jmax,jp,k,kk,kkw,kp,kstep,kw
            real(dp) :: absakk,alpha,colmax,rowmax
@@ -13122,7 +13122,7 @@ module stdlib_linalg_lapack_z
               ! k is the main loop index, decreasing from n in steps of 1 or 2
               ! kw is the column of w which corresponds to column k of a
               k = n
-10            continue
+              10 continue
               kw = nb + k - n
               ! exit from loop
               if ((k <= n - nb + 1 .and. nb < n) .or. k < 1) go to 30
@@ -13153,7 +13153,7 @@ module stdlib_linalg_lapack_z
                     ! copy column imax to column kw-1 of w and update it
                     call stdlib_zcopy(imax,a(1,imax),1,w(1,kw - 1),1)
                     call stdlib_zcopy(k - imax,a(imax,imax + 1),lda,w(imax + 1,kw - 1),1)
-                              
+
                     if (k < n) call stdlib_zgemv('NO TRANSPOSE',k,n - k,-cone,a(1,k + 1),lda,w( &
                                imax,kw + 1),ldw,cone,w(1,kw - 1),1)
                     ! jmax is the column-index of the largest off-diagonal
@@ -13274,7 +13274,7 @@ module stdlib_linalg_lapack_z
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-30            continue
+              30 continue
               ! update the upper triangle of a11 (= a(1:k,1:k)) as
               ! a11 := a11 - u12*d*u12**t = a11 - u12*w**t
               ! computing blocks of nb columns at a time
@@ -13292,7 +13292,7 @@ module stdlib_linalg_lapack_z
               ! put u12 in standard form by partially undoing the interchanges
               ! in columns k+1:n looping backwards from k+1 to n
               j = k + 1
-60            continue
+              60 continue
                  ! undo the interchanges (if any) of rows jj and jp at each
                  ! step j
                  ! (here, j is a diagonal index)
@@ -13317,7 +13317,7 @@ module stdlib_linalg_lapack_z
               ! for use in updating a22
               ! k is the main loop index, increasing from 1 in steps of 1 or 2
               k = 1
-70            continue
+              70 continue
               ! exit from loop
               if ((k >= nb .and. nb < n) .or. k > n) go to 90
               ! copy column k of a to column k of w and update it
@@ -13386,7 +13386,7 @@ module stdlib_linalg_lapack_z
                     a(kp,kp) = a(kk,kk)
                     call stdlib_zcopy(kp - kk - 1,a(kk + 1,kk),1,a(kp,kk + 1),lda)
                     if (kp < n) call stdlib_zcopy(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     ! interchange rows kk and kp in first k-1 columns of a
                     ! (columns k (or k and k+1 for 2-by-2 pivot) of a will be
                     ! later overwritten). interchange rows kk and kp
@@ -13468,7 +13468,7 @@ module stdlib_linalg_lapack_z
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 70
-90            continue
+              90 continue
               ! update the lower triangle of a22 (= a(k:n,k:n)) as
               ! a22 := a22 - l21*d*l21**t = a22 - l21*w**t
               ! computing blocks of nb columns at a time
@@ -13486,7 +13486,7 @@ module stdlib_linalg_lapack_z
               ! put l21 in standard form by partially undoing the interchanges
               ! of rows in columns 1:k-1 looping backwards from k-1 to 1
               j = k - 1
-120           continue
+              120 continue
                  ! undo the interchanges (if any) of rows jj and jp at each
                  ! step j
                  ! (here, j is a diagonal index)
@@ -13501,7 +13501,7 @@ module stdlib_linalg_lapack_z
                  ! of the rows to swap back doesn't include diagonal element)
                  j = j - 1
                  if (jp /= jj .and. j >= 1) call stdlib_zswap(j,a(jp,1),lda,a(jj,1),lda)
-                           
+
               if (j > 1) go to 120
               ! set kb to the number of columns factorized
               kb = k - 1
@@ -13537,7 +13537,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: sevten = 17.0e+0_dp
-           
+
            ! Local Scalars
            logical(lk) :: done
            integer(ilp) :: imax,itemp,j,jb,jj,jmax,k,kk,kw,kkw,kp,kstep,p,ii
@@ -13564,7 +13564,7 @@ module stdlib_linalg_lapack_z
               e(1) = czero
               ! k is the main loop index, decreasing from n in steps of 1 or 2
               k = n
-10            continue
+              10 continue
               ! kw is the column of w which corresponds to column k of a
               kw = nb + k - n
               ! exit from loop
@@ -13605,12 +13605,12 @@ module stdlib_linalg_lapack_z
                  else
                     done = .false.
                     ! loop until pivot found
-12   continue
+                    12 continue
                        ! begin pivot search loop body
                        ! copy column imax to column kw-1 of w and update it
                        call stdlib_zcopy(imax,a(1,imax),1,w(1,kw - 1),1)
                        call stdlib_zcopy(k - imax,a(imax,imax + 1),lda,w(imax + 1,kw - 1),1)
-                                 
+
                        if (k < n) call stdlib_zgemv('NO TRANSPOSE',k,n - k,-cone,a(1,k + 1),lda, &
                                   w(imax,kw + 1),ldw,cone,w(1,kw - 1),1)
                        ! jmax is the column-index of the largest off-diagonal
@@ -13739,7 +13739,7 @@ module stdlib_linalg_lapack_z
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-30            continue
+              30 continue
               ! update the upper triangle of a11 (= a(1:k,1:k)) as
               ! a11 := a11 - u12*d*u12**t = a11 - u12*w**t
               ! computing blocks of nb columns at a time
@@ -13764,7 +13764,7 @@ module stdlib_linalg_lapack_z
               e(n) = czero
               ! k is the main loop index, increasing from 1 in steps of 1 or 2
               k = 1
-70            continue
+              70 continue
               ! exit from loop
               if ((k >= nb .and. nb < n) .or. k > n) go to 90
               kstep = 1
@@ -13803,7 +13803,7 @@ module stdlib_linalg_lapack_z
                  else
                     done = .false.
                     ! loop until pivot found
-72   continue
+                    72 continue
                        ! begin pivot search loop body
                        ! copy column imax to column k+1 of w and update it
                        call stdlib_zcopy(imax - k,a(imax,k),lda,w(k,k + 1),1)
@@ -13932,7 +13932,7 @@ module stdlib_linalg_lapack_z
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 70
-90            continue
+              90 continue
               ! update the lower triangle of a22 (= a(k:n,k:n)) as
               ! a22 := a22 - l21*d*l21**t = a22 - l21*w**t
               ! computing blocks of nb columns at a time
@@ -13981,7 +13981,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: sevten = 17.0e+0_dp
-           
+
            ! Local Scalars
            logical(lk) :: done
            integer(ilp) :: imax,itemp,j,jb,jj,jmax,jp1,jp2,k,kk,kw,kkw,kp,kstep,p, &
@@ -14006,7 +14006,7 @@ module stdlib_linalg_lapack_z
               ! for use in updating a11
               ! k is the main loop index, decreasing from n in steps of 1 or 2
               k = n
-10            continue
+              10 continue
               ! kw is the column of w which corresponds to column k of a
               kw = nb + k - n
               ! exit from loop
@@ -14045,12 +14045,12 @@ module stdlib_linalg_lapack_z
                  else
                     done = .false.
                     ! loop until pivot found
-12   continue
+                    12 continue
                        ! begin pivot search loop body
                        ! copy column imax to column kw-1 of w and update it
                        call stdlib_zcopy(imax,a(1,imax),1,w(1,kw - 1),1)
                        call stdlib_zcopy(k - imax,a(imax,imax + 1),lda,w(imax + 1,kw - 1),1)
-                                 
+
                        if (k < n) call stdlib_zgemv('NO TRANSPOSE',k,n - k,-cone,a(1,k + 1),lda, &
                                   w(imax,kw + 1),ldw,cone,w(1,kw - 1),1)
                        ! jmax is the column-index of the largest off-diagonal
@@ -14172,7 +14172,7 @@ module stdlib_linalg_lapack_z
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-30            continue
+              30 continue
               ! update the upper triangle of a11 (= a(1:k,1:k)) as
               ! a11 := a11 - u12*d*u12**t = a11 - u12*w**t
               ! computing blocks of nb columns at a time
@@ -14190,7 +14190,7 @@ module stdlib_linalg_lapack_z
               ! put u12 in standard form by partially undoing the interchanges
               ! in columns k+1:n
               j = k + 1
-60            continue
+              60 continue
                  kstep = 1
                  jp1 = 1
                  jj = j
@@ -14216,7 +14216,7 @@ module stdlib_linalg_lapack_z
               ! for use in updating a22
               ! k is the main loop index, increasing from 1 in steps of 1 or 2
               k = 1
-70            continue
+              70 continue
               ! exit from loop
               if ((k >= nb .and. nb < n) .or. k > n) go to 90
               kstep = 1
@@ -14253,7 +14253,7 @@ module stdlib_linalg_lapack_z
                  else
                     done = .false.
                     ! loop until pivot found
-72   continue
+                    72 continue
                        ! begin pivot search loop body
                        ! copy column imax to column k+1 of w and update it
                        call stdlib_zcopy(imax - k,a(imax,k),lda,w(k,k + 1),1)
@@ -14375,7 +14375,7 @@ module stdlib_linalg_lapack_z
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 70
-90            continue
+              90 continue
               ! update the lower triangle of a22 (= a(k:n,k:n)) as
               ! a22 := a22 - l21*d*l21**t = a22 - l21*w**t
               ! computing blocks of nb columns at a time
@@ -14393,7 +14393,7 @@ module stdlib_linalg_lapack_z
               ! put l21 in standard form by partially undoing the interchanges
               ! in columns 1:k-1
               j = k - 1
-120           continue
+              120 continue
                  kstep = 1
                  jp1 = 1
                  jj = j
@@ -14406,7 +14406,7 @@ module stdlib_linalg_lapack_z
                  end if
                  j = j - 1
                  if (jp2 /= jj .and. j >= 1) call stdlib_zswap(j,a(jp2,1),lda,a(jj,1),lda)
-                           
+
                  jj = j + 1
                  if (jp1 /= jj .and. kstep == 2) call stdlib_zswap(j,a(jp1,1),lda,a(jj,1), &
                            lda)
@@ -14470,7 +14470,7 @@ module stdlib_linalg_lapack_z
                  end do
               end do
            end if
-50         continue
+           50 continue
            return
      end subroutine stdlib_zlat2c
 
@@ -14500,7 +14500,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: ab(ldab,*)
            complex(dp),intent(inout) :: x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            integer(ilp) :: i,imax,j,jfirst,jinc,jlast,jlen,maind
@@ -14513,7 +14513,7 @@ module stdlib_linalg_lapack_z
            ! Statement Function Definitions
            cabs1(zdum) = abs(real(zdum,KIND=dp)) + abs(aimag(zdum))
            cabs2(zdum) = abs(real(zdum,KIND=dp)/2._dp) + abs(aimag(zdum)/2._dp)
-                     
+
            ! Executable Statements
            info = 0
            upper = stdlib_lsame(uplo,'U')
@@ -14642,7 +14642,7 @@ module stdlib_linalg_lapack_z
                     grow = grow*(one/(one + cnorm(j)))
                  end do
               end if
-60            continue
+              60 continue
            else
               ! compute the growth in a**t * x = b  or  a**h * x = b.
               if (upper) then
@@ -14695,7 +14695,7 @@ module stdlib_linalg_lapack_z
                     grow = grow/xj
                  end do
               end if
-90            continue
+              90 continue
            end if
            if ((grow*tscal) > smlnum) then
               ! use the level 2 blas solve if the reciprocal of the bound on
@@ -14765,7 +14765,7 @@ module stdlib_linalg_lapack_z
                        scale = zero
                        xmax = zero
                     end if
-110                 continue
+                    110 continue
                     ! scale x if necessary to avoid overflow when adding a
                     ! multiple of column j of a.
                     if (xj > one) then
@@ -14838,11 +14838,11 @@ module stdlib_linalg_lapack_z
                        if (upper) then
                           jlen = min(kd,j - 1)
                           csumj = stdlib_zdotu(jlen,ab(kd + 1 - jlen,j),1,x(j - jlen),1)
-                                    
+
                        else
                           jlen = min(kd,n - j)
                           if (jlen > 1) csumj = stdlib_zdotu(jlen,ab(2,j),1,x(j + 1),1)
-                                    
+
                        end if
                     else
                        ! otherwise, use in-line code for the dot product.
@@ -14903,7 +14903,7 @@ module stdlib_linalg_lapack_z
                           scale = zero
                           xmax = zero
                        end if
-160                    continue
+                       160 continue
                     else
                        ! compute x(j) := x(j) / a(j,j) - csumj if the dot
                        ! product has already been divided by 1/a(j,j).
@@ -14946,11 +14946,11 @@ module stdlib_linalg_lapack_z
                        if (upper) then
                           jlen = min(kd,j - 1)
                           csumj = stdlib_zdotc(jlen,ab(kd + 1 - jlen,j),1,x(j - jlen),1)
-                                    
+
                        else
                           jlen = min(kd,n - j)
                           if (jlen > 1) csumj = stdlib_zdotc(jlen,ab(2,j),1,x(j + 1),1)
-                                    
+
                        end if
                     else
                        ! otherwise, use in-line code for the dot product.
@@ -14958,7 +14958,7 @@ module stdlib_linalg_lapack_z
                           jlen = min(kd,j - 1)
                           do i = 1,jlen
                              csumj = csumj + (conjg(ab(kd + i - jlen,j))*uscal)*x(j - jlen - 1 + i)
-                                       
+
                           end do
                        else
                           jlen = min(kd,n - j)
@@ -15012,7 +15012,7 @@ module stdlib_linalg_lapack_z
                           scale = zero
                           xmax = zero
                        end if
-210                    continue
+                       210 continue
                     else
                        ! compute x(j) := x(j) / a(j,j) - csumj if the dot
                        ! product has already been divided by 1/a(j,j).
@@ -15043,7 +15043,7 @@ module stdlib_linalg_lapack_z
      !> non-trivial solution to A*x = 0 is returned.
 
      pure subroutine stdlib_zlatps(uplo,trans,diag,normin,n,ap,x,scale,cnorm,info)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -15057,7 +15057,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: ap(*)
            complex(dp),intent(inout) :: x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            integer(ilp) :: i,imax,ip,j,jfirst,jinc,jlast,jlen
@@ -15070,7 +15070,7 @@ module stdlib_linalg_lapack_z
            ! Statement Function Definitions
            cabs1(zdum) = abs(real(zdum,KIND=dp)) + abs(aimag(zdum))
            cabs2(zdum) = abs(real(zdum,KIND=dp)/2._dp) + abs(aimag(zdum)/2._dp)
-                     
+
            ! Executable Statements
            info = 0
            upper = stdlib_lsame(uplo,'U')
@@ -15196,7 +15196,7 @@ module stdlib_linalg_lapack_z
                     grow = grow*(one/(one + cnorm(j)))
                  end do
               end if
-60            continue
+              60 continue
            else
               ! compute the growth in a**t * x = b  or  a**h * x = b.
               if (upper) then
@@ -15251,7 +15251,7 @@ module stdlib_linalg_lapack_z
                     grow = grow/xj
                  end do
               end if
-90            continue
+              90 continue
            end if
            if ((grow*tscal) > smlnum) then
               ! use the level 2 blas solve if the reciprocal of the bound on
@@ -15322,7 +15322,7 @@ module stdlib_linalg_lapack_z
                        scale = zero
                        xmax = zero
                     end if
-110                 continue
+                    110 continue
                     ! scale x if necessary to avoid overflow when adding a
                     ! multiple of column j of a.
                     if (xj > one) then
@@ -15352,7 +15352,7 @@ module stdlib_linalg_lapack_z
                           ! compute the update
                              ! x(j+1:n) := x(j+1:n) - x(j) * a(j+1:n,j)
                           call stdlib_zaxpy(n - j,-x(j)*tscal,ap(ip + 1),1,x(j + 1),1)
-                                    
+
                           i = j + stdlib_izamax(n - j,x(j + 1),1)
                           xmax = cabs1(x(i))
                        end if
@@ -15455,7 +15455,7 @@ module stdlib_linalg_lapack_z
                           scale = zero
                           xmax = zero
                        end if
-160                    continue
+                       160 continue
                     else
                        ! compute x(j) := x(j) / a(j,j) - csumj if the dot
                        ! product has already been divided by 1/a(j,j).
@@ -15561,7 +15561,7 @@ module stdlib_linalg_lapack_z
                           scale = zero
                           xmax = zero
                        end if
-210                    continue
+                       210 continue
                     else
                        ! compute x(j) := x(j) / a(j,j) - csumj if the dot
                        ! product has already been divided by 1/a(j,j).
@@ -15603,7 +15603,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: tau(*),w(ldw,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,iw
            complex(dp) :: alpha
@@ -15651,7 +15651,7 @@ module stdlib_linalg_lapack_z
                     end if
                     call stdlib_zscal(i - 1,tau(i - 1),w(1,iw),1)
                     alpha = -chalf*tau(i - 1)*stdlib_zdotc(i - 1,w(1,iw),1,a(1,i),1)
-                              
+
                     call stdlib_zaxpy(i - 1,alpha,a(1,i),1,w(1,iw),1)
                  end if
               end do loop_10
@@ -15689,7 +15689,7 @@ module stdlib_linalg_lapack_z
                               ,1,cone,w(i + 1,i),1)
                     call stdlib_zscal(n - i,tau(i),w(i + 1,i),1)
                     alpha = -chalf*tau(i)*stdlib_zdotc(n - i,w(i + 1,i),1,a(i + 1,i),1)
-                              
+
                     call stdlib_zaxpy(n - i,alpha,a(i + 1,i),1,w(i + 1,i),1)
                  end if
               end do loop_20
@@ -15709,7 +15709,7 @@ module stdlib_linalg_lapack_z
      !> then s is set to 0 and a non-trivial solution to A*x = 0 is returned.
 
      pure subroutine stdlib_zlatrs(uplo,trans,diag,normin,n,a,lda,x,scale,cnorm,info)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -15723,7 +15723,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: a(lda,*)
            complex(dp),intent(inout) :: x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            integer(ilp) :: i,imax,j,jfirst,jinc,jlast
@@ -15736,7 +15736,7 @@ module stdlib_linalg_lapack_z
            ! Statement Function Definitions
            cabs1(zdum) = abs(real(zdum,KIND=dp)) + abs(aimag(zdum))
            cabs2(zdum) = abs(real(zdum,KIND=dp)/2._dp) + abs(aimag(zdum)/2._dp)
-                     
+
            ! Executable Statements
            info = 0
            upper = stdlib_lsame(uplo,'U')
@@ -15856,7 +15856,7 @@ module stdlib_linalg_lapack_z
                     grow = grow*(one/(one + cnorm(j)))
                  end do
               end if
-60            continue
+              60 continue
            else
               ! compute the growth in a**t * x = b  or  a**h * x = b.
               if (upper) then
@@ -15907,7 +15907,7 @@ module stdlib_linalg_lapack_z
                     grow = grow/xj
                  end do
               end if
-90            continue
+              90 continue
            end if
            if ((grow*tscal) > smlnum) then
               ! use the level 2 blas solve if the reciprocal of the bound on
@@ -15977,7 +15977,7 @@ module stdlib_linalg_lapack_z
                        scale = zero
                        xmax = zero
                     end if
-110                 continue
+                    110 continue
                     ! scale x if necessary to avoid overflow when adding a
                     ! multiple of column j of a.
                     if (xj > one) then
@@ -16006,7 +16006,7 @@ module stdlib_linalg_lapack_z
                           ! compute the update
                              ! x(j+1:n) := x(j+1:n) - x(j) * a(j+1:n,j)
                           call stdlib_zaxpy(n - j,-x(j)*tscal,a(j + 1,j),1,x(j + 1),1)
-                                    
+
                           i = j + stdlib_izamax(n - j,x(j + 1),1)
                           xmax = cabs1(x(i))
                        end if
@@ -16106,7 +16106,7 @@ module stdlib_linalg_lapack_z
                           scale = zero
                           xmax = zero
                        end if
-160                    continue
+                       160 continue
                     else
                        ! compute x(j) := x(j) / a(j,j) - csumj if the dot
                        ! product has already been divided by 1/a(j,j).
@@ -16208,7 +16208,7 @@ module stdlib_linalg_lapack_z
                           scale = zero
                           xmax = zero
                        end if
-210                    continue
+                       210 continue
                     else
                        ! compute x(j) := x(j) / a(j,j) - csumj if the dot
                        ! product has already been divided by 1/a(j,j).
@@ -16241,7 +16241,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            complex(dp) :: alpha
@@ -16332,7 +16332,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: d(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(dp) :: sfmin
            integer(ilp) :: i,iinfo,n1,n2
@@ -16392,17 +16392,17 @@ module stdlib_linalg_lapack_z
               call stdlib_zlaunhr_col_getrfnp2(n1,n1,a,lda,d,iinfo)
               ! solve for b21
               call stdlib_ztrsm('R','U','N','N',m - n1,n1,cone,a,lda,a(n1 + 1,1),lda)
-                        
+
               ! solve for b12
               call stdlib_ztrsm('L','L','N','U',n1,n2,cone,a,lda,a(1,n1 + 1),lda)
-                        
+
               ! update b22, i.e. compute the schur complement
               ! b22 := b22 - b21*b12
               call stdlib_zgemm('N','N',m - n1,n2,n1,-cone,a(n1 + 1,1),lda,a(1,n1 + 1), &
                         lda,cone,a(n1 + 1,n1 + 1),lda)
               ! factor b22, recursive call
               call stdlib_zlaunhr_col_getrfnp2(m - n1,n2,a(n1 + 1,n1 + 1),lda,d(n1 + 1),iinfo)
-                        
+
            end if
            return
      end subroutine stdlib_zlaunhr_col_getrfnp2
@@ -16427,7 +16427,7 @@ module stdlib_linalg_lapack_z
            ! Array Arguments
            complex(dp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i
@@ -16505,7 +16505,7 @@ module stdlib_linalg_lapack_z
            ! Array Arguments
            complex(dp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,ib,nb
@@ -16576,7 +16576,7 @@ module stdlib_linalg_lapack_z
      !> condition number is computed as RCOND = 1 / (ANORM * norm(inv(A))).
 
      pure subroutine stdlib_zpbcon(uplo,n,kd,ab,ldab,anorm,rcond,work,rwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -16591,7 +16591,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: ab(ldab,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            character :: normin
@@ -16637,7 +16637,7 @@ module stdlib_linalg_lapack_z
            ! estimate the 1-norm of the inverse.
            kase = 0
            normin = 'N'
-10         continue
+           10 continue
            call stdlib_zlacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               if (upper) then
@@ -16668,7 +16668,7 @@ module stdlib_linalg_lapack_z
            end if
            ! compute the estimate of the reciprocal condition number.
            if (ainvnm /= zero) rcond = (one/ainvnm)/anorm
-20         continue
+           20 continue
            return
      end subroutine stdlib_zpbcon
 
@@ -16694,7 +16694,7 @@ module stdlib_linalg_lapack_z
            real(dp),intent(out) :: s(*)
            complex(dp),intent(in) :: ab(ldab,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,j
@@ -16780,7 +16780,7 @@ module stdlib_linalg_lapack_z
            ! Array Arguments
            complex(dp),intent(inout) :: ab(ldab,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,kld,km,m
@@ -16825,7 +16825,7 @@ module stdlib_linalg_lapack_z
                  ! the leading submatrix within the band.
                  call stdlib_zdscal(km,one/ajj,ab(kd + 1 - km,j),1)
                  call stdlib_zher('UPPER',km,-one,ab(kd + 1 - km,j),1,ab(kd + 1,j - km),kld)
-                           
+
               end do
               ! factorize the updated submatrix a(1:m,1:m) as u**h*u.
               do j = 1,m
@@ -16844,7 +16844,7 @@ module stdlib_linalg_lapack_z
                     call stdlib_zdscal(km,one/ajj,ab(kd,j + 1),kld)
                     call stdlib_zlacgv(km,ab(kd,j + 1),kld)
                     call stdlib_zher('UPPER',km,-one,ab(kd,j + 1),kld,ab(kd + 1,j + 1),kld)
-                              
+
                     call stdlib_zlacgv(km,ab(kd,j + 1),kld)
                  end if
               end do
@@ -16865,7 +16865,7 @@ module stdlib_linalg_lapack_z
                  call stdlib_zdscal(km,one/ajj,ab(km + 1,j - km),kld)
                  call stdlib_zlacgv(km,ab(km + 1,j - km),kld)
                  call stdlib_zher('LOWER',km,-one,ab(km + 1,j - km),kld,ab(1,j - km),kld)
-                           
+
                  call stdlib_zlacgv(km,ab(km + 1,j - km),kld)
               end do
               ! factorize the updated submatrix a(1:m,1:m) as u**h*u.
@@ -16888,7 +16888,7 @@ module stdlib_linalg_lapack_z
               end do
            end if
            return
-50         continue
+           50 continue
            info = j
            return
      end subroutine stdlib_zpbstf
@@ -16913,7 +16913,7 @@ module stdlib_linalg_lapack_z
            ! Array Arguments
            complex(dp),intent(inout) :: ab(ldab,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,kld,kn
@@ -16958,7 +16958,7 @@ module stdlib_linalg_lapack_z
                     call stdlib_zdscal(kn,one/ajj,ab(kd,j + 1),kld)
                     call stdlib_zlacgv(kn,ab(kd,j + 1),kld)
                     call stdlib_zher('UPPER',kn,-one,ab(kd,j + 1),kld,ab(kd + 1,j + 1),kld)
-                              
+
                     call stdlib_zlacgv(kn,ab(kd,j + 1),kld)
                  end if
               end do
@@ -16983,7 +16983,7 @@ module stdlib_linalg_lapack_z
               end do
            end if
            return
-30         continue
+           30 continue
            info = j
            return
      end subroutine stdlib_zpbtf2
@@ -17077,7 +17077,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            character :: normin
@@ -17121,7 +17121,7 @@ module stdlib_linalg_lapack_z
            ! estimate the 1-norm of inv(a).
            kase = 0
            normin = 'N'
-10         continue
+           10 continue
            call stdlib_zlacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               if (upper) then
@@ -17152,7 +17152,7 @@ module stdlib_linalg_lapack_z
            end if
            ! compute the estimate of the reciprocal condition number.
            if (ainvnm /= zero) rcond = (one/ainvnm)/anorm
-20         continue
+           20 continue
            return
      end subroutine stdlib_zpocon
 
@@ -17177,7 +17177,7 @@ module stdlib_linalg_lapack_z
            real(dp),intent(out) :: s(*)
            complex(dp),intent(in) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(dp) :: smin
@@ -17256,7 +17256,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: a(lda,*)
            real(dp),intent(out) :: s(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(dp) :: smin,base,tmp
@@ -17331,7 +17331,7 @@ module stdlib_linalg_lapack_z
            ! Array Arguments
            complex(dp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j
@@ -17399,9 +17399,9 @@ module stdlib_linalg_lapack_z
               end do
            end if
            go to 40
-30         continue
+           30 continue
            info = j
-40         continue
+           40 continue
            return
      end subroutine stdlib_zpotf2
 
@@ -17430,7 +17430,7 @@ module stdlib_linalg_lapack_z
            ! Array Arguments
            complex(dp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: n1,n2,iinfo
@@ -17521,7 +17521,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: a(lda,*)
            complex(dp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            ! Intrinsic Functions
@@ -17589,7 +17589,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: ap(*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            character :: normin
@@ -17631,7 +17631,7 @@ module stdlib_linalg_lapack_z
            ! estimate the 1-norm of the inverse.
            kase = 0
            normin = 'N'
-10         continue
+           10 continue
            call stdlib_zlacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               if (upper) then
@@ -17662,7 +17662,7 @@ module stdlib_linalg_lapack_z
            end if
            ! compute the estimate of the reciprocal condition number.
            if (ainvnm /= zero) rcond = (one/ainvnm)/anorm
-20         continue
+           20 continue
            return
      end subroutine stdlib_zppcon
 
@@ -17688,7 +17688,7 @@ module stdlib_linalg_lapack_z
            real(dp),intent(out) :: s(*)
            complex(dp),intent(in) :: ap(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,jj
@@ -17777,7 +17777,7 @@ module stdlib_linalg_lapack_z
            ! Array Arguments
            complex(dp),intent(inout) :: ap(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,jc,jj
@@ -17839,9 +17839,9 @@ module stdlib_linalg_lapack_z
               end do
            end if
            go to 40
-30         continue
+           30 continue
            info = j
-40         continue
+           40 continue
            return
      end subroutine stdlib_zpptrf
 
@@ -17893,14 +17893,14 @@ module stdlib_linalg_lapack_z
                            1)
                  ! solve u*x = b, overwriting b with x.
                  call stdlib_ztpsv('UPPER','NO TRANSPOSE','NON-UNIT',n,ap,b(1,i),1)
-                           
+
               end do
            else
               ! solve a*x = b where a = l * l**h.
               do i = 1,nrhs
                  ! solve l*y = b, overwriting b with x.
                  call stdlib_ztpsv('LOWER','NO TRANSPOSE','NON-UNIT',n,ap,b(1,i),1)
-                           
+
                  ! solve l**h *x = y, overwriting b with x.
                  call stdlib_ztpsv('LOWER','CONJUGATE TRANSPOSE','NON-UNIT',n,ap,b(1,i), &
                            1)
@@ -17933,7 +17933,7 @@ module stdlib_linalg_lapack_z
            real(dp),intent(out) :: work(2*n)
            integer(ilp),intent(out) :: piv(n)
         ! =====================================================================
-           
+
            ! Local Scalars
            complex(dp) :: ztemp
            real(dp) :: ajj,dstop,dtemp
@@ -17992,7 +17992,7 @@ module stdlib_linalg_lapack_z
                  do i = j,n
                     if (j > 1) then
                        work(i) = work(i) + real(conjg(a(j - 1,i))*a(j - 1,i),KIND=dp)
-                                 
+
                     end if
                     work(n + i) = real(a(i,i),KIND=dp) - work(i)
                  end do
@@ -18010,7 +18010,7 @@ module stdlib_linalg_lapack_z
                     a(pvt,pvt) = a(j,j)
                     call stdlib_zswap(j - 1,a(1,j),1,a(1,pvt),1)
                     if (pvt < n) call stdlib_zswap(n - pvt,a(j,pvt + 1),lda,a(pvt,pvt + 1),lda)
-                              
+
                     do i = j + 1,pvt - 1
                        ztemp = conjg(a(j,i))
                        a(j,i) = conjg(a(i,pvt))
@@ -18045,7 +18045,7 @@ module stdlib_linalg_lapack_z
                  do i = j,n
                     if (j > 1) then
                        work(i) = work(i) + real(conjg(a(i,j - 1))*a(i,j - 1),KIND=dp)
-                                 
+
                     end if
                     work(n + i) = real(a(i,i),KIND=dp) - work(i)
                  end do
@@ -18063,7 +18063,7 @@ module stdlib_linalg_lapack_z
                     a(pvt,pvt) = a(j,j)
                     call stdlib_zswap(j - 1,a(j,1),lda,a(pvt,1),lda)
                     if (pvt < n) call stdlib_zswap(n - pvt,a(pvt + 1,j),1,a(pvt + 1,pvt),1)
-                              
+
                     do i = j + 1,pvt - 1
                        ztemp = conjg(a(i,j))
                        a(i,j) = conjg(a(pvt,i))
@@ -18093,12 +18093,12 @@ module stdlib_linalg_lapack_z
            ! ran to completion, a has full rank
            rank = n
            go to 200
-190        continue
+           190 continue
            ! rank is number of steps completed.  set info = 1 to signal
            ! that the factorization cannot be used to solve a system.
            rank = j - 1
            info = 1
-200        continue
+           200 continue
            return
      end subroutine stdlib_zpstf2
 
@@ -18126,7 +18126,7 @@ module stdlib_linalg_lapack_z
            real(dp),intent(out) :: work(2*n)
            integer(ilp),intent(out) :: piv(n)
         ! =====================================================================
-           
+
            ! Local Scalars
            complex(dp) :: ztemp
            real(dp) :: ajj,dstop,dtemp
@@ -18318,12 +18318,12 @@ module stdlib_linalg_lapack_z
            ! ran to completion, a has full rank
            rank = n
            go to 230
-220        continue
+           220 continue
            ! rank is the number of steps completed.  set info = 1 to signal
            ! that the factorization cannot be used to solve a system.
            rank = j - 1
            info = 1
-230        continue
+           230 continue
            return
      end subroutine stdlib_zpstrf
 
@@ -18349,7 +18349,7 @@ module stdlib_linalg_lapack_z
            real(dp),intent(out) :: rwork(*)
            complex(dp),intent(in) :: e(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,ix
            real(dp) :: ainvnm
@@ -18416,7 +18416,7 @@ module stdlib_linalg_lapack_z
            real(dp),intent(inout) :: d(*)
            complex(dp),intent(inout) :: e(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,i4
            real(dp) :: eii,eir,f,g
@@ -18496,7 +18496,7 @@ module stdlib_linalg_lapack_z
            end do loop_20
            ! check d(n) for positive definiteness.
            if (d(n) <= zero) info = n
-30         continue
+           30 continue
            return
      end subroutine stdlib_zpttrf
 
@@ -18533,7 +18533,7 @@ module stdlib_linalg_lapack_z
               ! overwriting each right hand side vector with its solution.
               if (nrhs <= 2) then
                  j = 1
-10               continue
+                 10 continue
                  ! solve u**h * x = b.
                  do i = 2,n
                     b(i,j) = b(i,j) - b(i - 1,j)*conjg(e(i - 1))
@@ -18567,7 +18567,7 @@ module stdlib_linalg_lapack_z
               ! overwriting each right hand side vector with its solution.
               if (nrhs <= 2) then
                  j = 1
-80               continue
+                 80 continue
                  ! solve l * x = b.
                  do i = 2,n
                     b(i,j) = b(i,j) - b(i - 1,j)*e(i - 1)
@@ -18636,7 +18636,7 @@ module stdlib_linalg_lapack_z
            end do
            return
            ! code for both increments equal to 1
-20   continue
+           20 continue
            do i = 1,n
               stemp = c*cx(i) + s*cy(i)
               cy(i) = c*cy(i) - conjg(s)*cx(i)
@@ -18662,7 +18662,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: ap(*),x(*)
            complex(dp),intent(inout) :: y(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,info,ix,iy,j,jx,jy,k,kk,kx,ky
            complex(dp) :: temp1,temp2
@@ -18819,7 +18819,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: ap(*)
            complex(dp),intent(in) :: x(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,info,ix,j,jx,k,kk,kx
            complex(dp) :: temp
@@ -18944,7 +18944,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: sevten = 17.0e+0_dp
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,imax,j,jmax,k,kc,kk,knc,kp,kpc,kstep,kx,npp
@@ -18977,7 +18977,7 @@ module stdlib_linalg_lapack_z
               ! 1 or 2
               k = n
               kc = (n - 1)*n/2 + 1
-10            continue
+              10 continue
               knc = kc
               ! if k < 1, exit from loop
               if (k < 1) go to 110
@@ -19080,9 +19080,9 @@ module stdlib_linalg_lapack_z
                        d12 = t/d12
                        do j = k - 2,1,-1
                           wkm1 = d12*(d11*ap(j + (k - 2)*(k - 1)/2) - ap(j + (k - 1)*k/2))
-                                    
+
                           wk = d12*(d22*ap(j + (k - 1)*k/2) - ap(j + (k - 2)*(k - 1)/2))
-                                    
+
                           do i = j,1,-1
                              ap(i + (j - 1)*j/2) = ap(i + (j - 1)*j/2) - ap(i + (k - 1)*k/2) &
                                        *wk - ap(i + (k - 2)*(k - 1)/2)*wkm1
@@ -19111,7 +19111,7 @@ module stdlib_linalg_lapack_z
               k = 1
               kc = 1
               npp = n*(n + 1)/2
-60            continue
+              60 continue
               knc = kc
               ! if k > n, exit from loop
               if (k > n) go to 110
@@ -19172,7 +19172,7 @@ module stdlib_linalg_lapack_z
                     ! interchange rows and columns kk and kp in the trailing
                     ! submatrix a(k:n,k:n)
                     if (kp < n) call stdlib_zswap(n - kp,ap(knc + kp - kk + 1),1,ap(kpc + 1),1)
-                              
+
                     kx = knc + kp - kk
                     do j = kk + 1,kp - 1
                        kx = kx + n - j + 1
@@ -19220,7 +19220,7 @@ module stdlib_linalg_lapack_z
                        d21 = t/d21
                        do j = k + 2,n
                           wk = d21*(d11*ap(j + (k - 1)*(2*n - k)/2) - ap(j + k*(2*n - k - 1)/2))
-                                    
+
                           wkp1 = d21*(d22*ap(j + k*(2*n - k - 1)/2) - ap(j + (k - 1)*(2*n - k)/2) &
                                      )
                           do i = j,n
@@ -19245,7 +19245,7 @@ module stdlib_linalg_lapack_z
               kc = knc + n - k + 2
               go to 60
            end if
-110        continue
+           110 continue
            return
      end subroutine stdlib_zsptrf
 
@@ -19266,7 +19266,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: ap(*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kc,kcnext,kp,kpc,kstep,kx,npp
@@ -19311,7 +19311,7 @@ module stdlib_linalg_lapack_z
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
               kc = 1
-30            continue
+              30 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               kcnext = kc + k
@@ -19346,9 +19346,9 @@ module stdlib_linalg_lapack_z
                               kcnext),1)
                     call stdlib_zcopy(k - 1,ap(kcnext),1,work,1)
                     call stdlib_zspmv(uplo,k - 1,-cone,ap,work,1,czero,ap(kcnext),1)
-                              
+
                     ap(kcnext + k) = ap(kcnext + k) - stdlib_zdotu(k - 1,work,1,ap(kcnext),1)
-                              
+
                  end if
                  kstep = 2
                  kcnext = kcnext + k + 1
@@ -19378,7 +19378,7 @@ module stdlib_linalg_lapack_z
               k = k + kstep
               kc = kcnext
               go to 30
-50            continue
+              50 continue
            else
               ! compute inv(a) from the factorization a = l*d*l**t.
               ! k is the main loop index, increasing from 1 to n in steps of
@@ -19386,7 +19386,7 @@ module stdlib_linalg_lapack_z
               npp = n*(n + 1)/2
               k = n
               kc = npp
-60            continue
+              60 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 80
               kcnext = kc - (n - k + 2)
@@ -19425,7 +19425,7 @@ module stdlib_linalg_lapack_z
                     call stdlib_zspmv(uplo,n - k,-cone,ap(kc + (n - k + 1)),work,1,czero,ap( &
                               kcnext + 2),1)
                     ap(kcnext) = ap(kcnext) - stdlib_zdotu(n - k,work,1,ap(kcnext + 2),1)
-                              
+
                  end if
                  kstep = 2
                  kcnext = kcnext - (n - k + 3)
@@ -19455,7 +19455,7 @@ module stdlib_linalg_lapack_z
               k = k - kstep
               kc = kcnext
               go to 60
-80            continue
+              80 continue
            end if
            return
      end subroutine stdlib_zsptri
@@ -19477,7 +19477,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: ap(*)
            complex(dp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kc,kp
@@ -19509,7 +19509,7 @@ module stdlib_linalg_lapack_z
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
               kc = n*(n + 1)/2 + 1
-10            continue
+              10 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 30
               kc = kc - k
@@ -19521,7 +19521,7 @@ module stdlib_linalg_lapack_z
                  ! multiply by inv(u(k)), where u(k) is the transformation
                  ! stored in column k of a.
                  call stdlib_zgeru(k - 1,nrhs,-cone,ap(kc),1,b(k,1),ldb,b(1,1),ldb)
-                           
+
                  ! multiply by the inverse of the diagonal block.
                  call stdlib_zscal(nrhs,cone/ap(kc + k - 1),b(k,1),ldb)
                  k = k - 1
@@ -19533,7 +19533,7 @@ module stdlib_linalg_lapack_z
                  ! multiply by inv(u(k)), where u(k) is the transformation
                  ! stored in columns k-1 and k of a.
                  call stdlib_zgeru(k - 2,nrhs,-cone,ap(kc),1,b(k,1),ldb,b(1,1),ldb)
-                           
+
                  call stdlib_zgeru(k - 2,nrhs,-cone,ap(kc - (k - 1)),1,b(k - 1,1),ldb,b(1, &
                            1),ldb)
                  ! multiply by the inverse of the diagonal block.
@@ -19551,13 +19551,13 @@ module stdlib_linalg_lapack_z
                  k = k - 2
               end if
               go to 10
-30            continue
+              30 continue
               ! next solve u**t*x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
               kc = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               if (ipiv(k) > 0) then
@@ -19586,7 +19586,7 @@ module stdlib_linalg_lapack_z
                  k = k + 2
               end if
               go to 40
-50            continue
+              50 continue
            else
               ! solve a*x = b, where a = l*d*l**t.
               ! first solve l*d*x = b, overwriting b with x.
@@ -19594,7 +19594,7 @@ module stdlib_linalg_lapack_z
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
               kc = 1
-60            continue
+              60 continue
               ! if k > n, exit from loop.
               if (k > n) go to 80
               if (ipiv(k) > 0) then
@@ -19638,13 +19638,13 @@ module stdlib_linalg_lapack_z
                  k = k + 2
               end if
               go to 60
-80            continue
+              80 continue
               ! next solve l**t*x = b, overwriting b with x.
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
               kc = n*(n + 1)/2 + 1
-90            continue
+              90 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 100
               kc = kc - (n - k + 1)
@@ -19675,7 +19675,7 @@ module stdlib_linalg_lapack_z
                  k = k - 2
               end if
               go to 90
-100           continue
+              100 continue
            end if
            return
      end subroutine stdlib_zsptrs
@@ -19710,7 +19710,7 @@ module stdlib_linalg_lapack_z
            real(dp),parameter :: odm1 = 1.0e-1_dp
            integer(ilp),parameter :: maxits = 5
            integer(ilp),parameter :: extra = 2
-           
+
            ! Local Scalars
            integer(ilp) :: b1,blksiz,bn,gpind,i,iinfo,indrv1,indrv2,indrv3,indrv4, &
                      indrv5,its,j,j1,jblk,jmax,jr,nblk,nrmchk
@@ -19743,7 +19743,7 @@ module stdlib_linalg_lapack_z
                     go to 30
                  end if
               end do
-30            continue
+              30 continue
            end if
            if (info /= 0) then
               call stdlib_xerbla('ZSTEIN',-info)
@@ -19790,7 +19790,7 @@ module stdlib_linalg_lapack_z
               ortol = odm3*onenrm
               dtpcrt = sqrt(odm1/blksiz)
               ! loop through eigenvalues of block nblk.
-60   continue
+              60 continue
               jblk = 0
               loop_170: do j = j1,m
                  if (iblock(j) /= nblk) then
@@ -19825,7 +19825,7 @@ module stdlib_linalg_lapack_z
                  call stdlib_dlagtf(blksiz,work(indrv4 + 1),xj,work(indrv2 + 2),work(indrv3 + &
                            1),tol,work(indrv5 + 1),iwork,iinfo)
                  ! update iteration count.
-70   continue
+                 70 continue
                  its = its + 1
                  if (its > maxits) go to 120
                  ! normalize and scale the righthand side vector pb.
@@ -19853,7 +19853,7 @@ module stdlib_linalg_lapack_z
                     end do
                  end if
                  ! check the infinity norm of the iterate.
-110  continue
+                 110 continue
                  jmax = stdlib_idamax(blksiz,work(indrv1 + 1),1)
                  nrm = abs(work(indrv1 + jmax))
                  ! continue for additional iterations after norm reaches
@@ -19864,16 +19864,16 @@ module stdlib_linalg_lapack_z
                  go to 130
                  ! if stopping criterion was not satisfied, update info and
                  ! store eigenvector number in array ifail.
-120  continue
+                 120 continue
                  info = info + 1
                  ifail(info) = j
                  ! accept iterate as jth eigenvector.
-130  continue
+                 130 continue
                  scl = one/stdlib_dnrm2(blksiz,work(indrv1 + 1),1)
                  jmax = stdlib_idamax(blksiz,work(indrv1 + 1),1)
                  if (work(indrv1 + jmax) < zero) scl = -scl
                  call stdlib_dscal(blksiz,scl,work(indrv1 + 1),1)
-140              continue
+                 140 continue
                  do i = 1,n
                     z(i,j) = czero
                  end do
@@ -19909,7 +19909,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: maxit = 30
-           
+
            ! Local Scalars
            integer(ilp) :: i,icompz,ii,iscale,j,jtot,k,l,l1,lend,lendm1,lendp1,lendsv, &
                       lm1,lsv,m,mm,mm1,nm1,nmaxit
@@ -19963,7 +19963,7 @@ module stdlib_linalg_lapack_z
            ! element is smaller.
            l1 = 1
            nm1 = n - 1
-10         continue
+           10 continue
            if (l1 > n) go to 160
            if (l1 > 1) e(l1 - 1) = zero
            if (l1 <= nm1) then
@@ -19977,7 +19977,7 @@ module stdlib_linalg_lapack_z
               end do
            end if
            m = n
-30         continue
+           30 continue
            l = l1
            lsv = l
            lend = m
@@ -20005,7 +20005,7 @@ module stdlib_linalg_lapack_z
            if (lend > l) then
               ! ql iteration
               ! look for small subdiagonal element.
-40   continue
+              40 continue
               if (l /= lend) then
                  lendm1 = lend - 1
                  do m = l,lendm1
@@ -20014,7 +20014,7 @@ module stdlib_linalg_lapack_z
                  end do
               end if
               m = lend
-60            continue
+              60 continue
               if (m < lend) e(m) = zero
               p = d(l)
               if (m == l) go to 80
@@ -20074,7 +20074,7 @@ module stdlib_linalg_lapack_z
               e(l) = g
               go to 40
               ! eigenvalue found.
-80   continue
+              80 continue
               d(l) = p
               l = l + 1
               if (l <= lend) go to 40
@@ -20082,7 +20082,7 @@ module stdlib_linalg_lapack_z
            else
               ! qr iteration
               ! look for small superdiagonal element.
-90   continue
+              90 continue
               if (l /= lend) then
                  lendp1 = lend + 1
                  do m = l,lendp1,-1
@@ -20091,7 +20091,7 @@ module stdlib_linalg_lapack_z
                  end do
               end if
               m = lend
-110           continue
+              110 continue
               if (m > lend) e(m - 1) = zero
               p = d(l)
               if (m == l) go to 130
@@ -20151,24 +20151,24 @@ module stdlib_linalg_lapack_z
               e(lm1) = g
               go to 90
               ! eigenvalue found.
-130  continue
+              130 continue
               d(l) = p
               l = l - 1
               if (l >= lend) go to 90
               go to 140
            end if
            ! undo scaling if necessary
-140  continue
+           140 continue
            if (iscale == 1) then
               call stdlib_dlascl('G',0,0,ssfmax,anorm,lendsv - lsv + 1,1,d(lsv),n,info)
-                        
+
               call stdlib_dlascl('G',0,0,ssfmax,anorm,lendsv - lsv,1,e(lsv),n,info)
-                        
+
            else if (iscale == 2) then
               call stdlib_dlascl('G',0,0,ssfmin,anorm,lendsv - lsv + 1,1,d(lsv),n,info)
-                        
+
               call stdlib_dlascl('G',0,0,ssfmin,anorm,lendsv - lsv,1,e(lsv),n,info)
-                        
+
            end if
            ! check for no convergence to an eigenvalue after a total
            ! of n*maxit iterations.
@@ -20180,7 +20180,7 @@ module stdlib_linalg_lapack_z
            end if
            go to 10
            ! order eigenvalues and eigenvectors.
-160  continue
+           160 continue
            if (icompz == 0) then
               ! use quick sort
               call stdlib_dlasrt('I',n,d,info)
@@ -20223,7 +20223,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: e(*)
         ! =====================================================================
-           
+
            ! External Subroutines
            logical(lk) :: upper,convert
            integer(ilp) :: i,ip,j
@@ -20441,7 +20441,7 @@ module stdlib_linalg_lapack_z
            integer(ilp),intent(inout) :: ipiv(*)
            complex(dp),intent(inout) :: a(lda,*),e(*)
         ! =====================================================================
-           
+
            ! External Subroutines
            logical(lk) :: upper,convert
            integer(ilp) :: i,ip
@@ -20505,7 +20505,7 @@ module stdlib_linalg_lapack_z
                        if (i < n) then
                           if (ip /= (i - 1)) then
                              call stdlib_zswap(n - i,a(i - 1,i + 1),lda,a(ip,i + 1),lda)
-                                       
+
                           end if
                        end if
                        ! convert ipiv
@@ -20541,7 +20541,7 @@ module stdlib_linalg_lapack_z
                        if (i < n) then
                           if (ip /= (i - 1)) then
                              call stdlib_zswap(n - i,a(ip,i + 1),lda,a(i - 1,i + 1),lda)
-                                       
+
                           end if
                        end if
                        ! convert ipiv
@@ -20696,7 +20696,7 @@ module stdlib_linalg_lapack_z
            integer(ilp),intent(in) :: ipiv(*)
            complex(dp),intent(inout) :: a(lda,*),e(*)
         ! =====================================================================
-           
+
            ! External Subroutines
            logical(lk) :: upper,convert
            integer(ilp) :: i,ip,ip2
@@ -20765,7 +20765,7 @@ module stdlib_linalg_lapack_z
                           end if
                           if (ip2 /= (i - 1)) then
                              call stdlib_zswap(n - i,a(i - 1,i + 1),lda,a(ip2,i + 1),lda)
-                                       
+
                           end if
                        end if
                        i = i - 1
@@ -20798,7 +20798,7 @@ module stdlib_linalg_lapack_z
                        if (i < n) then
                           if (ip2 /= (i - 1)) then
                              call stdlib_zswap(n - i,a(ip2,i + 1),lda,a(i - 1,i + 1),lda)
-                                       
+
                           end if
                           if (ip /= i) then
                              call stdlib_zswap(n - i,a(ip,i + 1),lda,a(i,i + 1),lda)
@@ -20947,7 +20947,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: max_iter = 100
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,iter
            real(dp) :: avg,std,tol,c0,c1,c2,t,u,si,d,base,smin,smax,smlnum,bignum, &
@@ -21088,7 +21088,7 @@ module stdlib_linalg_lapack_z
                  s(i) = si
               end do
            end do
-999        continue
+           999 continue
            smlnum = stdlib_dlamch('SAFEMIN')
            bignum = one/smlnum
            smin = bignum
@@ -21121,7 +21121,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: a(lda,*),x(*)
            complex(dp),intent(inout) :: y(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,info,ix,iy,j,jx,jy,kx,ky
            complex(dp) :: temp1,temp2
@@ -21274,7 +21274,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(in) :: x(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,info,ix,j,jx,kx
            complex(dp) :: temp
@@ -21451,7 +21451,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: sevten = 17.0e+0_dp
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,imax,j,jmax,k,kk,kp,kstep
@@ -21485,7 +21485,7 @@ module stdlib_linalg_lapack_z
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 70
               kstep = 1
@@ -21600,7 +21600,7 @@ module stdlib_linalg_lapack_z
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop
               if (k > n) go to 70
               kstep = 1
@@ -21653,7 +21653,7 @@ module stdlib_linalg_lapack_z
                     ! interchange rows and columns kk and kp in the trailing
                     ! submatrix a(k:n,k:n)
                     if (kp < n) call stdlib_zswap(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     call stdlib_zswap(kp - kk - 1,a(kk + 1,kk),1,a(kp,kk + 1),lda)
                     t = a(kk,kk)
                     a(kk,kk) = a(kp,kp)
@@ -21674,7 +21674,7 @@ module stdlib_linalg_lapack_z
                        ! a := a - l(k)*d(k)*l(k)**t = a - w(k)*(1/d(k))*w(k)**t
                        r1 = cone/a(k,k)
                        call stdlib_zsyr(uplo,n - k,-r1,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                 
+
                        ! store l(k) in column k
                        call stdlib_zscal(n - k,r1,a(k + 1,k),1)
                     end if
@@ -21714,7 +21714,7 @@ module stdlib_linalg_lapack_z
               k = k + kstep
               go to 40
            end if
-70         continue
+           70 continue
            return
      end subroutine stdlib_zsytf2
 
@@ -21743,7 +21743,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: sevten = 17.0e+0_dp
-           
+
            ! Local Scalars
            logical(lk) :: upper,done
            integer(ilp) :: i,imax,j,jmax,itemp,k,kk,kp,kstep,p,ii
@@ -21782,7 +21782,7 @@ module stdlib_linalg_lapack_z
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 34
               kstep = 1
@@ -21816,7 +21816,7 @@ module stdlib_linalg_lapack_z
                  else
                     done = .false.
                     ! loop until pivot found
-12   continue
+                    12 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -21866,7 +21866,7 @@ module stdlib_linalg_lapack_z
                     ! submatrix a(1:k,1:k) if we have a 2-by-2 pivot
                     if (p > 1) call stdlib_zswap(p - 1,a(1,k),1,a(1,p),1)
                     if (p < (k - 1)) call stdlib_zswap(k - p - 1,a(p + 1,k),1,a(p,p + 1),lda)
-                              
+
                     t = a(k,k)
                     a(k,k) = a(p,p)
                     a(p,p) = t
@@ -21969,7 +21969,7 @@ module stdlib_linalg_lapack_z
               ! decrease k and return to the start of the main loop
               k = k - kstep
               go to 10
-34            continue
+              34 continue
            else
               ! factorize a as l*d*l**t using the lower triangle of a
               ! initialize the unused last entry of the subdiagonal array e.
@@ -21977,7 +21977,7 @@ module stdlib_linalg_lapack_z
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop
               if (k > n) go to 64
               kstep = 1
@@ -22010,7 +22010,7 @@ module stdlib_linalg_lapack_z
                  else
                     done = .false.
                     ! loop until pivot found
-42   continue
+                    42 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -22060,7 +22060,7 @@ module stdlib_linalg_lapack_z
                     ! submatrix a(k:n,k:n) if we have a 2-by-2 pivot
                     if (p < n) call stdlib_zswap(n - p,a(p + 1,k),1,a(p + 1,p),1)
                     if (p > (k + 1)) call stdlib_zswap(p - k - 1,a(k + 1,k),1,a(p,k + 1),lda)
-                              
+
                     t = a(k,k)
                     a(k,k) = a(p,p)
                     a(p,p) = t
@@ -22074,7 +22074,7 @@ module stdlib_linalg_lapack_z
                     ! interchange rows and columns kk and kp in the trailing
                     ! submatrix a(k:n,k:n)
                     if (kp < n) call stdlib_zswap(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     if ((kk < n) .and. (kp > (kk + 1))) call stdlib_zswap(kp - kk - 1,a(kk + 1,kk), &
                               1,a(kp,kk + 1),lda)
                     t = a(kk,kk)
@@ -22103,7 +22103,7 @@ module stdlib_linalg_lapack_z
                              ! = a - w(k)*(1/d(k))*w(k)**t
                           d11 = cone/a(k,k)
                           call stdlib_zsyr(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                           ! store l(k) in column k
                           call stdlib_zscal(n - k,d11,a(k + 1,k),1)
                        else
@@ -22117,7 +22117,7 @@ module stdlib_linalg_lapack_z
                              ! = a - w(k)*(1/d(k))*w(k)**t
                              ! = a - (w(k)/d(k))*(d(k))*(w(k)/d(k))**t
                           call stdlib_zsyr(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                        end if
                        ! store the subdiagonal element of d in array e
                        e(k) = czero
@@ -22168,7 +22168,7 @@ module stdlib_linalg_lapack_z
               ! increase k and return to the start of the main loop
               k = k + kstep
               go to 40
-64            continue
+              64 continue
            end if
            return
      end subroutine stdlib_zsytf2_rk
@@ -22195,7 +22195,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: sevten = 17.0e+0_dp
-           
+
            ! Local Scalars
            logical(lk) :: upper,done
            integer(ilp) :: i,imax,j,jmax,itemp,k,kk,kp,kstep,p,ii
@@ -22231,7 +22231,7 @@ module stdlib_linalg_lapack_z
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 70
               kstep = 1
@@ -22263,7 +22263,7 @@ module stdlib_linalg_lapack_z
                  else
                     done = .false.
                     ! loop until pivot found
-12   continue
+                    12 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -22313,7 +22313,7 @@ module stdlib_linalg_lapack_z
                     ! submatrix a(1:k,1:k) if we have a 2-by-2 pivot
                     if (p > 1) call stdlib_zswap(p - 1,a(1,k),1,a(1,p),1)
                     if (p < (k - 1)) call stdlib_zswap(k - p - 1,a(p + 1,k),1,a(p,p + 1),lda)
-                              
+
                     t = a(k,k)
                     a(k,k) = a(p,p)
                     a(p,p) = t
@@ -22407,7 +22407,7 @@ module stdlib_linalg_lapack_z
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop
               if (k > n) go to 70
               kstep = 1
@@ -22438,7 +22438,7 @@ module stdlib_linalg_lapack_z
                  else
                     done = .false.
                     ! loop until pivot found
-42   continue
+                    42 continue
                        ! begin pivot search loop body
                        ! jmax is the column-index of the largest off-diagonal
                        ! element in row imax, and rowmax is its absolute value.
@@ -22488,7 +22488,7 @@ module stdlib_linalg_lapack_z
                     ! submatrix a(k:n,k:n) if we have a 2-by-2 pivot
                     if (p < n) call stdlib_zswap(n - p,a(p + 1,k),1,a(p + 1,p),1)
                     if (p > (k + 1)) call stdlib_zswap(p - k - 1,a(k + 1,k),1,a(p,k + 1),lda)
-                              
+
                     t = a(k,k)
                     a(k,k) = a(p,p)
                     a(p,p) = t
@@ -22499,7 +22499,7 @@ module stdlib_linalg_lapack_z
                     ! interchange rows and columns kk and kp in the trailing
                     ! submatrix a(k:n,k:n)
                     if (kp < n) call stdlib_zswap(n - kp,a(kp + 1,kk),1,a(kp + 1,kp),1)
-                              
+
                     if ((kk < n) .and. (kp > (kk + 1))) call stdlib_zswap(kp - kk - 1,a(kk + 1,kk), &
                               1,a(kp,kk + 1),lda)
                     t = a(kk,kk)
@@ -22525,7 +22525,7 @@ module stdlib_linalg_lapack_z
                              ! = a - w(k)*(1/d(k))*w(k)**t
                           d11 = cone/a(k,k)
                           call stdlib_zsyr(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                           ! store l(k) in column k
                           call stdlib_zscal(n - k,d11,a(k + 1,k),1)
                        else
@@ -22539,7 +22539,7 @@ module stdlib_linalg_lapack_z
                              ! = a - w(k)*(1/d(k))*w(k)**t
                              ! = a - (w(k)/d(k))*(d(k))*(w(k)/d(k))**t
                           call stdlib_zsyr(uplo,n - k,-d11,a(k + 1,k),1,a(k + 1,k + 1),lda)
-                                    
+
                        end if
                     end if
                  else
@@ -22583,7 +22583,7 @@ module stdlib_linalg_lapack_z
               k = k + kstep
               go to 40
            end if
-70         continue
+           70 continue
            return
      end subroutine stdlib_zsytf2_rook
 
@@ -22658,7 +22658,7 @@ module stdlib_linalg_lapack_z
               ! kb, where kb is the number of columns factorized by stdlib_zlasyf;
               ! kb is either nb or nb-1, or k for the last block
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 40
               if (k > nb) then
@@ -22681,7 +22681,7 @@ module stdlib_linalg_lapack_z
               ! kb, where kb is the number of columns factorized by stdlib_zlasyf;
               ! kb is either nb or nb-1, or n-k+1 for the last block
               k = 1
-20            continue
+              20 continue
               ! if k > n, exit from loop
               if (k > n) go to 40
               if (k <= n - nb) then
@@ -22708,7 +22708,7 @@ module stdlib_linalg_lapack_z
               k = k + kb
               go to 20
            end if
-40         continue
+           40 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_zsytrf
@@ -22785,14 +22785,14 @@ module stdlib_linalg_lapack_z
               ! kb, where kb is the number of columns factorized by stdlib_zlasyf_rk;
               ! kb is either nb or nb-1, or k for the last block
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 15
               if (k > nb) then
                  ! factorize columns k-kb+1:k of a and use blocked code to
                  ! update columns 1:k-kb
                  call stdlib_zlasyf_rk(uplo,k,nb,kb,a,lda,e,ipiv,work,ldwork,iinfo)
-                           
+
               else
                  ! use unblocked code to factorize columns 1:k of a
                  call stdlib_zsytf2_rk(uplo,k,a,lda,e,ipiv,iinfo)
@@ -22821,14 +22821,14 @@ module stdlib_linalg_lapack_z
               go to 10
               ! this label is the exit from main loop over k decreasing
               ! from n to 1 in steps of kb
-15   continue
+              15 continue
            else
               ! factorize a as l*d*l**t using the lower triangle of a
               ! k is the main loop index, increasing from 1 to n in steps of
               ! kb, where kb is the number of columns factorized by stdlib_zlasyf_rk;
               ! kb is either nb or nb-1, or n-k+1 for the last block
               k = 1
-20            continue
+              20 continue
               ! if k > n, exit from loop
               if (k > n) go to 35
               if (k <= n - nb) then
@@ -22839,7 +22839,7 @@ module stdlib_linalg_lapack_z
               else
                  ! use unblocked code to factorize columns k:n of a
                  call stdlib_zsytf2_rk(uplo,n - k + 1,a(k,k),lda,e(k),ipiv(k),iinfo)
-                           
+
                  kb = n - k + 1
               end if
               ! set info on the first occurrence of a zero pivot
@@ -22872,7 +22872,7 @@ module stdlib_linalg_lapack_z
               go to 20
               ! this label is the exit from main loop over k increasing
               ! from 1 to n in steps of kb
-35   continue
+              35 continue
            ! end lower
            end if
            work(1) = lwkopt
@@ -22950,14 +22950,14 @@ module stdlib_linalg_lapack_z
               ! kb, where kb is the number of columns factorized by stdlib_zlasyf_rook;
               ! kb is either nb or nb-1, or k for the last block
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 40
               if (k > nb) then
                  ! factorize columns k-kb+1:k of a and use blocked code to
                  ! update columns 1:k-kb
                  call stdlib_zlasyf_rook(uplo,k,nb,kb,a,lda,ipiv,work,ldwork,iinfo)
-                           
+
               else
                  ! use unblocked code to factorize columns 1:k of a
                  call stdlib_zsytf2_rook(uplo,k,a,lda,ipiv,iinfo)
@@ -22975,7 +22975,7 @@ module stdlib_linalg_lapack_z
               ! kb, where kb is the number of columns factorized by stdlib_zlasyf_rook;
               ! kb is either nb or nb-1, or n-k+1 for the last block
               k = 1
-20            continue
+              20 continue
               ! if k > n, exit from loop
               if (k > n) go to 40
               if (k <= n - nb) then
@@ -23002,7 +23002,7 @@ module stdlib_linalg_lapack_z
               k = k + kb
               go to 20
            end if
-40         continue
+           40 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_zsytrf_rook
@@ -23024,7 +23024,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: k,kp,kstep
@@ -23066,7 +23066,7 @@ module stdlib_linalg_lapack_z
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-30            continue
+              30 continue
               ! if k > n, exit from loop.
               if (k > n) go to 40
               if (ipiv(k) > 0) then
@@ -23077,7 +23077,7 @@ module stdlib_linalg_lapack_z
                  if (k > 1) then
                     call stdlib_zcopy(k - 1,a(1,k),1,work,1)
                     call stdlib_zsymv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - stdlib_zdotu(k - 1,work,1,a(1,k),1)
                  end if
                  kstep = 1
@@ -23096,15 +23096,15 @@ module stdlib_linalg_lapack_z
                  if (k > 1) then
                     call stdlib_zcopy(k - 1,a(1,k),1,work,1)
                     call stdlib_zsymv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - stdlib_zdotu(k - 1,work,1,a(1,k),1)
                     a(k,k + 1) = a(k,k + 1) - stdlib_zdotu(k - 1,a(1,k),1,a(1,k + 1),1)
-                              
+
                     call stdlib_zcopy(k - 1,a(1,k + 1),1,work,1)
                     call stdlib_zsymv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k + 1),1)
-                              
+
                     a(k + 1,k + 1) = a(k + 1,k + 1) - stdlib_zdotu(k - 1,work,1,a(1,k + 1),1)
-                              
+
                  end if
                  kstep = 2
               end if
@@ -23125,13 +23125,13 @@ module stdlib_linalg_lapack_z
               end if
               k = k + kstep
               go to 30
-40            continue
+              40 continue
            else
               ! compute inv(a) from the factorization a = l*d*l**t.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-50            continue
+              50 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 60
               if (ipiv(k) > 0) then
@@ -23169,7 +23169,7 @@ module stdlib_linalg_lapack_z
                     call stdlib_zsymv(uplo,n - k,-cone,a(k + 1,k + 1),lda,work,1,czero,a(k + &
                               1,k - 1),1)
                     a(k - 1,k - 1) = a(k - 1,k - 1) - stdlib_zdotu(n - k,work,1,a(k + 1,k - 1),1)
-                              
+
                  end if
                  kstep = 2
               end if
@@ -23190,7 +23190,7 @@ module stdlib_linalg_lapack_z
               end if
               k = k - kstep
               go to 50
-60            continue
+              60 continue
            end if
            return
      end subroutine stdlib_zsytri
@@ -23212,7 +23212,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: k,kp,kstep
@@ -23254,7 +23254,7 @@ module stdlib_linalg_lapack_z
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-30            continue
+              30 continue
               ! if k > n, exit from loop.
               if (k > n) go to 40
               if (ipiv(k) > 0) then
@@ -23265,7 +23265,7 @@ module stdlib_linalg_lapack_z
                  if (k > 1) then
                     call stdlib_zcopy(k - 1,a(1,k),1,work,1)
                     call stdlib_zsymv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - stdlib_zdotu(k - 1,work,1,a(1,k),1)
                  end if
                  kstep = 1
@@ -23284,15 +23284,15 @@ module stdlib_linalg_lapack_z
                  if (k > 1) then
                     call stdlib_zcopy(k - 1,a(1,k),1,work,1)
                     call stdlib_zsymv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k),1)
-                              
+
                     a(k,k) = a(k,k) - stdlib_zdotu(k - 1,work,1,a(1,k),1)
                     a(k,k + 1) = a(k,k + 1) - stdlib_zdotu(k - 1,a(1,k),1,a(1,k + 1),1)
-                              
+
                     call stdlib_zcopy(k - 1,a(1,k + 1),1,work,1)
                     call stdlib_zsymv(uplo,k - 1,-cone,a,lda,work,1,czero,a(1,k + 1),1)
-                              
+
                     a(k + 1,k + 1) = a(k + 1,k + 1) - stdlib_zdotu(k - 1,work,1,a(1,k + 1),1)
-                              
+
                  end if
                  kstep = 2
               end if
@@ -23333,13 +23333,13 @@ module stdlib_linalg_lapack_z
               end if
               k = k + 1
               go to 30
-40            continue
+              40 continue
            else
               ! compute inv(a) from the factorization a = l*d*l**t.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-50            continue
+              50 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 60
               if (ipiv(k) > 0) then
@@ -23377,7 +23377,7 @@ module stdlib_linalg_lapack_z
                     call stdlib_zsymv(uplo,n - k,-cone,a(k + 1,k + 1),lda,work,1,czero,a(k + 1, &
                                k - 1),1)
                     a(k - 1,k - 1) = a(k - 1,k - 1) - stdlib_zdotu(n - k,work,1,a(k + 1,k - 1),1)
-                              
+
                  end if
                  kstep = 2
               end if
@@ -23418,7 +23418,7 @@ module stdlib_linalg_lapack_z
               end if
               k = k - 1
               go to 50
-60            continue
+              60 continue
            end if
            return
      end subroutine stdlib_zsytri_rook
@@ -23440,7 +23440,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: a(lda,*)
            complex(dp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kp
@@ -23473,7 +23473,7 @@ module stdlib_linalg_lapack_z
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 30
               if (ipiv(k) > 0) then
@@ -23513,12 +23513,12 @@ module stdlib_linalg_lapack_z
                  k = k - 2
               end if
               go to 10
-30            continue
+              30 continue
               ! next solve u**t *x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               if (ipiv(k) > 0) then
@@ -23545,14 +23545,14 @@ module stdlib_linalg_lapack_z
                  k = k + 2
               end if
               go to 40
-50            continue
+              50 continue
            else
               ! solve a*x = b, where a = l*d*l**t.
               ! first solve l*d*x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-60            continue
+              60 continue
               ! if k > n, exit from loop.
               if (k > n) go to 80
               if (ipiv(k) > 0) then
@@ -23594,12 +23594,12 @@ module stdlib_linalg_lapack_z
                  k = k + 2
               end if
               go to 60
-80            continue
+              80 continue
               ! next solve l**t *x = b, overwriting b with x.
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-90            continue
+              90 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 100
               if (ipiv(k) > 0) then
@@ -23628,7 +23628,7 @@ module stdlib_linalg_lapack_z
                  k = k - 2
               end if
               go to 90
-100           continue
+              100 continue
            end if
            return
      end subroutine stdlib_zsytrs
@@ -23650,7 +23650,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,iinfo,j,k,kp
@@ -23759,7 +23759,7 @@ module stdlib_linalg_lapack_z
                  ! interchange rows k and -ipiv(k+1).
                  kp = -ipiv(k + 1)
                  if (kp == -ipiv(k)) call stdlib_zswap(nrhs,b(k + 1,1),ldb,b(kp,1),ldb)
-                           
+
                  k = k + 2
               end if
              end do
@@ -23834,7 +23834,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: a(lda,*),e(*)
            complex(dp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,j,k,kp
@@ -23973,7 +23973,7 @@ module stdlib_linalg_lapack_z
      !> A = L*T*L**T computed by ZSYTRF_AA.
 
      pure subroutine stdlib_zsytrs_aa(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -23987,7 +23987,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: b(ldb,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            logical(lk) :: lquery,upper
            integer(ilp) :: k,kp,lwkopt
            ! Intrinsic Functions
@@ -24104,7 +24104,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: a(lda,*)
            complex(dp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kp
@@ -24137,7 +24137,7 @@ module stdlib_linalg_lapack_z
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 30
               if (ipiv(k) > 0) then
@@ -24181,12 +24181,12 @@ module stdlib_linalg_lapack_z
                  k = k - 2
               end if
               go to 10
-30            continue
+              30 continue
               ! next solve u**t *x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               if (ipiv(k) > 0) then
@@ -24217,14 +24217,14 @@ module stdlib_linalg_lapack_z
                  k = k + 2
               end if
               go to 40
-50            continue
+              50 continue
            else
               ! solve a*x = b, where a = l*d*l**t.
               ! first solve l*d*x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-60            continue
+              60 continue
               ! if k > n, exit from loop.
               if (k > n) go to 80
               if (ipiv(k) > 0) then
@@ -24268,12 +24268,12 @@ module stdlib_linalg_lapack_z
                  k = k + 2
               end if
               go to 60
-80            continue
+              80 continue
               ! next solve l**t *x = b, overwriting b with x.
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-90            continue
+              90 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 100
               if (ipiv(k) > 0) then
@@ -24304,7 +24304,7 @@ module stdlib_linalg_lapack_z
                  k = k - 2
               end if
               go to 90
-100           continue
+              100 continue
            end if
            return
      end subroutine stdlib_zsytrs_rook
@@ -24330,7 +24330,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: ab(ldab,*),b(ldb,*),x(ldx,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            character :: transn,transt
@@ -24523,7 +24523,7 @@ module stdlib_linalg_lapack_z
                  end if
               end do
               kase = 0
-210           continue
+              210 continue
               call stdlib_zlacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -24557,7 +24557,7 @@ module stdlib_linalg_lapack_z
      !> N-by-NRHS matrix.  A check is made to verify that A is nonsingular.
 
      pure subroutine stdlib_ztbtrs(uplo,trans,diag,n,kd,nrhs,ab,ldab,b,ldb,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -24569,7 +24569,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: ab(ldab,*)
            complex(dp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,upper
            integer(ilp) :: j
@@ -24634,7 +24634,7 @@ module stdlib_linalg_lapack_z
      !> The matrix X is overwritten on B.
 
      pure subroutine stdlib_ztfsm(transr,side,uplo,trans,diag,m,n,alpha,a,b,ldb)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -24646,7 +24646,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: a(0:*)
            complex(dp),intent(inout) :: b(0:ldb - 1,0:*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,lside,misodd,nisodd,normaltransr,notrans
            integer(ilp) :: m1,m2,n1,n2,k,info,i,j
@@ -24721,7 +24721,7 @@ module stdlib_linalg_lapack_z
                           ! trans = 'n'
                           if (m == 1) then
                              call stdlib_ztrsm('L','L','N',diag,m1,n,alpha,a,m,b,ldb)
-                                       
+
                           else
                              call stdlib_ztrsm('L','L','N',diag,m1,n,alpha,a(0),m,b, &
                                        ldb)
@@ -24764,7 +24764,7 @@ module stdlib_linalg_lapack_z
                           call stdlib_zgemm('N','N',m1,n,m2,-cone,a(0),m,b(m1,0), &
                                     ldb,alpha,b,ldb)
                           call stdlib_ztrsm('L','L','C',diag,m1,n,cone,a(m2),m,b,ldb)
-                                    
+
                        end if
                     end if
                  else
@@ -24846,7 +24846,7 @@ module stdlib_linalg_lapack_z
                           call stdlib_zgemm('C','N',k,n,k,-cone,a(k + 1),m + 1,b(k,0), &
                                     ldb,alpha,b,ldb)
                           call stdlib_ztrsm('L','L','C',diag,k,n,cone,a(1),m + 1,b,ldb)
-                                    
+
                        end if
                     else
                        ! side  ='l', n is even, transr = 'n', and uplo = 'u'
@@ -24878,7 +24878,7 @@ module stdlib_linalg_lapack_z
                           ! side  ='l', n is even, transr = 'c', uplo = 'l',
                           ! and trans = 'n'
                           call stdlib_ztrsm('L','U','C',diag,k,n,alpha,a(k),k,b,ldb)
-                                    
+
                           call stdlib_zgemm('C','N',k,n,k,-cone,a(k*(k + 1)),k,b,ldb, &
                                     alpha,b(k,0),ldb)
                           call stdlib_ztrsm('L','L','N',diag,k,n,cone,a(0),k,b(k,0), &
@@ -24891,7 +24891,7 @@ module stdlib_linalg_lapack_z
                           call stdlib_zgemm('N','N',k,n,k,-cone,a(k*(k + 1)),k,b(k,0) &
                                     ,ldb,alpha,b,ldb)
                           call stdlib_ztrsm('L','U','N',diag,k,n,cone,a(k),k,b,ldb)
-                                    
+
                        end if
                     else
                        ! side  ='l', n is even, transr = 'c', and uplo = 'u'
@@ -25670,7 +25670,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: vl(ldvl,*),vr(ldvr,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: compl,compr,ilall,ilback,ilbbad,ilcomp,lsa,lsb
            integer(ilp) :: i,ibeg,ieig,iend,ihwmny,im,iside,isrc,j,je,jr
@@ -25825,7 +25825,7 @@ module stdlib_linalg_lapack_z
                     scale = one
                     if (lsa) scale = (small/abs(sbeta))*min(anorm,big)
                     if (lsb) scale = max(scale, (small/abs1(salpha))*min(bnorm,big))
-                              
+
                     if (lsa .or. lsb) then
                        scale = min(scale,one/(safmin*max(one,abs(acoeff),abs1(bcoeff)) &
                                  ))
@@ -25954,7 +25954,7 @@ module stdlib_linalg_lapack_z
                     scale = one
                     if (lsa) scale = (small/abs(sbeta))*min(anorm,big)
                     if (lsb) scale = max(scale, (small/abs1(salpha))*min(bnorm,big))
-                              
+
                     if (lsa .or. lsb) then
                        scale = min(scale,one/(safmin*max(one,abs(acoeff),abs1(bcoeff)) &
                                  ))
@@ -26058,7 +26058,7 @@ module stdlib_linalg_lapack_z
      !> Q(in) * B(in) * Z(in)**H = Q(out) * B(out) * Z(out)**H
 
      pure subroutine stdlib_ztgex2(wantq,wantz,n,a,lda,b,ldb,q,ldq,z,ldz,j1,info)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -26073,7 +26073,7 @@ module stdlib_linalg_lapack_z
            real(dp),parameter :: twenty = 2.0e+1_dp
            integer(ilp),parameter :: ldst = 2
            logical(lk),parameter :: wands = .true.
-           
+
            ! Local Scalars
            logical(lk) :: strong,weak
            integer(ilp) :: i,m
@@ -26175,13 +26175,13 @@ module stdlib_linalg_lapack_z
            b(j1 + 1,j1) = czero
            ! accumulate transformations into q and z if requested.
            if (wantz) call stdlib_zrot(n,z(1,j1),1,z(1,j1 + 1),1,cz,conjg(sz))
-                     
+
            if (wantq) call stdlib_zrot(n,q(1,j1),1,q(1,j1 + 1),1,cq,conjg(sq))
-                     
+
            ! exit with info = 0 if swap was successfully performed.
            return
            ! exit with info = 1 if swap was rejected.
-20   continue
+           20 continue
            info = 1
            return
      end subroutine stdlib_ztgex2
@@ -26241,10 +26241,10 @@ module stdlib_linalg_lapack_z
            if (ifst == ilst) return
            if (ifst < ilst) then
               here = ifst
-10            continue
+              10 continue
               ! swap with next one below
               call stdlib_ztgex2(wantq,wantz,n,a,lda,b,ldb,q,ldq,z,ldz,here,info)
-                        
+
               if (info /= 0) then
                  ilst = here
                  return
@@ -26254,10 +26254,10 @@ module stdlib_linalg_lapack_z
               here = here - 1
            else
               here = ifst - 1
-20            continue
+              20 continue
               ! swap with next one above
               call stdlib_ztgex2(wantq,wantz,n,a,lda,b,ldb,q,ldq,z,ldz,here,info)
-                        
+
               if (info /= 0) then
                  ilst = here
                  return
@@ -26285,7 +26285,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(dp),intent(out) :: t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,p,mp,np
            complex(dp) :: alpha
@@ -26401,7 +26401,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(dp),intent(out) :: t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,p,mp,np
            complex(dp) :: alpha
@@ -26446,7 +26446,7 @@ module stdlib_linalg_lapack_z
                     a(i,i + j) = a(i,i + j) + alpha*conjg(t(j,n))
                  end do
                  call stdlib_zgerc(p,n - i,alpha,b(1,i),1,t(1,n),1,b(1,i + 1),ldb)
-                           
+
               end if
            end do
            do i = 2,n
@@ -26468,7 +26468,7 @@ module stdlib_linalg_lapack_z
                         np,i),1)
               ! b1
               call stdlib_zgemv('C',m - l,i - 1,alpha,b,ldb,b(1,i),1,cone,t(1,i),1)
-                        
+
               ! t(1:i-1,i) := t(1:i-1,1:i-1) * t(1:i-1,i)
               call stdlib_ztrmv('U','N','N',i - 1,t,ldt,t(1,i),1)
               ! t(i,i) = tau(i)
@@ -26494,7 +26494,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: t(ldt,*),v(ldv,*)
            complex(dp),intent(out) :: work(ldwork,*)
         ! ==========================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,mp,np,kp
            logical(lk) :: left,forward,column,right,backward,row
@@ -26552,9 +26552,9 @@ module stdlib_linalg_lapack_z
                  end do
               end do
               call stdlib_ztrmm('L','U','C','N',l,n,cone,v(mp,1),ldv,work,ldwork)
-                        
+
               call stdlib_zgemm('C','N',l,n,m - l,cone,v,ldv,b,ldb,cone,work,ldwork)
-                        
+
               call stdlib_zgemm('C','N',k - l,n,m,cone,v(1,kp),ldv,b,ldb,czero,work( &
                         kp,1),ldwork)
               do j = 1,n
@@ -26569,11 +26569,11 @@ module stdlib_linalg_lapack_z
                  end do
               end do
               call stdlib_zgemm('N','N',m - l,n,k,-cone,v,ldv,work,ldwork,cone,b,ldb)
-                        
+
               call stdlib_zgemm('N','N',l,n,k - l,-cone,v(mp,kp),ldv,work(kp,1), &
                         ldwork,cone,b(mp,1),ldb)
               call stdlib_ztrmm('L','U','N','N',l,n,cone,v(mp,1),ldv,work,ldwork)
-                        
+
               do j = 1,n
                  do i = 1,l
                     b(m - l + i,j) = b(m - l + i,j) - work(i,j)
@@ -26597,9 +26597,9 @@ module stdlib_linalg_lapack_z
                  end do
               end do
               call stdlib_ztrmm('R','U','N','N',m,l,cone,v(np,1),ldv,work,ldwork)
-                        
+
               call stdlib_zgemm('N','N',m,l,n - l,cone,b,ldb,v,ldv,cone,work,ldwork)
-                        
+
               call stdlib_zgemm('N','N',m,k - l,n,cone,b,ldb,v(1,kp),ldv,czero,work( &
                         1,kp),ldwork)
               do j = 1,k
@@ -26614,11 +26614,11 @@ module stdlib_linalg_lapack_z
                  end do
               end do
               call stdlib_zgemm('N','C',m,n - l,k,-cone,work,ldwork,v,ldv,cone,b,ldb)
-                        
+
               call stdlib_zgemm('N','C',m,l,k - l,-cone,work(1,kp),ldwork,v(np,kp), &
                         ldv,cone,b(1,np),ldb)
               call stdlib_ztrmm('R','U','C','N',m,l,cone,v(np,1),ldv,work,ldwork)
-                        
+
               do j = 1,l
                  do i = 1,m
                     b(i,n - l + j) = b(i,n - l + j) - work(i,j)
@@ -26647,7 +26647,7 @@ module stdlib_linalg_lapack_z
               call stdlib_zgemm('C','N',l,n,m - l,cone,v(mp,kp),ldv,b(mp,1),ldb, &
                         cone,work(kp,1),ldwork)
               call stdlib_zgemm('C','N',k - l,n,m,cone,v,ldv,b,ldb,czero,work,ldwork)
-                        
+
               do j = 1,n
                  do i = 1,k
                     work(i,j) = work(i,j) + a(i,j)
@@ -26662,7 +26662,7 @@ module stdlib_linalg_lapack_z
               call stdlib_zgemm('N','N',m - l,n,k,-cone,v(mp,1),ldv,work,ldwork,cone, &
                         b(mp,1),ldb)
               call stdlib_zgemm('N','N',l,n,k - l,-cone,v,ldv,work,ldwork,cone,b,ldb)
-                        
+
               call stdlib_ztrmm('L','L','N','N',l,n,cone,v(1,kp),ldv,work(kp,1), &
                         ldwork)
               do j = 1,n
@@ -26692,7 +26692,7 @@ module stdlib_linalg_lapack_z
               call stdlib_zgemm('N','N',m,l,n - l,cone,b(1,np),ldb,v(np,kp),ldv, &
                         cone,work(1,kp),ldwork)
               call stdlib_zgemm('N','N',m,k - l,n,cone,b,ldb,v,ldv,czero,work,ldwork)
-                        
+
               do j = 1,k
                  do i = 1,m
                     work(i,j) = work(i,j) + a(i,j)
@@ -26707,7 +26707,7 @@ module stdlib_linalg_lapack_z
               call stdlib_zgemm('N','C',m,n - l,k,-cone,work,ldwork,v(np,1),ldv,cone, &
                         b(1,np),ldb)
               call stdlib_zgemm('N','C',m,l,k - l,-cone,work,ldwork,v,ldv,cone,b,ldb)
-                        
+
               call stdlib_ztrmm('R','L','C','N',m,l,cone,v(1,kp),ldv,work(1,kp), &
                         ldwork)
               do j = 1,l
@@ -26733,9 +26733,9 @@ module stdlib_linalg_lapack_z
                  end do
               end do
               call stdlib_ztrmm('L','L','N','N',l,n,cone,v(1,mp),ldv,work,ldb)
-                        
+
               call stdlib_zgemm('N','N',l,n,m - l,cone,v,ldv,b,ldb,cone,work,ldwork)
-                        
+
               call stdlib_zgemm('N','N',k - l,n,m,cone,v(kp,1),ldv,b,ldb,czero,work( &
                         kp,1),ldwork)
               do j = 1,n
@@ -26750,11 +26750,11 @@ module stdlib_linalg_lapack_z
                  end do
               end do
               call stdlib_zgemm('C','N',m - l,n,k,-cone,v,ldv,work,ldwork,cone,b,ldb)
-                        
+
               call stdlib_zgemm('C','N',l,n,k - l,-cone,v(kp,mp),ldv,work(kp,1), &
                         ldwork,cone,b(mp,1),ldb)
               call stdlib_ztrmm('L','L','C','N',l,n,cone,v(1,mp),ldv,work,ldwork)
-                        
+
               do j = 1,n
                  do i = 1,l
                     b(m - l + i,j) = b(m - l + i,j) - work(i,j)
@@ -26777,9 +26777,9 @@ module stdlib_linalg_lapack_z
                  end do
               end do
               call stdlib_ztrmm('R','L','C','N',m,l,cone,v(1,np),ldv,work,ldwork)
-                        
+
               call stdlib_zgemm('N','C',m,l,n - l,cone,b,ldb,v,ldv,cone,work,ldwork)
-                        
+
               call stdlib_zgemm('N','C',m,k - l,n,cone,b,ldb,v(kp,1),ldv,czero,work( &
                         1,kp),ldwork)
               do j = 1,k
@@ -26794,11 +26794,11 @@ module stdlib_linalg_lapack_z
                  end do
               end do
               call stdlib_zgemm('N','N',m,n - l,k,-cone,work,ldwork,v,ldv,cone,b,ldb)
-                        
+
               call stdlib_zgemm('N','N',m,l,k - l,-cone,work(1,kp),ldwork,v(kp,np), &
                         ldv,cone,b(1,np),ldb)
               call stdlib_ztrmm('R','L','N','N',m,l,cone,v(1,np),ldv,work,ldwork)
-                        
+
               do j = 1,l
                  do i = 1,m
                     b(i,n - l + j) = b(i,n - l + j) - work(i,j)
@@ -26826,7 +26826,7 @@ module stdlib_linalg_lapack_z
               call stdlib_zgemm('N','N',l,n,m - l,cone,v(kp,mp),ldv,b(mp,1),ldb, &
                         cone,work(kp,1),ldwork)
               call stdlib_zgemm('N','N',k - l,n,m,cone,v,ldv,b,ldb,czero,work,ldwork)
-                        
+
               do j = 1,n
                  do i = 1,k
                     work(i,j) = work(i,j) + a(i,j)
@@ -26841,7 +26841,7 @@ module stdlib_linalg_lapack_z
               call stdlib_zgemm('C','N',m - l,n,k,-cone,v(1,mp),ldv,work,ldwork,cone, &
                         b(mp,1),ldb)
               call stdlib_zgemm('C','N',l,n,k - l,-cone,v,ldv,work,ldwork,cone,b,ldb)
-                        
+
               call stdlib_ztrmm('L','U','C','N',l,n,cone,v(kp,1),ldv,work(kp,1), &
                         ldwork)
               do j = 1,n
@@ -26870,7 +26870,7 @@ module stdlib_linalg_lapack_z
               call stdlib_zgemm('N','C',m,l,n - l,cone,b(1,np),ldb,v(kp,np),ldv, &
                         cone,work(1,kp),ldwork)
               call stdlib_zgemm('N','C',m,k - l,n,cone,b,ldb,v,ldv,czero,work,ldwork)
-                        
+
               do j = 1,k
                  do i = 1,m
                     work(i,j) = work(i,j) + a(i,j)
@@ -26885,7 +26885,7 @@ module stdlib_linalg_lapack_z
               call stdlib_zgemm('N','N',m,n - l,k,-cone,work,ldwork,v(1,np),ldv,cone, &
                         b(1,np),ldb)
               call stdlib_zgemm('N','N',m,l,k - l,-cone,work,ldwork,v,ldv,cone,b,ldb)
-                        
+
               call stdlib_ztrmm('R','U','N','N',m,l,cone,v(kp,1),ldv,work(1,kp), &
                         ldwork)
               do j = 1,l
@@ -26918,7 +26918,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: ap(*),b(ldb,*),x(ldx,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            character :: transn,transt
@@ -27119,7 +27119,7 @@ module stdlib_linalg_lapack_z
                  end if
               end do
               kase = 0
-210           continue
+              210 continue
               call stdlib_zlacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -27161,7 +27161,7 @@ module stdlib_linalg_lapack_z
            ! Array Arguments
            complex(dp),intent(inout) :: ap(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,upper
            integer(ilp) :: j,jc,jclast,jj
@@ -27255,7 +27255,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: ap(*)
            complex(dp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,upper
            integer(ilp) :: j,jc
@@ -27656,7 +27656,7 @@ module stdlib_linalg_lapack_z
            ! Parameters
            complex(dp),parameter :: cmzero = (0.0e+0_dp,0.0e+0_dp)
            complex(dp),parameter :: cmone = (1.0e+0_dp,0.0e+0_dp)
-           
+
            ! Local Scalars
            logical(lk) :: allv,bothv,leftv,over,rightv,somev
            integer(ilp) :: i,ii,is,j,k,ki
@@ -27856,7 +27856,7 @@ module stdlib_linalg_lapack_z
            ! Parameters
            integer(ilp),parameter :: nbmin = 8
            integer(ilp),parameter :: nbmax = 128
-           
+
            ! Local Scalars
            logical(lk) :: allv,bothv,leftv,lquery,over,rightv,somev
            integer(ilp) :: i,ii,is,j,k,ki,iv,maxwrk,nb
@@ -28183,7 +28183,7 @@ module stdlib_linalg_lapack_z
               call stdlib_zlartg(t(k,k + 1),t22 - t11,cs,sn,temp)
               ! apply transformation to the matrix t.
               if (k + 2 <= n) call stdlib_zrot(n - k - 1,t(k,k + 2),ldt,t(k + 1,k + 2),ldt,cs,sn)
-                        
+
               call stdlib_zrot(k - 1,t(1,k),1,t(1,k + 1),1,cs,conjg(sn))
               t(k,k) = t22
               t(k + 1,k + 1) = t11
@@ -28216,7 +28216,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: a(lda,*),b(ldb,*),x(ldx,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran,nounit,upper
            character :: transn,transt
@@ -28407,7 +28407,7 @@ module stdlib_linalg_lapack_z
                  end if
               end do
               kase = 0
-210           continue
+              210 continue
               call stdlib_zlacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -28454,7 +28454,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: t(ldt,*),vl(ldvl,*),vr(ldvr,*)
            complex(dp),intent(out) :: work(ldwork,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: somcon,wantbh,wants,wantsp
            character :: normin
@@ -28553,7 +28553,7 @@ module stdlib_linalg_lapack_z
                  est = zero
                  kase = 0
                  normin = 'N'
-30               continue
+                 30 continue
                  call stdlib_zlacn2(n - 1,work(1,n + 1),work,est,kase,isave)
                  if (kase /= 0) then
                     if (kase == 1) then
@@ -28578,7 +28578,7 @@ module stdlib_linalg_lapack_z
                  end if
                  sep(ks) = one/max(est,smlnum)
               end if
-40            continue
+              40 continue
               ks = ks + 1
            end do loop_50
            return
@@ -28599,7 +28599,7 @@ module stdlib_linalg_lapack_z
            ! Array Arguments
            complex(dp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,upper
            integer(ilp) :: j
@@ -28635,7 +28635,7 @@ module stdlib_linalg_lapack_z
                  end if
                  ! compute elements 1:j-1 of j-th column.
                  call stdlib_ztrmv('UPPER','NO TRANSPOSE',diag,j - 1,a,lda,a(1,j),1)
-                           
+
                  call stdlib_zscal(j - 1,ajj,a(1,j),1)
               end do
            else
@@ -28673,7 +28673,7 @@ module stdlib_linalg_lapack_z
            ! Array Arguments
            complex(dp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,upper
            integer(ilp) :: j,jb,nb,nn
@@ -28762,7 +28762,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: a(lda,*)
            complex(dp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit
            ! Intrinsic Functions
@@ -29126,7 +29126,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,iws,ki,kk,ldwork,lwkmin,lwkopt,m1,mu,nb,nbmin, &
@@ -29211,7 +29211,7 @@ module stdlib_linalg_lapack_z
                     ! apply h to a(1:i-1,i:n) from the right
                     call stdlib_zlarzb('RIGHT','NO TRANSPOSE','BACKWARD','ROWWISE',i - 1,n - i + 1, &
                      ib,n - m,a(i,m1),lda,work,ldwork,a(1,i),lda,work(ib + 1),ldwork)
-                               
+
                  end if
               end do
               mu = i + nb - 1
@@ -29254,11 +29254,11 @@ module stdlib_linalg_lapack_z
            real(dp),intent(out) :: phi(*),theta(*)
            complex(dp),intent(out) :: taup1(*),taup2(*),tauq1(*),tauq2(*),work(*)
            complex(dp),intent(inout) :: x11(ldx11,*),x12(ldx12,*),x21(ldx21,*),x22(ldx22,*)
-                     
+
         ! ====================================================================
            ! Parameters
            real(dp),parameter :: realone = 1.0_dp
-           
+
            ! Local Scalars
            logical(lk) :: colmajor,lquery
            integer(ilp) :: i,lworkmin,lworkopt
@@ -29393,7 +29393,7 @@ module stdlib_linalg_lapack_z
                        call stdlib_zlarfgp(m - q - i + 1,x12(i,i),x12(i,i),ldx12,tauq2(i))
                     else
                        call stdlib_zlarfgp(m - q - i + 1,x12(i,i),x12(i,i + 1),ldx12,tauq2(i))
-                                 
+
                     end if
                  end if
                  x12(i,i) = cone
@@ -29417,7 +29417,7 @@ module stdlib_linalg_lapack_z
               ! reduce columns q + 1, ..., p of x12, x22
               do i = q + 1,p
                  call stdlib_zscal(m - q - i + 1,cmplx(-z1*z4,0.0_dp,KIND=dp),x12(i,i),ldx12)
-                           
+
                  call stdlib_zlacgv(m - q - i + 1,x12(i,i),ldx12)
                  if (i >= m - q) then
                     call stdlib_zlarfgp(m - q - i + 1,x12(i,i),x12(i,i),ldx12,tauq2(i))
@@ -29436,10 +29436,10 @@ module stdlib_linalg_lapack_z
               ! reduce columns p + 1, ..., m - q of x12, x22
               do i = 1,m - p - q
                  call stdlib_zscal(m - p - q - i + 1,cmplx(z2*z4,0.0_dp,KIND=dp),x22(q + i,p + i),ldx22)
-                           
+
                  call stdlib_zlacgv(m - p - q - i + 1,x22(q + i,p + i),ldx22)
                  call stdlib_zlarfgp(m - p - q - i + 1,x22(q + i,p + i),x22(q + i,p + i + 1),ldx22,tauq2(p + i))
-                           
+
                  x22(q + i,p + i) = cone
                  call stdlib_zlarf('R',m - p - q - i,m - p - q - i + 1,x22(q + i,p + i),ldx22,tauq2(p + i),x22( &
                            q + i + 1,p + i),ldx22,work)
@@ -29458,7 +29458,7 @@ module stdlib_linalg_lapack_z
                  end if
                  if (i == 1) then
                     call stdlib_zscal(m - p - i + 1,cmplx(z2,0.0_dp,KIND=dp),x21(i,i),ldx21)
-                              
+
                  else
                     call stdlib_zscal(m - p - i + 1,cmplx(z2*cos(phi(i - 1)),0.0_dp,KIND=dp),x21(i,i), &
                                ldx21)
@@ -29533,9 +29533,9 @@ module stdlib_linalg_lapack_z
               ! reduce columns p + 1, ..., m - q of x12, x22
               do i = 1,m - p - q
                  call stdlib_zscal(m - p - q - i + 1,cmplx(z2*z4,0.0_dp,KIND=dp),x22(p + i,q + i),1)
-                           
+
                  call stdlib_zlarfgp(m - p - q - i + 1,x22(p + i,q + i),x22(p + i + 1,q + i),1,tauq2(p + i))
-                           
+
                  x22(p + i,q + i) = cone
                  if (m - p - q /= i) then
                     call stdlib_zlarf('L',m - p - q - i + 1,m - p - q - i,x22(p + i,q + i),1,conjg(tauq2(p + i)), &
@@ -29573,7 +29573,7 @@ module stdlib_linalg_lapack_z
            real(dp),parameter :: alphasq = 0.01_dp
            real(dp),parameter :: realone = 1.0_dp
            real(dp),parameter :: realzero = 0.0_dp
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(dp) :: normsq1,normsq2,scl1,scl2,ssq1,ssq2
@@ -29691,7 +29691,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: tau(*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,ii,j,l
            ! Intrinsic Functions
@@ -29726,7 +29726,7 @@ module stdlib_linalg_lapack_z
               ! apply h(i) to a(1:m-k+i,1:n-k+i) from the left
               a(m - n + ii,ii) = cone
               call stdlib_zlarf('LEFT',m - n + ii,ii - 1,a(1,ii),1,tau(i),a,lda,work)
-                        
+
               call stdlib_zscal(m - n + ii - 1,-tau(i),a(1,ii),1)
               a(m - n + ii,ii) = cone - tau(i)
               ! set a(m-k+i+1:m,n-k+i) to czero
@@ -29755,7 +29755,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: tau(*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,l
            ! Intrinsic Functions
@@ -29820,7 +29820,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: tau(*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,l
            ! Intrinsic Functions
@@ -29891,7 +29891,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: tau(*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,iinfo,iws,j,ki,kk,l,ldwork,lwkopt,nb,nbmin,nx
@@ -30007,7 +30007,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: tau(*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,iinfo,iws,j,kk,l,ldwork,lwkopt,nb,nbmin,nx
@@ -30093,7 +30093,7 @@ module stdlib_linalg_lapack_z
                     ! apply h to a(1:m-k+i+ib-1,1:n-k+i-1) from the left
                     call stdlib_zlarfb('LEFT','NO TRANSPOSE','BACKWARD','COLUMNWISE',m - k + i + ib - &
                     1,n - k + i - 1,ib,a(1,n - k + i),lda,work,ldwork,a,lda,work(ib + 1),ldwork)
-                              
+
                  end if
                  ! apply h to rows 1:m-k+i+ib-1 of current block
                  call stdlib_zung2l(m - k + i + ib - 1,ib,ib,a(1,n - k + i),lda,tau(i),work,iinfo &
@@ -30128,7 +30128,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: tau(*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,iinfo,iws,j,ki,kk,l,ldwork,lwkopt,nb,nbmin,nx
@@ -30244,7 +30244,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: tau(*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,ii,j,l
            ! Intrinsic Functions
@@ -30312,7 +30312,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: tau(*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,ii,iinfo,iws,j,kk,l,ldwork,lwkopt,nb,nbmin,nx
@@ -30399,11 +30399,11 @@ module stdlib_linalg_lapack_z
                     ! apply h**h to a(1:m-k+i-1,1:n-k+i+ib-1) from the right
                     call stdlib_zlarfb('RIGHT','CONJUGATE TRANSPOSE','BACKWARD','ROWWISE',ii - &
                     1,n - k + i + ib - 1,ib,a(ii,1),lda,work,ldwork,a,lda,work(ib + 1),ldwork)
-                              
+
                  end if
                  ! apply h**h to columns 1:n-k+i+ib-1 of current block
                  call stdlib_zungr2(ib,n - k + i + ib - 1,ib,a(ii,1),lda,tau(i),work,iinfo)
-                           
+
                  ! set columns n-k+i+ib:n of current block to czero
                  do l = n - k + i + ib,n
                     do j = ii,ii + ib - 1
@@ -30444,7 +30444,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: t(ldt,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: nblocal,mb2,m_plus_one,itmp,ib_bottom,lworkopt, &
@@ -30560,7 +30560,7 @@ module stdlib_linalg_lapack_z
      end subroutine stdlib_zungtsqr_row
 
      pure subroutine stdlib_zunm22(side,trans,m,n,n1,n2,q,ldq,c,ldc,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -30573,7 +30573,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: c(ldc,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            integer(ilp) :: i,ldwork,len,lwkopt,nb,nq,nw
@@ -30632,12 +30632,12 @@ module stdlib_linalg_lapack_z
            ! degenerate cases (n1 = 0 or n2 = 0) are handled using stdlib_ztrmm.
            if (n1 == 0) then
               call stdlib_ztrmm(side,'UPPER',trans,'NON-UNIT',m,n,cone,q,ldq,c,ldc)
-                        
+
               work(1) = cone
               return
            else if (n2 == 0) then
               call stdlib_ztrmm(side,'LOWER',trans,'NON-UNIT',m,n,cone,q,ldq,c,ldc)
-                        
+
               work(1) = cone
               return
            end if
@@ -30657,7 +30657,7 @@ module stdlib_linalg_lapack_z
                               c(1,i),ldc,cone,work,ldwork)
                     ! multiply top part of c by q21.
                     call stdlib_zlacpy('ALL',n2,len,c(1,i),ldc,work(n1 + 1),ldwork)
-                              
+
                     call stdlib_ztrmm('LEFT','UPPER','NO TRANSPOSE','NON-UNIT',n2,len,cone, &
                               q(n1 + 1,1),ldq,work(n1 + 1),ldwork)
                     ! multiply bottom part of c by q22.
@@ -30679,7 +30679,7 @@ module stdlib_linalg_lapack_z
                               1,i),ldc,cone,work,ldwork)
                     ! multiply top part of c by q12**h.
                     call stdlib_zlacpy('ALL',n1,len,c(1,i),ldc,work(n2 + 1),ldwork)
-                              
+
                     call stdlib_ztrmm('LEFT','LOWER','CONJUGATE','NON-UNIT',n1,len,cone,q( &
                               1,n2 + 1),ldq,work(n2 + 1),ldwork)
                     ! multiply bottom part of c by q22**h.
@@ -30764,7 +30764,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: tau(*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: left,notran
            integer(ilp) :: i,i1,i2,i3,mi,ni,nq
@@ -30863,7 +30863,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: tau(*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: left,notran
            integer(ilp) :: i,i1,i2,i3,ic,jc,mi,ni,nq
@@ -30966,7 +30966,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: tau(*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: left,notran
            integer(ilp) :: i,i1,i2,i3,ic,jc,mi,ni,nq
@@ -31041,7 +31041,7 @@ module stdlib_linalg_lapack_z
               aii = a(i,i)
               a(i,i) = cone
               call stdlib_zlarf(side,mi,ni,a(i,i),lda,taui,c(ic,jc),ldc,work)
-                        
+
               a(i,i) = aii
               if (i < nq) call stdlib_zlacgv(nq - i,a(i,i + 1),lda)
            end do
@@ -31059,7 +31059,7 @@ module stdlib_linalg_lapack_z
      !> if SIDE = 'R'.
 
      pure subroutine stdlib_zunmlq(side,trans,m,n,k,a,lda,tau,c,ldc,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -31076,7 +31076,7 @@ module stdlib_linalg_lapack_z
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            character :: transt
@@ -31202,7 +31202,7 @@ module stdlib_linalg_lapack_z
      !> if SIDE = 'R'.
 
      pure subroutine stdlib_zunmql(side,trans,m,n,k,a,lda,tau,c,ldc,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -31219,7 +31219,7 @@ module stdlib_linalg_lapack_z
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            integer(ilp) :: i,i1,i2,i3,ib,iinfo,iwt,ldwork,lwkopt,mi,nb,nbmin,ni,nq, &
@@ -31263,7 +31263,7 @@ module stdlib_linalg_lapack_z
                  lwkopt = 1
               else
                  nb = min(nbmax,stdlib_ilaenv(1,'ZUNMQL',side//trans,m,n,k,-1))
-                           
+
                  lwkopt = nw*nb + tsize
               end if
               work(1) = lwkopt
@@ -31339,7 +31339,7 @@ module stdlib_linalg_lapack_z
      !> if SIDE = 'R'.
 
      pure subroutine stdlib_zunmqr(side,trans,m,n,k,a,lda,tau,c,ldc,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -31356,7 +31356,7 @@ module stdlib_linalg_lapack_z
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            integer(ilp) :: i,i1,i2,i3,ib,ic,iinfo,iwt,jc,ldwork,lwkopt,mi,nb,nbmin, &
@@ -31489,7 +31489,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: tau(*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: left,notran
            integer(ilp) :: i,i1,i2,i3,mi,ni,nq
@@ -31578,7 +31578,7 @@ module stdlib_linalg_lapack_z
      !> if SIDE = 'R'.
 
      pure subroutine stdlib_zunmr3(side,trans,m,n,k,l,a,lda,tau,c,ldc,work,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -31666,7 +31666,7 @@ module stdlib_linalg_lapack_z
                  taui = conjg(tau(i))
               end if
               call stdlib_zlarz(side,mi,ni,l,a(i,ja),lda,taui,c(ic,jc),ldc,work)
-                        
+
            end do
            return
      end subroutine stdlib_zunmr3
@@ -31682,7 +31682,7 @@ module stdlib_linalg_lapack_z
      !> if SIDE = 'R'.
 
      pure subroutine stdlib_zunmrq(side,trans,m,n,k,a,lda,tau,c,ldc,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -31699,7 +31699,7 @@ module stdlib_linalg_lapack_z
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            character :: transt
@@ -31744,7 +31744,7 @@ module stdlib_linalg_lapack_z
                  lwkopt = 1
               else
                  nb = min(nbmax,stdlib_ilaenv(1,'ZUNMRQ',side//trans,m,n,k,-1))
-                           
+
                  lwkopt = nw*nb + tsize
               end if
               work(1) = lwkopt
@@ -31842,7 +31842,7 @@ module stdlib_linalg_lapack_z
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: left,lquery,notran
            character :: transt
@@ -31889,7 +31889,7 @@ module stdlib_linalg_lapack_z
                  lwkopt = 1
               else
                  nb = min(nbmax,stdlib_ilaenv(1,'ZUNMRQ',side//trans,m,n,k,-1))
-                           
+
                  lwkopt = nw*nb + tsize
               end if
               work(1) = lwkopt
@@ -31918,7 +31918,7 @@ module stdlib_linalg_lapack_z
            if (nb < nbmin .or. nb >= k) then
               ! use unblocked code
               call stdlib_zunmr3(side,trans,m,n,k,l,a,lda,tau,c,ldc,work,iinfo)
-                        
+
            else
               ! use blocked code
               iwt = 1 + nw*nb
@@ -32006,14 +32006,14 @@ module stdlib_linalg_lapack_z
                       b22e(*),rwork(*)
            real(dp),intent(inout) :: phi(*),theta(*)
            complex(dp),intent(inout) :: u1(ldu1,*),u2(ldu2,*),v1t(ldv1t,*),v2t(ldv2t,*)
-                     
+
         ! ===================================================================
            ! Parameters
            integer(ilp),parameter :: maxitr = 6
            real(dp),parameter :: hundred = 100.0_dp
            real(dp),parameter :: meighth = -0.125_dp
            real(dp),parameter :: piover2 = 1.57079632679489661923132169163975144210_dp
-           
+
            ! Local Scalars
            logical(lk) :: colmajor,lquery,restart11,restart12,restart21,restart22,wantu1, &
                      wantu2,wantv1t,wantv2t
@@ -32163,9 +32163,9 @@ module stdlib_linalg_lapack_z
               else
                  ! compute shifts for b11 and b21 and use the lesser
                  call stdlib_dlas2(b11d(imax - 1),b11e(imax - 1),b11d(imax),sigma11,dummy)
-                           
+
                  call stdlib_dlas2(b21d(imax - 1),b21e(imax - 1),b21d(imax),sigma21,dummy)
-                           
+
                  if (sigma11 <= sigma21) then
                     mu = sigma11
                     nu = sqrt(one - mu**2)
@@ -32192,13 +32192,13 @@ module stdlib_linalg_lapack_z
               end if
               temp = rwork(iv1tcs + imin - 1)*b11d(imin) + rwork(iv1tsn + imin - 1)*b11e(imin)
               b11e(imin) = rwork(iv1tcs + imin - 1)*b11e(imin) - rwork(iv1tsn + imin - 1)*b11d(imin)
-                        
+
               b11d(imin) = temp
               b11bulge = rwork(iv1tsn + imin - 1)*b11d(imin + 1)
               b11d(imin + 1) = rwork(iv1tcs + imin - 1)*b11d(imin + 1)
               temp = rwork(iv1tcs + imin - 1)*b21d(imin) + rwork(iv1tsn + imin - 1)*b21e(imin)
               b21e(imin) = rwork(iv1tcs + imin - 1)*b21e(imin) - rwork(iv1tsn + imin - 1)*b21d(imin)
-                        
+
               b21d(imin) = temp
               b21bulge = rwork(iv1tsn + imin - 1)*b21d(imin + 1)
               b21d(imin + 1) = rwork(iv1tcs + imin - 1)*b21d(imin + 1)
@@ -32230,7 +32230,7 @@ module stdlib_linalg_lapack_z
               rwork(iu2sn + imin - 1) = -rwork(iu2sn + imin - 1)
               temp = rwork(iu1cs + imin - 1)*b11e(imin) + rwork(iu1sn + imin - 1)*b11d(imin + 1)
               b11d(imin + 1) = rwork(iu1cs + imin - 1)*b11d(imin + 1) - rwork(iu1sn + imin - 1)*b11e(imin)
-                        
+
               b11e(imin) = temp
               if (imax > imin + 1) then
                  b11bulge = rwork(iu1sn + imin - 1)*b11e(imin + 1)
@@ -32243,7 +32243,7 @@ module stdlib_linalg_lapack_z
               b12d(imin + 1) = rwork(iu1cs + imin - 1)*b12d(imin + 1)
               temp = rwork(iu2cs + imin - 1)*b21e(imin) + rwork(iu2sn + imin - 1)*b21d(imin + 1)
               b21d(imin + 1) = rwork(iu2cs + imin - 1)*b21d(imin + 1) - rwork(iu2sn + imin - 1)*b21e(imin)
-                        
+
               b21e(imin) = temp
               if (imax > imin + 1) then
                  b21bulge = rwork(iu2sn + imin - 1)*b21e(imin + 1)
@@ -32292,7 +32292,7 @@ module stdlib_linalg_lapack_z
                  rwork(iv1tsn + i - 1) = -rwork(iv1tsn + i - 1)
                  if (.not. restart12 .and. .not. restart22) then
                     call stdlib_dlartgp(y2,y1,rwork(iv2tsn + i - 1 - 1),rwork(iv2tcs + i - 1 - 1),r)
-                              
+
                  else if (.not. restart12 .and. restart22) then
                     call stdlib_dlartgp(b12bulge,b12d(i - 1),rwork(iv2tsn + i - 1 - 1),rwork(iv2tcs + i - &
                               1 - 1),r)
@@ -32345,7 +32345,7 @@ module stdlib_linalg_lapack_z
                     call stdlib_dlartgp(x2,x1,rwork(iu1sn + i - 1),rwork(iu1cs + i - 1),r)
                  else if (.not. restart11 .and. restart12) then
                     call stdlib_dlartgp(b11bulge,b11d(i),rwork(iu1sn + i - 1),rwork(iu1cs + i - 1),r)
-                              
+
                  else if (restart11 .and. .not. restart12) then
                     call stdlib_dlartgp(b12bulge,b12e(i - 1),rwork(iu1sn + i - 1),rwork(iu1cs + i - 1), &
                               r)
@@ -32354,13 +32354,13 @@ module stdlib_linalg_lapack_z
                                )
                  else
                     call stdlib_dlartgs(b12d(i),b12e(i),nu,rwork(iu1cs + i - 1),rwork(iu1sn + i - 1))
-                              
+
                  end if
                  if (.not. restart21 .and. .not. restart22) then
                     call stdlib_dlartgp(y2,y1,rwork(iu2sn + i - 1),rwork(iu2cs + i - 1),r)
                  else if (.not. restart21 .and. restart22) then
                     call stdlib_dlartgp(b21bulge,b21d(i),rwork(iu2sn + i - 1),rwork(iu2cs + i - 1),r)
-                              
+
                  else if (restart21 .and. .not. restart22) then
                     call stdlib_dlartgp(b22bulge,b22e(i - 1),rwork(iu2sn + i - 1),rwork(iu2cs + i - 1), &
                               r)
@@ -32369,7 +32369,7 @@ module stdlib_linalg_lapack_z
                                )
                  else
                     call stdlib_dlartgs(b22d(i),b22e(i),mu,rwork(iu2cs + i - 1),rwork(iu2sn + i - 1))
-                              
+
                  end if
                  rwork(iu2cs + i - 1) = -rwork(iu2cs + i - 1)
                  rwork(iu2sn + i - 1) = -rwork(iu2sn + i - 1)
@@ -32408,7 +32408,7 @@ module stdlib_linalg_lapack_z
               restart22 = b22d(imax - 1)**2 + b22bulge**2 <= thresh**2
               if (.not. restart12 .and. .not. restart22) then
                  call stdlib_dlartgp(y2,y1,rwork(iv2tsn + imax - 1 - 1),rwork(iv2tcs + imax - 1 - 1),r)
-                           
+
               else if (.not. restart12 .and. restart22) then
                  call stdlib_dlartgp(b12bulge,b12d(imax - 1),rwork(iv2tsn + imax - 1 - 1),rwork(iv2tcs + &
                            imax - 1 - 1),r)
@@ -32423,14 +32423,14 @@ module stdlib_linalg_lapack_z
                            iv2tsn + imax - 1 - 1))
               end if
               temp = rwork(iv2tcs + imax - 1 - 1)*b12e(imax - 1) + rwork(iv2tsn + imax - 1 - 1)*b12d(imax)
-                        
+
               b12d(imax) = rwork(iv2tcs + imax - 1 - 1)*b12d(imax) - rwork(iv2tsn + imax - 1 - 1)*b12e(imax - 1)
-                        
+
               b12e(imax - 1) = temp
               temp = rwork(iv2tcs + imax - 1 - 1)*b22e(imax - 1) + rwork(iv2tsn + imax - 1 - 1)*b22d(imax)
-                        
+
               b22d(imax) = rwork(iv2tcs + imax - 1 - 1)*b22d(imax) - rwork(iv2tsn + imax - 1 - 1)*b22e(imax - 1)
-                        
+
               b22e(imax - 1) = temp
               ! update singular vectors
               if (wantu1) then
@@ -32565,9 +32565,9 @@ module stdlib_linalg_lapack_z
                     if (wantu1) call stdlib_zswap(p,u1(1,i),1,u1(1,mini),1)
                     if (wantu2) call stdlib_zswap(m - p,u2(1,i),1,u2(1,mini),1)
                     if (wantv1t) call stdlib_zswap(q,v1t(i,1),ldv1t,v1t(mini,1),ldv1t)
-                              
+
                     if (wantv2t) call stdlib_zswap(m - q,v2t(i,1),ldv2t,v2t(mini,1),ldv2t)
-                              
+
                  else
                     if (wantu1) call stdlib_zswap(p,u1(i,1),ldu1,u1(mini,1),ldu1)
                     if (wantu2) call stdlib_zswap(m - p,u2(i,1),ldu2,u2(mini,1),ldu2)
@@ -32623,7 +32623,7 @@ module stdlib_linalg_lapack_z
            real(dp),parameter :: hndrd = 100.0_dp
            real(dp),parameter :: meigth = -0.125_dp
            integer(ilp),parameter :: maxitr = 6
-           
+
            ! Local Scalars
            logical(lk) :: lower,rotate
            integer(ilp) :: i,idir,isub,iter,j,ll,lll,m,maxit,nm1,nm12,nm13,oldll, &
@@ -32689,9 +32689,9 @@ module stdlib_linalg_lapack_z
               end do
               ! update singular vectors if desired
               if (nru > 0) call stdlib_zlasr('R','V','F',nru,n,rwork(1),rwork(n),u,ldu)
-                        
+
               if (ncc > 0) call stdlib_zlasr('L','V','F',n,ncc,rwork(1),rwork(n),c,ldc)
-                        
+
            end if
            ! compute singular values to relative accuracy tol
            ! (by setting tol to be negative, algorithm will compute
@@ -32717,7 +32717,7 @@ module stdlib_linalg_lapack_z
                  sminoa = min(sminoa,mu)
                  if (sminoa == zero) go to 50
               end do
-50            continue
+              50 continue
               sminoa = sminoa/sqrt(real(n,KIND=dp))
               thresh = max(tol*sminoa,maxitr*n*n*unfl)
            else
@@ -32734,7 +32734,7 @@ module stdlib_linalg_lapack_z
            ! m points to last element of unconverged part of matrix
            m = n
            ! begin main iteration loop
-60   continue
+           60 continue
            ! check for convergence or exceeding iteration count
            if (m <= 1) go to 160
            if (iter > maxit) go to 200
@@ -32753,7 +32753,7 @@ module stdlib_linalg_lapack_z
            end do
            ll = 0
            go to 90
-80         continue
+           80 continue
            e(ll) = zero
            ! matrix splits since e(ll) = 0
            if (ll == m - 1) then
@@ -32761,7 +32761,7 @@ module stdlib_linalg_lapack_z
               m = m - 1
               go to 60
            end if
-90         continue
+           90 continue
            ll = ll + 1
            ! e(ll) through e(m-1) are nonzero, e(ll-1) is zero
            if (ll == m - 1) then
@@ -32775,9 +32775,9 @@ module stdlib_linalg_lapack_z
               if (ncvt > 0) call stdlib_zdrot(ncvt,vt(m - 1,1),ldvt,vt(m,1),ldvt,cosr, &
                         sinr)
               if (nru > 0) call stdlib_zdrot(nru,u(1,m - 1),1,u(1,m),1,cosl,sinl)
-                        
+
               if (ncc > 0) call stdlib_zdrot(ncc,c(m - 1,1),ldc,c(m,1),ldc,cosl,sinl)
-                        
+
               m = m - 2
               go to 60
            end if
@@ -32993,7 +32993,7 @@ module stdlib_linalg_lapack_z
            ! qr iteration finished, go back and check convergence
            go to 60
            ! all singular values converged, so make them positive
-160  continue
+           160 continue
            do i = 1,n
               if (d(i) < zero) then
                  d(i) = -d(i)
@@ -33018,20 +33018,20 @@ module stdlib_linalg_lapack_z
                  d(isub) = d(n + 1 - i)
                  d(n + 1 - i) = smin
                  if (ncvt > 0) call stdlib_zswap(ncvt,vt(isub,1),ldvt,vt(n + 1 - i,1),ldvt)
-                           
+
                  if (nru > 0) call stdlib_zswap(nru,u(1,isub),1,u(1,n + 1 - i),1)
                  if (ncc > 0) call stdlib_zswap(ncc,c(isub,1),ldc,c(n + 1 - i,1),ldc)
-                           
+
               end if
            end do
            go to 220
            ! maximum number of iterations exceeded, failure to converge
-200  continue
+           200 continue
            info = 0
            do i = 1,n - 1
               if (e(i) /= zero) info = info + 1
            end do
-220        continue
+           220 continue
            return
      end subroutine stdlib_zbdsqr
 
@@ -33059,7 +33059,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: ab(ldab,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lnoti,onenrm
            character :: normin
@@ -33115,7 +33115,7 @@ module stdlib_linalg_lapack_z
            kd = kl + ku + 1
            lnoti = kl > 0
            kase = 0
-10         continue
+           10 continue
            call stdlib_zlacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == kase1) then
@@ -33144,7 +33144,7 @@ module stdlib_linalg_lapack_z
                     do j = n - 1,1,-1
                        lm = min(kl,n - j)
                        work(j) = work(j) - stdlib_zdotc(lm,ab(kd + 1,j),1,work(j + 1),1)
-                                 
+
                        jp = ipiv(j)
                        if (jp /= j) then
                           t = work(jp)
@@ -33165,7 +33165,7 @@ module stdlib_linalg_lapack_z
            end if
            ! compute the estimate of the reciprocal condition number.
            if (ainvnm /= zero) rcond = (one/ainvnm)/anorm
-40         continue
+           40 continue
            return
      end subroutine stdlib_zgbcon
 
@@ -33187,7 +33187,7 @@ module stdlib_linalg_lapack_z
            ! Parameters
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldwork = nbmax + 1
-           
+
            ! Local Scalars
            integer(ilp) :: i,i2,i3,ii,ip,j,j2,j3,jb,jj,jm,jp,ju,k2,km,kv,nb, &
                      nw
@@ -33319,7 +33319,7 @@ module stdlib_linalg_lapack_z
                     ! use stdlib_zlaswp to apply the row interchanges to a12, a22, and
                     ! a32.
                     call stdlib_zlaswp(j2,ab(kv + 1 - jb,j + jb),ldab - 1,1,jb,ipiv(j),1)
-                              
+
                     ! adjust the pivot indices.
                     do i = j,j + jb - 1
                        ipiv(i) = ipiv(i) + j - 1
@@ -33371,7 +33371,7 @@ module stdlib_linalg_lapack_z
                           ! update a23
                           call stdlib_zgemm('NO TRANSPOSE','NO TRANSPOSE',i2,j3,jb,-cone,ab( &
                            kv + 1 + jb,j),ldab - 1,work13,ldwork,cone,ab(1 + jb,j + kv),ldab - 1)
-                                     
+
                        end if
                        if (i3 > 0) then
                           ! update a33
@@ -33436,7 +33436,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: ab(ldab,*)
            complex(dp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lnoti,notran
            integer(ilp) :: i,j,kd,l,lm
@@ -33547,7 +33547,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: taup(*),tauq(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            complex(dp) :: alpha
@@ -33651,7 +33651,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: onenrm
            character :: normin
@@ -33701,7 +33701,7 @@ module stdlib_linalg_lapack_z
               kase1 = 2
            end if
            kase = 0
-10         continue
+           10 continue
            call stdlib_zlacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == kase1) then
@@ -33731,7 +33731,7 @@ module stdlib_linalg_lapack_z
            end if
            ! compute the estimate of the reciprocal condition number.
            if (ainvnm /= zero) rcond = (one/ainvnm)/anorm
-20         continue
+           20 continue
            return
      end subroutine stdlib_zgecon
 
@@ -33749,7 +33749,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            complex(dp) :: alpha
@@ -33805,7 +33805,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            complex(dp) :: alpha
@@ -33927,7 +33927,7 @@ module stdlib_linalg_lapack_z
                     ! apply h to a(i+ib:m,i:n) from the right
                     call stdlib_zlarfb('RIGHT','NO TRANSPOSE','FORWARD','ROWWISE',m - i - ib + 1,n - &
                     i + 1,ib,a(i,i),lda,work,ldwork,a(i + ib,i),lda,work(ib + 1),ldwork)
-                              
+
                  end if
               end do
            else
@@ -33935,7 +33935,7 @@ module stdlib_linalg_lapack_z
            end if
            ! use unblocked code to factor the last or only block.
            if (i <= k) call stdlib_zgelq2(m - i + 1,n - i + 1,a(i,i),lda,tau(i),work,iinfo)
-                     
+
            work(1) = iws
            return
      end subroutine stdlib_zgelqf
@@ -33956,7 +33956,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,i1,j,j1,m1,m2,iinfo
            ! Executable Statements
@@ -33993,15 +33993,15 @@ module stdlib_linalg_lapack_z
                  end do
               end do
               call stdlib_ztrmm('R','U','C','U',m2,m1,cone,a,lda,t(i1,1),ldt)
-                        
+
               call stdlib_zgemm('N','C',m2,m1,n - m1,cone,a(i1,i1),lda,a(1,i1),lda, &
                         cone,t(i1,1),ldt)
               call stdlib_ztrmm('R','U','N','N',m2,m1,cone,t,ldt,t(i1,1),ldt)
-                        
+
               call stdlib_zgemm('N','N',m2,n - m1,m1,-cone,t(i1,1),ldt,a(1,i1),lda, &
                         cone,a(i1,i1),lda)
               call stdlib_ztrmm('R','U','N','U',m2,m1,cone,a,lda,t(i1,1),ldt)
-                        
+
               do i = 1,m2
                  do j = 1,m1
                     a(i + m1,j) = a(i + m1,j) - t(i + m1,j)
@@ -34021,7 +34021,7 @@ module stdlib_linalg_lapack_z
               call stdlib_zgemm('N','C',m1,m2,n - m,cone,a(1,j1),lda,a(i1,j1),lda, &
                         cone,t(1,i1),ldt)
               call stdlib_ztrmm('L','U','N','N',m1,m2,-cone,t,ldt,t(1,i1),ldt)
-                        
+
               call stdlib_ztrmm('R','U','N','N',m1,m2,cone,t(i1,i1),ldt,t(1,i1), &
                         ldt)
               ! y = (y1,y2); l = [ l1            0  ];  t = [t1 t3]
@@ -34041,7 +34041,7 @@ module stdlib_linalg_lapack_z
      !> Q is of order M if SIDE = 'L' and of order N  if SIDE = 'R'.
 
      pure subroutine stdlib_zgemlqt(side,trans,m,n,k,mb,v,ldv,t,ldt,c,ldc,work,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -34139,7 +34139,7 @@ module stdlib_linalg_lapack_z
      !> Q is of order M if SIDE = 'L' and of order N  if SIDE = 'R'.
 
      pure subroutine stdlib_zgemqrt(side,trans,m,n,k,nb,v,ldv,t,ldt,c,ldc,work,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -34240,7 +34240,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            complex(dp) :: alpha
@@ -34357,7 +34357,7 @@ module stdlib_linalg_lapack_z
                  ! compute the ql factorization of the current block
                  ! a(1:m-k+i+ib-1,n-k+i:n-k+i+ib-1)
                  call stdlib_zgeql2(m - k + i + ib - 1,ib,a(1,n - k + i),lda,tau(i),work,iinfo)
-                           
+
                  if (n - k + i > 1) then
                     ! form the triangular factor of the block reflector
                     ! h = h(i+ib-1) . . . h(i+1) h(i)
@@ -34400,7 +34400,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            complex(dp) :: alpha
@@ -34456,7 +34456,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            complex(dp) :: alpha
@@ -34589,7 +34589,7 @@ module stdlib_linalg_lapack_z
            end if
            ! use unblocked code to factor the last or only block.
            if (i <= k) call stdlib_zgeqr2(m - i + 1,n - i + 1,a(i,i),lda,tau(i),work,iinfo)
-                     
+
            work(1) = iws
            return
      end subroutine stdlib_zgeqrf
@@ -34688,7 +34688,7 @@ module stdlib_linalg_lapack_z
            end if
            ! use unblocked code to factor the last or only block.
            if (i <= k) call stdlib_zgeqr2p(m - i + 1,n - i + 1,a(i,i),lda,tau(i),work,iinfo)
-                     
+
            work(1) = iws
            return
      end subroutine stdlib_zgeqrfp
@@ -34707,7 +34707,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            complex(dp) :: aii,alpha
@@ -34777,7 +34777,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,i1,j,j1,n1,n2,iinfo
            ! Executable Statements
@@ -34813,15 +34813,15 @@ module stdlib_linalg_lapack_z
                  end do
               end do
               call stdlib_ztrmm('L','L','C','U',n1,n2,cone,a,lda,t(1,j1),ldt)
-                        
+
               call stdlib_zgemm('C','N',n1,n2,m - n1,cone,a(j1,1),lda,a(j1,j1),lda, &
                         cone,t(1,j1),ldt)
               call stdlib_ztrmm('L','U','C','N',n1,n2,cone,t,ldt,t(1,j1),ldt)
-                        
+
               call stdlib_zgemm('N','N',m - n1,n2,n1,-cone,a(j1,1),lda,t(1,j1),ldt, &
                         cone,a(j1,j1),lda)
               call stdlib_ztrmm('L','L','N','U',n1,n2,cone,a,lda,t(1,j1),ldt)
-                        
+
               do j = 1,n2
                  do i = 1,n1
                     a(i,j + n1) = a(i,j + n1) - t(i,j + n1)
@@ -34840,7 +34840,7 @@ module stdlib_linalg_lapack_z
               call stdlib_zgemm('C','N',n1,n2,m - n,cone,a(i1,1),lda,a(i1,j1),lda, &
                         cone,t(1,j1),ldt)
               call stdlib_ztrmm('L','U','N','N',n1,n2,-cone,t,ldt,t(1,j1),ldt)
-                        
+
               call stdlib_ztrmm('R','U','N','N',n1,n2,cone,t(j1,j1),ldt,t(1,j1), &
                         ldt)
               ! y = (y1,y2); r = [ r1  a(1:n1,j1:n) ];  t = [t1 t3]
@@ -34863,7 +34863,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,k
            complex(dp) :: alpha
@@ -34982,7 +34982,7 @@ module stdlib_linalg_lapack_z
                  ! compute the rq factorization of the current block
                  ! a(m-k+i:m-k+i+ib-1,1:n-k+i+ib-1)
                  call stdlib_zgerq2(ib,n - k + i + ib - 1,a(m - k + i,1),lda,tau(i),work,iinfo)
-                           
+
                  if (m - k + i > 1) then
                     ! form the triangular factor of the block reflector
                     ! h = h(i+ib-1) . . . h(i+1) h(i)
@@ -34991,7 +34991,7 @@ module stdlib_linalg_lapack_z
                     ! apply h to a(1:m-k+i-1,1:n-k+i+ib-1) from the right
                     call stdlib_zlarfb('RIGHT','NO TRANSPOSE','BACKWARD','ROWWISE',m - k + i - 1,n - &
                     k + i + ib - 1,ib,a(m - k + i,1),lda,work,ldwork,a,lda,work(ib + 1),ldwork)
-                              
+
                  end if
               end do
               mu = m - k + i + nb - 1
@@ -35023,7 +35023,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: a(lda,*)
            complex(dp),intent(inout) :: rhs(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(dp) :: bignum,eps,smlnum
@@ -35096,7 +35096,7 @@ module stdlib_linalg_lapack_z
            integer(ilp),intent(out) :: ipiv(*)
            complex(dp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(dp) :: sfmin
            complex(dp) :: temp
@@ -35164,7 +35164,7 @@ module stdlib_linalg_lapack_z
               call stdlib_zlaswp(n2,a(1,n1 + 1),lda,1,n1,ipiv,1)
               ! solve a12
               call stdlib_ztrsm('L','L','N','U',n1,n2,cone,a,lda,a(1,n1 + 1),lda)
-                        
+
               ! update a22
               call stdlib_zgemm('N','N',m - n1,n2,n1,-cone,a(n1 + 1,1),lda,a(1,n1 + 1), &
                         lda,cone,a(n1 + 1,n1 + 1),lda)
@@ -35198,7 +35198,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,iws,j,jb,jj,jp,ldwork,lwkopt,nb,nbmin,nn
@@ -35301,7 +35301,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: a(lda,*)
            complex(dp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notran
            ! Intrinsic Functions
@@ -35345,7 +35345,7 @@ module stdlib_linalg_lapack_z
                         )
               ! solve l**t *x = b, or l**h *x = b overwriting b with x.
               call stdlib_ztrsm('LEFT','LOWER',trans,'UNIT',n,nrhs,cone,a,lda,b,ldb)
-                        
+
               ! apply row interchanges to the solution vectors.
               call stdlib_zlaswp(nrhs,b,ldb,1,n,ipiv,-1)
            end if
@@ -35388,7 +35388,7 @@ module stdlib_linalg_lapack_z
            ! Array Arguments
            complex(dp),intent(inout) :: a(lda,*),b(ldb,*),q(ldq,*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: ilq,ilz
            integer(ilp) :: icompq,icompz,jcol,jrow
@@ -35467,11 +35467,11 @@ module stdlib_linalg_lapack_z
                  call stdlib_zlartg(ctemp,a(jrow,jcol),c,s,a(jrow - 1,jcol))
                  a(jrow,jcol) = czero
                  call stdlib_zrot(n - jcol,a(jrow - 1,jcol + 1),lda,a(jrow,jcol + 1),lda,c,s)
-                           
+
                  call stdlib_zrot(n + 2 - jrow,b(jrow - 1,jrow - 1),ldb,b(jrow,jrow - 1),ldb,c, &
                            s)
                  if (ilq) call stdlib_zrot(n,q(1,jrow - 1),1,q(1,jrow),1,c,conjg(s))
-                           
+
                  ! step 2: rotate columns jrow, jrow-1 to kill b(jrow,jrow-1)
                  ctemp = b(jrow,jrow)
                  call stdlib_zlartg(ctemp,b(jrow,jrow - 1),c,s,b(jrow,jrow))
@@ -35504,7 +35504,7 @@ module stdlib_linalg_lapack_z
      !> conjugate transpose of matrix Z.
 
      pure subroutine stdlib_zggqrf(n,m,p,a,lda,taua,b,ldb,taub,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -35582,7 +35582,7 @@ module stdlib_linalg_lapack_z
      !> conjugate transpose of the matrix Z.
 
      pure subroutine stdlib_zggrqf(m,p,n,a,lda,taua,b,ldb,taub,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -35722,7 +35722,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: v(*),tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,j1,j2,lm,ln,vpos,taupos,dpos,ofdpos,ajeter
@@ -35811,7 +35811,7 @@ module stdlib_linalg_lapack_z
                        a(ofdpos + i,st - 1) = czero
                    end do
                    call stdlib_zlarfg(lm,a(ofdpos,st - 1),v(vpos + 1),1,tau(taupos))
-                             
+
                    lm = ed - st + 1
                    call stdlib_zlarfy(uplo,lm,v(vpos),1,conjg(tau(taupos)),a(dpos,st) &
                              ,lda - 1,work)
@@ -35842,7 +35842,7 @@ module stdlib_linalg_lapack_z
                            a(dpos + nb + i,st) = czero
                        end do
                        call stdlib_zlarfg(lm,a(dpos + nb,st),v(vpos + 1),1,tau(taupos))
-                                 
+
                        call stdlib_zlarfx('LEFT',lm,ln - 1,v(vpos),conjg(tau(taupos)),a( &
                                  dpos + nb - 1,st + 1),lda - 1,work)
                    end if
@@ -35875,7 +35875,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: max_iter = 100
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,iter
            real(dp) :: avg,std,tol,c0,c1,c2,t,u,si,d,base,smin,smax,smlnum,bignum, &
@@ -36016,7 +36016,7 @@ module stdlib_linalg_lapack_z
                  s(i) = si
               end do
            end do
-999        continue
+           999 continue
            smlnum = stdlib_dlamch('SAFEMIN')
            bignum = one/smlnum
            smin = bignum
@@ -36051,7 +36051,7 @@ module stdlib_linalg_lapack_z
            ! Array Arguments
            complex(dp),intent(inout) :: a(lda,*),b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: k
@@ -36134,7 +36134,7 @@ module stdlib_linalg_lapack_z
                     ct = half*akk
                     call stdlib_zaxpy(k - 1,ct,b(1,k),1,a(1,k),1)
                     call stdlib_zher2(uplo,k - 1,cone,a(1,k),1,b(1,k),1,a,lda)
-                              
+
                     call stdlib_zaxpy(k - 1,ct,b(1,k),1,a(1,k),1)
                     call stdlib_zdscal(k - 1,bkk,a(1,k),1)
                     a(k,k) = akk*bkk**2
@@ -36152,7 +36152,7 @@ module stdlib_linalg_lapack_z
                     call stdlib_zlacgv(k - 1,b(k,1),ldb)
                     call stdlib_zaxpy(k - 1,ct,b(k,1),ldb,a(k,1),lda)
                     call stdlib_zher2(uplo,k - 1,cone,a(k,1),lda,b(k,1),ldb,a,lda)
-                              
+
                     call stdlib_zaxpy(k - 1,ct,b(k,1),ldb,a(k,1),lda)
                     call stdlib_zlacgv(k - 1,b(k,1),ldb)
                     call stdlib_zdscal(k - 1,bkk,a(k,1),lda)
@@ -36183,7 +36183,7 @@ module stdlib_linalg_lapack_z
            ! Array Arguments
            complex(dp),intent(inout) :: a(lda,*),b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: k,kb,nb
@@ -36224,7 +36224,7 @@ module stdlib_linalg_lapack_z
                        kb = min(n - k + 1,nb)
                        ! update the upper triangle of a(k:n,k:n)
                        call stdlib_zhegs2(itype,uplo,kb,a(k,k),lda,b(k,k),ldb,info)
-                                 
+
                        if (k + kb <= n) then
                           call stdlib_ztrsm('LEFT',uplo,'CONJUGATE TRANSPOSE','NON-UNIT',kb, &
                                     n - k - kb + 1,cone,b(k,k),ldb,a(k,k + kb),lda)
@@ -36244,7 +36244,7 @@ module stdlib_linalg_lapack_z
                        kb = min(n - k + 1,nb)
                        ! update the lower triangle of a(k:n,k:n)
                        call stdlib_zhegs2(itype,uplo,kb,a(k,k),lda,b(k,k),ldb,info)
-                                 
+
                        if (k + kb <= n) then
                           call stdlib_ztrsm('RIGHT',uplo,'CONJUGATE TRANSPOSE','NON-UNIT',n - k - &
                                     kb + 1,kb,cone,b(k,k),ldb,a(k + kb,k),lda)
@@ -36276,7 +36276,7 @@ module stdlib_linalg_lapack_z
                        call stdlib_ztrmm('RIGHT',uplo,'CONJUGATE TRANSPOSE','NON-UNIT',k - 1, &
                                  kb,cone,b(k,k),ldb,a(1,k),lda)
                        call stdlib_zhegs2(itype,uplo,kb,a(k,k),lda,b(k,k),ldb,info)
-                                 
+
                     end do
                  else
                     ! compute l**h*a*l
@@ -36294,7 +36294,7 @@ module stdlib_linalg_lapack_z
                        call stdlib_ztrmm('LEFT',uplo,'CONJUGATE TRANSPOSE','NON-UNIT',kb,k - 1, &
                                   cone,b(k,k),ldb,a(k,1),lda)
                        call stdlib_zhegs2(itype,uplo,kb,a(k,k),lda,b(k,k),ldb,info)
-                                 
+
                     end do
                  end if
               end if
@@ -36319,7 +36319,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: tau(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i
@@ -36357,7 +36357,7 @@ module stdlib_linalg_lapack_z
                     a(i,i + 1) = cone
                     ! compute  x := tau * a * v  storing x in tau(1:i)
                     call stdlib_zhemv(uplo,i,taui,a,lda,a(1,i + 1),1,czero,tau,1)
-                              
+
                     ! compute  w := x - 1/2 * tau * (x**h * v) * v
                     alpha = -chalf*taui*stdlib_zdotc(i,tau,1,a(1,i + 1),1)
                     call stdlib_zaxpy(i,alpha,a(1,i + 1),1,tau,1)
@@ -36423,7 +36423,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper
            integer(ilp) :: i,iinfo,iws,j,kk,ldwork,lwkopt,nb,nbmin,nx
@@ -36527,7 +36527,7 @@ module stdlib_linalg_lapack_z
               end do
               ! use unblocked code to reduce the last or only block
               call stdlib_zhetd2(uplo,n - i + 1,a(i,i),lda,d(i),e(i),tau(i),iinfo)
-                        
+
            end if
            work(1) = lwkopt
            return
@@ -36555,7 +36555,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: rzero = 0.0e+0_dp
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wantq,upper,afters1
            integer(ilp) :: i,m,k,ib,sweepid,myid,shift,stt,st,ed,stind,edind, &
@@ -36822,7 +36822,7 @@ module stdlib_linalg_lapack_z
      !> Q**H * A * Q = AB.
 
      pure subroutine stdlib_zhetrd_he2hb(uplo,n,kd,a,lda,ab,ldab,tau,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -36836,7 +36836,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: rone = 1.0e+0_dp
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper
            integer(ilp) :: i,j,iinfo,lwmin,pn,pk,lk,ldt,ldw,lds2,lds1,ls2,ls1,lw,lt, &
@@ -36979,7 +36979,7 @@ module stdlib_linalg_lapack_z
                    ! do 45 j = i, i+pk-1
                       ! lk = min( kd, n-j ) + 1
                       ! call stdlib_zcopy( lk, ab( 1, j ), 1, a( j, j ), 1 )
-45   continue
+                      45 continue
                   ! ==================================================================
                end do loop_40
               ! copy the lower band to ab which is the band storage matrix
@@ -37063,7 +37063,7 @@ module stdlib_linalg_lapack_z
               ! kb, where kb is the number of columns factorized by stdlib_zlahef;
               ! kb is either nb or nb-1, or k for the last block
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 40
               if (k > nb) then
@@ -37086,7 +37086,7 @@ module stdlib_linalg_lapack_z
               ! kb, where kb is the number of columns factorized by stdlib_zlahef;
               ! kb is either nb or nb-1, or n-k+1 for the last block
               k = 1
-20            continue
+              20 continue
               ! if k > n, exit from loop
               if (k > n) go to 40
               if (k <= n - nb) then
@@ -37113,7 +37113,7 @@ module stdlib_linalg_lapack_z
               k = k + kb
               go to 20
            end if
-40         continue
+           40 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_zhetrf
@@ -37190,14 +37190,14 @@ module stdlib_linalg_lapack_z
               ! kb, where kb is the number of columns factorized by stdlib_zlahef_rk;
               ! kb is either nb or nb-1, or k for the last block
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 15
               if (k > nb) then
                  ! factorize columns k-kb+1:k of a and use blocked code to
                  ! update columns 1:k-kb
                  call stdlib_zlahef_rk(uplo,k,nb,kb,a,lda,e,ipiv,work,ldwork,iinfo)
-                           
+
               else
                  ! use unblocked code to factorize columns 1:k of a
                  call stdlib_zhetf2_rk(uplo,k,a,lda,e,ipiv,iinfo)
@@ -37226,14 +37226,14 @@ module stdlib_linalg_lapack_z
               go to 10
               ! this label is the exit from main loop over k decreasing
               ! from n to 1 in steps of kb
-15   continue
+              15 continue
            else
               ! factorize a as l*d*l**t using the lower triangle of a
               ! k is the main loop index, increasing from 1 to n in steps of
               ! kb, where kb is the number of columns factorized by stdlib_zlahef_rk;
               ! kb is either nb or nb-1, or n-k+1 for the last block
               k = 1
-20            continue
+              20 continue
               ! if k > n, exit from loop
               if (k > n) go to 35
               if (k <= n - nb) then
@@ -37244,7 +37244,7 @@ module stdlib_linalg_lapack_z
               else
                  ! use unblocked code to factorize columns k:n of a
                  call stdlib_zhetf2_rk(uplo,n - k + 1,a(k,k),lda,e(k),ipiv(k),iinfo)
-                           
+
                  kb = n - k + 1
               end if
               ! set info on the first occurrence of a zero pivot
@@ -37277,7 +37277,7 @@ module stdlib_linalg_lapack_z
               go to 20
               ! this label is the exit from main loop over k increasing
               ! from 1 to n in steps of kb
-35   continue
+              35 continue
            ! end lower
            end if
            work(1) = lwkopt
@@ -37355,14 +37355,14 @@ module stdlib_linalg_lapack_z
               ! kb, where kb is the number of columns factorized by stdlib_zlahef_rook;
               ! kb is either nb or nb-1, or k for the last block
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop
               if (k < 1) go to 40
               if (k > nb) then
                  ! factorize columns k-kb+1:k of a and use blocked code to
                  ! update columns 1:k-kb
                  call stdlib_zlahef_rook(uplo,k,nb,kb,a,lda,ipiv,work,ldwork,iinfo)
-                           
+
               else
                  ! use unblocked code to factorize columns 1:k of a
                  call stdlib_zhetf2_rook(uplo,k,a,lda,ipiv,iinfo)
@@ -37380,7 +37380,7 @@ module stdlib_linalg_lapack_z
               ! kb, where kb is the number of columns factorized by stdlib_zlahef_rook;
               ! kb is either nb or nb-1, or n-k+1 for the last block
               k = 1
-20            continue
+              20 continue
               ! if k > n, exit from loop
               if (k > n) go to 40
               if (k <= n - nb) then
@@ -37407,7 +37407,7 @@ module stdlib_linalg_lapack_z
               k = k + kb
               go to 20
            end if
-40         continue
+           40 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_zhetrf_rook
@@ -37429,7 +37429,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: a(lda,*)
            complex(dp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kp
@@ -37463,7 +37463,7 @@ module stdlib_linalg_lapack_z
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 30
               if (ipiv(k) > 0) then
@@ -37504,12 +37504,12 @@ module stdlib_linalg_lapack_z
                  k = k - 2
               end if
               go to 10
-30            continue
+              30 continue
               ! next solve u**h *x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               if (ipiv(k) > 0) then
@@ -37546,14 +37546,14 @@ module stdlib_linalg_lapack_z
                  k = k + 2
               end if
               go to 40
-50            continue
+              50 continue
            else
               ! solve a*x = b, where a = l*d*l**h.
               ! first solve l*d*x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-60            continue
+              60 continue
               ! if k > n, exit from loop.
               if (k > n) go to 80
               if (ipiv(k) > 0) then
@@ -37596,12 +37596,12 @@ module stdlib_linalg_lapack_z
                  k = k + 2
               end if
               go to 60
-80            continue
+              80 continue
               ! next solve l**h *x = b, overwriting b with x.
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-90            continue
+              90 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 100
               if (ipiv(k) > 0) then
@@ -37638,7 +37638,7 @@ module stdlib_linalg_lapack_z
                  k = k - 2
               end if
               go to 90
-100           continue
+              100 continue
            end if
            return
      end subroutine stdlib_zhetrs
@@ -37660,7 +37660,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,iinfo,j,k,kp
@@ -37771,7 +37771,7 @@ module stdlib_linalg_lapack_z
                  ! interchange rows k and -ipiv(k+1).
                  kp = -ipiv(k + 1)
                  if (kp == -ipiv(k)) call stdlib_zswap(nrhs,b(k + 1,1),ldb,b(kp,1),ldb)
-                           
+
                  k = k + 2
               end if
              end do
@@ -37829,7 +37829,7 @@ module stdlib_linalg_lapack_z
      !> A = L*T*L**H computed by ZHETRF_AA.
 
      pure subroutine stdlib_zhetrs_aa(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -37843,7 +37843,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: b(ldb,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            logical(lk) :: lquery,upper
            integer(ilp) :: k,kp,lwkopt
            ! Intrinsic Functions
@@ -37962,7 +37962,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: a(lda,*)
            complex(dp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kp
@@ -37996,7 +37996,7 @@ module stdlib_linalg_lapack_z
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-10            continue
+              10 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 30
               if (ipiv(k) > 0) then
@@ -38039,12 +38039,12 @@ module stdlib_linalg_lapack_z
                  k = k - 2
               end if
               go to 10
-30            continue
+              30 continue
               ! next solve u**h *x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               if (ipiv(k) > 0) then
@@ -38083,14 +38083,14 @@ module stdlib_linalg_lapack_z
                  k = k + 2
               end if
               go to 40
-50            continue
+              50 continue
            else
               ! solve a*x = b, where a = l*d*l**h.
               ! first solve l*d*x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
-60            continue
+              60 continue
               ! if k > n, exit from loop.
               if (k > n) go to 80
               if (ipiv(k) > 0) then
@@ -38135,12 +38135,12 @@ module stdlib_linalg_lapack_z
                  k = k + 2
               end if
               go to 60
-80            continue
+              80 continue
               ! next solve l**h *x = b, overwriting b with x.
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
-90            continue
+              90 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 100
               if (ipiv(k) > 0) then
@@ -38179,7 +38179,7 @@ module stdlib_linalg_lapack_z
                  k = k - 2
               end if
               go to 90
-100           continue
+              100 continue
            end if
            return
      end subroutine stdlib_zhetrs_rook
@@ -38201,7 +38201,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: ap(*)
            complex(dp),intent(out) :: tau(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,i1,i1i1,ii
@@ -38276,7 +38276,7 @@ module stdlib_linalg_lapack_z
                     ! apply the transformation as a rank-2 update:
                        ! a := a - v * w**h - w * v**h
                     call stdlib_zhpr2(uplo,n - i,-cone,ap(ii + 1),1,tau(i),1,ap(i1i1))
-                              
+
                  end if
                  ap(ii + 1) = e(i)
                  d(i) = real(ap(ii),KIND=dp)
@@ -38305,7 +38305,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: ap(*)
            complex(dp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,k,kc,kp
@@ -38338,7 +38338,7 @@ module stdlib_linalg_lapack_z
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
               kc = n*(n + 1)/2 + 1
-10            continue
+              10 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 30
               kc = kc - k
@@ -38350,7 +38350,7 @@ module stdlib_linalg_lapack_z
                  ! multiply by inv(u(k)), where u(k) is the transformation
                  ! stored in column k of a.
                  call stdlib_zgeru(k - 1,nrhs,-cone,ap(kc),1,b(k,1),ldb,b(1,1),ldb)
-                           
+
                  ! multiply by the inverse of the diagonal block.
                  s = real(cone,KIND=dp)/real(ap(kc + k - 1),KIND=dp)
                  call stdlib_zdscal(nrhs,s,b(k,1),ldb)
@@ -38363,7 +38363,7 @@ module stdlib_linalg_lapack_z
                  ! multiply by inv(u(k)), where u(k) is the transformation
                  ! stored in columns k-1 and k of a.
                  call stdlib_zgeru(k - 2,nrhs,-cone,ap(kc),1,b(k,1),ldb,b(1,1),ldb)
-                           
+
                  call stdlib_zgeru(k - 2,nrhs,-cone,ap(kc - (k - 1)),1,b(k - 1,1),ldb,b(1, &
                            1),ldb)
                  ! multiply by the inverse of the diagonal block.
@@ -38381,13 +38381,13 @@ module stdlib_linalg_lapack_z
                  k = k - 2
               end if
               go to 10
-30            continue
+              30 continue
               ! next solve u**h *x = b, overwriting b with x.
               ! k is the main loop index, increasing from 1 to n in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
               kc = 1
-40            continue
+              40 continue
               ! if k > n, exit from loop.
               if (k > n) go to 50
               if (ipiv(k) > 0) then
@@ -38426,7 +38426,7 @@ module stdlib_linalg_lapack_z
                  k = k + 2
               end if
               go to 40
-50            continue
+              50 continue
            else
               ! solve a*x = b, where a = l*d*l**h.
               ! first solve l*d*x = b, overwriting b with x.
@@ -38434,7 +38434,7 @@ module stdlib_linalg_lapack_z
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = 1
               kc = 1
-60            continue
+              60 continue
               ! if k > n, exit from loop.
               if (k > n) go to 80
               if (ipiv(k) > 0) then
@@ -38479,13 +38479,13 @@ module stdlib_linalg_lapack_z
                  k = k + 2
               end if
               go to 60
-80            continue
+              80 continue
               ! next solve l**h *x = b, overwriting b with x.
               ! k is the main loop index, decreasing from n to 1 in steps of
               ! 1 or 2, depending on the size of the diagonal blocks.
               k = n
               kc = n*(n + 1)/2 + 1
-90            continue
+              90 continue
               ! if k < 1, exit from loop.
               if (k < 1) go to 100
               kc = kc - (n - k + 1)
@@ -38524,7 +38524,7 @@ module stdlib_linalg_lapack_z
                  k = k - 2
               end if
               go to 90
-100           continue
+              100 continue
            end if
            return
      end subroutine stdlib_zhptrs
@@ -38630,7 +38630,7 @@ module stdlib_linalg_lapack_z
            ! estimate the norm of inv(op(a)).
            ainvnm = zero
            kase = 0
-10         continue
+           10 continue
            call stdlib_zlacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == 2) then
@@ -38771,7 +38771,7 @@ module stdlib_linalg_lapack_z
            ! estimate the norm of inv(op(a)).
            ainvnm = zero
            kase = 0
-10         continue
+           10 continue
            call stdlib_zlacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == 2) then
@@ -38781,7 +38781,7 @@ module stdlib_linalg_lapack_z
                  end do
                  if (notrans) then
                     call stdlib_zgetrs('NO TRANSPOSE',n,1,af,ldaf,ipiv,work,n,info)
-                              
+
                  else
                     call stdlib_zgetrs('CONJUGATE TRANSPOSE',n,1,af,ldaf,ipiv,work,n,info &
                               )
@@ -38804,7 +38804,7 @@ module stdlib_linalg_lapack_z
                               )
                  else
                     call stdlib_zgetrs('NO TRANSPOSE',n,1,af,ldaf,ipiv,work,n,info)
-                              
+
                  end if
                  ! multiply by r.
                  do i = 1,n
@@ -38925,7 +38925,7 @@ module stdlib_linalg_lapack_z
            ! estimate the norm of inv(op(a)).
            ainvnm = zero
            kase = 0
-10         continue
+           10 continue
            call stdlib_zlacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == 2) then
@@ -39264,7 +39264,7 @@ module stdlib_linalg_lapack_z
            ! estimate the norm of inv(op(a)).
            ainvnm = zero
            kase = 0
-10         continue
+           10 continue
            call stdlib_zlacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == 2) then
@@ -39415,7 +39415,7 @@ module stdlib_linalg_lapack_z
            ! estimate the norm of inv(op(a)).
            ainvnm = zero
            kase = 0
-10         continue
+           10 continue
            call stdlib_zlacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == 2) then
@@ -39666,7 +39666,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: taup(*),tauq(*),x(ldx,*),y(ldy,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            complex(dp) :: alpha
@@ -39833,7 +39833,7 @@ module stdlib_linalg_lapack_z
            real(dp),intent(inout) :: rho
            ! Array Arguments
            integer(ilp),intent(inout) :: givcol(2,*),givptr(*),perm(*),prmptr(*),qptr(*)
-                     
+
            integer(ilp),intent(out) :: indxq(*),iwork(*)
            real(dp),intent(inout) :: d(*),givnum(2,*),qstore(*)
            real(dp),intent(out) :: rwork(*)
@@ -39898,7 +39898,7 @@ module stdlib_linalg_lapack_z
            call stdlib_zlaed8(k,n,qsiz,q,ldq,d,rho,cutpnt,rwork(iz),rwork(idlmda), &
            work,qsiz,rwork(iw),iwork(indxp),iwork(indx),indxq,perm(prmptr(curr)), &
            givptr(curr + 1),givcol(1,givptr(curr)),givnum(1,givptr(curr)),info)
-                     
+
            prmptr(curr + 1) = prmptr(curr) + n
            givptr(curr + 1) = givptr(curr + 1) + givptr(curr)
            ! solve secular equation.
@@ -39947,7 +39947,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: tenth = 1.0e-1_dp
-           
+
            ! Local Scalars
            character :: normin,trans
            integer(ilp) :: i,ierr,its,j
@@ -40060,7 +40060,7 @@ module stdlib_linalg_lapack_z
            end do
            ! failure to find eigenvector in n iterations.
            info = 1
-120        continue
+           120 continue
            ! normalize eigenvector.
            i = stdlib_izamax(n,v,1)
            call stdlib_zdscal(n,one/cabs1(v(i)),v,1)
@@ -40093,7 +40093,7 @@ module stdlib_linalg_lapack_z
      !> zero.
 
      pure subroutine stdlib_zlags2(upper,a1,a2,a3,b1,b2,b3,csu,snu,csv,snv,csq,snq)
-               
+
         ! -- lapack auxiliary routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -40104,7 +40104,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: a2,b2
            complex(dp),intent(out) :: snq,snu,snv
         ! =====================================================================
-           
+
            ! Local Scalars
            real(dp) :: a,aua11,aua12,aua21,aua22,avb12,avb11,avb21,avb22,csl,csr,d,fb, &
                       fc,s1,s2,snl,snr,ua11r,ua22r,vb11r,vb22r
@@ -40144,17 +40144,17 @@ module stdlib_linalg_lapack_z
                  ! zero (1,2) elements of u**h *a and v**h *b
                  if ((abs(ua11r) + abs1(ua12)) == zero) then
                     call stdlib_zlartg(-cmplx(vb11r,KIND=dp),conjg(vb12),csq,snq,r)
-                              
+
                  else if ((abs(vb11r) + abs1(vb12)) == zero) then
                     call stdlib_zlartg(-cmplx(ua11r,KIND=dp),conjg(ua12),csq,snq,r)
-                              
+
                  else if (aua12/(abs(ua11r) + abs1(ua12)) <= avb12/(abs(vb11r) + abs1(vb12 &
                            ))) then
                     call stdlib_zlartg(-cmplx(ua11r,KIND=dp),conjg(ua12),csq,snq,r)
-                              
+
                  else
                     call stdlib_zlartg(-cmplx(vb11r,KIND=dp),conjg(vb12),csq,snq,r)
-                              
+
                  end if
                  csu = csl
                  snu = -d1*snl
@@ -40277,7 +40277,7 @@ module stdlib_linalg_lapack_z
            real(dp),parameter :: rone = 1.0_dp
            real(dp),parameter :: dat1 = 3.0_dp/4.0_dp
            integer(ilp),parameter :: kexsh = 10
-           
+
            ! Local Scalars
            complex(dp) :: cdum,h11,h11s,h22,sc,sum,t,t1,temp,u,v2,x,y
            real(dp) :: aa,ab,ba,bb,h10,h21,rtemp,s,safmax,safmin,smlnum,sx,t2,tst, &
@@ -40351,7 +40351,7 @@ module stdlib_linalg_lapack_z
            ! eigenvalues i+1 to ihi have already converged. either l = ilo, or
            ! h(l,l-1) is negligible so that the matrix splits.
            i = ihi
-30         continue
+           30 continue
            if (i < ilo) go to 150
            ! perform qr iterations on rows and columns ilo to i until a
            ! submatrix of order 1 splits off at the bottom because a
@@ -40379,7 +40379,7 @@ module stdlib_linalg_lapack_z
                     if (ba*(ab/s) <= max(smlnum,ulp*(bb*(aa/s)))) go to 50
                  end if
               end do
-50            continue
+              50 continue
               l = k
               if (l > ilo) then
                  ! h(l,l-1) is negligible
@@ -40447,7 +40447,7 @@ module stdlib_linalg_lapack_z
               h21 = h21/s
               v(1) = h11s
               v(2) = h21
-70            continue
+              70 continue
               ! single-shift qr step
               loop_120: do k = m,i - 1
                  ! the first iteration of this loop determines a reflection g
@@ -40525,7 +40525,7 @@ module stdlib_linalg_lapack_z
            ! failure to converge in remaining number of iterations
            info = i
            return
-140        continue
+           140 continue
            ! h(i,i-1) is negligible: cone eigenvalue has converged.
            w(i) = h(i,i)
            ! reset deflation counter
@@ -40533,7 +40533,7 @@ module stdlib_linalg_lapack_z
            ! return to start of the main loop with new value of i.
            i = l - 1
            go to 30
-150        continue
+           150 continue
            return
      end subroutine stdlib_zlahqr
 
@@ -40554,7 +40554,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: t(ldt,nb),tau(nb),y(ldy,nb)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            complex(dp) :: ei
@@ -40598,7 +40598,7 @@ module stdlib_linalg_lapack_z
               ! generate the elementary reflector h(i) to annihilate
               ! a(k+i+1:n,i)
               call stdlib_zlarfg(n - k - i + 1,a(k + i,i),a(min(k + i + 1,n),i),1,tau(i))
-                        
+
               ei = a(k + i,i)
               a(k + i,i) = cone
               ! compute  y(k+1:n,i)
@@ -40612,7 +40612,7 @@ module stdlib_linalg_lapack_z
               ! compute t(1:i,i)
               call stdlib_zscal(i - 1,-tau(i),t(1,i),1)
               call stdlib_ztrmv('UPPER','NO TRANSPOSE','NON-UNIT',i - 1,t,ldt,t(1,i),1)
-                        
+
               t(i,i) = tau(i)
            end do loop_10
            a(k + nb,nb) = ei
@@ -40666,7 +40666,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: b(ldb,*)
            complex(dp),intent(out) :: bx(ldbx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,jcol,jrow,m,n,nlp1
            real(dp) :: diflj,difrj,dj,dsigj,dsigjp,temp
@@ -40782,7 +40782,7 @@ module stdlib_linalg_lapack_z
                        b(j,jcol) = cmplx(rwork(jcol + k),rwork(jcol + k + nrhs),KIND=dp)
                     end do
                     call stdlib_zlascl('G',0,0,temp,one,1,nrhs,b(j,1),ldb,info)
-                              
+
                  end do loop_100
               end if
               ! move the deflated rows of bx to b also.
@@ -40801,7 +40801,7 @@ module stdlib_linalg_lapack_z
                        rwork(j) = zero
                     else
                        rwork(j) = -z(j)/difl(j)/(dsigj + poles(j,1))/difr(j,2)
-                                 
+
                     end if
                     do i = 1,j - 1
                        if (z(j) == zero) then
@@ -40843,7 +40843,7 @@ module stdlib_linalg_lapack_z
                               zero,rwork(1 + k + nrhs),1)
                     do jcol = 1,nrhs
                        bx(j,jcol) = cmplx(rwork(jcol + k),rwork(jcol + k + nrhs),KIND=dp)
-                                 
+
                     end do
                  end do loop_180
               end if
@@ -40899,7 +40899,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: b(ldb,*)
            complex(dp),intent(out) :: bx(ldbx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,i1,ic,im1,inode,j,jcol,jimag,jreal,jrow,lf,ll,lvl,lvl2, &
                      nd,ndb1,ndiml,ndimr,nl,nlf,nlp1,nlvl,nr,nrf,nrp1,sqre
@@ -41057,7 +41057,7 @@ module stdlib_linalg_lapack_z
            end do
            go to 330
            ! icompq = 1: applying back the right singular vector factors.
-170  continue
+           170 continue
            ! first now go through the right singular vector matrices of all
            ! the tree nodes top-down.
            j = 0
@@ -41171,7 +41171,7 @@ module stdlib_linalg_lapack_z
                  end do
               end do
            end do loop_320
-330        continue
+           330 continue
            return
      end subroutine stdlib_zlalsa
 
@@ -41207,7 +41207,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: b(ldb,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: bx,bxst,c,difl,difr,givcol,givnum,givptr,i,icmpq1,icmpq2, &
            irwb,irwib,irwrb,irwu,irwvt,irwwrk,iwk,j,jcol,jimag,jreal,jrow,k,nlvl, &
@@ -41336,7 +41336,7 @@ module stdlib_linalg_lapack_z
                     call stdlib_zlaset('A',1,nrhs,czero,czero,b(i,1),ldb)
                  else
                     call stdlib_zlascl('G',0,0,d(i),one,1,nrhs,b(i,1),ldb,info)
-                              
+
                     rank = rank + 1
                  end if
               end do
@@ -41448,7 +41448,7 @@ module stdlib_linalg_lapack_z
                     call stdlib_dlaset('A',nsize,nsize,zero,one,rwork(u + st1),n)
                     call stdlib_dlasdq('U',0,nsize,nsize,nsize,0,d(st),e(st),rwork( &
                     vt + st1),n,rwork(u + st1),n,rwork(nrwork),1,rwork(nrwork),info)
-                              
+
                     if (info /= 0) then
                        return
                     end if
@@ -41483,7 +41483,7 @@ module stdlib_linalg_lapack_z
                        end do
                     end do
                     call stdlib_zlacpy('A',nsize,nrhs,b(st,1),ldb,work(bx + st1),n)
-                              
+
                  else
                     ! a large problem. solve it using divide and conquer.
                     call stdlib_dlasda(icmpq1,smlsiz,nsize,sqre,d(st),e(st),rwork(u + &
@@ -41517,7 +41517,7 @@ module stdlib_linalg_lapack_z
               else
                  rank = rank + 1
                  call stdlib_zlascl('G',0,0,d(i),one,1,nrhs,work(bx + i - 1),n,info)
-                           
+
               end if
               d(i) = abs(d(i))
            end do
@@ -41600,7 +41600,7 @@ module stdlib_linalg_lapack_z
            real(dp),intent(out) :: work(*)
            complex(dp),intent(in) :: ab(ldab,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,k,l
            real(dp) :: scale,sum,value,temp
@@ -41675,7 +41675,7 @@ module stdlib_linalg_lapack_z
            real(dp),intent(out) :: work(*)
            complex(dp),intent(in) :: a(lda,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(dp) :: scale,sum,value,temp
@@ -41746,7 +41746,7 @@ module stdlib_linalg_lapack_z
            ! Array Arguments
            complex(dp),intent(in) :: d(*),dl(*),du(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(dp) :: anorm,scale,sum,temp
@@ -41760,11 +41760,11 @@ module stdlib_linalg_lapack_z
               anorm = abs(d(n))
               do i = 1,n - 1
                  if (anorm < abs(dl(i)) .or. stdlib_disnan(abs(dl(i)))) anorm = abs(dl(i))
-                           
+
                  if (anorm < abs(d(i)) .or. stdlib_disnan(abs(d(i)))) anorm = abs(d(i))
-                           
+
                  if (anorm < abs(du(i)) .or. stdlib_disnan(abs(du(i)))) anorm = abs(du(i))
-                           
+
               end do
            else if (stdlib_lsame(norm,'O') .or. norm == '1') then
               ! find norm1(a).
@@ -41823,7 +41823,7 @@ module stdlib_linalg_lapack_z
            real(dp),intent(out) :: work(*)
            complex(dp),intent(in) :: ab(ldab,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,l
            real(dp) :: absa,scale,sum,value
@@ -41897,7 +41897,7 @@ module stdlib_linalg_lapack_z
                  if (stdlib_lsame(uplo,'U')) then
                     do j = 2,n
                        call stdlib_zlassq(min(j - 1,k),ab(max(k + 2 - j,1),j),1,scale,sum)
-                                 
+
                     end do
                     l = k + 1
                  else
@@ -41942,7 +41942,7 @@ module stdlib_linalg_lapack_z
            real(dp),intent(out) :: work(*)
            complex(dp),intent(in) :: a(lda,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(dp) :: absa,scale,sum,value
@@ -42052,7 +42052,7 @@ module stdlib_linalg_lapack_z
            real(dp),intent(out) :: work(0:*)
            complex(dp),intent(in) :: a(0:*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,ifm,ilu,noe,n1,k,l,lda
            real(dp) :: scale,s,value,aa,temp
@@ -42424,7 +42424,7 @@ module stdlib_linalg_lapack_z
                           end do
                           work(j) = work(j) + s
                        end do
-10                     continue
+                       10 continue
                        value = work(0)
                        do i = 1,n - 1
                           temp = work(i)
@@ -43272,7 +43272,7 @@ module stdlib_linalg_lapack_z
            real(dp),intent(out) :: work(*)
            complex(dp),intent(in) :: ap(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,k
            real(dp) :: absa,scale,sum,value
@@ -43400,7 +43400,7 @@ module stdlib_linalg_lapack_z
            real(dp),intent(out) :: work(*)
            complex(dp),intent(in) :: a(lda,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(dp) :: scale,sum,value
@@ -43472,7 +43472,7 @@ module stdlib_linalg_lapack_z
            real(dp),intent(in) :: d(*)
            complex(dp),intent(in) :: e(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i
            real(dp) :: anorm,scale,sum
@@ -43535,7 +43535,7 @@ module stdlib_linalg_lapack_z
            real(dp),intent(out) :: work(*)
            complex(dp),intent(in) :: ab(ldab,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,l
            real(dp) :: absa,scale,sum,value
@@ -43605,7 +43605,7 @@ module stdlib_linalg_lapack_z
                  if (stdlib_lsame(uplo,'U')) then
                     do j = 2,n
                        call stdlib_zlassq(min(j - 1,k),ab(max(k + 2 - j,1),j),1,scale,sum)
-                                 
+
                     end do
                     l = k + 1
                  else
@@ -43640,7 +43640,7 @@ module stdlib_linalg_lapack_z
            real(dp),intent(out) :: work(*)
            complex(dp),intent(in) :: ap(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j,k
            real(dp) :: absa,scale,sum,value
@@ -43773,7 +43773,7 @@ module stdlib_linalg_lapack_z
            real(dp),intent(out) :: work(*)
            complex(dp),intent(in) :: a(lda,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,j
            real(dp) :: absa,scale,sum,value
@@ -43869,7 +43869,7 @@ module stdlib_linalg_lapack_z
            real(dp),intent(out) :: work(*)
            complex(dp),intent(in) :: ab(ldab,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: udiag
            integer(ilp) :: i,j,l
@@ -44021,7 +44021,7 @@ module stdlib_linalg_lapack_z
                     sum = one
                     do j = 1,n
                        call stdlib_zlassq(min(j,k + 1),ab(max(k + 2 - j,1),j),1,scale,sum)
-                                 
+
                     end do
                  end if
               else
@@ -44062,7 +44062,7 @@ module stdlib_linalg_lapack_z
            real(dp),intent(out) :: work(*)
            complex(dp),intent(in) :: ap(*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: udiag
            integer(ilp) :: i,j,k
@@ -44268,7 +44268,7 @@ module stdlib_linalg_lapack_z
            real(dp),intent(out) :: work(*)
            complex(dp),intent(in) :: a(lda,*)
        ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: udiag
            integer(ilp) :: i,j
@@ -44456,7 +44456,7 @@ module stdlib_linalg_lapack_z
            ! Array Arguments
            complex(dp),intent(inout) :: x(*),y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            real(dp) :: ssmax
            complex(dp) :: a11,a12,a22,c,tau
@@ -44498,7 +44498,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: tau(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,itemp,j,mn,offpi,pvt
            real(dp) :: temp,temp2,tol3z
@@ -44524,7 +44524,7 @@ module stdlib_linalg_lapack_z
               ! generate elementary reflector h(i).
               if (offpi < m) then
                  call stdlib_zlarfg(m - offpi + 1,a(offpi,i),a(offpi + 1,i),1,tau(i))
-                           
+
               else
                  call stdlib_zlarfg(1,a(m,i),a(m,i),1,tau(i))
               end if
@@ -44584,7 +44584,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*),auxv(*),f(ldf,*)
            complex(dp),intent(out) :: tau(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: itemp,j,k,lastrk,lsticc,pvt,rk
            real(dp) :: temp,temp2,tol3z
@@ -44597,7 +44597,7 @@ module stdlib_linalg_lapack_z
            k = 0
            tol3z = sqrt(stdlib_dlamch('EPSILON'))
            ! beginning of while loop.
-10   continue
+           10 continue
            if ((k < nb) .and. (lsticc == 0)) then
               k = k + 1
               rk = offset + k
@@ -44689,7 +44689,7 @@ module stdlib_linalg_lapack_z
                         rk + 1,1),lda,f(kb + 1,1),ldf,cone,a(rk + 1,kb + 1),lda)
            end if
            ! recomputation of difficult columns.
-60   continue
+           60 continue
            if (lsticc > 0) then
               itemp = nint(vn2(lsticc),KIND=ilp)
               vn1(lsticc) = stdlib_dznrm2(m - rk,a(rk + 1,lsticc),1)
@@ -44722,7 +44722,7 @@ module stdlib_linalg_lapack_z
            ! Parameters
            real(dp),parameter :: rzero = 0.0_dp
            real(dp),parameter :: rone = 1.0_dp
-           
+
            ! Local Scalars
            complex(dp) :: alpha,beta,cdum,refsum
            real(dp) :: h11,h12,h21,h22,safmax,safmin,scl,smlnum,tst1,tst2,ulp
@@ -44858,9 +44858,9 @@ module stdlib_linalg_lapack_z
                              h12 = max(cabs1(h(k + 1,k)),cabs1(h(k,k + 1)))
                              h21 = min(cabs1(h(k + 1,k)),cabs1(h(k,k + 1)))
                              h11 = max(cabs1(h(k + 1,k + 1)),cabs1(h(k,k) - h(k + 1,k + 1)))
-                                       
+
                              h22 = min(cabs1(h(k + 1,k + 1)),cabs1(h(k,k) - h(k + 1,k + 1)))
-                                       
+
                              scl = h11 + h12
                              tst2 = h22*(h11/scl)
                              if (tst2 == rzero .or. h21*(h12/scl) <= max(smlnum,ulp*tst2)) h( &
@@ -44923,11 +44923,11 @@ module stdlib_linalg_lapack_z
                           ! .    reflector is too large, then abandon it.
                           ! .    otherwise, use the new cone. ====
                           call stdlib_zlaqr1(3,h(k + 1,k + 1),ldh,s(2*m - 1),s(2*m),vt)
-                                    
+
                           alpha = vt(1)
                           call stdlib_zlarfg(3,alpha,vt(2),1,vt(1))
                           refsum = conjg(vt(1))*(h(k + 1,k) + conjg(vt(2))*h(k + 2,k))
-                                    
+
                           if (cabs1(h(k + 2,k) - refsum*vt(2)) + cabs1(refsum*vt(3)) > ulp*( &
                           cabs1(h(k,k)) + cabs1(h(k + 1,k + 1)) + cabs1(h(k + 2,k + 2)))) &
                                     then
@@ -44993,9 +44993,9 @@ module stdlib_linalg_lapack_z
                           h12 = max(cabs1(h(k + 1,k)),cabs1(h(k,k + 1)))
                           h21 = min(cabs1(h(k + 1,k)),cabs1(h(k,k + 1)))
                           h11 = max(cabs1(h(k + 1,k + 1)),cabs1(h(k,k) - h(k + 1,k + 1)))
-                                    
+
                           h22 = min(cabs1(h(k + 1,k + 1)),cabs1(h(k,k) - h(k + 1,k + 1)))
-                                    
+
                           scl = h11 + h12
                           tst2 = h22*(h11/scl)
                           if (tst2 == rzero .or. h21*(h12/scl) <= max(smlnum,ulp*tst2)) h(k + 1, &
@@ -45076,7 +45076,7 @@ module stdlib_linalg_lapack_z
                     call stdlib_zgemm('C','N',nu,jlen,nu,cone,u(k1,k1),ldu,h(incol + k1, &
                                jcol),ldh,czero,wh,ldwh)
                     call stdlib_zlacpy('ALL',nu,jlen,wh,ldwh,h(incol + k1,jcol),ldh)
-                              
+
                  end do
                  ! ==== vertical multiply ====
                  do jrow = jtop,max(ktop,incol) - 1,nv
@@ -45084,7 +45084,7 @@ module stdlib_linalg_lapack_z
                     call stdlib_zgemm('N','N',jlen,nu,nu,cone,h(jrow,incol + k1),ldh,u( &
                               k1,k1),ldu,czero,wv,ldwv)
                     call stdlib_zlacpy('ALL',jlen,nu,wv,ldwv,h(jrow,incol + k1),ldh)
-                              
+
                  end do
                  ! ==== z multiply (also vertical) ====
                  if (wantz) then
@@ -45093,7 +45093,7 @@ module stdlib_linalg_lapack_z
                        call stdlib_zgemm('N','N',jlen,nu,nu,cone,z(jrow,incol + k1),ldz, &
                                  u(k1,k1),ldu,czero,wv,ldwv)
                        call stdlib_zlacpy('ALL',jlen,nu,wv,ldwv,z(jrow,incol + k1),ldz)
-                                 
+
                     end do
                  end if
               end if
@@ -45109,7 +45109,7 @@ module stdlib_linalg_lapack_z
            integer(ilp),intent(in) :: k,lda,ldb,ldq,ldz,istartm,istopm,nq,nz,qstart, &
                      zstart,ihi
            complex(dp),intent(inout) :: a(lda,*),b(ldb,*),q(ldq,*),z(ldz,*)
-           
+
            ! local variables
            real(dp) :: c
            complex(dp) :: s,temp
@@ -45119,12 +45119,12 @@ module stdlib_linalg_lapack_z
               b(ihi,ihi) = temp
               b(ihi,ihi - 1) = czero
               call stdlib_zrot(ihi - istartm,b(istartm,ihi),1,b(istartm,ihi - 1),1,c,s)
-                        
+
               call stdlib_zrot(ihi - istartm + 1,a(istartm,ihi),1,a(istartm,ihi - 1),1,c,s)
-                        
+
               if (ilz) then
                  call stdlib_zrot(nz,z(1,ihi - zstart + 1),1,z(1,ihi - 1 - zstart + 1),1,c,s)
-                           
+
               end if
            else
               ! normal operation, move bulge down
@@ -45133,12 +45133,12 @@ module stdlib_linalg_lapack_z
               b(k + 1,k + 1) = temp
               b(k + 1,k) = czero
               call stdlib_zrot(k + 2 - istartm + 1,a(istartm,k + 1),1,a(istartm,k),1,c,s)
-                        
+
               call stdlib_zrot(k - istartm + 1,b(istartm,k + 1),1,b(istartm,k),1,c,s)
-                        
+
               if (ilz) then
                  call stdlib_zrot(nz,z(1,k + 1 - zstart + 1),1,z(1,k - zstart + 1),1,c,s)
-                           
+
               end if
               ! apply transformation from the left
               call stdlib_zlartg(a(k + 1,k),a(k + 2,k),c,s,temp)
@@ -45164,7 +45164,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*),b(ldb,*),q(ldq,*),z(ldz,*),qc( &
                      ldqc,*),zc(ldzc,*),work(*),alpha(*),beta(*)
            integer(ilp),intent(out) :: info
-           
+
            ! local scalars
            integer(ilp) :: i,j,ns,istartm,istopm,sheight,swidth,k,np,istartb,istopb, &
                      ishift,nblock,npos
@@ -45240,11 +45240,11 @@ module stdlib_linalg_lapack_z
               call stdlib_zgemm('C','N',sheight,swidth,sheight,cone,qc,ldqc,a(ilo,ilo + &
                         ns),lda,czero,work,sheight)
               call stdlib_zlacpy('ALL',sheight,swidth,work,sheight,a(ilo,ilo + ns),lda)
-                        
+
               call stdlib_zgemm('C','N',sheight,swidth,sheight,cone,qc,ldqc,b(ilo,ilo + &
                         ns),ldb,czero,work,sheight)
               call stdlib_zlacpy('ALL',sheight,swidth,work,sheight,b(ilo,ilo + ns),ldb)
-                        
+
            end if
            if (ilq) then
               call stdlib_zgemm('N','N',n,sheight,sheight,cone,q(1,ilo),ldq,qc,ldqc, &
@@ -45259,11 +45259,11 @@ module stdlib_linalg_lapack_z
               call stdlib_zgemm('N','N',sheight,swidth,swidth,cone,a(istartm,ilo),lda, &
                         zc,ldzc,czero,work,sheight)
               call stdlib_zlacpy('ALL',sheight,swidth,work,sheight,a(istartm,ilo),lda)
-                        
+
               call stdlib_zgemm('N','N',sheight,swidth,swidth,cone,b(istartm,ilo),ldb, &
                         zc,ldzc,czero,work,sheight)
               call stdlib_zlacpy('ALL',sheight,swidth,work,sheight,b(istartm,ilo),ldb)
-                        
+
            end if
            if (ilz) then
               call stdlib_zgemm('N','N',n,swidth,swidth,cone,z(1,ilo),ldz,zc,ldzc, &
@@ -45323,11 +45323,11 @@ module stdlib_linalg_lapack_z
                  call stdlib_zgemm('N','N',sheight,swidth,swidth,cone,a(istartm,k),lda, &
                            zc,ldzc,czero,work,sheight)
                  call stdlib_zlacpy('ALL',sheight,swidth,work,sheight,a(istartm,k),lda)
-                           
+
                  call stdlib_zgemm('N','N',sheight,swidth,swidth,cone,b(istartm,k),ldb, &
                            zc,ldzc,czero,work,sheight)
                  call stdlib_zlacpy('ALL',sheight,swidth,work,sheight,b(istartm,k),ldb)
-                           
+
               end if
               if (ilz) then
                  call stdlib_zgemm('N','N',n,nblock,nblock,cone,z(1,k),ldz,zc,ldzc, &
@@ -45413,7 +45413,7 @@ module stdlib_linalg_lapack_z
            real(dp),intent(out) :: c(*)
            complex(dp),intent(inout) :: x(*),y(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            ! logical            first
            integer(ilp) :: count,i,ic,ix,iy,j
@@ -45451,7 +45451,7 @@ module stdlib_linalg_lapack_z
               gs = g
               count = 0
               if (scale >= safmx2) then
-10            continue
+              10 continue
                  count = count + 1
                  fs = fs*safmn2
                  gs = gs*safmn2
@@ -45464,7 +45464,7 @@ module stdlib_linalg_lapack_z
                     r = f
                     go to 50
                  end if
-20               continue
+                 20 continue
                  count = count - 1
                  fs = fs*safmx2
                  gs = gs*safmx2
@@ -45534,7 +45534,7 @@ module stdlib_linalg_lapack_z
                     end if
                  end if
               end if
-50            continue
+              50 continue
               c(ic) = cs
               y(iy) = sn
               x(ix) = r
@@ -45569,7 +45569,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: maxitr = 10
-           
+
            ! Local Scalars
            logical(lk) :: eskip,needbs,stp2ii,tryrqc,usedbs,usedrq
            integer(ilp) :: done,i,ibegin,idone,iend,ii,iindc1,iindc2,iindr,iindwk,iinfo, &
@@ -45652,7 +45652,7 @@ module stdlib_linalg_lapack_z
               ! find the eigenvectors of the submatrix indexed ibegin
               ! through iend.
               wend = wbegin - 1
-15            continue
+              15 continue
               if (wend < m) then
                  if (iblock(wend + 1) == jblk) then
                     wend = wend + 1
@@ -45720,7 +45720,7 @@ module stdlib_linalg_lapack_z
               ! loop while( idone<im )
               ! generate the representation tree for the current block and
               ! compute the eigenvectors
-40   continue
+              40 continue
               if (idone < im) then
                  ! this is a crude protection against infinitely deep trees
                  if (ndepth > m) then
@@ -45776,7 +45776,7 @@ module stdlib_linalg_lapack_z
                        sigma = real(z(iend,j + 1),KIND=dp)
                        ! set the corresponding entries in z to zero
                        call stdlib_zlaset('FULL',in,2,czero,czero,z(ibegin,j),ldz)
-                                 
+
                     end if
                     ! compute dl and dll of current rrr
                     do j = ibegin,iend - 1
@@ -45812,7 +45812,7 @@ module stdlib_linalg_lapack_z
                        if (oldfst > 1) then
                           wgap(wbegin + oldfst - 2) = max(wgap(wbegin + oldfst - 2),w(wbegin + oldfst - 1) - &
                           werr(wbegin + oldfst - 1) - w(wbegin + oldfst - 2) - werr(wbegin + oldfst - 2))
-                                    
+
                        end if
                        if (wbegin + oldlst - 1 < wend) then
                           wgap(wbegin + oldlst - 1) = max(wgap(wbegin + oldlst - 1),w(wbegin + oldlst) - &
@@ -45908,15 +45908,15 @@ module stdlib_linalg_lapack_z
                           call stdlib_dlarrf(in,d(ibegin),l(ibegin),work(indld + ibegin - 1), &
                           newfst,newlst,work(wbegin),wgap(wbegin),werr(wbegin),spdiam,lgap, &
                           rgap,pivmin,tau,work(indin1),work(indin2),work(indwrk),iinfo)
-                                    
+
                           ! in the complex case, stdlib_dlarrf cannot write
                           ! the new rrr directly into z and needs an intermediate
                           ! workspace
                           do k = 1,in - 1
                              z(ibegin + k - 1,newftt) = cmplx(work(indin1 + k - 1),zero,KIND=dp)
-                                       
+
                              z(ibegin + k - 1,newftt + 1) = cmplx(work(indin2 + k - 1),zero,KIND=dp)
-                                       
+
                           end do
                           z(iend,newftt) = cmplx(work(indin1 + in - 1),zero,KIND=dp)
                           if (iinfo == 0) then
@@ -46023,7 +46023,7 @@ module stdlib_linalg_lapack_z
                           usedrq = .false.
                           ! bisection is initially turned off unless it is forced
                           needbs = .not. tryrqc
-120                       continue
+                          120 continue
                           ! check if bisection should be used to refine eigenvalue
                           if (needbs) then
                              ! take the bisection as new iterate
@@ -46157,7 +46157,7 @@ module stdlib_linalg_lapack_z
                              end do
                           end if
                           call stdlib_zdscal(zto - zfrom + 1,nrminv,z(zfrom,windex),1)
-125                       continue
+                          125 continue
                           ! update w
                           w(windex) = lambda + sigma
                           ! recompute the gaps on the left and right
@@ -46179,7 +46179,7 @@ module stdlib_linalg_lapack_z
                           idone = idone + 1
                        end if
                        ! here ends the code for the current child
-139  continue
+                       139 continue
                        ! proceed to any remaining child nodes
                        newfst = j + 1
                     end do loop_140
@@ -46215,7 +46215,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: maxdim = 2
-           
+
            ! Local Scalars
            integer(ilp) :: i,info,j,k
            real(dp) :: rtemp,scale,sminu,splus
@@ -46238,7 +46238,7 @@ module stdlib_linalg_lapack_z
                  ! lockahead for l- part rhs(1:n-1) = +-1
                  ! splus and smin computed more efficiently than in bsolve[1].
                  splus = splus + real(stdlib_zdotc(n - j,z(j + 1,j),1,z(j + 1,j),1),KIND=dp)
-                           
+
                  sminu = real(stdlib_zdotc(n - j,z(j + 1,j),1,rhs(j + 1),1),KIND=dp)
                  splus = splus*real(rhs(j),KIND=dp)
                  if (splus > sminu) then
@@ -46350,7 +46350,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: d(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: iinfo,j,jb,nb
            ! Intrinsic Functions
@@ -46382,7 +46382,7 @@ module stdlib_linalg_lapack_z
                  jb = min(min(m,n) - j + 1,nb)
                  ! factor diagonal and subdiagonal blocks.
                  call stdlib_zlaunhr_col_getrfnp2(m - j + 1,jb,a(j,j),lda,d(j),iinfo)
-                           
+
                  if (j + jb <= n) then
                     ! compute block row of u.
                     call stdlib_ztrsm('LEFT','LOWER','NO TRANSPOSE','UNIT',jb,n - j - jb + 1,cone, &
@@ -46391,7 +46391,7 @@ module stdlib_linalg_lapack_z
                        ! update trailing submatrix.
                        call stdlib_zgemm('NO TRANSPOSE','NO TRANSPOSE',m - j - jb + 1,n - j - jb + 1,jb,- &
                        cone,a(j + jb,j),lda,a(j,j + jb),lda,cone,a(j + jb,j + jb),lda)
-                                 
+
                     end if
                  end if
               end do
@@ -46421,7 +46421,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,j,k,kase,l,nz
@@ -46478,12 +46478,12 @@ module stdlib_linalg_lapack_z
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_zcopy(n,b(1,j),1,work,1)
               call stdlib_zhbmv(uplo,n,kd,-cone,ab,ldab,x(1,j),1,cone,work,1)
-                        
+
               ! compute componentwise relative backward error from formula
               ! max(i) ( abs(r(i)) / ( abs(a)*abs(x) + abs(b) )(i) )
               ! where abs(z) is the componentwise absolute value of the matrix
@@ -46565,7 +46565,7 @@ module stdlib_linalg_lapack_z
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_zlacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -46614,7 +46614,7 @@ module stdlib_linalg_lapack_z
            ! Parameters
            integer(ilp),parameter :: nbmax = 32
            integer(ilp),parameter :: ldwork = nbmax + 1
-           
+
            ! Local Scalars
            integer(ilp) :: i,i2,i3,ib,ii,j,jj,nb
            ! Local Arrays
@@ -46787,7 +46787,7 @@ module stdlib_linalg_lapack_z
               end if
            end if
            return
-150        continue
+           150 continue
            return
      end subroutine stdlib_zpbtrf
 
@@ -46807,7 +46807,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: a(0:*)
            complex(dp),intent(inout) :: b(ldb,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,normaltransr
            ! Intrinsic Functions
@@ -46867,7 +46867,7 @@ module stdlib_linalg_lapack_z
         ! ====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,j,k,kase,nz
@@ -46922,7 +46922,7 @@ module stdlib_linalg_lapack_z
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_zcopy(n,b(1,j),1,work,1)
@@ -47006,7 +47006,7 @@ module stdlib_linalg_lapack_z
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_zlacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -47053,7 +47053,7 @@ module stdlib_linalg_lapack_z
            ! Array Arguments
            complex(dp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,jb,nb
@@ -47122,9 +47122,9 @@ module stdlib_linalg_lapack_z
               end if
            end if
            go to 40
-30         continue
+           30 continue
            info = info + j - 1
-40         continue
+           40 continue
            return
      end subroutine stdlib_zpotrf
 
@@ -47191,7 +47191,7 @@ module stdlib_linalg_lapack_z
         ! ====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,ik,j,k,kase,kk,nz
@@ -47242,7 +47242,7 @@ module stdlib_linalg_lapack_z
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_zcopy(n,b(1,j),1,work,1)
@@ -47333,7 +47333,7 @@ module stdlib_linalg_lapack_z
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_zlacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -47435,7 +47435,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: afp(*),ap(*),b(ldb,*)
            complex(dp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: equil,nofact,rcequ
            integer(ilp) :: i,infequ,j
@@ -47565,7 +47565,7 @@ module stdlib_linalg_lapack_z
            ! Array Arguments
            complex(dp),intent(inout) :: ap(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: j,jc,jj,jjn
@@ -47643,7 +47643,7 @@ module stdlib_linalg_lapack_z
            real(dp),intent(out) :: work(*)
            complex(dp),intent(inout) :: z(ldz,*)
         ! ====================================================================
-           
+
            ! Local Arrays
            complex(dp) :: c(1,1),vt(1,1)
            ! Local Scalars
@@ -47697,7 +47697,7 @@ module stdlib_linalg_lapack_z
               nru = 0
            end if
            call stdlib_zbdsqr('LOWER',n,0,nru,0,d,e,vt,1,z,ldz,c,1,work,info)
-                     
+
            ! square the singular values.
            if (info == 0) then
               do i = 1,n
@@ -47797,7 +47797,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: ap(*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,ip,kase
@@ -47845,7 +47845,7 @@ module stdlib_linalg_lapack_z
            end if
            ! estimate the 1-norm of the inverse.
            kase = 0
-30         continue
+           30 continue
            call stdlib_zlacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               ! multiply by inv(l*d*l**t) or inv(u*d*u**t).
@@ -47880,7 +47880,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,ik,j,k,kase,kk,nz
@@ -47931,7 +47931,7 @@ module stdlib_linalg_lapack_z
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_zcopy(n,b(1,j),1,work,1)
@@ -48022,7 +48022,7 @@ module stdlib_linalg_lapack_z
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_zlacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -48125,7 +48125,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: ap(*),b(ldb,*)
            complex(dp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nofact
            real(dp) :: anorm
@@ -48258,7 +48258,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: minrgp = 1.0e-3_dp
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,lquery,valeig,wantz,zquery
            integer(ilp) :: i,ibegin,iend,ifirst,iil,iindbl,iindw,iindwk,iinfo,iinspl, &
@@ -48337,7 +48337,7 @@ module stdlib_linalg_lapack_z
                  nzcmin = n
               else if (wantz .and. valeig) then
                  call stdlib_dlarrc('T',n,vl,vu,d,e,safmin,nzcmin,itmp,itmp2,info)
-                           
+
               else if (wantz .and. indeig) then
                  nzcmin = iiu - iil + 1
               else
@@ -48507,7 +48507,7 @@ module stdlib_linalg_lapack_z
               call stdlib_dlarre(range,n,wl,wu,iil,iiu,d,e,work(inde2),rtol1,rtol2, &
               thresh,nsplit,iwork(iinspl),m,w,work(inderr),work(indgp),iwork(iindbl), &
               iwork(iindw),work(indgrs),pivmin,work(indwrk),iwork(iindwk),iinfo)
-                        
+
               if (iinfo /= 0) then
                  info = 10 + abs(iinfo)
                  return
@@ -48546,7 +48546,7 @@ module stdlib_linalg_lapack_z
                     in = iend - ibegin + 1
                     wend = wbegin - 1
                     ! check if any eigenvalues have to be refined in this block
-36   continue
+                    36 continue
                     if (wend < m) then
                        if (iwork(iindbl + wend) == jblk) then
                           wend = wend + 1
@@ -48634,7 +48634,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: a(lda,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,kase
@@ -48682,7 +48682,7 @@ module stdlib_linalg_lapack_z
            end if
            ! estimate the 1-norm of the inverse.
            kase = 0
-30         continue
+           30 continue
            call stdlib_zlacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               ! multiply by inv(l*d*l**t) or inv(u*d*u**t).
@@ -48715,7 +48715,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: a(lda,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,kase
@@ -48763,7 +48763,7 @@ module stdlib_linalg_lapack_z
            end if
            ! estimate the 1-norm of the inverse.
            kase = 0
-30         continue
+           30 continue
            call stdlib_zlacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               ! multiply by inv(l*d*l**t) or inv(u*d*u**t).
@@ -48797,7 +48797,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,j,k,kase,nz
@@ -48852,7 +48852,7 @@ module stdlib_linalg_lapack_z
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_zcopy(n,b(1,j),1,work,1)
@@ -48936,7 +48936,7 @@ module stdlib_linalg_lapack_z
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_zlacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -49058,7 +49058,7 @@ module stdlib_linalg_lapack_z
      !> the system of equations A * X = B by calling BLAS3 routine ZSYTRS_3.
 
      pure subroutine stdlib_zsysv_rk(uplo,n,nrhs,a,lda,e,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -49137,7 +49137,7 @@ module stdlib_linalg_lapack_z
      !> of equations A * X = B by calling ZSYTRS_ROOK.
 
      pure subroutine stdlib_zsysv_rook(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -49222,7 +49222,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: af(ldaf,*)
            complex(dp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,nofact
            integer(ilp) :: lwkopt,nb
@@ -49303,7 +49303,7 @@ module stdlib_linalg_lapack_z
      !> RCOND = 1 / ( norm(A) * norm(inv(A)) ).
 
      subroutine stdlib_ztbcon(norm,uplo,diag,n,kd,ab,ldab,rcond,work,rwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -49317,7 +49317,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: ab(ldab,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,onenrm,upper
            character :: normin
@@ -49375,7 +49375,7 @@ module stdlib_linalg_lapack_z
                  kase1 = 2
               end if
               kase = 0
-10            continue
+              10 continue
               call stdlib_zlacn2(n,work(n + 1),work,ainvnm,kase,isave)
               if (kase /= 0) then
                  if (kase == kase1) then
@@ -49400,7 +49400,7 @@ module stdlib_linalg_lapack_z
               ! compute the estimate of the reciprocal condition number.
               if (ainvnm /= zero) rcond = (one/anorm)/ainvnm
            end if
-20         continue
+           20 continue
            return
      end subroutine stdlib_ztbcon
 
@@ -49419,7 +49419,7 @@ module stdlib_linalg_lapack_z
            ! Array Arguments
            complex(dp),intent(inout) :: a(0:*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,nisodd,normaltransr
            integer(ilp) :: n1,n2,k
@@ -49474,12 +49474,12 @@ module stdlib_linalg_lapack_z
                     call stdlib_ztrtri('L',diag,n1,a(0),n,info)
                     if (info > 0) return
                     call stdlib_ztrmm('R','L','N',diag,n2,n1,-cone,a(0),n,a(n1),n)
-                              
+
                     call stdlib_ztrtri('U',diag,n2,a(n),n,info)
                     if (info > 0) info = info + n1
                     if (info > 0) return
                     call stdlib_ztrmm('L','U','C',diag,n2,n1,cone,a(n),n,a(n1),n)
-                              
+
                  else
                    ! srpa for upper, normal and n is odd ( a(0:n-1,0:n2-1)
                    ! t1 -> a(n1+1,0), t2 -> a(n1,0), s -> a(0,0)
@@ -49487,12 +49487,12 @@ module stdlib_linalg_lapack_z
                     call stdlib_ztrtri('L',diag,n1,a(n2),n,info)
                     if (info > 0) return
                     call stdlib_ztrmm('L','L','C',diag,n1,n2,-cone,a(n2),n,a(0),n)
-                              
+
                     call stdlib_ztrtri('U',diag,n2,a(n1),n,info)
                     if (info > 0) info = info + n1
                     if (info > 0) return
                     call stdlib_ztrmm('R','U','N',diag,n1,n2,cone,a(n1),n,a(0),n)
-                              
+
                  end if
               else
                  ! n is odd and transr = 'c'
@@ -49551,7 +49551,7 @@ module stdlib_linalg_lapack_z
                     if (info > 0) info = info + k
                     if (info > 0) return
                     call stdlib_ztrmm('R','U','N',diag,k,k,cone,a(k),n + 1,a(0),n + 1)
-                              
+
                  end if
               else
                  ! n is even and transr = 'c'
@@ -49580,7 +49580,7 @@ module stdlib_linalg_lapack_z
                     if (info > 0) info = info + k
                     if (info > 0) return
                     call stdlib_ztrmm('L','L','N',diag,k,k,cone,a(k*k),k,a(0),k)
-                              
+
                  end if
               end if
            end if
@@ -49668,7 +49668,7 @@ module stdlib_linalg_lapack_z
            ! Parameters
            integer(ilp),parameter :: maxit = 40
            real(dp),parameter :: hugenum = huge(zero)
-           
+
            ! Local Scalars
            logical(lk) :: initq,initu,initv,upper,wantq,wantu,wantv
            integer(ilp) :: i,j,kcycle
@@ -49747,7 +49747,7 @@ module stdlib_linalg_lapack_z
                     ! update (n-l+i)-th and (n-l+j)-th columns of matrices
                     ! a and b: a*q and b*q
                     call stdlib_zrot(min(k + l,m),a(1,n - l + j),1,a(1,n - l + i),1,csq,snq)
-                              
+
                     call stdlib_zrot(l,b(1,n - l + j),1,b(1,n - l + i),1,csq,snq)
                     if (upper) then
                        if (k + i <= m) a(k + i,n - l + j) = czero
@@ -49766,7 +49766,7 @@ module stdlib_linalg_lapack_z
                               csu,snu)
                     if (wantv) call stdlib_zrot(p,v(1,j),1,v(1,i),1,csv,snv)
                     if (wantq) call stdlib_zrot(n,q(1,n - l + j),1,q(1,n - l + i),1,csq,snq)
-                              
+
                  end do loop_10
               end do loop_20
               if (.not. upper) then
@@ -49788,7 +49788,7 @@ module stdlib_linalg_lapack_z
            ! the algorithm has not converged after maxit cycles.
            info = 1
            go to 100
-50         continue
+           50 continue
            ! if error <= min(tola,tolb), then the algorithm has converged.
            ! compute the generalized singular value pairs (alpha, beta), and
            ! set the triangular matrix r to array a.
@@ -49829,7 +49829,7 @@ module stdlib_linalg_lapack_z
                  beta(i) = zero
               end do
            end if
-100        continue
+           100 continue
            ncycle = kcycle
            return
      end subroutine stdlib_ztgsja
@@ -49877,7 +49877,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: ldz = 2
-           
+
            ! Local Scalars
            logical(lk) :: notran
            integer(ilp) :: i,ierr,j,k
@@ -49948,15 +49948,15 @@ module stdlib_linalg_lapack_z
                        if (scaloc /= one) then
                           do k = 1,n
                              call stdlib_zscal(m,cmplx(scaloc,zero,KIND=dp),c(1,k),1)
-                                       
+
                              call stdlib_zscal(m,cmplx(scaloc,zero,KIND=dp),f(1,k),1)
-                                       
+
                           end do
                           scale = scale*scaloc
                        end if
                     else
                        call stdlib_zlatdf(ijob,ldz,z,ldz,rhs,rdsum,rdscal,ipiv,jpiv)
-                                 
+
                     end if
                     ! unpack solution vector(s)
                     c(i,j) = rhs(1)
@@ -49969,9 +49969,9 @@ module stdlib_linalg_lapack_z
                     end if
                     if (j < n) then
                        call stdlib_zaxpy(n - j,rhs(2),b(j,j + 1),ldb,c(i,j + 1),ldc)
-                                 
+
                        call stdlib_zaxpy(n - j,rhs(2),e(j,j + 1),lde,f(i,j + 1),ldf)
-                                 
+
                     end if
                  end do loop_20
               end do loop_30
@@ -49999,9 +49999,9 @@ module stdlib_linalg_lapack_z
                     if (scaloc /= one) then
                        do k = 1,n
                           call stdlib_zscal(m,cmplx(scaloc,zero,KIND=dp),c(1,k),1)
-                                    
+
                           call stdlib_zscal(m,cmplx(scaloc,zero,KIND=dp),f(1,k),1)
-                                    
+
                        end do
                        scale = scale*scaloc
                     end if
@@ -50069,7 +50069,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
         ! replaced various illegal calls to stdlib_ccopy by calls to stdlib_claset.
         ! sven hammarling, 1/5/02.
-           
+
            ! Local Scalars
            logical(lk) :: lquery,notran
            integer(ilp) :: i,ie,ifunc,iround,is,isolve,j,je,js,k,linfo,lwmin,mb,nb, &
@@ -50189,27 +50189,27 @@ module stdlib_linalg_lapack_z
            ! determine block structure of a
            p = 0
            i = 1
-40         continue
+           40 continue
            if (i > m) go to 50
            p = p + 1
            iwork(p) = i
            i = i + mb
            if (i >= m) go to 50
            go to 40
-50         continue
+           50 continue
            iwork(p + 1) = m + 1
            if (iwork(p) == iwork(p + 1)) p = p - 1
            ! determine block structure of b
            q = p + 1
            j = 1
-60         continue
+           60 continue
            if (j > n) go to 70
            q = q + 1
            iwork(q) = j
            j = j + nb
            if (j >= n) go to 70
            go to 60
-70         continue
+           70 continue
            iwork(q + 1) = n + 1
            if (iwork(q) == iwork(q + 1)) q = q - 1
            if (notran) then
@@ -50238,15 +50238,15 @@ module stdlib_linalg_lapack_z
                        if (scaloc /= one) then
                           do k = 1,js - 1
                              call stdlib_zscal(m,cmplx(scaloc,zero,KIND=dp),c(1,k),1)
-                                       
+
                              call stdlib_zscal(m,cmplx(scaloc,zero,KIND=dp),f(1,k),1)
-                                       
+
                           end do
                           do k = js,je
                              call stdlib_zscal(is - 1,cmplx(scaloc,zero,KIND=dp),c(1,k),1)
-                                       
+
                              call stdlib_zscal(is - 1,cmplx(scaloc,zero,KIND=dp),f(1,k),1)
-                                       
+
                           end do
                           do k = js,je
                              call stdlib_zscal(m - ie,cmplx(scaloc,zero,KIND=dp),c(ie + 1,k), &
@@ -50256,9 +50256,9 @@ module stdlib_linalg_lapack_z
                           end do
                           do k = je + 1,n
                              call stdlib_zscal(m,cmplx(scaloc,zero,KIND=dp),c(1,k),1)
-                                       
+
                              call stdlib_zscal(m,cmplx(scaloc,zero,KIND=dp),f(1,k),1)
-                                       
+
                           end do
                           scale = scale*scaloc
                        end if
@@ -50324,27 +50324,27 @@ module stdlib_linalg_lapack_z
                     if (scaloc /= one) then
                        do k = 1,js - 1
                           call stdlib_zscal(m,cmplx(scaloc,zero,KIND=dp),c(1,k),1)
-                                    
+
                           call stdlib_zscal(m,cmplx(scaloc,zero,KIND=dp),f(1,k),1)
-                                    
+
                        end do
                        do k = js,je
                           call stdlib_zscal(is - 1,cmplx(scaloc,zero,KIND=dp),c(1,k),1)
-                                    
+
                           call stdlib_zscal(is - 1,cmplx(scaloc,zero,KIND=dp),f(1,k),1)
-                                    
+
                        end do
                        do k = js,je
                           call stdlib_zscal(m - ie,cmplx(scaloc,zero,KIND=dp),c(ie + 1,k),1)
-                                    
+
                           call stdlib_zscal(m - ie,cmplx(scaloc,zero,KIND=dp),f(ie + 1,k),1)
-                                    
+
                        end do
                        do k = je + 1,n
                           call stdlib_zscal(m,cmplx(scaloc,zero,KIND=dp),c(1,k),1)
-                                    
+
                           call stdlib_zscal(m,cmplx(scaloc,zero,KIND=dp),f(1,k),1)
-                                    
+
                        end do
                        scale = scale*scaloc
                     end if
@@ -50352,10 +50352,10 @@ module stdlib_linalg_lapack_z
                     if (j > p + 2) then
                        call stdlib_zgemm('N','C',mb,js - 1,nb,cmplx(one,zero,KIND=dp),c(is, &
                         js),ldc,b(1,js),ldb,cmplx(one,zero,KIND=dp),f(is,1),ldf)
-                                  
+
                        call stdlib_zgemm('N','C',mb,js - 1,nb,cmplx(one,zero,KIND=dp),f(is, &
                         js),ldf,e(1,js),lde,cmplx(one,zero,KIND=dp),f(is,1),ldf)
-                                  
+
                     end if
                     if (i < p) then
                        call stdlib_zgemm('C','N',m - ie,nb,mb,cmplx(-one,zero,KIND=dp),a( &
@@ -50393,7 +50393,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: ap(*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,onenrm,upper
            character :: normin
@@ -50447,7 +50447,7 @@ module stdlib_linalg_lapack_z
                  kase1 = 2
               end if
               kase = 0
-10            continue
+              10 continue
               call stdlib_zlacn2(n,work(n + 1),work,ainvnm,kase,isave)
               if (kase /= 0) then
                  if (kase == kase1) then
@@ -50472,7 +50472,7 @@ module stdlib_linalg_lapack_z
               ! compute the estimate of the reciprocal condition number.
               if (ainvnm /= zero) rcond = (one/anorm)/ainvnm
            end if
-20         continue
+           20 continue
            return
      end subroutine stdlib_ztpcon
 
@@ -50528,7 +50528,7 @@ module stdlib_linalg_lapack_z
                  lb = nb - n + l - i + 1
               end if
               call stdlib_ztplqt2(ib,nb,lb,a(i,i),lda,b(i,1),ldb,t(1,i),ldt,iinfo)
-                        
+
            ! update by applying h**t to b(i+ib:m,:) from the right
               if (i + ib <= m) then
                  call stdlib_ztprfb('R','N','F','R',m - i - ib + 1,nb,ib,lb,b(i,1),ldb,t( &
@@ -50828,7 +50828,7 @@ module stdlib_linalg_lapack_z
                  lb = mb - m + l - i + 1
               end if
               call stdlib_ztpqrt2(mb,ib,lb,a(i,i),lda,b(1,i),ldb,t(1,i),ldt,iinfo)
-                        
+
            ! update by applying h**h to b(:,i+ib:n) from the left
               if (i + ib <= n) then
                  call stdlib_ztprfb('L','C','F','C',mb,n - i - ib + 1,ib,lb,b(1,i),ldb,t( &
@@ -50859,7 +50859,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: a(lda,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nounit,onenrm,upper
            character :: normin
@@ -50915,7 +50915,7 @@ module stdlib_linalg_lapack_z
                  kase1 = 2
               end if
               kase = 0
-10            continue
+              10 continue
               call stdlib_zlacn2(n,work(n + 1),work,ainvnm,kase,isave)
               if (kase /= 0) then
                  if (kase == kase1) then
@@ -50940,7 +50940,7 @@ module stdlib_linalg_lapack_z
               ! compute the estimate of the reciprocal condition number.
               if (ainvnm /= zero) rcond = (one/anorm)/ainvnm
            end if
-20         continue
+           20 continue
            return
      end subroutine stdlib_ztrcon
 
@@ -50953,7 +50953,7 @@ module stdlib_linalg_lapack_z
      !> overflow in X.
 
      subroutine stdlib_ztrsyl(trana,tranb,isgn,m,n,a,lda,b,ldb,c,ldc,scale,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -50966,7 +50966,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: a(lda,*),b(ldb,*)
            complex(dp),intent(inout) :: c(ldc,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: notrna,notrnb
            integer(ilp) :: j,k,l
@@ -51195,7 +51195,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(out) :: work(*)
            complex(dp),intent(inout) :: x1(*),x2(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: childinfo,i,j
            ! Intrinsic Function
@@ -51299,11 +51299,11 @@ module stdlib_linalg_lapack_z
            real(dp),intent(out) :: theta(*)
            real(dp),intent(out) :: rwork(*)
            complex(dp),intent(out) :: u1(ldu1,*),u2(ldu2,*),v1t(ldv1t,*),v2t(ldv2t,*),work(*)
-                     
+
            complex(dp),intent(inout) :: x11(ldx11,*),x12(ldx12,*),x21(ldx21,*),x22(ldx22,*)
-                     
+
         ! ===================================================================
-           
+
            ! Local Scalars
            character :: transt,signst
            integer(ilp) :: childinfo,i,ib11d,ib11e,ib12d,ib12e,ib21d,ib21e,ib22d,ib22e, &
@@ -51514,7 +51514,7 @@ module stdlib_linalg_lapack_z
                  call stdlib_zlacpy('L',m - q,p,x12,ldx12,v2t,ldv2t)
                  if (m > p + q) then
                     call stdlib_zlacpy('L',m - p - q,m - p - q,x22(p1,q1),ldx22,v2t(p + 1,p + 1),ldv2t)
-                              
+
                  end if
                  call stdlib_zungqr(m - q,m - q,m - q,v2t,ldv2t,work(itauq2),work(iorgqr), &
                            lorgqrwork,info)
@@ -51576,7 +51576,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: tau(*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,iinfo,j,lwkopt,nb,nh
@@ -51668,7 +51668,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: tau(*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper
            integer(ilp) :: i,iinfo,j,lwkopt,nb
@@ -51743,7 +51743,7 @@ module stdlib_linalg_lapack_z
               if (n > 1) then
                  ! generate q(2:n,2:n)
                  call stdlib_zungqr(n - 1,n - 1,n - 1,a(2,2),lda,tau,work,lwork,iinfo)
-                           
+
               end if
            end if
            work(1) = lwkopt
@@ -51771,7 +51771,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: d(*),t(ldt,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,iinfo,j,jb,jbtemp1,jbtemp2,jnb,nplusone
            ! Intrinsic Functions
@@ -51811,7 +51811,7 @@ module stdlib_linalg_lapack_z
            ! (1-2) solve for v2.
            if (m > n) then
               call stdlib_ztrsm('R','U','N','N',m - n,n,cone,a,lda,a(n + 1,1),lda)
-                        
+
            end if
            ! (2) reconstruct the block reflector t stored in t(1:nb, 1:n)
            ! as a sequence of upper-triangular blocks with nb-size column
@@ -52120,7 +52120,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: ap(*),tau(*)
            complex(dp),intent(out) :: q(ldq,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,iinfo,ij,j
@@ -52213,7 +52213,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: tau(*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: forwrd,left,notran,upper
            integer(ilp) :: i,i1,i2,i3,ic,ii,jc,mi,ni,nq
@@ -52334,7 +52334,7 @@ module stdlib_linalg_lapack_z
                     taui = conjg(tau(i))
                  end if
                  call stdlib_zlarf(side,mi,ni,ap(ii),1,taui,c(ic,jc),ldc,work)
-                           
+
                  ap(ii) = aii
                  if (forwrd) then
                     ii = ii + nq - i + 1
@@ -52395,7 +52395,7 @@ module stdlib_linalg_lapack_z
            logical(lk),parameter :: doitref = .true.
            integer(ilp),parameter :: itermax = 30
            real(dp),parameter :: bwdmax = 1.0e+00_dp
-           
+
            ! Local Scalars
            integer(ilp) :: i,iiter,ptsa,ptsx
            real(dp) :: anrm,cte,eps,rnrm,xnrm
@@ -52469,7 +52469,7 @@ module stdlib_linalg_lapack_z
            ! compute r = b - ax (r is work).
            call stdlib_zlacpy('ALL',n,nrhs,b,ldb,work,n)
            call stdlib_zhemm('LEFT',uplo,n,nrhs,cnegone,a,lda,x,ldx,cone,work,n)
-                     
+
            ! check whether the nrhs normwise backward errors satisfy the
            ! stopping criterion. if yes, set iter=0 and return.
            do i = 1,nrhs
@@ -52481,7 +52481,7 @@ module stdlib_linalg_lapack_z
            ! stopping criterion. we are good to exit.
            iter = 0
            return
-10         continue
+           10 continue
            loop_30: do iiter = 1,itermax
               ! convert r (in work) from double precision to single precision
               ! and store the result in sx.
@@ -52501,7 +52501,7 @@ module stdlib_linalg_lapack_z
               ! compute r = b - ax (r is work).
               call stdlib_zlacpy('ALL',n,nrhs,b,ldb,work,n)
               call stdlib_zhemm('L',uplo,n,nrhs,cnegone,a,lda,x,ldx,cone,work,n)
-                        
+
               ! check whether the nrhs normwise backward errors satisfy the
               ! stopping criterion. if yes, set iter=iiter>0 and return.
               do i = 1,nrhs
@@ -52513,14 +52513,14 @@ module stdlib_linalg_lapack_z
               ! stopping criterion, we are good to exit.
               iter = iiter
               return
-20            continue
+              20 continue
            end do loop_30
            ! if we are at this place of the code, this is because we have
            ! performed iter=itermax iterations and never satisfied the
            ! stopping criterion, set up the iter flag accordingly and follow
            ! up on double precision routine.
            iter = -itermax - 1
-40         continue
+           40 continue
            ! single-precision iterative refinement failed to converge to a
            ! satisfactory solution, so we resort to double precision.
            call stdlib_zpotrf(uplo,n,a,lda,info)
@@ -52549,7 +52549,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: ab(ldab,*),c(ldc,*)
            complex(dp),intent(out) :: pt(ldpt,*),q(ldq,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: wantb,wantc,wantpt,wantq
            integer(ilp) :: i,inca,j,j1,j2,kb,kb1,kk,klm,klu1,kun,l,minmn,ml,ml0,mu, &
@@ -52745,9 +52745,9 @@ module stdlib_linalg_lapack_z
                     ab(1,i + 1) = rc*ab(1,i + 1)
                  end if
                  if (wantq) call stdlib_zrot(m,q(1,i),1,q(1,i + 1),1,rc,conjg(rs))
-                           
+
                  if (wantc) call stdlib_zrot(ncc,c(i,1),ldc,c(i + 1,1),ldc,rc,rs)
-                           
+
               end do
            else
               ! a has been reduced to complex upper bidiagonal form or is
@@ -52828,7 +52828,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: notran
            character :: transn,transt
@@ -52896,7 +52896,7 @@ module stdlib_linalg_lapack_z
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - op(a) * x,
               ! where op(a) = a, a**t, or a**h, depending on trans.
@@ -52978,13 +52978,13 @@ module stdlib_linalg_lapack_z
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_zlacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(op(a)**h).
                     call stdlib_zgbtrs(transt,n,kl,ku,1,afb,ldafb,ipiv,work,n,info)
-                              
+
                     do i = 1,n
                        work(i) = rwork(i)*work(i)
                     end do
@@ -52994,7 +52994,7 @@ module stdlib_linalg_lapack_z
                        work(i) = rwork(i)*work(i)
                     end do
                     call stdlib_zgbtrs(transn,n,kl,ku,1,afb,ldafb,ipiv,work,n,info)
-                              
+
                  end if
                  go to 100
               end if
@@ -53055,7 +53055,7 @@ module stdlib_linalg_lapack_z
            if (info == 0) then
               ! solve the system a*x = b, overwriting b with x.
               call stdlib_zgbtrs('NO TRANSPOSE',n,kl,ku,nrhs,ab,ldab,ipiv,b,ldb,info)
-                        
+
            end if
            return
      end subroutine stdlib_zgbsv
@@ -53088,7 +53088,7 @@ module stdlib_linalg_lapack_z
         ! moved setting of info = n+1 so info does not subsequently get
         ! overwritten.  sven, 17 mar 05.
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: colequ,equil,nofact,notran,rowequ
            character :: norm
@@ -53178,11 +53178,11 @@ module stdlib_linalg_lapack_z
            if (equil) then
               ! compute row and column scalings to equilibrate the matrix a.
               call stdlib_zgbequ(n,n,kl,ku,ab,ldab,r,c,rowcnd,colcnd,amax,infequ)
-                        
+
               if (infequ == 0) then
                  ! equilibrate the matrix.
                  call stdlib_zlaqgb(n,n,kl,ku,ab,ldab,r,c,rowcnd,colcnd,amax,equed)
-                           
+
                  rowequ = stdlib_lsame(equed,'R') .or. stdlib_lsame(equed,'B')
                  colequ = stdlib_lsame(equed,'C') .or. stdlib_lsame(equed,'B')
               end if
@@ -53209,7 +53209,7 @@ module stdlib_linalg_lapack_z
                  j1 = max(j - ku,1)
                  j2 = min(j + kl,n)
                  call stdlib_zcopy(j2 - j1 + 1,ab(ku + 1 - j + j1,j),1,afb(kl + ku + 1 - j + j1,j),1)
-                           
+
               end do
               call stdlib_zgbtrf(n,n,kl,ku,afb,ldafb,ipiv,info)
               ! return if info is non-zero.
@@ -53250,7 +53250,7 @@ module stdlib_linalg_lapack_z
            end if
            ! compute the reciprocal of the condition number of a.
            call stdlib_zgbcon(norm,n,kl,ku,afb,ldafb,ipiv,anorm,rcond,work,rwork,info)
-                     
+
            ! compute the solution matrix x.
            call stdlib_zlacpy('FULL',n,nrhs,b,ldb,x,ldx)
            call stdlib_zgbtrs(trans,n,kl,ku,nrhs,afb,ldafb,ipiv,x,ldx,info)
@@ -53303,7 +53303,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: taup(*),tauq(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,iinfo,j,ldwrkx,ldwrky,lwkopt,minmn,nb,nbmin,nx,ws
@@ -53371,7 +53371,7 @@ module stdlib_linalg_lapack_z
               ! an update of the form  a := a - v*y**h - x*u**h
               call stdlib_zgemm('NO TRANSPOSE','CONJUGATE TRANSPOSE',m - i - nb + 1,n - i - nb + 1,nb,- &
               cone,a(i + nb,i),lda,work(ldwrkx*nb + nb + 1),ldwrky,cone,a(i + nb,i + nb),lda)
-                        
+
               call stdlib_zgemm('NO TRANSPOSE','NO TRANSPOSE',m - i - nb + 1,n - i - nb + 1,nb,-cone, &
                         work(nb + 1),ldwrkx,a(i,i + nb),lda,cone,a(i + nb,i + nb),lda)
               ! copy diagonal and off-diagonal elements of b back into a
@@ -53412,7 +53412,7 @@ module stdlib_linalg_lapack_z
            integer(ilp),parameter :: nbmax = 64
            integer(ilp),parameter :: ldt = nbmax + 1
            integer(ilp),parameter :: tsize = ldt*nbmax
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,ib,iinfo,iwt,j,ldwork,lwkopt,nb,nbmin,nh,nx
@@ -53605,7 +53605,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,tpsd
            integer(ilp) :: brow,i,iascl,ibscl,j,mn,nb,scllen,wsize
@@ -53786,7 +53786,7 @@ module stdlib_linalg_lapack_z
            else if (ibscl == 2) then
               call stdlib_zlascl('G',0,0,bignum,bnrm,scllen,nrhs,b,ldb,info)
            end if
-50         continue
+           50 continue
            work(1) = real(wsize,KIND=dp)
            return
      end subroutine stdlib_zgels
@@ -53811,7 +53811,7 @@ module stdlib_linalg_lapack_z
            integer(ilp),parameter :: inb = 1
            integer(ilp),parameter :: inbmin = 2
            integer(ilp),parameter :: ixover = 3
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: fjb,iws,j,jb,lwkopt,minmn,minws,na,nb,nbmin,nfxd,nx,sm, &
@@ -53908,7 +53908,7 @@ module stdlib_linalg_lapack_z
                        ! determine the minimum value of nb.
                        nb = lwork/(sn + 1)
                        nbmin = max(2,stdlib_ilaenv(inbmin,'ZGEQRF',' ',sm,sn,-1,-1))
-                                 
+
                     end if
                  end if
               end if
@@ -53923,7 +53923,7 @@ module stdlib_linalg_lapack_z
                  j = nfxd + 1
                  ! compute factorization: while loop.
                  topbmn = minmn - nx
-30               continue
+                 30 continue
                  if (j <= topbmn) then
                     jb = min(nb,topbmn - j + 1)
                     ! factorize jb columns among columns j:n.
@@ -53960,7 +53960,7 @@ module stdlib_linalg_lapack_z
            ! Local Scalars
            logical(lk),parameter :: use_recursive_qr = .true.
            integer(ilp) :: i,ib,iinfo,k
-           
+
            ! Executable Statements
            ! test the input arguments
            info = 0
@@ -54022,7 +54022,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: notran
            character :: transn,transt
@@ -54086,7 +54086,7 @@ module stdlib_linalg_lapack_z
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - op(a) * x,
               ! where op(a) = a, a**t, or a**h, depending on trans.
@@ -54165,7 +54165,7 @@ module stdlib_linalg_lapack_z
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_zlacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -54213,7 +54213,7 @@ module stdlib_linalg_lapack_z
            integer(ilp),intent(out) :: ipiv(*)
            complex(dp),intent(inout) :: a(lda,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: i,iinfo,j,jb,nb
            ! Intrinsic Functions
@@ -54263,7 +54263,7 @@ module stdlib_linalg_lapack_z
                        ! update trailing submatrix.
                        call stdlib_zgemm('NO TRANSPOSE','NO TRANSPOSE',m - j - jb + 1,n - j - jb + 1,jb,- &
                        cone,a(j + jb,j),lda,a(j,j + jb),lda,cone,a(j + jb,j + jb),lda)
-                                 
+
                     end if
                  end if
               end do
@@ -54301,7 +54301,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*),b(ldb,*),d(*)
            complex(dp),intent(out) :: work(*),x(*),y(*)
         ! ===================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,lopt,lwkmin,lwkopt,nb,nb1,nb2,nb3,nb4,np
@@ -54392,7 +54392,7 @@ module stdlib_linalg_lapack_z
            ! solve triangular system: r11*x = d1
            if (m > 0) then
               call stdlib_ztrtrs('UPPER','NO TRANSPOSE','NON UNIT',m,1,a,lda,d,m,info)
-                        
+
               if (info > 0) then
                  info = 2
                  return
@@ -54446,7 +54446,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*),b(ldb,*),q(ldq,*),z(ldz,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: blk22,initq,initz,lquery,wantq,wantz
            character :: compq2,compz2
@@ -54545,7 +54545,7 @@ module stdlib_linalg_lapack_z
                  pw = nblst*nblst + 1
                  do i = 1,n2nb
                     call stdlib_zlaset('ALL',2*nnb,2*nnb,czero,cone,work(pw),2*nnb)
-                              
+
                     pw = pw + 4*nnb*nnb
                  end do
                  ! reduce columns jcol:jcol+nnb-1 of a to hessenberg form.
@@ -54615,7 +54615,7 @@ module stdlib_linalg_lapack_z
                           call stdlib_zlartg(temp,b(jj + 1,jj),c,s,b(jj + 1,jj + 1))
                           b(jj + 1,jj) = czero
                           call stdlib_zrot(jj - top,b(top + 1,jj + 1),1,b(top + 1,jj),1,c,s)
-                                    
+
                           a(jj + 1,j) = cmplx(c,KIND=dp)
                           b(jj + 1,j) = -conjg(s)
                        end if
@@ -54671,7 +54671,7 @@ module stdlib_linalg_lapack_z
                                  len*nblst + 1),nblst,work(pw + len),1)
                        call stdlib_zgemv('CONJUGATE',len,nblst - len,cone,work((len + 1)*nblst - &
                        len + 1),nblst,a(jrow + nblst - len,j + 1),1,cone,work(pw + len),1)
-                                 
+
                        ppw = pw
                        do i = jrow,jrow + nblst - 1
                           a(i,j + 1) = work(ppw)
@@ -54723,7 +54723,7 @@ module stdlib_linalg_lapack_z
                  call stdlib_zgemm('CONJUGATE','NO TRANSPOSE',nblst,cola,nblst,cone,work, &
                            nblst,a(j,jcol + nnb),lda,czero,work(pw),nblst)
                  call stdlib_zlacpy('ALL',nblst,cola,work(pw),nblst,a(j,jcol + nnb),lda)
-                           
+
                  ppwo = nblst*nblst + 1
                  j0 = j - nnb
                  do j = j0,jcol + 1,-nnb
@@ -54740,7 +54740,7 @@ module stdlib_linalg_lapack_z
                        ! ignore the structure of u.
                        call stdlib_zgemm('CONJUGATE','NO TRANSPOSE',2*nnb,cola,2*nnb,cone, &
                        work(ppwo),2*nnb,a(j,jcol + nnb),lda,czero,work(pw),2*nnb)
-                                 
+
                        call stdlib_zlacpy('ALL',2*nnb,cola,work(pw),2*nnb,a(j,jcol + nnb), &
                                   lda)
                     end if
@@ -54759,7 +54759,7 @@ module stdlib_linalg_lapack_z
                     call stdlib_zgemm('NO TRANSPOSE','NO TRANSPOSE',nh,nblst,nblst,cone,q( &
                               topq,j),ldq,work,nblst,czero,work(pw),nh)
                     call stdlib_zlacpy('ALL',nh,nblst,work(pw),nh,q(topq,j),ldq)
-                              
+
                     ppwo = nblst*nblst + 1
                     j0 = j - nnb
                     do j = j0,jcol + 1,-nnb
@@ -54775,9 +54775,9 @@ module stdlib_linalg_lapack_z
                           ! ignore the structure of u.
                           call stdlib_zgemm('NO TRANSPOSE','NO TRANSPOSE',nh,2*nnb,2*nnb, &
                           cone,q(topq,j),ldq,work(ppwo),2*nnb,czero,work(pw),nh)
-                                    
+
                           call stdlib_zlacpy('ALL',nh,2*nnb,work(pw),nh,q(topq,j),ldq)
-                                    
+
                        end if
                        ppwo = ppwo + 4*nnb*nnb
                     end do
@@ -54790,7 +54790,7 @@ module stdlib_linalg_lapack_z
                     pw = nblst*nblst + 1
                     do i = 1,n2nb
                        call stdlib_zlaset('ALL',2*nnb,2*nnb,czero,cone,work(pw),2*nnb)
-                                 
+
                        pw = pw + 4*nnb*nnb
                     end do
                     ! accumulate givens rotations into workspace array.
@@ -54844,7 +54844,7 @@ module stdlib_linalg_lapack_z
                     call stdlib_zgemm('NO TRANSPOSE','NO TRANSPOSE',top,nblst,nblst,cone,a( &
                               1,j),lda,work,nblst,czero,work(pw),top)
                     call stdlib_zlacpy('ALL',top,nblst,work(pw),top,a(1,j),lda)
-                              
+
                     ppwo = nblst*nblst + 1
                     j0 = j - nnb
                     do j = j0,jcol + 1,-nnb
@@ -54856,9 +54856,9 @@ module stdlib_linalg_lapack_z
                           ! ignore the structure of u.
                           call stdlib_zgemm('NO TRANSPOSE','NO TRANSPOSE',top,2*nnb,2*nnb, &
                           cone,a(1,j),lda,work(ppwo),2*nnb,czero,work(pw),top)
-                                    
+
                           call stdlib_zlacpy('ALL',top,2*nnb,work(pw),top,a(1,j),lda)
-                                    
+
                        end if
                        ppwo = ppwo + 4*nnb*nnb
                     end do
@@ -54866,7 +54866,7 @@ module stdlib_linalg_lapack_z
                     call stdlib_zgemm('NO TRANSPOSE','NO TRANSPOSE',top,nblst,nblst,cone,b( &
                               1,j),ldb,work,nblst,czero,work(pw),top)
                     call stdlib_zlacpy('ALL',top,nblst,work(pw),top,b(1,j),ldb)
-                              
+
                     ppwo = nblst*nblst + 1
                     j0 = j - nnb
                     do j = j0,jcol + 1,-nnb
@@ -54878,9 +54878,9 @@ module stdlib_linalg_lapack_z
                           ! ignore the structure of u.
                           call stdlib_zgemm('NO TRANSPOSE','NO TRANSPOSE',top,2*nnb,2*nnb, &
                           cone,b(1,j),ldb,work(ppwo),2*nnb,czero,work(pw),top)
-                                    
+
                           call stdlib_zlacpy('ALL',top,2*nnb,work(pw),top,b(1,j),ldb)
-                                    
+
                        end if
                        ppwo = ppwo + 4*nnb*nnb
                     end do
@@ -54898,7 +54898,7 @@ module stdlib_linalg_lapack_z
                     call stdlib_zgemm('NO TRANSPOSE','NO TRANSPOSE',nh,nblst,nblst,cone,z( &
                               topq,j),ldz,work,nblst,czero,work(pw),nh)
                     call stdlib_zlacpy('ALL',nh,nblst,work(pw),nh,z(topq,j),ldz)
-                              
+
                     ppwo = nblst*nblst + 1
                     j0 = j - nnb
                     do j = j0,jcol + 1,-nnb
@@ -54914,9 +54914,9 @@ module stdlib_linalg_lapack_z
                           ! ignore the structure of u.
                           call stdlib_zgemm('NO TRANSPOSE','NO TRANSPOSE',nh,2*nnb,2*nnb, &
                           cone,z(topq,j),ldz,work(ppwo),2*nnb,czero,work(pw),nh)
-                                    
+
                           call stdlib_zlacpy('ALL',nh,2*nnb,work(pw),nh,z(topq,j),ldz)
-                                    
+
                        end if
                        ppwo = ppwo + 4*nnb*nnb
                     end do
@@ -54961,7 +54961,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*),b(ldb,*),c(*),d(*)
            complex(dp),intent(out) :: work(*),x(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: lopt,lwkmin,lwkopt,mn,nb,nb1,nb2,nb3,nb4,nr
@@ -55076,7 +55076,7 @@ module stdlib_linalg_lapack_z
      !> condition number is computed as RCOND = 1 / (ANORM * norm(inv(A))).
 
      pure subroutine stdlib_zgtcon(norm,n,dl,d,du,du2,ipiv,anorm,rcond,work,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -55091,7 +55091,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: d(*),dl(*),du(*),du2(*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: onenrm
            integer(ilp) :: i,kase,kase1
@@ -55134,13 +55134,13 @@ module stdlib_linalg_lapack_z
               kase1 = 2
            end if
            kase = 0
-20         continue
+           20 continue
            call stdlib_zlacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               if (kase == kase1) then
                  ! multiply by inv(u)*inv(l).
                  call stdlib_zgttrs('NO TRANSPOSE',n,1,dl,d,du,du2,ipiv,work,n,info)
-                           
+
               else
                  ! multiply by inv(l**h)*inv(u**h).
                  call stdlib_zgttrs('CONJUGATE TRANSPOSE',n,1,dl,d,du,du2,ipiv,work,n, &
@@ -55170,13 +55170,13 @@ module stdlib_linalg_lapack_z
            integer(ilp),intent(in) :: ipiv(*)
            real(dp),intent(out) :: berr(*),ferr(*),rwork(*)
            complex(dp),intent(in) :: b(ldb,*),d(*),df(*),dl(*),dlf(*),du(*),du2(*),duf(*)
-                     
+
            complex(dp),intent(out) :: work(*)
            complex(dp),intent(inout) :: x(ldx,*)
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: notran
            character :: transn,transt
@@ -55236,13 +55236,13 @@ module stdlib_linalg_lapack_z
            loop_110: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - op(a) * x,
               ! where op(a) = a, a**t, or a**h, depending on trans.
               call stdlib_zcopy(n,b(1,j),1,work,1)
               call stdlib_zlagtm(trans,n,1,-one,dl,d,du,x(1,j),ldx,one,work,n)
-                        
+
               ! compute abs(op(a))*abs(x) + abs(b) for use in the backward
               ! error bound.
               if (notran) then
@@ -55254,7 +55254,7 @@ module stdlib_linalg_lapack_z
                     do i = 2,n - 1
                        rwork(i) = cabs1(b(i,j)) + cabs1(dl(i - 1))*cabs1(x(i - 1,j)) + &
                        cabs1(d(i))*cabs1(x(i,j)) + cabs1(du(i))*cabs1(x(i + 1,j))
-                                 
+
                     end do
                     rwork(n) = cabs1(b(n,j)) + cabs1(dl(n - 1))*cabs1(x(n - 1,j)) + &
                               cabs1(d(n))*cabs1(x(n,j))
@@ -55268,7 +55268,7 @@ module stdlib_linalg_lapack_z
                     do i = 2,n - 1
                        rwork(i) = cabs1(b(i,j)) + cabs1(du(i - 1))*cabs1(x(i - 1,j)) + &
                        cabs1(d(i))*cabs1(x(i,j)) + cabs1(dl(i))*cabs1(x(i + 1,j))
-                                 
+
                     end do
                     rwork(n) = cabs1(b(n,j)) + cabs1(du(n - 1))*cabs1(x(n - 1,j)) + &
                               cabs1(d(n))*cabs1(x(n,j))
@@ -55327,13 +55327,13 @@ module stdlib_linalg_lapack_z
                  end if
               end do
               kase = 0
-70            continue
+              70 continue
               call stdlib_zlacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
                     ! multiply by diag(w)*inv(op(a)**h).
                     call stdlib_zgttrs(transt,n,1,dlf,df,duf,du2,ipiv,work,n,info)
-                              
+
                     do i = 1,n
                        work(i) = rwork(i)*work(i)
                     end do
@@ -55343,7 +55343,7 @@ module stdlib_linalg_lapack_z
                        work(i) = rwork(i)*work(i)
                     end do
                     call stdlib_zgttrs(transn,n,1,dlf,df,duf,du2,ipiv,work,n,info)
-                              
+
                  end if
                  go to 70
               end if
@@ -55381,7 +55381,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: df(*),dlf(*),du2(*),duf(*)
            complex(dp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nofact,notran
            character :: norm
@@ -55468,7 +55468,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: bb(ldbb,*)
            complex(dp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: update,upper,wantx
            integer(ilp) :: i,i0,i1,i2,inca,j,j1,j1t,j2,j2t,k,ka1,kb1,kbt,l,m,nr, &
@@ -55559,7 +55559,7 @@ module stdlib_linalg_lapack_z
            ! to avoid duplicating code, the two loops are merged.
            update = .true.
            i = n + 1
-10         continue
+           10 continue
            if (update) then
               i = i - 1
               kbt = min(kb,i - 1)
@@ -55603,7 +55603,7 @@ module stdlib_linalg_lapack_z
                  do j = i,i1
                     do k = max(j - ka,i - kbt),i - 1
                        ab(k - j + ka1,j) = ab(k - j + ka1,j) - bb(k - i + kb1,i)*ab(i - j + ka1,j)
-                                 
+
                     end do
                  end do
                  if (wantx) then
@@ -55632,7 +55632,7 @@ module stdlib_linalg_lapack_z
                        work(i - k) = rwork(i - k + ka - m)*t - conjg(work(i - k + ka - m))*ab(1,i - k + ka &
                                  )
                        ab(1,i - k + ka) = work(i - k + ka - m)*t + rwork(i - k + ka - m)*ab(1,i - k + ka)
-                                 
+
                        ra1 = ra
                     end if
                  end if
@@ -55724,7 +55724,7 @@ module stdlib_linalg_lapack_z
                     ! generate rotations in 2nd set to annihilate elements
                     ! which have been created outside the band
                     call stdlib_zlargv(nr,ab(1,j2),inca,work(j2),ka1,rwork(j2),ka1)
-                              
+
                     ! apply rotations in 2nd set from the right
                     do l = 1,ka - 1
                        call stdlib_zlartv(nr,ab(ka1 - l,j2),inca,ab(ka - l,j2 + 1),inca, &
@@ -55785,7 +55785,7 @@ module stdlib_linalg_lapack_z
                     end do
                     do j = max(1,i - ka),i - kbt - 1
                        ab(k - j + 1,j) = ab(k - j + 1,j) - conjg(bb(i - k + 1,k))*ab(i - j + 1,j)
-                                 
+
                     end do
                  end do
                  do j = i,i1
@@ -55817,9 +55817,9 @@ module stdlib_linalg_lapack_z
                        ! band and store it in work(i-k)
                        t = -bb(k + 1,i - k)*ra1
                        work(i - k) = rwork(i - k + ka - m)*t - conjg(work(i - k + ka - m))*ab(ka1,i - k)
-                                 
+
                        ab(ka1,i - k) = work(i - k + ka - m)*t + rwork(i - k + ka - m)*ab(ka1,i - k)
-                                 
+
                        ra1 = ra
                     end if
                  end if
@@ -55954,7 +55954,7 @@ module stdlib_linalg_lapack_z
               end if
            end if
            go to 10
-480        continue
+           480 continue
            ! **************************** phase 2 *****************************
            ! the logical structure of this phase is:
            ! update = .true.
@@ -55969,7 +55969,7 @@ module stdlib_linalg_lapack_z
            ! to avoid duplicating code, the two loops are merged.
            update = .true.
            i = 0
-490        continue
+           490 continue
            if (update) then
               i = i + 1
               kbt = min(kb,m - i)
@@ -56018,7 +56018,7 @@ module stdlib_linalg_lapack_z
                  do j = i1,i
                     do k = i + 1,min(j + ka,i + kbt)
                        ab(j - k + ka1,k) = ab(j - k + ka1,k) - bb(i - k + kb1,k)*ab(j - i + ka1,i)
-                                 
+
                     end do
                  end do
                  if (wantx) then
@@ -56039,12 +56039,12 @@ module stdlib_linalg_lapack_z
                     if (i + k - ka1 > 0 .and. i + k < m) then
                        ! generate rotation to annihilate a(i+k-ka-1,i)
                        call stdlib_zlartg(ab(k + 1,i),ra1,rwork(i + k - ka),work(i + k - ka),ra)
-                                 
+
                        ! create nonzero element a(i+k-ka-1,i+k) outside the
                        ! band and store it in work(m-kb+i+k)
                        t = -bb(kb1 - k,i + k)*ra1
                        work(m - kb + i + k) = rwork(i + k - ka)*t - conjg(work(i + k - ka))*ab(1,i + k)
-                                 
+
                        ab(1,i + k) = work(i + k - ka)*t + rwork(i + k - ka)*ab(1,i + k)
                        ra1 = ra
                     end if
@@ -56091,7 +56091,7 @@ module stdlib_linalg_lapack_z
                     ! post-multiply x by product of rotations in 1st set
                     do j = j1,j2,ka1
                        call stdlib_zrot(nx,x(1,j),1,x(1,j - 1),1,rwork(j),work(j))
-                                 
+
                     end do
                  end if
               end do loop_610
@@ -56202,7 +56202,7 @@ module stdlib_linalg_lapack_z
                     end do
                     do j = i + kbt + 1,min(n,i + ka)
                        ab(j - k + 1,k) = ab(j - k + 1,k) - conjg(bb(k - i + 1,i))*ab(j - i + 1,i)
-                                 
+
                     end do
                  end do
                  do j = i1,i
@@ -56235,7 +56235,7 @@ module stdlib_linalg_lapack_z
                        work(m - kb + i + k) = rwork(i + k - ka)*t - conjg(work(i + k - ka))*ab(ka1,i + k - &
                                  ka)
                        ab(ka1,i + k - ka) = work(i + k - ka)*t + rwork(i + k - ka)*ab(ka1,i + k - ka)
-                                 
+
                        ra1 = ra
                     end if
                  end if
@@ -56393,7 +56393,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: ab(ldab,*),q(ldq,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: initq,upper,wantq
            integer(ilp) :: i,i2,ibl,inca,incx,iqaend,iqb,iqend,j,j1,j1end,j1inc,j2, &
@@ -56760,7 +56760,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: a(lda,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,kase
@@ -56808,7 +56808,7 @@ module stdlib_linalg_lapack_z
            end if
            ! estimate the 1-norm of the inverse.
            kase = 0
-30         continue
+           30 continue
            call stdlib_zlacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               ! multiply by inv(l*d*l**h) or inv(u*d*u**h).
@@ -56841,7 +56841,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: a(lda,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,kase
@@ -56889,7 +56889,7 @@ module stdlib_linalg_lapack_z
            end if
            ! estimate the 1-norm of the inverse.
            kase = 0
-30         continue
+           30 continue
            call stdlib_zlacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               ! multiply by inv(l*d*l**h) or inv(u*d*u**h).
@@ -56917,7 +56917,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,lquery,wantz
            integer(ilp) :: iinfo,imax,inde,indtau,indwrk,iscale,llwork,lwkopt,nb
@@ -56992,10 +56992,10 @@ module stdlib_linalg_lapack_z
               call stdlib_dsterf(n,w,rwork(inde),info)
            else
               call stdlib_zungtr(uplo,n,a,lda,work(indtau),work(indwrk),llwork,iinfo)
-                        
+
               indwrk = inde + n
               call stdlib_zsteqr(jobz,n,w,rwork(inde),a,lda,rwork(indwrk),info)
-                        
+
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
            if (iscale == 1) then
@@ -57078,7 +57078,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,lower,lquery,test,valeig,wantz,tryrac
            character :: order
@@ -57275,7 +57275,7 @@ module stdlib_linalg_lapack_z
                  end if
                  call stdlib_zstemr(jobz,'A',n,rwork(indrdd),rwork(indree),vl,vu,il, &
                  iu,m,w,z,ldz,n,isuppz,tryrac,rwork(indrwk),llrwork,iwork,liwork,info)
-                           
+
                  ! apply unitary matrix used in reduction to tridiagonal
                  ! form to eigenvectors returned by stdlib_zstemr.
                  if (wantz .and. info == 0) then
@@ -57312,7 +57312,7 @@ module stdlib_linalg_lapack_z
                         indwkn),llwrkn,iinfo)
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
-30   continue
+           30 continue
            if (iscale == 1) then
               if (info == 0) then
                  imax = m
@@ -57371,7 +57371,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,lower,lquery,test,valeig,wantz
            character :: order
@@ -57521,7 +57521,7 @@ module stdlib_linalg_lapack_z
                            iinfo)
                  call stdlib_dcopy(n - 1,rwork(inde),1,rwork(indee),1)
                  call stdlib_zsteqr(jobz,n,w,rwork(indee),z,ldz,rwork(indrwk),info)
-                           
+
                  if (info == 0) then
                     do i = 1,n
                        ifail(i) = 0
@@ -57555,7 +57555,7 @@ module stdlib_linalg_lapack_z
                         indwrk),llwork,iinfo)
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
-40   continue
+           40 continue
            if (iscale == 1) then
               if (info == 0) then
                  imax = m
@@ -57603,7 +57603,7 @@ module stdlib_linalg_lapack_z
      !> positive definite.
 
      subroutine stdlib_zhegv(itype,jobz,uplo,n,a,lda,b,ldb,w,work,lwork,rwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -57616,7 +57616,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper,wantz
            character :: trans
@@ -57720,7 +57720,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(dp),intent(out) :: work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,lquery,upper,valeig,wantz
            character :: trans
@@ -57807,7 +57807,7 @@ module stdlib_linalg_lapack_z
                     trans = 'C'
                  end if
                  call stdlib_ztrsm('LEFT',uplo,trans,'NON-UNIT',n,m,cone,b,ldb,z,ldz)
-                           
+
               else if (itype == 3) then
                  ! for b*a*x=(lambda)*x;
                  ! backtransform eigenvectors: x = l*y or u**h *y
@@ -57817,7 +57817,7 @@ module stdlib_linalg_lapack_z
                     trans = 'N'
                  end if
                  call stdlib_ztrmm('LEFT',uplo,trans,'NON-UNIT',n,m,cone,b,ldb,z,ldz)
-                           
+
               end if
            end if
            ! set work(1) to optimal complex workspace size.
@@ -57847,7 +57847,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,j,k,kase,nz
@@ -57902,7 +57902,7 @@ module stdlib_linalg_lapack_z
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_zcopy(n,b(1,j),1,work,1)
@@ -57986,7 +57986,7 @@ module stdlib_linalg_lapack_z
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_zlacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -58108,7 +58108,7 @@ module stdlib_linalg_lapack_z
      !> the system of equations A * X = B by calling BLAS3 routine ZHETRS_3.
 
      pure subroutine stdlib_zhesv_rk(uplo,n,nrhs,a,lda,e,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -58187,7 +58187,7 @@ module stdlib_linalg_lapack_z
      !> of equations A * X = B by calling ZHETRS_ROOK (uses BLAS 2).
 
      pure subroutine stdlib_zhesv_rook(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -58272,7 +58272,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: af(ldaf,*)
            complex(dp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,nofact
            integer(ilp) :: lwkopt,nb
@@ -58393,7 +58393,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(out) :: alpha(*),beta(*),work(*)
            complex(dp),intent(inout) :: h(ldh,*),q(ldq,*),t(ldt,*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: ilazr2,ilazro,ilq,ilschr,ilz,lquery
            integer(ilp) :: icompq,icompz,ifirst,ifrstm,iiter,ilast,ilastm,in,ischur, &
@@ -58623,7 +58623,7 @@ module stdlib_linalg_lapack_z
                        do jch = j,ilast - 1
                           ctemp = t(jch,jch + 1)
                           call stdlib_zlartg(ctemp,t(jch + 1,jch + 1),c,s,t(jch,jch + 1))
-                                    
+
                           t(jch + 1,jch + 1) = czero
                           if (jch < ilastm - 1) call stdlib_zrot(ilastm - jch - 1,t(jch,jch + 2),ldt, &
                                     t(jch + 1,jch + 2),ldt,c,s)
@@ -58633,14 +58633,14 @@ module stdlib_linalg_lapack_z
                                      s))
                           ctemp = h(jch + 1,jch)
                           call stdlib_zlartg(ctemp,h(jch + 1,jch - 1),c,s,h(jch + 1,jch))
-                                    
+
                           h(jch + 1,jch - 1) = czero
                           call stdlib_zrot(jch + 1 - ifrstm,h(ifrstm,jch),1,h(ifrstm,jch - 1), &
                                     1,c,s)
                           call stdlib_zrot(jch - ifrstm,t(ifrstm,jch),1,t(ifrstm,jch - 1),1, &
                                      c,s)
                           if (ilz) call stdlib_zrot(n,z(1,jch),1,z(1,jch - 1),1,c,s)
-                                    
+
                        end do
                        go to 50
                     end if
@@ -58656,7 +58656,7 @@ module stdlib_linalg_lapack_z
               go to 210
               ! t(ilast,ilast)=0 -- clear h(ilast,ilast-1) to split off a
               ! 1x1 block.
-50   continue
+              50 continue
               ctemp = h(ilast,ilast)
               call stdlib_zlartg(ctemp,h(ilast,ilast - 1),c,s,h(ilast,ilast))
               h(ilast,ilast - 1) = czero
@@ -58666,7 +58666,7 @@ module stdlib_linalg_lapack_z
                         )
               if (ilz) call stdlib_zrot(n,z(1,ilast),1,z(1,ilast - 1),1,c,s)
               ! h(ilast,ilast-1)=0 -- standardize b, set alpha and beta
-60   continue
+              60 continue
               absb = abs(t(ilast,ilast))
               if (absb > safmin) then
                  signbc = conjg(t(ilast,ilast)/absb)
@@ -58697,7 +58697,7 @@ module stdlib_linalg_lapack_z
               ! qz step
               ! this iteration only involves rows/columns ifirst:ilast.  we
               ! assume ifirst < ilast, and that the diagonal of b is non-zero.
-70   continue
+              70 continue
               iiter = iiter + 1
               if (.not. ilschr) then
                  ifrstm = ifirst
@@ -58738,7 +58738,7 @@ module stdlib_linalg_lapack_z
                  if ((iiter/20)*20 == iiter .and. bscale*abs1(t(ilast,ilast)) > safmin) &
                            then
                     eshift = eshift + (ascale*h(ilast,ilast))/(bscale*t(ilast,ilast))
-                              
+
                  else
                     eshift = eshift + (ascale*h(ilast,ilast - 1))/(bscale*t(ilast - 1,ilast - 1) &
                                )
@@ -58760,7 +58760,7 @@ module stdlib_linalg_lapack_z
               end do
               istart = ifirst
               ctemp = ascale*h(ifirst,ifirst) - shift*(bscale*t(ifirst,ifirst))
-90            continue
+              90 continue
               ! do an implicit-shift qz sweep.
               ! initial q
               ctemp2 = ascale*h(istart + 1,istart)
@@ -58808,14 +58808,14 @@ module stdlib_linalg_lapack_z
                     end do
                  end if
               end do loop_150
-160           continue
+              160 continue
            end do loop_170
            ! drop-through = non-convergence
-180  continue
+           180 continue
            info = ilast
            go to 210
            ! successful completion of all qz steps
-190  continue
+           190 continue
            ! set eigenvalues 1:ilo-1
            do j = 1,ilo - 1
               absb = abs(t(j,j))
@@ -58838,7 +58838,7 @@ module stdlib_linalg_lapack_z
            ! normal termination
            info = 0
            ! exit (other than argument error) -- return optimal workspace size
-210  continue
+           210 continue
            work(1) = cmplx(n,KIND=dp)
            return
      end subroutine stdlib_zhgeqz
@@ -58864,7 +58864,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: ap(*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: i,ip,kase
@@ -58912,7 +58912,7 @@ module stdlib_linalg_lapack_z
            end if
            ! estimate the 1-norm of the inverse.
            kase = 0
-30         continue
+           30 continue
            call stdlib_zlacn2(n,work(n + 1),work,ainvnm,kase,isave)
            if (kase /= 0) then
               ! multiply by inv(l*d*l**h) or inv(u*d*u**h).
@@ -58940,7 +58940,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: ap(*)
            complex(dp),intent(out) :: work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: wantz
            integer(ilp) :: iinfo,imax,inde,indrwk,indtau,indwrk,iscale
@@ -59004,10 +59004,10 @@ module stdlib_linalg_lapack_z
            else
               indwrk = indtau + n
               call stdlib_zupgtr(uplo,n,ap,work(indtau),z,ldz,work(indwrk),iinfo)
-                        
+
               indrwk = inde + n
               call stdlib_zsteqr(jobz,n,w,rwork(inde),z,ldz,rwork(indrwk),info)
-                        
+
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
            if (iscale == 1) then
@@ -59042,7 +59042,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: ap(*)
            complex(dp),intent(out) :: work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,test,valeig,wantz
            character :: order
@@ -59142,7 +59142,7 @@ module stdlib_linalg_lapack_z
            indtau = 1
            indwrk = indtau + n
            call stdlib_zhptrd(uplo,n,ap,rwork(indd),rwork(inde),work(indtau),iinfo)
-                     
+
            ! if all eigenvalues are desired and abstol is less than or equal
            ! to zero, then call stdlib_dsterf or stdlib_zupgtr and stdlib_zsteqr.  if this fails
            ! for some eigenvalue, then try stdlib_dstebz.
@@ -59160,10 +59160,10 @@ module stdlib_linalg_lapack_z
                  call stdlib_dsterf(n,w,rwork(indee),info)
               else
                  call stdlib_zupgtr(uplo,n,ap,work(indtau),z,ldz,work(indwrk),iinfo)
-                           
+
                  call stdlib_dcopy(n - 1,rwork(inde),1,rwork(indee),1)
                  call stdlib_zsteqr(jobz,n,w,rwork(indee),z,ldz,rwork(indrwk),info)
-                           
+
                  if (info == 0) then
                     do i = 1,n
                        ifail(i) = 0
@@ -59198,7 +59198,7 @@ module stdlib_linalg_lapack_z
                          iinfo)
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
-20   continue
+           20 continue
            if (iscale == 1) then
               if (info == 0) then
                  imax = m
@@ -59457,7 +59457,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,ik,j,k,kase,kk,nz
@@ -59508,7 +59508,7 @@ module stdlib_linalg_lapack_z
            loop_140: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x
               call stdlib_zcopy(n,b(1,j),1,work,1)
@@ -59599,7 +59599,7 @@ module stdlib_linalg_lapack_z
                  end if
               end do
               kase = 0
-100           continue
+              100 continue
               call stdlib_zlacn2(n,work(n + 1),work,ferr(j),kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -59702,7 +59702,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: ap(*),b(ldb,*)
            complex(dp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nofact
            real(dp) :: anorm
@@ -59782,7 +59782,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            real(dp),parameter :: rzero = 0.0e+0_dp
-           
+
            ! Local Scalars
            logical(lk) :: bothv,fromqr,leftv,noinit,rightv
            integer(ilp) :: i,iinfo,k,kl,kln,kr,ks,ldwork
@@ -59859,13 +59859,13 @@ module stdlib_linalg_lapack_z
                     do i = k,kl + 1,-1
                        if (h(i,i - 1) == czero) go to 30
                     end do
-30                  continue
+                    30 continue
                     kl = i
                     if (k > kr) then
                        do i = k,n - 1
                           if (h(i + 1,i) == czero) go to 50
                        end do
-50                     continue
+                       50 continue
                        kr = i
                     end if
                  end if
@@ -59887,7 +59887,7 @@ module stdlib_linalg_lapack_z
                  ! selected eigenvalues affiliated to the submatrix
                  ! h(kl:kr,kl:kr). close roots are modified by eps3.
                  wk = w(k)
-60               continue
+                 60 continue
                  do i = k - 1,kl,-1
                     if (select(i) .and. cabs1(w(i) - wk) < eps3) then
                        wk = wk + eps3
@@ -59935,7 +59935,7 @@ module stdlib_linalg_lapack_z
      !> corresponding eigenvectors of the dense or band matrix.
 
      pure subroutine stdlib_zlaed0(qsiz,n,d,e,q,ldq,qstore,ldqs,rwork,iwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -59950,7 +59950,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(out) :: qstore(ldqs,*)
         ! =====================================================================
         ! warning:      n could be as big as qsiz!
-           
+
            ! Local Scalars
            integer(ilp) :: curlvl,curprb,curr,i,igivcl,igivnm,igivpt,indxq,iperm,iprmpt, &
            iq,iqptr,iwrem,j,k,lgn,ll,matsiz,msd2,smlsiz,smm1,spm1,spm2,submat, &
@@ -59986,7 +59986,7 @@ module stdlib_linalg_lapack_z
            iwork(1) = n
            subpbs = 1
            tlvls = 0
-10         continue
+           10 continue
            if (iwork(subpbs) > smlsiz) then
               do j = subpbs,1,-1
                  iwork(2*j) = (iwork(j) + 1)/2
@@ -60061,7 +60061,7 @@ module stdlib_linalg_lapack_z
            ! into eigensystem for the corresponding larger matrix.
            ! while ( subpbs > 1 )
            curlvl = 1
-80         continue
+           80 continue
            if (subpbs > 1) then
               spm2 = subpbs - 2
               do i = 0,spm2,2
@@ -60181,7 +60181,7 @@ module stdlib_linalg_lapack_z
            end if
            if ((nb <= k) .or. (nb >= max(m,n,k))) then
              call stdlib_zgemlqt(side,trans,m,n,k,mb,a,lda,t,ldt,c,ldc,work,info)
-                       
+
              return
            end if
            if (left .and. tran) then
@@ -60343,7 +60343,7 @@ module stdlib_linalg_lapack_z
            end if
            if ((mb <= k) .or. (mb >= max(m,n,k))) then
              call stdlib_zgemqrt(side,trans,m,n,k,nb,a,lda,t,ldt,c,ldc,work,info)
-                       
+
              return
             end if
            if (left .and. notran) then
@@ -60456,7 +60456,7 @@ module stdlib_linalg_lapack_z
            ! Parameters
            real(dp),parameter :: rzero = 0.0_dp
            real(dp),parameter :: rone = 1.0_dp
-           
+
            ! Local Scalars
            complex(dp) :: beta,cdum,s,tau
            real(dp) :: foo,safmax,safmin,smlnum,ulp
@@ -60479,7 +60479,7 @@ module stdlib_linalg_lapack_z
               lwk1 = int(work(1),KIND=ilp)
               ! ==== workspace query call to stdlib_zunmhr ====
               call stdlib_zunmhr('R','N',jw,jw,1,jw - 1,t,ldt,work,v,ldv,work,-1,info)
-                        
+
               lwk2 = int(work(1),KIND=ilp)
               ! ==== optimal workspace ====
               lwkopt = jw + max(lwk1,lwk2)
@@ -60564,7 +60564,7 @@ module stdlib_linalg_lapack_z
                  end do
                  ilst = i
                  if (ifst /= ilst) call stdlib_ztrexc('V',jw,t,ldt,v,ldv,ifst,ilst,info)
-                           
+
               end do
            end if
            ! ==== restore shift/eigenvalue array from t ====
@@ -60583,11 +60583,11 @@ module stdlib_linalg_lapack_z
                  work(1) = cone
                  call stdlib_zlaset('L',jw - 2,jw - 2,czero,czero,t(3,1),ldt)
                  call stdlib_zlarf('L',ns,jw,work,1,conjg(tau),t,ldt,work(jw + 1))
-                           
+
                  call stdlib_zlarf('R',ns,ns,work,1,tau,t,ldt,work(jw + 1))
                  call stdlib_zlarf('R',jw,ns,work,1,tau,v,ldv,work(jw + 1))
                  call stdlib_zgehrd(jw,1,ns,t,ldt,work,work(jw + 1),lwork - jw,info)
-                           
+
               end if
               ! ==== copy updated reduced window into place ====
               if (kwtop > 1) h(kwtop,kwtop - 1) = s*conjg(v(1,1))
@@ -60888,7 +60888,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: ab(ldab,*),afb(ldafb,*),b(ldb,*)
            complex(dp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: equil,nofact,rcequ,upper
            integer(ilp) :: i,infequ,j,j1,j2
@@ -60977,7 +60977,7 @@ module stdlib_linalg_lapack_z
                  do j = 1,n
                     j1 = max(j - kd,1)
                     call stdlib_zcopy(j - j1 + 1,ab(kd + 1 - j + j1,j),1,afb(kd + 1 - j + j1,j),1)
-                              
+
                  end do
               else
                  do j = 1,n
@@ -61039,7 +61039,7 @@ module stdlib_linalg_lapack_z
            ! Array Arguments
            complex(dp),intent(inout) :: a(0:*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,nisodd,normaltransr
            integer(ilp) :: n1,n2,k
@@ -61091,7 +61091,7 @@ module stdlib_linalg_lapack_z
                     call stdlib_zpotrf('L',n1,a(0),n,info)
                     if (info > 0) return
                     call stdlib_ztrsm('R','L','C','N',n2,n1,cone,a(0),n,a(n1),n)
-                              
+
                     call stdlib_zherk('U','N',n2,n1,-one,a(n1),n,one,a(n),n)
                     call stdlib_zpotrf('U',n2,a(n),n,info)
                     if (info > 0) info = info + n1
@@ -61102,7 +61102,7 @@ module stdlib_linalg_lapack_z
                     call stdlib_zpotrf('L',n1,a(n2),n,info)
                     if (info > 0) return
                     call stdlib_ztrsm('L','L','N','N',n1,n2,cone,a(n2),n,a(0),n)
-                              
+
                     call stdlib_zherk('U','C',n2,n1,-one,a(0),n,one,a(n1),n)
                     call stdlib_zpotrf('U',n2,a(n1),n,info)
                     if (info > 0) info = info + n1
@@ -61118,7 +61118,7 @@ module stdlib_linalg_lapack_z
                     call stdlib_ztrsm('L','U','C','N',n1,n2,cone,a(0),n1,a(n1*n1), &
                               n1)
                     call stdlib_zherk('L','C',n2,n1,-one,a(n1*n1),n1,one,a(1),n1)
-                              
+
                     call stdlib_zpotrf('L',n2,a(1),n1,info)
                     if (info > 0) info = info + n1
                  else
@@ -61130,7 +61130,7 @@ module stdlib_linalg_lapack_z
                     call stdlib_ztrsm('R','U','N','N',n2,n1,cone,a(n2*n2),n2,a(0), &
                               n2)
                     call stdlib_zherk('L','N',n2,n1,-one,a(0),n2,one,a(n1*n2),n2)
-                              
+
                     call stdlib_zpotrf('L',n2,a(n1*n2),n2,info)
                     if (info > 0) info = info + n1
                  end if
@@ -61146,9 +61146,9 @@ module stdlib_linalg_lapack_z
                     call stdlib_zpotrf('L',k,a(1),n + 1,info)
                     if (info > 0) return
                     call stdlib_ztrsm('R','L','C','N',k,k,cone,a(1),n + 1,a(k + 1),n + 1)
-                              
+
                     call stdlib_zherk('U','N',k,k,-one,a(k + 1),n + 1,one,a(0),n + 1)
-                              
+
                     call stdlib_zpotrf('U',k,a(0),n + 1,info)
                     if (info > 0) info = info + k
                  else
@@ -61158,9 +61158,9 @@ module stdlib_linalg_lapack_z
                     call stdlib_zpotrf('L',k,a(k + 1),n + 1,info)
                     if (info > 0) return
                     call stdlib_ztrsm('L','L','N','N',k,k,cone,a(k + 1),n + 1,a(0),n + 1)
-                              
+
                     call stdlib_zherk('U','C',k,k,-one,a(0),n + 1,one,a(k),n + 1)
-                              
+
                     call stdlib_zpotrf('U',k,a(k),n + 1,info)
                     if (info > 0) info = info + k
                  end if
@@ -61175,7 +61175,7 @@ module stdlib_linalg_lapack_z
                     call stdlib_ztrsm('L','U','C','N',k,k,cone,a(k),n1,a(k*(k + 1)), &
                               k)
                     call stdlib_zherk('L','C',k,k,-one,a(k*(k + 1)),k,one,a(0),k)
-                              
+
                     call stdlib_zpotrf('L',k,a(0),k,info)
                     if (info > 0) info = info + k
                  else
@@ -61210,7 +61210,7 @@ module stdlib_linalg_lapack_z
            ! Array Arguments
            complex(dp),intent(inout) :: a(0:*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,nisodd,normaltransr
            integer(ilp) :: n1,n2,k
@@ -61266,7 +61266,7 @@ module stdlib_linalg_lapack_z
                     call stdlib_zlauum('L',n1,a(0),n,info)
                     call stdlib_zherk('L','C',n1,n2,one,a(n1),n,one,a(0),n)
                     call stdlib_ztrmm('L','U','N','N',n2,n1,cone,a(n),n,a(n1),n)
-                              
+
                     call stdlib_zlauum('U',n2,a(n),n,info)
                  else
                     ! srpa for upper, normal and n is odd ( a(0:n-1,0:n2-1)
@@ -61275,7 +61275,7 @@ module stdlib_linalg_lapack_z
                     call stdlib_zlauum('L',n1,a(n2),n,info)
                     call stdlib_zherk('L','N',n1,n2,one,a(0),n,one,a(n2),n)
                     call stdlib_ztrmm('R','U','C','N',n1,n2,cone,a(n1),n,a(0),n)
-                              
+
                     call stdlib_zlauum('U',n2,a(n1),n,info)
                  end if
               else
@@ -61285,7 +61285,7 @@ module stdlib_linalg_lapack_z
                     ! t1 -> a(0), t2 -> a(1), s -> a(0+n1*n1)
                     call stdlib_zlauum('U',n1,a(0),n1,info)
                     call stdlib_zherk('U','N',n1,n2,one,a(n1*n1),n1,one,a(0),n1)
-                              
+
                     call stdlib_ztrmm('R','L','N','N',n1,n2,cone,a(1),n1,a(n1*n1), &
                               n1)
                     call stdlib_zlauum('L',n2,a(1),n1,info)
@@ -61294,7 +61294,7 @@ module stdlib_linalg_lapack_z
                     ! t1 -> a(0+n2*n2), t2 -> a(0+n1*n2), s -> a(0)
                     call stdlib_zlauum('U',n1,a(n2*n2),n2,info)
                     call stdlib_zherk('U','C',n1,n2,one,a(0),n2,one,a(n2*n2),n2)
-                              
+
                     call stdlib_ztrmm('L','L','C','N',n2,n1,cone,a(n1*n2),n2,a(0), &
                               n2)
                     call stdlib_zlauum('L',n2,a(n1*n2),n2,info)
@@ -61310,9 +61310,9 @@ module stdlib_linalg_lapack_z
                     ! t1 -> a(1), t2 -> a(0), s -> a(k+1)
                     call stdlib_zlauum('L',k,a(1),n + 1,info)
                     call stdlib_zherk('L','C',k,k,one,a(k + 1),n + 1,one,a(1),n + 1)
-                              
+
                     call stdlib_ztrmm('L','U','N','N',k,k,cone,a(0),n + 1,a(k + 1),n + 1)
-                              
+
                     call stdlib_zlauum('U',k,a(0),n + 1,info)
                  else
                     ! srpa for upper, normal, and n is even ( a(0:n,0:k-1) )
@@ -61320,9 +61320,9 @@ module stdlib_linalg_lapack_z
                     ! t1 -> a(k+1), t2 -> a(k), s -> a(0)
                     call stdlib_zlauum('L',k,a(k + 1),n + 1,info)
                     call stdlib_zherk('L','N',k,k,one,a(0),n + 1,one,a(k + 1),n + 1)
-                              
+
                     call stdlib_ztrmm('R','U','C','N',k,k,cone,a(k),n + 1,a(0),n + 1)
-                              
+
                     call stdlib_zlauum('U',k,a(k),n + 1,info)
                  end if
               else
@@ -61333,7 +61333,7 @@ module stdlib_linalg_lapack_z
                     ! t1 -> a(0+k), t2 -> a(0+0), s -> a(0+k*(k+1)); lda=k
                     call stdlib_zlauum('U',k,a(k),k,info)
                     call stdlib_zherk('U','N',k,k,one,a(k*(k + 1)),k,one,a(k),k)
-                              
+
                     call stdlib_ztrmm('R','L','N','N',k,k,cone,a(0),k,a(k*(k + 1)), &
                               k)
                     call stdlib_zlauum('L',k,a(0),k,info)
@@ -61343,9 +61343,9 @@ module stdlib_linalg_lapack_z
                     ! t1 -> a(0+k*(k+1)), t2 -> a(0+k*k), s -> a(0+0)); lda=k
                     call stdlib_zlauum('U',k,a(k*(k + 1)),k,info)
                     call stdlib_zherk('U','C',k,k,one,a(0),k,one,a(k*(k + 1)),k)
-                              
+
                     call stdlib_ztrmm('L','L','C','N',k,k,cone,a(k*k),k,a(0),k)
-                              
+
                     call stdlib_zlauum('L',k,a(k*k),k,info)
                  end if
               end if
@@ -61429,7 +61429,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*),af(ldaf,*),b(ldb,*)
            complex(dp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: equil,nofact,rcequ
            integer(ilp) :: i,infequ,j
@@ -61571,7 +61571,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: itmax = 5
-           
+
            ! Local Scalars
            logical(lk) :: upper
            integer(ilp) :: count,i,ix,j,nz
@@ -61620,7 +61620,7 @@ module stdlib_linalg_lapack_z
            loop_100: do j = 1,nrhs
               count = 1
               lstres = three
-20            continue
+              20 continue
               ! loop until stopping criterion is satisfied.
               ! compute residual r = b - a * x.  also compute
               ! abs(a)*abs(x) + abs(b) for use in the backward error bound.
@@ -61636,7 +61636,7 @@ module stdlib_linalg_lapack_z
                     ex = e(1)*x(2,j)
                     work(1) = bi - dx - ex
                     rwork(1) = cabs1(bi) + cabs1(dx) + cabs1(e(1))*cabs1(x(2,j))
-                              
+
                     do i = 2,n - 1
                        bi = b(i,j)
                        cx = conjg(e(i - 1))*x(i - 1,j)
@@ -61665,7 +61665,7 @@ module stdlib_linalg_lapack_z
                     ex = conjg(e(1))*x(2,j)
                     work(1) = bi - dx - ex
                     rwork(1) = cabs1(bi) + cabs1(dx) + cabs1(e(1))*cabs1(x(2,j))
-                              
+
                     do i = 2,n - 1
                        bi = b(i,j)
                        cx = e(i - 1)*x(i - 1,j)
@@ -61829,7 +61829,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: ef(*)
            complex(dp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: nofact
            real(dp) :: anorm
@@ -61909,7 +61909,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(out) :: work(*)
            complex(dp),intent(inout) :: z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: finish,i,icompz,ii,j,k,lgn,liwmin,ll,lrwmin,lwmin,m,smlsiz, &
@@ -62022,7 +62022,7 @@ module stdlib_linalg_lapack_z
               eps = stdlib_dlamch('EPSILON')
               start = 1
               ! while ( start <= n )
-30   continue
+              30 continue
               if (start <= n) then
                  ! let finish be the position of the next subdiagonal entry
                  ! such that e( finish ) <= tiny or finish = n if no such
@@ -62030,7 +62030,7 @@ module stdlib_linalg_lapack_z
                  ! between start and finish constitutes an independent
                  ! sub-problem.
                  finish = start
-40               continue
+                 40 continue
                  if (finish < n) then
                     tiny = eps*sqrt(abs(d(finish)))*sqrt(abs(d(finish + 1)))
                     if (abs(e(finish)) > tiny) then
@@ -62045,7 +62045,7 @@ module stdlib_linalg_lapack_z
                     orgnrm = stdlib_dlanst('M',m,d(start),e(start))
                     call stdlib_dlascl('G',0,0,orgnrm,one,m,1,d(start),m,info)
                     call stdlib_dlascl('G',0,0,orgnrm,one,m - 1,1,e(start),m - 1,info)
-                              
+
                     call stdlib_zlaed0(n,m,d(start),e(start),z(1,start),ldz,work,n, &
                               rwork,iwork,info)
                     if (info > 0) then
@@ -62088,7 +62088,7 @@ module stdlib_linalg_lapack_z
                 end if
               end do
            end if
-70         continue
+           70 continue
            work(1) = lwmin
            rwork(1) = lrwmin
            iwork(1) = liwmin
@@ -62175,7 +62175,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: idifjb = 3
-           
+
            ! Local Scalars
            logical(lk) :: lquery,swap,wantd,wantd1,wantd2,wantp
            integer(ilp) :: i,ierr,ijb,k,kase,ks,liwmin,lwmin,mn2,n1,n2
@@ -62354,7 +62354,7 @@ module stdlib_linalg_lapack_z
                  ijb = 0
                  mn2 = 2*n1*n2
                  ! 1-norm-based estimate of difu.
-40   continue
+                 40 continue
                  call stdlib_zlacn2(mn2,work(mn2 + 1),work,dif(1),kase,isave)
                  if (kase /= 0) then
                     if (kase == 1) then
@@ -62372,7 +62372,7 @@ module stdlib_linalg_lapack_z
                  end if
                  dif(1) = dscale/dif(1)
                  ! 1-norm-based estimate of difl.
-50   continue
+                 50 continue
                  call stdlib_zlacn2(mn2,work(mn2 + 1),work,dif(2),kase,isave)
                  if (kase /= 0) then
                     if (kase == 1) then
@@ -62409,7 +62409,7 @@ module stdlib_linalg_lapack_z
               alpha(k) = a(k,k)
               beta(k) = b(k,k)
            end do
-70         continue
+           70 continue
            work(1) = lwmin
            iwork(1) = liwmin
            return
@@ -62438,7 +62438,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Parameters
            integer(ilp),parameter :: idifjb = 3
-           
+
            ! Local Scalars
            logical(lk) :: lquery,somcon,wantbh,wantdf,wants
            integer(ilp) :: i,ierr,ifst,ilst,k,ks,lwmin,n1,n2
@@ -62594,7 +62594,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: q(ldq,*),t(ldt,*)
            complex(dp),intent(out) :: w(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wantbh,wantq,wants,wantsp
            integer(ilp) :: ierr,k,kase,ks,lwmin,n1,n2,nn
@@ -62683,7 +62683,7 @@ module stdlib_linalg_lapack_z
               ! estimate sep(t11,t22).
               est = zero
               kase = 0
-30            continue
+              30 continue
               call stdlib_zlacn2(nn,work(nn + 1),work,est,kase,isave)
               if (kase /= 0) then
                  if (kase == 1) then
@@ -62699,7 +62699,7 @@ module stdlib_linalg_lapack_z
               end if
               sep = scale/est
            end if
-40         continue
+           40 continue
            ! copy reordered eigenvalues to w.
            do k = 1,n
               w(k) = t(k,k)
@@ -62737,7 +62737,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(out) :: taup1(*),taup2(*),tauq1(*),work(*)
            complex(dp),intent(inout) :: x11(ldx11,*),x21(ldx21,*)
         ! ====================================================================
-           
+
            ! Local Scalars
            real(dp) :: c,s
            integer(ilp) :: childinfo,i,ilarf,iorbdb5,llarf,lorbdb5,lworkmin, &
@@ -62842,7 +62842,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(out) :: taup1(*),taup2(*),tauq1(*),work(*)
            complex(dp),intent(inout) :: x11(ldx11,*),x21(ldx21,*)
         ! ====================================================================
-           
+
            ! Local Scalars
            real(dp) :: c,s
            integer(ilp) :: childinfo,i,ilarf,iorbdb5,llarf,lorbdb5,lworkmin, &
@@ -62957,7 +62957,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(out) :: taup1(*),taup2(*),tauq1(*),work(*)
            complex(dp),intent(inout) :: x11(ldx11,*),x21(ldx21,*)
         ! ====================================================================
-           
+
            ! Local Scalars
            real(dp) :: c,s
            integer(ilp) :: childinfo,i,ilarf,iorbdb5,llarf,lorbdb5,lworkmin, &
@@ -63071,7 +63071,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(out) :: phantom(*),taup1(*),taup2(*),tauq1(*),work(*)
            complex(dp),intent(inout) :: x11(ldx11,*),x21(ldx21,*)
         ! ====================================================================
-           
+
            ! Local Scalars
            real(dp) :: c,s
            integer(ilp) :: childinfo,i,ilarf,iorbdb5,j,llarf,lorbdb5,lworkmin, &
@@ -63126,7 +63126,7 @@ module stdlib_linalg_lapack_z
                  call stdlib_zlarfgp(p,phantom(1),phantom(2),1,taup1(1))
                  call stdlib_zlarfgp(m - p,phantom(p + 1),phantom(p + 2),1,taup2(1))
                  theta(i) = atan2(real(phantom(1),KIND=dp),real(phantom(p + 1),KIND=dp))
-                           
+
                  c = cos(theta(i))
                  s = sin(theta(i))
                  phantom(1) = cone
@@ -63182,7 +63182,7 @@ module stdlib_linalg_lapack_z
            do i = p + 1,q
               call stdlib_zlacgv(q - i + 1,x21(m - q + i - p,i),ldx21)
               call stdlib_zlarfgp(q - i + 1,x21(m - q + i - p,i),x21(m - q + i - p,i + 1),ldx21,tauq1(i))
-                        
+
               x21(m - q + i - p,i) = cone
               call stdlib_zlarf('R',q - i,q - i + 1,x21(m - q + i - p,i),ldx21,tauq1(i),x21(m - q + i - p + 1,i) &
                         ,ldx21,work(ilarf))
@@ -63225,7 +63225,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: x11(ldx11,*),x21(ldx21,*)
            integer(ilp),intent(out) :: iwork(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: childinfo,i,ib11d,ib11e,ib12d,ib12e,ib21d,ib21e,ib22d,ib22e, &
            ibbcsd,iorbdb,iorglq,iorgqr,iphi,itaup1,itaup2,itauq1,j,lbbcsd,lorbdb, &
@@ -63325,13 +63325,13 @@ module stdlib_linalg_lapack_z
                  end if
                  if (wantu2 .and. m - p > 0) then
                     call stdlib_zungqr(m - p,m - p,q,u2,ldu2,cdum,work(1),-1,childinfo)
-                              
+
                     lorgqrmin = max(lorgqrmin,m - p)
                     lorgqropt = max(lorgqropt,int(work(1),KIND=ilp))
                  end if
                  if (wantv1t .and. q > 0) then
                     call stdlib_zunglq(q - 1,q - 1,q - 1,v1t,ldv1t,cdum,work(1),-1,childinfo)
-                              
+
                     lorglqmin = max(lorglqmin,q - 1)
                     lorglqopt = max(lorglqopt,int(work(1),KIND=ilp))
                  end if
@@ -63351,7 +63351,7 @@ module stdlib_linalg_lapack_z
                  end if
                  if (wantu2 .and. m - p > 0) then
                     call stdlib_zungqr(m - p,m - p,q,u2,ldu2,cdum,work(1),-1,childinfo)
-                              
+
                     lorgqrmin = max(lorgqrmin,m - p)
                     lorgqropt = max(lorgqropt,int(work(1),KIND=ilp))
                  end if
@@ -63399,7 +63399,7 @@ module stdlib_linalg_lapack_z
                  end if
                  if (wantu2 .and. m - p > 0) then
                     call stdlib_zungqr(m - p,m - p,m - q,u2,ldu2,cdum,work(1),-1,childinfo)
-                              
+
                     lorgqrmin = max(lorgqrmin,m - p)
                     lorgqropt = max(lorgqropt,int(work(1),KIND=ilp))
                  end if
@@ -63599,7 +63599,7 @@ module stdlib_linalg_lapack_z
                  call stdlib_zlacpy('U',p - (m - q),q - (m - q),x11(m - q + 1,m - q + 1),ldx11,v1t(m - q + 1,m - q + &
                            1),ldv1t)
                  call stdlib_zlacpy('U',-p + q,q - p,x21(m - q + 1,p + 1),ldx21,v1t(p + 1,p + 1),ldv1t)
-                           
+
                  call stdlib_zunglq(q,q,q,v1t,ldv1t,work(itauq1),work(iorglq),lorglq, &
                            childinfo)
               end if
@@ -63658,7 +63658,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: tau(*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wantq
            integer(ilp) :: i,iinfo,j,lwkopt,mn
@@ -63742,7 +63742,7 @@ module stdlib_linalg_lapack_z
                  if (m > 1) then
                     ! form q(2:m,2:m)
                     call stdlib_zungqr(m - 1,m - 1,m - 1,a(2,2),lda,tau,work,lwork,iinfo)
-                              
+
                  end if
               end if
            else
@@ -63769,7 +63769,7 @@ module stdlib_linalg_lapack_z
                  if (n > 1) then
                     ! form p**h(2:n,2:n)
                     call stdlib_zunglq(n - 1,n - 1,n - 1,a(2,2),lda,tau,work,lwork,iinfo)
-                              
+
                  end if
               end if
            end if
@@ -63795,7 +63795,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(in) :: t(ldt,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: iinfo,ldc,lworkopt,lc,lw,nblocal,j
@@ -64084,7 +64084,7 @@ module stdlib_linalg_lapack_z
            logical(lk),parameter :: doitref = .true.
            integer(ilp),parameter :: itermax = 30
            real(dp),parameter :: bwdmax = 1.0e+00_dp
-           
+
            ! Local Scalars
            integer(ilp) :: i,iiter,ptsa,ptsx
            real(dp) :: anrm,cte,eps,rnrm,xnrm
@@ -64169,7 +64169,7 @@ module stdlib_linalg_lapack_z
            ! stopping criterion. we are good to exit.
            iter = 0
            return
-10         continue
+           10 continue
            loop_30: do iiter = 1,itermax
               ! convert r (in work) from double precision to single precision
               ! and store the result in sx.
@@ -64202,14 +64202,14 @@ module stdlib_linalg_lapack_z
               ! stopping criterion, we are good to exit.
               iter = iiter
               return
-20            continue
+              20 continue
            end do loop_30
            ! if we are at this place of the code, this is because we have
            ! performed iter=itermax iterations and never satisfied the stopping
            ! criterion, set up the iter flag accordingly and follow up on double
            ! precision routine.
            iter = -itermax - 1
-40         continue
+           40 continue
            ! single-precision iterative refinement failed to converge to a
            ! satisfactory solution, so we resort to double precision.
            call stdlib_zgetrf(n,n,a,lda,ipiv,info)
@@ -64385,7 +64385,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: iascl,ibscl,ie,il,itau,itaup,itauq,ldwork,liwork,lrwork, &
@@ -64433,9 +64433,9 @@ module stdlib_linalg_lapack_z
                               ! columns.
                     mm = n
                     maxwrk = max(maxwrk,n*stdlib_ilaenv(1,'ZGEQRF',' ',m,n,-1,-1))
-                              
+
                     maxwrk = max(maxwrk,nrhs*stdlib_ilaenv(1,'ZUNMQR','LC',m,nrhs,n,-1))
-                              
+
                  end if
                  if (m >= n) then
                     ! path 1 - overdetermined or exactly determined.
@@ -64475,7 +64475,7 @@ module stdlib_linalg_lapack_z
                     else
                        ! path 2 - underdetermined.
                        maxwrk = 2*m + (n + m)*stdlib_ilaenv(1,'ZGEBRD',' ',m,n,-1,-1)
-                                 
+
                        maxwrk = max(maxwrk,2*m + nrhs*stdlib_ilaenv(1,'ZUNMBR','QLC',m,nrhs, &
                                   m,-1))
                        maxwrk = max(maxwrk,2*m + m*stdlib_ilaenv(1,'ZUNMBR','PLN',n,nrhs,m, &
@@ -64600,7 +64600,7 @@ module stdlib_linalg_lapack_z
               ! compute a=l*q.
               ! (cworkspace: need 2*m, prefer m+m*nb)
               call stdlib_zgelqf(m,n,a,lda,work(itau),work(nwork),lwork - nwork + 1,info)
-                        
+
               il = nwork
               ! copy l to work(il), zeroing out above its diagonal.
               call stdlib_zlacpy('L',m,m,a,lda,work(il),ldwork)
@@ -64674,7 +64674,7 @@ module stdlib_linalg_lapack_z
            else if (ibscl == 2) then
               call stdlib_zlascl('G',0,0,bignum,bnrm,n,nrhs,b,ldb,info)
            end if
-10         continue
+           10 continue
            work(1) = maxwrk
            iwork(1) = liwork
            rwork(1) = lrwork
@@ -64708,7 +64708,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: bl,chunk,i,iascl,ibscl,ie,il,irwork,itau,itaup,itauq,iwork, &
@@ -64762,7 +64762,7 @@ module stdlib_linalg_lapack_z
                     lwork_zunmqr = real(dum(1),KIND=dp)
                     mm = n
                     maxwrk = max(maxwrk,n + n*stdlib_ilaenv(1,'ZGEQRF',' ',m,n,-1,-1))
-                              
+
                     maxwrk = max(maxwrk,n + nrhs*stdlib_ilaenv(1,'ZUNMQR','LC',m,nrhs,n,- &
                               1))
                  end if
@@ -64770,7 +64770,7 @@ module stdlib_linalg_lapack_z
                     ! path 1 - overdetermined or exactly determined
                     ! compute space needed for stdlib_zgebrd
                     call stdlib_zgebrd(mm,n,a,lda,s,s,dum(1),dum(1),dum(1),-1,info)
-                              
+
                     lwork_zgebrd = real(dum(1),KIND=dp)
                     ! compute space needed for stdlib_zunmbr
                     call stdlib_zunmbr('Q','L','C',mm,nrhs,n,a,lda,dum(1),b,ldb,dum(1), &
@@ -64796,7 +64796,7 @@ module stdlib_linalg_lapack_z
                        lwork_zgelqf = real(dum(1),KIND=dp)
                        ! compute space needed for stdlib_zgebrd
                        call stdlib_zgebrd(m,m,a,lda,s,s,dum(1),dum(1),dum(1),-1,info)
-                                 
+
                        lwork_zgebrd = real(dum(1),KIND=dp)
                        ! compute space needed for stdlib_zunmbr
                        call stdlib_zunmbr('Q','L','C',m,nrhs,n,a,lda,dum(1),b,ldb,dum( &
@@ -64824,7 +64824,7 @@ module stdlib_linalg_lapack_z
                        ! path 2 - underdetermined
                        ! compute space needed for stdlib_zgebrd
                        call stdlib_zgebrd(m,n,a,lda,s,s,dum(1),dum(1),dum(1),-1,info)
-                                 
+
                        lwork_zgebrd = real(dum(1),KIND=dp)
                        ! compute space needed for stdlib_zunmbr
                        call stdlib_zunmbr('Q','L','C',m,nrhs,m,a,lda,dum(1),b,ldb,dum( &
@@ -64958,7 +64958,7 @@ module stdlib_linalg_lapack_z
               ! (rworkspace: none)
               if (lwork >= ldb*nrhs .and. nrhs > 1) then
                  call stdlib_zgemm('C','N',n,nrhs,n,cone,a,lda,b,ldb,czero,work,ldb)
-                           
+
                  call stdlib_zlacpy('G',n,nrhs,work,ldb,b,ldb)
               else if (nrhs > 1) then
                  chunk = lwork/n
@@ -64984,7 +64984,7 @@ module stdlib_linalg_lapack_z
               ! (cworkspace: need 2*m, prefer m+m*nb)
               ! (rworkspace: none)
               call stdlib_zgelqf(m,n,a,lda,work(itau),work(iwork),lwork - iwork + 1,info)
-                        
+
               il = iwork
               ! copy l to work(il), zeroing out above it
               call stdlib_zlacpy('L',m,m,a,lda,work(il),ldwork)
@@ -65105,7 +65105,7 @@ module stdlib_linalg_lapack_z
               ! (rworkspace: none)
               if (lwork >= ldb*nrhs .and. nrhs > 1) then
                  call stdlib_zgemm('C','N',n,nrhs,m,cone,a,lda,b,ldb,czero,work,ldb)
-                           
+
                  call stdlib_zlacpy('G',n,nrhs,work,ldb,b,ldb)
               else if (nrhs > 1) then
                  chunk = lwork/n
@@ -65133,7 +65133,7 @@ module stdlib_linalg_lapack_z
            else if (ibscl == 2) then
               call stdlib_zlascl('G',0,0,bignum,bnrm,n,nrhs,b,ldb,info)
            end if
-70         continue
+           70 continue
            work(1) = maxwrk
            return
      end subroutine stdlib_zgelss
@@ -65189,7 +65189,7 @@ module stdlib_linalg_lapack_z
            ! Parameters
            integer(ilp),parameter :: imax = 1
            integer(ilp),parameter :: imin = 2
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,iascl,ibscl,ismax,ismin,j,lwkopt,mn,nb,nb1,nb2,nb3, &
@@ -65271,7 +65271,7 @@ module stdlib_linalg_lapack_z
            ! compute qr factorization with column pivoting of a:
               ! a * p = q * r
            call stdlib_zgeqp3(m,n,a,lda,jpvt,work(1),work(mn + 1),lwork - mn,rwork,info)
-                     
+
            wsize = mn + real(work(mn + 1),KIND=dp)
            ! complex workspace: mn+nb*(n+1). real workspace 2*n.
            ! details of householder rotations stored in work(1:mn).
@@ -65287,7 +65287,7 @@ module stdlib_linalg_lapack_z
            else
               rank = 1
            end if
-10         continue
+           10 continue
            if (rank < mn) then
               i = rank + 1
               call stdlib_zlaic1(imin,rank,work(ismin),smin,a(1,i),a(i,i),sminpr, &
@@ -65356,7 +65356,7 @@ module stdlib_linalg_lapack_z
            else if (ibscl == 2) then
               call stdlib_zlascl('G',0,0,bignum,bnrm,n,nrhs,b,ldb,info)
            end if
-70         continue
+           70 continue
            work(1) = cmplx(lwkopt,KIND=dp)
            return
      end subroutine stdlib_zgelsy
@@ -65703,7 +65703,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: u(ldu,*),vt(ldvt,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wntqa,wntqas,wntqn,wntqo,wntqs
            integer(ilp) :: blk,chunk,i,ie,ierr,il,ir,iru,irvt,iscl,itau,itaup,itauq, &
@@ -66128,7 +66128,7 @@ module stdlib_linalg_lapack_z
                        call stdlib_zgemm('N','N',chunk,n,n,cone,a(i,1),lda,work(iu), &
                                  ldwrku,czero,work(ir),ldwrkr)
                        call stdlib_zlacpy('F',chunk,n,work(ir),ldwrkr,a(i,1),lda)
-                                 
+
                     end do
                  else if (wntqs) then
                     ! path 3 (m >> n, jobz='s')
@@ -66342,7 +66342,7 @@ module stdlib_linalg_lapack_z
                        call stdlib_zlacrm(chunk,n,a(i,1),lda,rwork(iru),n,work(iu), &
                                  ldwrku,rwork(nrwork))
                        call stdlib_zlacpy('F',chunk,n,work(iu),ldwrku,a(i,1),lda)
-                                 
+
                     end do
                  else if (wntqs) then
                     ! path 5s (m >> n, jobz='s')
@@ -66375,7 +66375,7 @@ module stdlib_linalg_lapack_z
                     ! cworkspace: need   0
                     ! rworkspace: need   n [e] + n*n [ru] + n*n [rvt] + 2*n*n [rwork]
                     call stdlib_zlarcm(n,n,rwork(irvt),n,vt,ldvt,a,lda,rwork(nrwork))
-                              
+
                     call stdlib_zlacpy('F',n,n,a,lda,vt,ldvt)
                     ! multiply q in u by realmatrix rwork(iru,KIND=dp), storing the
                     ! result in a, copying to u
@@ -66383,7 +66383,7 @@ module stdlib_linalg_lapack_z
                     ! rworkspace: need   n [e] + n*n [ru] + 2*m*n [rwork] < n + 5*n*n since m < 2*n here
                     nrwork = irvt
                     call stdlib_zlacrm(m,n,u,ldu,rwork(iru),n,a,lda,rwork(nrwork))
-                              
+
                     call stdlib_zlacpy('F',m,n,a,lda,u,ldu)
                  else
                     ! path 5a (m >> n, jobz='a')
@@ -66416,7 +66416,7 @@ module stdlib_linalg_lapack_z
                     ! cworkspace: need   0
                     ! rworkspace: need   n [e] + n*n [ru] + n*n [rvt] + 2*n*n [rwork]
                     call stdlib_zlarcm(n,n,rwork(irvt),n,vt,ldvt,a,lda,rwork(nrwork))
-                              
+
                     call stdlib_zlacpy('F',n,n,a,lda,vt,ldvt)
                     ! multiply q in u by realmatrix rwork(iru,KIND=dp), storing the
                     ! result in a, copying to u
@@ -66424,7 +66424,7 @@ module stdlib_linalg_lapack_z
                     ! rworkspace: need   n [e] + n*n [ru] + 2*m*n [rwork] < n + 5*n*n since m < 2*n here
                     nrwork = irvt
                     call stdlib_zlacrm(m,n,u,ldu,rwork(iru),n,a,lda,rwork(nrwork))
-                              
+
                     call stdlib_zlacpy('F',m,n,a,lda,u,ldu)
                  end if
               else
@@ -66512,7 +66512,7 @@ module stdlib_linalg_lapack_z
                           call stdlib_zlacrm(chunk,n,a(i,1),lda,rwork(iru),n,work(iu) &
                                     ,ldwrku,rwork(nrwork))
                           call stdlib_zlacpy('F',chunk,n,work(iu),ldwrku,a(i,1),lda)
-                                    
+
                        end do
                     end if
                  else if (wntqs) then
@@ -66641,7 +66641,7 @@ module stdlib_linalg_lapack_z
                     ! copy l to work(il), zeroing about above it
                     call stdlib_zlacpy('L',m,m,a,lda,work(il),ldwrkl)
                     call stdlib_zlaset('U',m - 1,m - 1,czero,czero,work(il + ldwrkl),ldwrkl)
-                              
+
                     ! generate q in a
                     ! cworkspace: need   m*m [vt] + m*m [l] + m [tau] + m    [work]
                     ! cworkspace: prefer m*m [vt] + m*m [l] + m [tau] + m*nb [work]
@@ -66694,7 +66694,7 @@ module stdlib_linalg_lapack_z
                        call stdlib_zgemm('N','N',m,blk,m,cone,work(ivt),m,a(1,i), &
                                  lda,czero,work(il),ldwrkl)
                        call stdlib_zlacpy('F',m,blk,work(il),ldwrkl,a(1,i),lda)
-                                 
+
                     end do
                  else if (wntqs) then
                     ! path 3t (n >> m, jobz='s')
@@ -66714,7 +66714,7 @@ module stdlib_linalg_lapack_z
                     ! copy l to work(il), zeroing out above it
                     call stdlib_zlacpy('L',m,m,a,lda,work(il),ldwrkl)
                     call stdlib_zlaset('U',m - 1,m - 1,czero,czero,work(il + ldwrkl),ldwrkl)
-                              
+
                     ! generate q in a
                     ! cworkspace: need   m*m [l] + m [tau] + m    [work]
                     ! cworkspace: prefer m*m [l] + m [tau] + m*nb [work]
@@ -66911,7 +66911,7 @@ module stdlib_linalg_lapack_z
                        call stdlib_zlarcm(m,blk,rwork(irvt),m,a(1,i),lda,work(ivt), &
                                  ldwkvt,rwork(nrwork))
                        call stdlib_zlacpy('F',m,blk,work(ivt),ldwkvt,a(1,i),lda)
-                                 
+
                     end do
                  else if (wntqs) then
                     ! path 5ts (n >> m, jobz='s')
@@ -66944,7 +66944,7 @@ module stdlib_linalg_lapack_z
                     ! cworkspace: need   0
                     ! rworkspace: need   m [e] + m*m [rvt] + m*m [ru] + 2*m*m [rwork]
                     call stdlib_zlacrm(m,m,u,ldu,rwork(iru),m,a,lda,rwork(nrwork))
-                              
+
                     call stdlib_zlacpy('F',m,m,a,lda,u,ldu)
                     ! multiply realmatrix rwork(irvt,KIND=dp) by p**h in vt,
                     ! storing the result in a, copying to vt
@@ -66952,7 +66952,7 @@ module stdlib_linalg_lapack_z
                     ! rworkspace: need   m [e] + m*m [rvt] + 2*m*n [rwork] < m + 5*m*m since n < 2*m here
                     nrwork = iru
                     call stdlib_zlarcm(m,n,rwork(irvt),m,vt,ldvt,a,lda,rwork(nrwork))
-                              
+
                     call stdlib_zlacpy('F',m,n,a,lda,vt,ldvt)
                  else
                     ! path 5ta (n >> m, jobz='a')
@@ -66985,7 +66985,7 @@ module stdlib_linalg_lapack_z
                     ! cworkspace: need   0
                     ! rworkspace: need   m [e] + m*m [rvt] + m*m [ru] + 2*m*m [rwork]
                     call stdlib_zlacrm(m,m,u,ldu,rwork(iru),m,a,lda,rwork(nrwork))
-                              
+
                     call stdlib_zlacpy('F',m,m,a,lda,u,ldu)
                     ! multiply realmatrix rwork(irvt,KIND=dp) by p**h in vt,
                     ! storing the result in a, copying to vt
@@ -66993,7 +66993,7 @@ module stdlib_linalg_lapack_z
                     ! rworkspace: need   m [e] + m*m [rvt] + 2*m*n [rwork] < m + 5*m*m since n < 2*m here
                     nrwork = iru
                     call stdlib_zlarcm(m,n,rwork(irvt),m,vt,ldvt,a,lda,rwork(nrwork))
-                              
+
                     call stdlib_zlacpy('F',m,n,a,lda,vt,ldvt)
                  end if
               else
@@ -67059,7 +67059,7 @@ module stdlib_linalg_lapack_z
                        ! cworkspace: prefer 2*m [tauq, taup] + m*n [vt] + m*nb [work]
                        ! rworkspace: need   m [e] + m*m [rvt]
                        call stdlib_zlacp2('F',m,m,rwork(irvt),m,work(ivt),ldwkvt)
-                                 
+
                        call stdlib_zunmbr('P','R','C',m,n,m,a,lda,work(itaup),work( &
                                  ivt),ldwkvt,work(nwork),lwork - nwork + 1,ierr)
                        call stdlib_zlacpy('F',m,n,work(ivt),ldwkvt,a,lda)
@@ -67083,7 +67083,7 @@ module stdlib_linalg_lapack_z
                           call stdlib_zlarcm(m,blk,rwork(irvt),m,a(1,i),lda,work(ivt) &
                                     ,ldwkvt,rwork(nrwork))
                           call stdlib_zlacpy('F',m,blk,work(ivt),ldwkvt,a(1,i),lda)
-                                    
+
                        end do
                     end if
                  else if (wntqs) then
@@ -67238,7 +67238,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: u(ldu,*),vt(ldvt,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wntua,wntuas,wntun,wntuo,wntus,wntva,wntvas,wntvn,wntvo, &
                       wntvs
@@ -67308,7 +67308,7 @@ module stdlib_linalg_lapack_z
                  lwork_zungqr_m = int(cdum(1),KIND=ilp)
                  ! compute space needed for stdlib_zgebrd
                  call stdlib_zgebrd(n,n,a,lda,s,dum(1),cdum(1),cdum(1),cdum(1),-1,ierr)
-                           
+
                  lwork_zgebrd = int(cdum(1),KIND=ilp)
                  ! compute space needed for stdlib_zungbr
                  call stdlib_zungbr('P',n,n,n,a,lda,cdum(1),cdum(1),-1,ierr)
@@ -67403,13 +67403,13 @@ module stdlib_linalg_lapack_z
                     maxwrk = 2*n + lwork_zgebrd
                     if (wntus .or. wntuo) then
                        call stdlib_zungbr('Q',m,n,n,a,lda,cdum(1),cdum(1),-1,ierr)
-                                 
+
                        lwork_zungbr_q = int(cdum(1),KIND=ilp)
                        maxwrk = max(maxwrk,2*n + lwork_zungbr_q)
                     end if
                     if (wntua) then
                        call stdlib_zungbr('Q',m,m,n,a,lda,cdum(1),cdum(1),-1,ierr)
-                                 
+
                        lwork_zungbr_q = int(cdum(1),KIND=ilp)
                        maxwrk = max(maxwrk,2*n + lwork_zungbr_q)
                     end if
@@ -67431,7 +67431,7 @@ module stdlib_linalg_lapack_z
                  lwork_zunglq_m = int(cdum(1),KIND=ilp)
                  ! compute space needed for stdlib_zgebrd
                  call stdlib_zgebrd(m,m,a,lda,s,dum(1),cdum(1),cdum(1),cdum(1),-1,ierr)
-                           
+
                  lwork_zgebrd = int(cdum(1),KIND=ilp)
                   ! compute space needed for stdlib_zungbr p
                  call stdlib_zungbr('P',m,m,m,a,n,cdum(1),cdum(1),-1,ierr)
@@ -67648,7 +67648,7 @@ module stdlib_linalg_lapack_z
                        ! copy r to work(ir) and zero out below it
                        call stdlib_zlacpy('U',n,n,a,lda,work(ir),ldwrkr)
                        call stdlib_zlaset('L',n - 1,n - 1,czero,czero,work(ir + 1),ldwrkr)
-                                 
+
                        ! generate q in a
                        ! (cworkspace: need n*n+2*n, prefer n*n+n+n*nb)
                        ! (rworkspace: 0)
@@ -67685,7 +67685,7 @@ module stdlib_linalg_lapack_z
                           call stdlib_zgemm('N','N',chunk,n,n,cone,a(i,1),lda,work(ir &
                                     ),ldwrkr,czero,work(iu),ldwrku)
                           call stdlib_zlacpy('F',chunk,n,work(iu),ldwrku,a(i,1),lda)
-                                    
+
                        end do
                     else
                        ! insufficient workspace for a fast algorithm
@@ -67741,7 +67741,7 @@ module stdlib_linalg_lapack_z
                        ! copy r to vt, zeroing out below it
                        call stdlib_zlacpy('U',n,n,a,lda,vt,ldvt)
                        if (n > 1) call stdlib_zlaset('L',n - 1,n - 1,czero,czero,vt(2,1),ldvt)
-                                 
+
                        ! generate q in a
                        ! (cworkspace: need n*n+2*n, prefer n*n+n+n*nb)
                        ! (rworkspace: 0)
@@ -67785,7 +67785,7 @@ module stdlib_linalg_lapack_z
                           call stdlib_zgemm('N','N',chunk,n,n,cone,a(i,1),lda,work(ir &
                                     ),ldwrkr,czero,work(iu),ldwrku)
                           call stdlib_zlacpy('F',chunk,n,work(iu),ldwrku,a(i,1),lda)
-                                    
+
                        end do
                     else
                        ! insufficient workspace for a fast algorithm
@@ -67799,7 +67799,7 @@ module stdlib_linalg_lapack_z
                        ! copy r to vt, zeroing out below it
                        call stdlib_zlacpy('U',n,n,a,lda,vt,ldvt)
                        if (n > 1) call stdlib_zlaset('L',n - 1,n - 1,czero,czero,vt(2,1),ldvt)
-                                 
+
                        ! generate q in a
                        ! (cworkspace: need 2*n, prefer n+n*nb)
                        ! (rworkspace: 0)
@@ -67858,7 +67858,7 @@ module stdlib_linalg_lapack_z
                           ! copy r to work(ir), zeroing out below it
                           call stdlib_zlacpy('U',n,n,a,lda,work(ir),ldwrkr)
                           call stdlib_zlaset('L',n - 1,n - 1,czero,czero,work(ir + 1),ldwrkr)
-                                    
+
                           ! generate q in a
                           ! (cworkspace: need n*n+2*n, prefer n*n+n+n*nb)
                           ! (rworkspace: 0)
@@ -67913,7 +67913,7 @@ module stdlib_linalg_lapack_z
                           ! zero out below r in a
                           if (n > 1) then
                              call stdlib_zlaset('L',n - 1,n - 1,czero,czero,a(2,1),lda)
-                                       
+
                           end if
                           ! bidiagonalize r in a
                           ! (cworkspace: need 3*n, prefer 2*n+2*n*nb)
@@ -67966,7 +67966,7 @@ module stdlib_linalg_lapack_z
                           ! copy r to work(iu), zeroing out below it
                           call stdlib_zlacpy('U',n,n,a,lda,work(iu),ldwrku)
                           call stdlib_zlaset('L',n - 1,n - 1,czero,czero,work(iu + 1),ldwrku)
-                                    
+
                           ! generate q in a
                           ! (cworkspace: need 2*n*n+2*n, prefer 2*n*n+n+n*nb)
                           ! (rworkspace: 0)
@@ -67984,7 +67984,7 @@ module stdlib_linalg_lapack_z
                           call stdlib_zgebrd(n,n,work(iu),ldwrku,s,rwork(ie),work( &
                                     itauq),work(itaup),work(iwork),lwork - iwork + 1,ierr)
                           call stdlib_zlacpy('U',n,n,work(iu),ldwrku,work(ir),ldwrkr)
-                                    
+
                           ! generate left bidiagonalizing vectors in work(iu)
                           ! (cworkspace: need 2*n*n+3*n, prefer 2*n*n+2*n+n*nb)
                           ! (rworkspace: 0)
@@ -68036,7 +68036,7 @@ module stdlib_linalg_lapack_z
                           ! zero out below r in a
                           if (n > 1) then
                              call stdlib_zlaset('L',n - 1,n - 1,czero,czero,a(2,1),lda)
-                                       
+
                           end if
                           ! bidiagonalize r in a
                           ! (cworkspace: need 3*n, prefer 2*n+2*n*nb)
@@ -68087,7 +68087,7 @@ module stdlib_linalg_lapack_z
                           ! copy r to work(iu), zeroing out below it
                           call stdlib_zlacpy('U',n,n,a,lda,work(iu),ldwrku)
                           call stdlib_zlaset('L',n - 1,n - 1,czero,czero,work(iu + 1),ldwrku)
-                                    
+
                           ! generate q in a
                           ! (cworkspace: need n*n+2*n, prefer n*n+n+n*nb)
                           ! (rworkspace: 0)
@@ -68203,7 +68203,7 @@ module stdlib_linalg_lapack_z
                           ! copy r to work(ir), zeroing out below it
                           call stdlib_zlacpy('U',n,n,a,lda,work(ir),ldwrkr)
                           call stdlib_zlaset('L',n - 1,n - 1,czero,czero,work(ir + 1),ldwrkr)
-                                    
+
                           ! generate q in u
                           ! (cworkspace: need n*n+n+m, prefer n*n+n+m*nb)
                           ! (rworkspace: 0)
@@ -68260,7 +68260,7 @@ module stdlib_linalg_lapack_z
                           ! zero out below r in a
                           if (n > 1) then
                              call stdlib_zlaset('L',n - 1,n - 1,czero,czero,a(2,1),lda)
-                                       
+
                           end if
                           ! bidiagonalize r in a
                           ! (cworkspace: need 3*n, prefer 2*n+2*n*nb)
@@ -68320,7 +68320,7 @@ module stdlib_linalg_lapack_z
                           ! copy r to work(iu), zeroing out below it
                           call stdlib_zlacpy('U',n,n,a,lda,work(iu),ldwrku)
                           call stdlib_zlaset('L',n - 1,n - 1,czero,czero,work(iu + 1),ldwrku)
-                                    
+
                           ie = 1
                           itauq = itau
                           itaup = itauq + n
@@ -68333,7 +68333,7 @@ module stdlib_linalg_lapack_z
                           call stdlib_zgebrd(n,n,work(iu),ldwrku,s,rwork(ie),work( &
                                     itauq),work(itaup),work(iwork),lwork - iwork + 1,ierr)
                           call stdlib_zlacpy('U',n,n,work(iu),ldwrku,work(ir),ldwrkr)
-                                    
+
                           ! generate left bidiagonalizing vectors in work(iu)
                           ! (cworkspace: need 2*n*n+3*n, prefer 2*n*n+2*n+n*nb)
                           ! (rworkspace: 0)
@@ -68385,7 +68385,7 @@ module stdlib_linalg_lapack_z
                           ! zero out below r in a
                           if (n > 1) then
                              call stdlib_zlaset('L',n - 1,n - 1,czero,czero,a(2,1),lda)
-                                       
+
                           end if
                           ! bidiagonalize r in a
                           ! (cworkspace: need 3*n, prefer 2*n+2*n*nb)
@@ -68443,7 +68443,7 @@ module stdlib_linalg_lapack_z
                           ! copy r to work(iu), zeroing out below it
                           call stdlib_zlacpy('U',n,n,a,lda,work(iu),ldwrku)
                           call stdlib_zlaset('L',n - 1,n - 1,czero,czero,work(iu + 1),ldwrku)
-                                    
+
                           ie = 1
                           itauq = itau
                           itaup = itauq + n
@@ -68688,7 +68688,7 @@ module stdlib_linalg_lapack_z
                        ! copy l to work(ir) and zero out above it
                        call stdlib_zlacpy('L',m,m,a,lda,work(ir),ldwrkr)
                        call stdlib_zlaset('U',m - 1,m - 1,czero,czero,work(ir + ldwrkr),ldwrkr)
-                                 
+
                        ! generate q in a
                        ! (cworkspace: need m*m+2*m, prefer m*m+m+m*nb)
                        ! (rworkspace: 0)
@@ -68725,7 +68725,7 @@ module stdlib_linalg_lapack_z
                           call stdlib_zgemm('N','N',m,blk,m,cone,work(ir),ldwrkr,a(1, &
                                     i),lda,czero,work(iu),ldwrku)
                           call stdlib_zlacpy('F',m,blk,work(iu),ldwrku,a(1,i),lda)
-                                    
+
                        end do
                     else
                        ! insufficient workspace for a fast algorithm
@@ -68827,7 +68827,7 @@ module stdlib_linalg_lapack_z
                           call stdlib_zgemm('N','N',m,blk,m,cone,work(ir),ldwrkr,a(1, &
                                     i),lda,czero,work(iu),ldwrku)
                           call stdlib_zlacpy('F',m,blk,work(iu),ldwrku,a(1,i),lda)
-                                    
+
                        end do
                     else
                        ! insufficient workspace for a fast algorithm
@@ -69024,7 +69024,7 @@ module stdlib_linalg_lapack_z
                           call stdlib_zgebrd(m,m,work(iu),ldwrku,s,rwork(ie),work( &
                                     itauq),work(itaup),work(iwork),lwork - iwork + 1,ierr)
                           call stdlib_zlacpy('L',m,m,work(iu),ldwrku,work(ir),ldwrkr)
-                                    
+
                           ! generate right bidiagonalizing vectors in work(iu)
                           ! (cworkspace: need   2*m*m+3*m-1,
                                        ! prefer 2*m*m+2*m+(m-1)*nb)
@@ -69367,7 +69367,7 @@ module stdlib_linalg_lapack_z
                           call stdlib_zgebrd(m,m,work(iu),ldwrku,s,rwork(ie),work( &
                                     itauq),work(itaup),work(iwork),lwork - iwork + 1,ierr)
                           call stdlib_zlacpy('L',m,m,work(iu),ldwrku,work(ir),ldwrkr)
-                                    
+
                           ! generate right bidiagonalizing vectors in work(iu)
                           ! (cworkspace: need   2*m*m+3*m-1,
                                        ! prefer 2*m*m+2*m+(m-1)*nb)
@@ -69680,7 +69680,7 @@ module stdlib_linalg_lapack_z
            real(dp),intent(out) :: s(*),rwork(*)
            integer(ilp),intent(out) :: iwork(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: ierr,nr,n1,optratio,p,q
            integer(ilp) :: lwcon,lwqp3,lwrk_zgelqf,lwrk_zgesvd,lwrk_zgesvd2,lwrk_zgeqp3, &
@@ -69768,7 +69768,7 @@ module stdlib_linalg_lapack_z
               lwsvd = max(3*n,1)
               if (lquery) then
                   call stdlib_zgeqp3(m,n,a,lda,iwork,cdummy,cdummy,-1,rdummy,ierr)
-                            
+
                   lwrk_zgeqp3 = int(cdummy(1),KIND=ilp)
                   if (wntus .or. wntur) then
                       call stdlib_zunmqr('L','N',m,n,n,a,lda,cdummy,u,ldu,cdummy,-1, &
@@ -70005,7 +70005,7 @@ module stdlib_linalg_lapack_z
                      ! .. to prevent overflow in the qr factorization, scale the
                      ! matrix by 1/sqrt(m) if too large entry detected
                      call stdlib_zlascl('G',0,0,sqrt(real(m,KIND=dp)),one,m,n,a,lda,ierr)
-                               
+
                      ascaled = .true.
                  end if
                  call stdlib_zlaswp(n,a,lda,1,m - 1,iwork(n + 1),1)
@@ -70025,7 +70025,7 @@ module stdlib_linalg_lapack_z
                    ! .. to prevent overflow in the qr factorization, scale the
                    ! matrix by 1/sqrt(m) if too large entry detected
                    call stdlib_zlascl('G',0,0,sqrt(real(m,KIND=dp)),one,m,n,a,lda,ierr)
-                             
+
                    ascaled = .true.
                end if
            end if
@@ -70037,7 +70037,7 @@ module stdlib_linalg_lapack_z
               iwork(p) = 0
            end do
            call stdlib_zgeqp3(m,n,a,lda,iwork,cwork,cwork(n + 1),lcwork - n,rwork,ierr)
-                     
+
           ! if the user requested accuracy level allows truncation in the
           ! computed upper triangular factor, the matrix r is examined and,
           ! if possible, replaced with its leading upper trapezoidal part.
@@ -70056,7 +70056,7 @@ module stdlib_linalg_lapack_z
                  if (abs(a(p,p)) < (rtmp*abs(a(1,1)))) go to 3002
                     nr = nr + 1
               end do
-3002          continue
+              3002 continue
            elseif (acclm) then
               ! .. similarly as above, only slightly more gentle (less aggressive).
               ! sudden drop on the diagonal of r is used as the criterion for being
@@ -70070,7 +70070,7 @@ module stdlib_linalg_lapack_z
                            to 3402
                  nr = nr + 1
               end do
-3402          continue
+              3402 continue
            else
               ! Rrqr Not Authorized To Determine Numerical Rank Except In The
               ! obvious case of zero pivots.
@@ -70081,7 +70081,7 @@ module stdlib_linalg_lapack_z
                  if (abs(a(p,p)) == zero) go to 3502
                  nr = nr + 1
               end do
-3502          continue
+              3502 continue
               if (conda) then
                  ! estimate the scaled condition number of a. use the fact that it is
                  ! the same as the scaled condition number of r.
@@ -70098,10 +70098,10 @@ module stdlib_linalg_lapack_z
                     end do
                     if (.not. (lsvec .or. rsvec)) then
                         call stdlib_zpocon('U',nr,v,ldv,one,rtmp,cwork,rwork,ierr)
-                                  
+
                     else
                         call stdlib_zpocon('U',nr,v,ldv,one,rtmp,cwork(n + 1),rwork,ierr)
-                                  
+
                     end if
                     sconda = one/sqrt(rtmp)
                  ! for nr=n, sconda is an estimate of sqrt(||(r^* * r)^(-1)||_1),
@@ -70136,7 +70136,7 @@ module stdlib_linalg_lapack_z
               else
                  ! .. compute the singular values of r = [a](1:nr,1:n)
                  if (nr > 1) call stdlib_zlaset('L',nr - 1,nr - 1,czero,czero,a(2,1),lda)
-                           
+
                  call stdlib_zgesvd('N','N',nr,n,a,lda,s,u,ldu,v,ldv,cwork,lcwork, &
                            rwork,info)
               end if
@@ -70154,7 +70154,7 @@ module stdlib_linalg_lapack_z
                     end do
                  end do
                  if (nr > 1) call stdlib_zlaset('U',nr - 1,nr - 1,czero,czero,u(1,2),ldu)
-                           
+
                  ! .. the left singular vectors not computed, the nr right singular
                  ! vectors overwrite [u](1:nr,1:nr) as conjugate transposed. these
                  ! will be pre-multiplied by q to build the left singular vectors of a.
@@ -70173,7 +70173,7 @@ module stdlib_linalg_lapack_z
                   ! .. copy r into [u] and overwrite [u] with the left singular vectors
                   call stdlib_zlacpy('U',nr,n,a,lda,u,ldu)
                   if (nr > 1) call stdlib_zlaset('L',nr - 1,nr - 1,czero,czero,u(2,1),ldu)
-                            
+
                   ! .. the right singular vectors not computed, the nr left singular
                   ! vectors overwrite [u](1:nr,1:nr)
                      call stdlib_zgesvd('O','N',nr,n,u,ldu,s,u,ldu,v,ldv,cwork(n + 1), &
@@ -70210,7 +70210,7 @@ module stdlib_linalg_lapack_z
                     end do
                  end do
                  if (nr > 1) call stdlib_zlaset('U',nr - 1,nr - 1,czero,czero,v(1,2),ldv)
-                           
+
                  ! .. the left singular vectors of r**h overwrite v, the right singular
                  ! vectors not computed
                  if (wntvr .or. (nr == n)) then
@@ -70256,7 +70256,7 @@ module stdlib_linalg_lapack_z
                   ! Copy R Into V And Overwrite V With The Right Singular Vectors
                   call stdlib_zlacpy('U',nr,n,a,lda,v,ldv)
                   if (nr > 1) call stdlib_zlaset('L',nr - 1,nr - 1,czero,czero,v(2,1),ldv)
-                            
+
                   ! .. the right singular vectors overwrite v, the nr left singular
                   ! vectors stored in u(1:nr,1:nr)
                   if (wntvr .or. (nr == n)) then
@@ -70293,7 +70293,7 @@ module stdlib_linalg_lapack_z
                     end do
                  end do
                  if (nr > 1) call stdlib_zlaset('U',nr - 1,nr - 1,czero,czero,v(1,2),ldv)
-                           
+
                  ! .. the left singular vectors of r**h overwrite [v], the nr right
                  ! singular vectors of r**h stored in [u](1:nr,1:nr) as conjugate
                  ! transposed
@@ -70329,7 +70329,7 @@ module stdlib_linalg_lapack_z
                        if (nr < n1) then
                           call stdlib_zlaset('A',nr,n1 - nr,czero,czero,u(1,nr + 1),ldu)
                           call stdlib_zlaset('A',m - nr,n1 - nr,czero,cone,u(nr + 1,nr + 1),ldu)
-                                    
+
                        end if
                     end if
                  else
@@ -70349,7 +70349,7 @@ module stdlib_linalg_lapack_z
                            end do
                         end do
                         if (nr > 1) call stdlib_zlaset('U',nr - 1,nr - 1,czero,czero,v(1,2),ldv)
-                                  
+
                         call stdlib_zlaset('A',n,n - nr,czero,czero,v(1,nr + 1),ldv)
                         call stdlib_zgesvd('O','A',n,n,v,ldv,s,v,ldv,u,ldu,cwork(n + 1), &
                                   lcwork - n,rwork,info)
@@ -70388,7 +70388,7 @@ module stdlib_linalg_lapack_z
                            end do
                         end do
                         if (nr > 1) call stdlib_zlaset('U',nr - 1,nr - 1,czero,czero,u(1,nr + 2),ldu)
-                                  
+
                         call stdlib_zgeqrf(n,nr,u(1,nr + 1),ldu,cwork(n + 1),cwork(n + nr + 1), &
                                   lcwork - n - nr,ierr)
                         do p = 1,nr
@@ -70422,7 +70422,7 @@ module stdlib_linalg_lapack_z
                       ! .. copy r into [v] and overwrite v with the right singular vectors
                       call stdlib_zlacpy('U',nr,n,a,lda,v,ldv)
                      if (nr > 1) call stdlib_zlaset('L',nr - 1,nr - 1,czero,czero,v(2,1),ldv)
-                               
+
                      ! .. the right singular vectors of r overwrite [v], the nr left
                      ! singular vectors of r stored in [u](1:nr,1:nr)
                      call stdlib_zgesvd('S','O',nr,n,v,ldv,s,u,ldu,v,ldv,cwork(n + 1), &
@@ -70436,7 +70436,7 @@ module stdlib_linalg_lapack_z
                        if (nr < n1) then
                           call stdlib_zlaset('A',nr,n1 - nr,czero,czero,u(1,nr + 1),ldu)
                           call stdlib_zlaset('A',m - nr,n1 - nr,czero,cone,u(nr + 1,nr + 1),ldu)
-                                    
+
                        end if
                     end if
                   else
@@ -70452,7 +70452,7 @@ module stdlib_linalg_lapack_z
                     if (optratio*nr > n) then
                        call stdlib_zlacpy('U',nr,n,a,lda,v,ldv)
                        if (nr > 1) call stdlib_zlaset('L',nr - 1,nr - 1,czero,czero,v(2,1),ldv)
-                                 
+
                     ! .. the right singular vectors of r overwrite [v], the nr left
                        ! singular vectors of r stored in [u](1:nr,1:nr)
                        call stdlib_zlaset('A',n - nr,n,czero,czero,v(nr + 1,1),ldv)
@@ -70474,12 +70474,12 @@ module stdlib_linalg_lapack_z
                     else
                        call stdlib_zlacpy('U',nr,n,a,lda,u(nr + 1,1),ldu)
                        if (nr > 1) call stdlib_zlaset('L',nr - 1,nr - 1,czero,czero,u(nr + 2,1),ldu)
-                                 
+
                        call stdlib_zgelqf(nr,n,u(nr + 1,1),ldu,cwork(n + 1),cwork(n + nr + 1), &
                                  lcwork - n - nr,ierr)
                        call stdlib_zlacpy('L',nr,nr,u(nr + 1,1),ldu,v,ldv)
                        if (nr > 1) call stdlib_zlaset('U',nr - 1,nr - 1,czero,czero,v(1,2),ldv)
-                                 
+
                        call stdlib_zgesvd('S','O',nr,nr,v,ldv,s,u,ldu,v,ldv,cwork(n + nr + &
                                  1),lcwork - n - nr,rwork,info)
                        call stdlib_zlaset('A',n - nr,nr,czero,czero,v(nr + 1,1),ldv)
@@ -70495,7 +70495,7 @@ module stdlib_linalg_lapack_z
                           if (nr < n1) then
                           call stdlib_zlaset('A',nr,n1 - nr,czero,czero,u(1,nr + 1),ldu)
                           call stdlib_zlaset('A',m - nr,n1 - nr,czero,cone,u(nr + 1,nr + 1),ldu)
-                                    
+
                           end if
                        end if
                     end if
@@ -70517,7 +70517,7 @@ module stdlib_linalg_lapack_z
                if (s(q) > zero) go to 4002
                nr = nr - 1
            end do
-4002       continue
+           4002 continue
            ! .. if numerical rank deficiency is detected, the truncated
            ! singular values are set to zero.
            if (nr < n) call stdlib_dlaset('G',n - nr,1,zero,zero,s(nr + 1),n)
@@ -70559,7 +70559,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*),af(ldaf,*),b(ldb,*)
            complex(dp),intent(out) :: work(*),x(ldx,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: colequ,equil,nofact,notran,rowequ
            character :: norm
@@ -70770,7 +70770,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,tran
            integer(ilp) :: i,iascl,ibscl,j,maxmn,brow,scllen,tszo,tszm,lwo,lwm,lw1, &
@@ -70970,7 +70970,7 @@ module stdlib_linalg_lapack_z
            else if (ibscl == 2) then
              call stdlib_zlascl('G',0,0,bignum,bnrm,scllen,nrhs,b,ldb,info)
            end if
-50         continue
+           50 continue
            work(1) = real(tszo + lwo,KIND=dp)
            return
      end subroutine stdlib_zgetsls
@@ -70989,7 +70989,7 @@ module stdlib_linalg_lapack_z
      !> of ZGEQRT for more details on the format.
 
      pure subroutine stdlib_zgetsqrhrt(m,n,mb1,nb1,nb2,a,lda,t,ldt,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -71000,7 +71000,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: t(ldt,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery
            integer(ilp) :: i,iinfo,j,lw1,lw2,lwt,ldwt,lworkopt,nb1local,nb2local, &
@@ -71069,7 +71069,7 @@ module stdlib_linalg_lapack_z
            nb2local = min(nb2,n)
            ! (1) perform tsqr-factorization of the m-by-n matrix a.
            call stdlib_zlatsqr(m,n,mb1,nb1local,a,lda,work,ldwt,work(lwt + 1),lw1,iinfo)
-                     
+
            ! (2) copy the factor r_tsqr stored in the upper-triangular part
                ! of a into the square matrix in the work array
                ! work(lwt+1:lwt+n*n) column-by-column.
@@ -71083,7 +71083,7 @@ module stdlib_linalg_lapack_z
            ! (4) perform the reconstruction of householder vectors from
            ! the matrix q (stored in a) in place.
            call stdlib_zunhr_col(m,n,nb2local,a,lda,t,ldt,work(lwt + n*n + 1),iinfo)
-                     
+
            ! (5) copy the factor r_tsqr stored in the square matrix in the
            ! work array work(lwt+1:lwt+n*n) into the upper-triangular
            ! part of a.
@@ -71143,11 +71143,11 @@ module stdlib_linalg_lapack_z
            real(dp),intent(out) :: rwork(*)
            complex(dp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(dp),intent(out) :: alpha(*),beta(*),vsl(ldvsl,*),vsr(ldvsr,*),work(*)
-                     
+
            ! Function Arguments
            procedure(stdlib_selctg_z) :: selctg
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: cursl,ilascl,ilbscl,ilvsl,ilvsr,lastsl,lquery,wantst
            integer(ilp) :: i,icols,ierr,ihi,ijobvl,ijobvr,ileft,ilo,iright,irows,irwrk, &
@@ -71213,7 +71213,7 @@ module stdlib_linalg_lapack_z
               lwkopt = max(lwkopt,n + n*stdlib_ilaenv(1,'ZUNMQR',' ',n,1,n,-1))
               if (ilvsl) then
                  lwkopt = max(lwkopt,n + n*stdlib_ilaenv(1,'ZUNGQR',' ',n,1,n,-1))
-                           
+
               end if
               work(1) = lwkopt
               if (lwork < lwkmin .and. .not. lquery) info = -18
@@ -71316,16 +71316,16 @@ module stdlib_linalg_lapack_z
            if (wantst) then
               ! undo scaling on eigenvalues before selecting
               if (ilascl) call stdlib_zlascl('G',0,0,anrm,anrmto,n,1,alpha,n,ierr)
-                        
+
               if (ilbscl) call stdlib_zlascl('G',0,0,bnrm,bnrmto,n,1,beta,n,ierr)
-                        
+
               ! select eigenvalues
               do i = 1,n
                  bwork(i) = selctg(alpha(i),beta(i))
               end do
               call stdlib_ztgsen(0,ilvsl,ilvsr,bwork,n,a,lda,b,ldb,alpha,beta,vsl, &
               ldvsl,vsr,ldvsr,sdim,pvsl,pvsr,dif,work(iwrk),lwork - iwrk + 1,idum,1,ierr)
-                        
+
               if (ierr == 1) info = n + 3
            end if
            ! apply back-permutation to vsl and vsr
@@ -71354,7 +71354,7 @@ module stdlib_linalg_lapack_z
                  lastsl = cursl
               end do
            end if
-30         continue
+           30 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_zgges
@@ -71384,7 +71384,7 @@ module stdlib_linalg_lapack_z
 
      subroutine stdlib_zggesx(jobvsl,jobvsr,sort,selctg,sense,n,a,lda,b,ldb,sdim,alpha, &
       beta,vsl,ldvsl,vsr,ldvsr,rconde,rcondv,work,lwork,rwork,iwork,liwork,bwork,info)
-                
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -71398,11 +71398,11 @@ module stdlib_linalg_lapack_z
            real(dp),intent(out) :: rconde(2),rcondv(2),rwork(*)
            complex(dp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(dp),intent(out) :: alpha(*),beta(*),vsl(ldvsl,*),vsr(ldvsr,*),work(*)
-                     
+
            ! Function Arguments
            procedure(stdlib_selctg_z) :: selctg
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: cursl,ilascl,ilbscl,ilvsl,ilvsr,lastsl,lquery,wantsb,wantse, &
                      wantsn,wantst,wantsv
@@ -71483,7 +71483,7 @@ module stdlib_linalg_lapack_z
                  minwrk = 2*n
                  maxwrk = n*(1 + stdlib_ilaenv(1,'ZGEQRF',' ',n,1,n,0))
                  maxwrk = max(maxwrk,n*(1 + stdlib_ilaenv(1,'ZUNMQR',' ',n,1,n,-1)))
-                           
+
                  if (ilvsl) then
                     maxwrk = max(maxwrk,n*(1 + stdlib_ilaenv(1,'ZUNGQR',' ',n,1,n,-1)) &
                               )
@@ -71606,9 +71606,9 @@ module stdlib_linalg_lapack_z
            if (wantst) then
               ! undo scaling on eigenvalues before selctging
               if (ilascl) call stdlib_zlascl('G',0,0,anrmto,anrm,n,1,alpha,n,ierr)
-                        
+
               if (ilbscl) call stdlib_zlascl('G',0,0,bnrmto,bnrm,n,1,beta,n,ierr)
-                        
+
               ! select eigenvalues
               do i = 1,n
                  bwork(i) = selctg(alpha(i),beta(i))
@@ -71662,7 +71662,7 @@ module stdlib_linalg_lapack_z
                  lastsl = cursl
               end do
            end if
-40         continue
+           40 continue
            work(1) = maxwrk
            iwork(1) = liwmin
            return
@@ -71698,7 +71698,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(dp),intent(out) :: alpha(*),beta(*),vl(ldvl,*),vr(ldvr,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: ilascl,ilbscl,ilv,ilvl,ilvr,lquery
            character :: chtemp
@@ -71768,7 +71768,7 @@ module stdlib_linalg_lapack_z
               lwkopt = max(lwkopt,n + n*stdlib_ilaenv(1,'ZUNMQR',' ',n,1,n,0))
               if (ilvl) then
                  lwkopt = max(lwkopt,n + n*stdlib_ilaenv(1,'ZUNGQR',' ',n,1,n,-1))
-                           
+
               end if
               work(1) = lwkopt
               if (lwork < lwkmin .and. .not. lquery) info = -15
@@ -71930,7 +71930,7 @@ module stdlib_linalg_lapack_z
               end if
            end if
            ! undo scaling if necessary
-70   continue
+           70 continue
            if (ilascl) call stdlib_zlascl('G',0,0,anrmto,anrm,n,1,alpha,n,ierr)
            if (ilbscl) call stdlib_zlascl('G',0,0,bnrmto,bnrm,n,1,beta,n,ierr)
            work(1) = lwkopt
@@ -71976,7 +71976,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(dp),intent(out) :: alpha(*),beta(*),vl(ldvl,*),vr(ldvr,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: ilascl,ilbscl,ilv,ilvl,ilvr,lquery,noscl,wantsb,wantse,wantsn, &
                      wantsv
@@ -72064,12 +72064,12 @@ module stdlib_linalg_lapack_z
                  end if
                  maxwrk = minwrk
                  maxwrk = max(maxwrk,n + n*stdlib_ilaenv(1,'ZGEQRF',' ',n,1,n,0))
-                           
+
                  maxwrk = max(maxwrk,n + n*stdlib_ilaenv(1,'ZUNMQR',' ',n,1,n,0))
-                           
+
                  if (ilvl) then
                     maxwrk = max(maxwrk,n + n*stdlib_ilaenv(1,'ZUNGQR',' ',n,1,n,0))
-                              
+
                  end if
               end if
               work(1) = maxwrk
@@ -72117,7 +72117,7 @@ module stdlib_linalg_lapack_z
            ! permute and/or balance the matrix pair (a,b)
            ! (real workspace: need 6*n if balanc = 's' or 'b', 1 otherwise)
            call stdlib_zggbal(balanc,n,a,lda,b,ldb,ilo,ihi,lscale,rscale,rwork,ierr)
-                     
+
            ! compute abnrm and bbnrm
            abnrm = stdlib_zlange('1',n,n,a,lda,rwork(1))
            if (ilascl) then
@@ -72248,7 +72248,7 @@ module stdlib_linalg_lapack_z
            ! (workspace: none needed)
            if (ilvl) then
               call stdlib_zggbak(balanc,'L',n,ilo,ihi,lscale,rscale,n,vl,ldvl,ierr)
-                        
+
               loop_50: do jc = 1,n
                  temp = zero
                  do jr = 1,n
@@ -72263,7 +72263,7 @@ module stdlib_linalg_lapack_z
            end if
            if (ilvr) then
               call stdlib_zggbak(balanc,'R',n,ilo,ihi,lscale,rscale,n,vr,ldvr,ierr)
-                        
+
               loop_80: do jc = 1,n
                  temp = zero
                  do jr = 1,n
@@ -72277,7 +72277,7 @@ module stdlib_linalg_lapack_z
               end do loop_80
            end if
            ! undo scaling if necessary
-90   continue
+           90 continue
            if (ilascl) call stdlib_zlascl('G',0,0,anrmto,anrm,n,1,alpha,n,ierr)
            if (ilbscl) call stdlib_zlascl('G',0,0,bnrmto,bnrm,n,1,beta,n,ierr)
            work(1) = maxwrk
@@ -72300,7 +72300,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: ab(ldab,*)
            complex(dp),intent(out) :: work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,wantz
            integer(ilp) :: iinfo,imax,inde,indrwk,iscale
@@ -72367,14 +72367,14 @@ module stdlib_linalg_lapack_z
            ! call stdlib_zhbtrd to reduce hermitian band matrix to tridiagonal form.
            inde = 1
            call stdlib_zhbtrd(jobz,uplo,n,kd,ab,ldab,w,rwork(inde),z,ldz,work,iinfo)
-                     
+
            ! for eigenvalues only, call stdlib_dsterf.  for eigenvectors, call stdlib_zsteqr.
            if (.not. wantz) then
               call stdlib_dsterf(n,w,rwork(inde),info)
            else
               indrwk = inde + n
               call stdlib_zsteqr(jobz,n,w,rwork(inde),z,ldz,rwork(indrwk),info)
-                        
+
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
            if (iscale == 1) then
@@ -72413,7 +72413,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: ab(ldab,*)
            complex(dp),intent(out) :: work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,lquery,wantz
            integer(ilp) :: iinfo,imax,inde,indwk2,indwrk,iscale,liwmin,llrwk,llwk2, &
@@ -72511,7 +72511,7 @@ module stdlib_linalg_lapack_z
            llwk2 = lwork - indwk2 + 1
            llrwk = lrwork - indwrk + 1
            call stdlib_zhbtrd(jobz,uplo,n,kd,ab,ldab,w,rwork(inde),z,ldz,work,iinfo)
-                     
+
            ! for eigenvalues only, call stdlib_dsterf.  for eigenvectors, call stdlib_zstedc.
            if (.not. wantz) then
               call stdlib_dsterf(n,w,rwork(inde),info)
@@ -72558,7 +72558,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: ab(ldab,*)
            complex(dp),intent(out) :: q(ldq,*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,lower,test,valeig,wantz
            character :: order
@@ -72692,7 +72692,7 @@ module stdlib_linalg_lapack_z
                  call stdlib_zlacpy('A',n,n,q,ldq,z,ldz)
                  call stdlib_dcopy(n - 1,rwork(inde),1,rwork(indee),1)
                  call stdlib_zsteqr(jobz,n,w,rwork(indee),z,ldz,rwork(indrwk),info)
-                           
+
                  if (info == 0) then
                     do i = 1,n
                        ifail(i) = 0
@@ -72728,7 +72728,7 @@ module stdlib_linalg_lapack_z
               end do
            end if
            ! if matrix was scaled, then rescale eigenvalues appropriately.
-30   continue
+           30 continue
            if (iscale == 1) then
               if (info == 0) then
                  imax = m
@@ -72836,13 +72836,13 @@ module stdlib_linalg_lapack_z
               vect = 'N'
            end if
            call stdlib_zhbtrd(vect,uplo,n,ka,ab,ldab,w,rwork(inde),z,ldz,work,iinfo)
-                     
+
            ! for eigenvalues only, call stdlib_dsterf.  for eigenvectors, call stdlib_zsteqr.
            if (.not. wantz) then
               call stdlib_dsterf(n,w,rwork(inde),info)
            else
               call stdlib_zsteqr(jobz,n,w,rwork(inde),z,ldz,rwork(indwrk),info)
-                        
+
            end if
            return
      end subroutine stdlib_zhbgv
@@ -72874,7 +72874,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: ab(ldab,*),bb(ldbb,*)
            complex(dp),intent(out) :: work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper,wantz
            character :: vect
@@ -72957,7 +72957,7 @@ module stdlib_linalg_lapack_z
               vect = 'N'
            end if
            call stdlib_zhbtrd(vect,uplo,n,ka,ab,ldab,w,rwork(inde),z,ldz,work,iinfo)
-                     
+
            ! for eigenvalues only, call stdlib_dsterf.  for eigenvectors, call stdlib_zstedc.
            if (.not. wantz) then
               call stdlib_dsterf(n,w,rwork(inde),info)
@@ -72997,7 +72997,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: ab(ldab,*),bb(ldbb,*)
            complex(dp),intent(out) :: q(ldq,*),work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: alleig,indeig,test,upper,valeig,wantz
            character :: order,vect
@@ -73095,7 +73095,7 @@ module stdlib_linalg_lapack_z
               else
                  call stdlib_zlacpy('A',n,n,q,ldq,z,ldz)
                  call stdlib_zsteqr(jobz,n,w,rwork(indee),z,ldz,rwork(indrwk),info)
-                           
+
                  if (info == 0) then
                     do i = 1,n
                        ifail(i) = 0
@@ -73131,7 +73131,7 @@ module stdlib_linalg_lapack_z
                  call stdlib_zgemv('N',n,n,cone,q,ldq,work,1,czero,z(1,j),1)
               end do
            end if
-30         continue
+           30 continue
            ! if eigenvalues are not in order, then sort them, along with
            ! eigenvectors.
            if (wantz) then
@@ -73187,7 +73187,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lower,lquery,wantz
            integer(ilp) :: iinfo,imax,inde,indrwk,indtau,indwk2,indwrk,iscale,liopt, &
@@ -73341,7 +73341,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper,wantz
            character :: trans
@@ -73427,7 +73427,7 @@ module stdlib_linalg_lapack_z
                     trans = 'C'
                  end if
                  call stdlib_ztrsm('LEFT',uplo,trans,'NON-UNIT',n,n,cone,b,ldb,a,lda)
-                           
+
               else if (itype == 3) then
                  ! for b*a*x=(lambda)*x;
                  ! backtransform eigenvectors: x = l*y or u**h *y
@@ -73437,7 +73437,7 @@ module stdlib_linalg_lapack_z
                     trans = 'N'
                  end if
                  call stdlib_ztrmm('LEFT',uplo,trans,'NON-UNIT',n,n,cone,b,ldb,a,lda)
-                           
+
               end if
            end if
            work(1) = lopt
@@ -73471,7 +73471,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: ap(*)
            complex(dp),intent(out) :: work(*),z(ldz,*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,wantz
            integer(ilp) :: iinfo,imax,inde,indrwk,indtau,indwrk,iscale,liwmin,llrwk, &
@@ -73746,7 +73746,7 @@ module stdlib_linalg_lapack_z
            ! Function Arguments
            procedure(stdlib_select_z) :: select
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,scalea,wantst,wantvs
            integer(ilp) :: hswork,i,ibal,icond,ierr,ieval,ihi,ilo,itau,iwrk,maxwrk, &
@@ -73791,7 +73791,7 @@ module stdlib_linalg_lapack_z
                  maxwrk = n + n*stdlib_ilaenv(1,'ZGEHRD',' ',n,1,n,0)
                  minwrk = 2*n
                  call stdlib_zhseqr('S',jobvs,n,1,n,a,lda,w,vs,ldvs,work,-1,ieval)
-                           
+
                  hswork = real(work(1),KIND=dp)
                  if (.not. wantvs) then
                     maxwrk = max(maxwrk,hswork)
@@ -73924,7 +73924,7 @@ module stdlib_linalg_lapack_z
            ! Function Arguments
            procedure(stdlib_select_z) :: select
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,scalea,wantsb,wantse,wantsn,wantst,wantsv,wantvs
            integer(ilp) :: hswork,i,ibal,icond,ierr,ieval,ihi,ilo,itau,iwrk,lwrk, &
@@ -73979,7 +73979,7 @@ module stdlib_linalg_lapack_z
                  maxwrk = n + n*stdlib_ilaenv(1,'ZGEHRD',' ',n,1,n,0)
                  minwrk = 2*n
                  call stdlib_zhseqr('S',jobvs,n,1,n,a,lda,w,vs,ldvs,work,-1,ieval)
-                           
+
                  hswork = real(work(1),KIND=dp)
                  if (.not. wantvs) then
                     maxwrk = max(maxwrk,hswork)
@@ -74118,7 +74118,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: vl(ldvl,*),vr(ldvr,*),w(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,scalea,wantvl,wantvr
            character :: side
@@ -74175,7 +74175,7 @@ module stdlib_linalg_lapack_z
                     lwork_trevc = int(work(1),KIND=ilp)
                     maxwrk = max(maxwrk,n + lwork_trevc)
                     call stdlib_zhseqr('S','V',n,1,n,a,lda,w,vl,ldvl,work,-1,info)
-                              
+
                  else if (wantvr) then
                     maxwrk = max(maxwrk,n + (n - 1)*stdlib_ilaenv(1,'ZUNGHR',' ',n,1,n,- &
                               1))
@@ -74184,10 +74184,10 @@ module stdlib_linalg_lapack_z
                     lwork_trevc = int(work(1),KIND=ilp)
                     maxwrk = max(maxwrk,n + lwork_trevc)
                     call stdlib_zhseqr('S','V',n,1,n,a,lda,w,vr,ldvr,work,-1,info)
-                              
+
                  else
                     call stdlib_zhseqr('E','N',n,1,n,a,lda,w,vr,ldvr,work,-1,info)
-                              
+
                  end if
                  hswork = int(work(1),KIND=ilp)
                  maxwrk = max(maxwrk,hswork,minwrk)
@@ -74330,7 +74330,7 @@ module stdlib_linalg_lapack_z
               end do
            end if
            ! undo scaling if necessary
-50   continue
+           50 continue
            if (scalea) then
               call stdlib_zlascl('G',0,0,cscale,anrm,n - info,1,w(info + 1),max(n - info,1) &
                         ,ierr)
@@ -74383,7 +74383,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: vl(ldvl,*),vr(ldvr,*),w(*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,scalea,wantvl,wantvr,wntsnb,wntsne,wntsnn,wntsnv
            character :: job,side
@@ -74447,21 +74447,21 @@ module stdlib_linalg_lapack_z
                     lwork_trevc = int(work(1),KIND=ilp)
                     maxwrk = max(maxwrk,lwork_trevc)
                     call stdlib_zhseqr('S','V',n,1,n,a,lda,w,vl,ldvl,work,-1,info)
-                              
+
                  else if (wantvr) then
                     call stdlib_ztrevc3('R','B',select,n,a,lda,vl,ldvl,vr,ldvr,n,nout, &
                               work,-1,rwork,-1,ierr)
                     lwork_trevc = int(work(1),KIND=ilp)
                     maxwrk = max(maxwrk,lwork_trevc)
                     call stdlib_zhseqr('S','V',n,1,n,a,lda,w,vr,ldvr,work,-1,info)
-                              
+
                  else
                     if (wntsnn) then
                        call stdlib_zhseqr('E','N',n,1,n,a,lda,w,vr,ldvr,work,-1,info)
-                                 
+
                     else
                        call stdlib_zhseqr('S','N',n,1,n,a,lda,w,vr,ldvr,work,-1,info)
-                                 
+
                     end if
                  end if
                  hswork = int(work(1),KIND=ilp)
@@ -74629,7 +74629,7 @@ module stdlib_linalg_lapack_z
               end do
            end if
            ! undo scaling if necessary
-50   continue
+           50 continue
            if (scalea) then
               call stdlib_zlascl('G',0,0,cscale,anrm,n - info,1,w(info + 1),max(n - info,1) &
                         ,ierr)
@@ -74670,7 +74670,7 @@ module stdlib_linalg_lapack_z
            integer(ilp),intent(out) :: iwork(*)
            character,intent(in) :: joba,jobp,jobr,jobt,jobu,jobv
         ! ===========================================================================
-           
+
            ! Local Scalars
            complex(dp) :: ctemp
            real(dp) :: aapp,aaqq,aatmax,aatmin,big,big1,cond_ok,condr1,condr2,entra, &
@@ -74758,7 +74758,7 @@ module stdlib_linalg_lapack_z
                lrwsvdj = n
                if (lquery) then
                    call stdlib_zgeqp3(m,n,a,lda,iwork,cdummy,cdummy,-1,rdummy,ierr)
-                             
+
                    lwrk_zgeqp3 = real(cdummy(1),KIND=dp)
                    call stdlib_zgeqrf(n,n,a,lda,cdummy,cdummy,-1,ierr)
                    lwrk_zgeqrf = real(cdummy(1),KIND=dp)
@@ -74782,7 +74782,7 @@ module stdlib_linalg_lapack_z
                        lwrk_zgesvj = real(cdummy(1),KIND=dp)
                        if (errest) then
                            optwrk = max(n + lwrk_zgeqp3,n**2 + lwcon,n + lwrk_zgeqrf,lwrk_zgesvj)
-                                     
+
                        else
                            optwrk = max(n + lwrk_zgeqp3,n + lwrk_zgeqrf,lwrk_zgesvj)
                        end if
@@ -74809,7 +74809,7 @@ module stdlib_linalg_lapack_z
                                 lwunmlq)
                   else
                       minwrk = max(n + lwqp3,lwsvdj,n + lwlqf,2*n + lwqrf,n + lwsvdj,n + lwunmlq)
-                                
+
                   end if
                   if (lquery) then
                       call stdlib_zgesvj('L','U','N',n,n,u,ldu,sva,n,a,lda,cdummy,-1, &
@@ -74860,7 +74860,7 @@ module stdlib_linalg_lapack_z
                                 lwrk_zunmqrm)
                       else
                       optwrk = n + max(lwrk_zgeqp3,n + lwrk_zgeqrf,lwrk_zgesvj,lwrk_zunmqrm)
-                                
+
                       end if
                   end if
                   if (l2tran .or. rowpiv) then
@@ -74913,7 +74913,7 @@ module stdlib_linalg_lapack_z
                       lwrk_zunmqr = real(cdummy(1),KIND=dp)
                       if (.not. jracc) then
                           call stdlib_zgeqp3(n,n,a,lda,iwork,cdummy,cdummy,-1,rdummy,ierr)
-                                    
+
                           lwrk_zgeqp3n = real(cdummy(1),KIND=dp)
                           call stdlib_zgesvj('L','U','N',n,n,u,ldu,sva,n,v,ldv,cdummy, &
                                     -1,rdummy,-1,ierr)
@@ -75299,7 +75299,7 @@ module stdlib_linalg_lapack_z
               iwork(p) = 0
            end do
            call stdlib_zgeqp3(m,n,a,lda,iwork,cwork,cwork(n + 1),lwork - n,rwork,ierr)
-                     
+
            ! the upper triangular matrix r1 from the first qrf is inspected for
            ! rank deficiency and possibilities for deflation, or possible
            ! ill-conditioning. depending on the user specified flag l2rank,
@@ -75321,7 +75321,7 @@ module stdlib_linalg_lapack_z
                     go to 3002
                  end if
               end do
-3002          continue
+              3002 continue
            else if (l2rank) then
               ! .. similarly as above, only slightly more gentle (less aggressive).
               ! sudden drop on the diagonal of r1 is used as the criterion for
@@ -75332,7 +75332,7 @@ module stdlib_linalg_lapack_z
                            l2kill .and. (abs(a(p,p)) < temp1))) go to 3402
                  nr = nr + 1
               end do
-3402          continue
+              3402 continue
            else
               ! the goal is high relative accuracy. however, if the matrix
               ! has high scaled condition number the relative accuracy is in
@@ -75347,7 +75347,7 @@ module stdlib_linalg_lapack_z
                            3302
                  nr = nr + 1
               end do
-3302          continue
+              3302 continue
            end if
            almort = .false.
            if (nr == n) then
@@ -75372,10 +75372,10 @@ module stdlib_linalg_lapack_z
                     end do
                     if (lsvec) then
                         call stdlib_zpocon('U',n,v,ldv,one,temp1,cwork(n + 1),rwork,ierr)
-                                  
+
                     else
                         call stdlib_zpocon('U',n,v,ldv,one,temp1,cwork,rwork,ierr)
-                                  
+
                     end if
                  else if (lsvec) then
                     ! U Is Available As Workspace
@@ -75385,7 +75385,7 @@ module stdlib_linalg_lapack_z
                        call stdlib_zdscal(p,one/temp1,u(1,p),1)
                     end do
                     call stdlib_zpocon('U',n,u,ldu,one,temp1,cwork(n + 1),rwork,ierr)
-                              
+
                  else
                     call stdlib_zlacpy('U',n,n,a,lda,cwork,n)
       ! []            call stdlib_zlacpy( 'u', n, n, a, lda, cwork(n+1), n )
@@ -75400,7 +75400,7 @@ module stdlib_linalg_lapack_z
       ! []               call stdlib_zpocon( 'u', n, cwork(n+1), n, one, temp1,
       ! []     $              cwork(n+n*n+1), rwork, ierr )
                     call stdlib_zpocon('U',n,cwork,n,one,temp1,cwork(n*n + 1),rwork,ierr)
-                              
+
                  end if
                  if (temp1 /= zero) then
                     sconda = one/sqrt(temp1)
@@ -75504,7 +75504,7 @@ module stdlib_linalg_lapack_z
                  call stdlib_zlacpy('L',nr,nr,a,lda,v,ldv)
                  call stdlib_zlaset('U',nr - 1,nr - 1,czero,czero,v(1,2),ldv)
                  call stdlib_zgeqrf(nr,nr,v,ldv,cwork(n + 1),cwork(2*n + 1),lwork - 2*n,ierr)
-                           
+
                  do p = 1,nr
                     call stdlib_zcopy(nr - p + 1,v(p,p),ldv,v(p,p),1)
                     call stdlib_zlacgv(nr - p + 1,v(p,p),1)
@@ -75525,7 +75525,7 @@ module stdlib_linalg_lapack_z
                ! Permute The Rows Of V
                ! do 8991 p = 1, n
                   ! call stdlib_zcopy( n, v(p,1), ldv, a(iwork(p),1), lda )
-8991 continue
+                  8991 continue
                ! call stdlib_zlacpy( 'all', n, n, a, lda, v, ldv )
               call stdlib_zlapmr(.false.,n,n,v,ldv,iwork)
                if (transp) then
@@ -75548,7 +75548,7 @@ module stdlib_linalg_lapack_z
               end do
               call stdlib_zlaset('U',nr - 1,nr - 1,czero,czero,u(1,2),ldu)
               call stdlib_zgeqrf(n,nr,u,ldu,cwork(n + 1),cwork(2*n + 1),lwork - 2*n,ierr)
-                        
+
               do p = 1,nr - 1
                  call stdlib_zcopy(nr - p,u(p,p + 1),ldu,u(p + 1,p),1)
                  call stdlib_zlacgv(n - p + 1,u(p,p),1)
@@ -75637,7 +75637,7 @@ module stdlib_linalg_lapack_z
                     ! of a lower triangular matrix.
                     ! r1^* = q2 * r2
                     call stdlib_zgeqrf(n,nr,v,ldv,cwork(n + 1),cwork(2*n + 1),lwork - 2*n,ierr)
-                              
+
                     if (l2pert) then
                        xsc = sqrt(small)/epsln
                        do p = 2,nr
@@ -75649,7 +75649,7 @@ module stdlib_linalg_lapack_z
                        end do
                     end if
                     if (nr /= n) call stdlib_zlacpy('A',n,nr,v,ldv,cwork(2*n + 1),n)
-                              
+
                     ! .. save ...
                  ! This Transposed Copy Should Be Better Than Naive
                     do p = 1,nr - 1
@@ -75950,7 +75950,7 @@ module stdlib_linalg_lapack_z
                  call stdlib_zlaset('U',nr - 1,nr - 1,czero,czero,v(1,2),ldv)
               end if
               call stdlib_zgeqrf(n,nr,v,ldv,cwork(n + 1),cwork(2*n + 1),lwork - 2*n,ierr)
-                        
+
               call stdlib_zlacpy('L',n,nr,v,ldv,cwork(2*n + 1),n)
               do p = 1,nr
                  call stdlib_zcopy(nr - p + 1,v(p,p),ldv,u(p,p),1)
@@ -76074,7 +76074,7 @@ module stdlib_linalg_lapack_z
         ! =====================================================================
            ! Local Parameters
            integer(ilp),parameter :: nsweep = 30
-           
+
            ! Local Scalars
            complex(dp) :: aapq,ompq
            real(dp) :: aapp,aapp0,aapq1,aaqq,apoaq,aqoap,big,bigtheta,cs,ctol,epsln, &
@@ -76286,7 +76286,7 @@ module stdlib_linalg_lapack_z
        ! #:) quick return for one-column matrix
            if (n == 1) then
               if (lsvec) call stdlib_zlascl('G',0,0,sva(1),skl,m,1,a(1,1),lda,ierr)
-                        
+
               rwork(1) = one/skl
               if (sva(1) >= sfmin) then
                  rwork(2) = one
@@ -76402,12 +76402,12 @@ module stdlib_linalg_lapack_z
                            tol,2,cwork(n + 1),lwork - n,ierr)
                  call stdlib_zgsvj0(jobv,n2,n4,a(1,n4 + 1),lda,cwork(n4 + 1),sva(n4 + 1), &
                  mvl,v(n4*q + 1,n4 + 1),ldv,epsln,sfmin,tol,1,cwork(n + 1),lwork - n,ierr)
-                           
+
                  call stdlib_zgsvj1(jobv,n2,n2,n4,a,lda,cwork,sva,mvl,v,ldv,epsln, &
                            sfmin,tol,1,cwork(n + 1),lwork - n,ierr)
                  call stdlib_zgsvj0(jobv,n2 + n4,n4,a(1,n2 + 1),lda,cwork(n2 + 1),sva(n2 + 1) &
                  ,mvl,v(n2*q + 1,n2 + 1),ldv,epsln,sfmin,tol,1,cwork(n + 1),lwork - n,ierr)
-                           
+
               end if
            end if
            ! .. row-cyclic pivot strategy with de rijk's pivoting ..
@@ -76521,19 +76521,19 @@ module stdlib_linalg_lapack_z
                                                        conjg(ompq)*t)
                                          end if
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq1))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq1))
                                          mxsinj = max(mxsinj,abs(t))
                                       else
                        ! Choose Correct Signum For Theta And Rotate
                                          thsign = -sign(one,aapq1)
                                          t = one/(theta + thsign*sqrt(one + theta*theta))
-                                                   
+
                                          cs = sqrt(one/(one + t*t))
                                          sn = t*cs
                                          mxsinj = max(mxsinj,abs(sn))
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq1))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq1))
                                          call stdlib_zrot(m,a(1,p),1,a(1,q),1,cs,conjg(ompq) &
                                                    *sn)
@@ -76551,7 +76551,7 @@ module stdlib_linalg_lapack_z
                                       call stdlib_zlascl('G',0,0,aaqq,one,m,1,a(1,q), &
                                                 lda,ierr)
                                       call stdlib_zaxpy(m,-aapq,cwork(n + 1),1,a(1,q),1)
-                                                
+
                                       call stdlib_zlascl('G',0,0,one,aaqq,m,1,a(1,q), &
                                                 lda,ierr)
                                       sva(q) = aaqq*sqrt(max(zero,one - aapq1*aapq1))
@@ -76599,7 +76599,7 @@ module stdlib_linalg_lapack_z
                              end if
                           end do loop_2002
            ! end q-loop
-2103 continue
+           2103 continue
            ! bailed out of q-loop
                           sva(p) = aapp
                        else
@@ -76686,7 +76686,7 @@ module stdlib_linalg_lapack_z
                                                        conjg(ompq)*t)
                                          end if
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq1))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq1))
                                          mxsinj = max(mxsinj,abs(t))
                                       else
@@ -76694,12 +76694,12 @@ module stdlib_linalg_lapack_z
                                          thsign = -sign(one,aapq1)
                                          if (aaqq > aapp0) thsign = -thsign
                                          t = one/(theta + thsign*sqrt(one + theta*theta))
-                                                   
+
                                          cs = sqrt(one/(one + t*t))
                                          sn = t*cs
                                          mxsinj = max(mxsinj,abs(sn))
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq1))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq1))
                                          call stdlib_zrot(m,a(1,p),1,a(1,q),1,cs,conjg(ompq) &
                                                    *sn)
@@ -76713,17 +76713,17 @@ module stdlib_linalg_lapack_z
                     ! .. have to use modified gram-schmidt like transformation
                                     if (aapp > aaqq) then
                                          call stdlib_zcopy(m,a(1,p),1,cwork(n + 1),1)
-                                                   
+
                                          call stdlib_zlascl('G',0,0,aapp,one,m,1,cwork(n + 1) &
                                                    ,lda,ierr)
                                          call stdlib_zlascl('G',0,0,aaqq,one,m,1,a(1,q), &
                                                     lda,ierr)
                                          call stdlib_zaxpy(m,-aapq,cwork(n + 1),1,a(1,q),1)
-                                                   
+
                                          call stdlib_zlascl('G',0,0,one,aaqq,m,1,a(1,q), &
                                                     lda,ierr)
                                          sva(q) = aaqq*sqrt(max(zero,one - aapq1*aapq1))
-                                                   
+
                                          mxsinj = max(mxsinj,sfmin)
                                     else
                                         call stdlib_zcopy(m,a(1,q),1,cwork(n + 1),1)
@@ -76736,7 +76736,7 @@ module stdlib_linalg_lapack_z
                                          call stdlib_zlascl('G',0,0,one,aapp,m,1,a(1,p), &
                                                     lda,ierr)
                                          sva(p) = aapp*sqrt(max(zero,one - aapq1*aapq1))
-                                                   
+
                                          mxsinj = max(mxsinj,sfmin)
                                     end if
                                    end if
@@ -76788,7 +76788,7 @@ module stdlib_linalg_lapack_z
                              end if
                           end do loop_2200
               ! end of the q-loop
-2203 continue
+              2203 continue
                           sva(p) = aapp
                        else
                           if (aapp == zero) notrot = notrot + min(jgl + kbl - 1,n) - jgl + 1
@@ -76798,7 +76798,7 @@ module stdlib_linalg_lapack_z
            ! end of the p-loop
                  end do loop_2010
            ! end of the jbc-loop
-2011 continue
+           2011 continue
       ! 2011 bailed out of the jbc-loop
                  do p = igl,min(igl + kbl - 1,n)
                     sva(p) = abs(sva(p))
@@ -76827,12 +76827,12 @@ module stdlib_linalg_lapack_z
        ! #:( reaching this point means that the procedure has not converged.
            info = nsweep - 1
            go to 1995
-1994       continue
+           1994 continue
        ! #:) reaching this point means numerical convergence after the i-th
            ! sweep.
            info = 0
        ! #:) info = 0 confirms successful iterations.
-1995 continue
+       1995 continue
            ! sort the singular values and find how many are above
            ! the underflow threshold.
            n2 = 0
@@ -76933,11 +76933,11 @@ module stdlib_linalg_lapack_z
            real(dp),intent(out) :: rwork(*)
            complex(dp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(dp),intent(out) :: alpha(*),beta(*),vsl(ldvsl,*),vsr(ldvsr,*),work(*)
-                     
+
            ! Function Arguments
            procedure(stdlib_selctg_z) :: selctg
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: cursl,ilascl,ilbscl,ilvsl,ilvsr,lastsl,lquery,wantst
            integer(ilp) :: i,icols,ierr,ihi,ijobvl,ijobvr,ileft,ilo,iright,irows,irwrk, &
@@ -77106,16 +77106,16 @@ module stdlib_linalg_lapack_z
            if (wantst) then
               ! undo scaling on eigenvalues before selecting
               if (ilascl) call stdlib_zlascl('G',0,0,anrm,anrmto,n,1,alpha,n,ierr)
-                        
+
               if (ilbscl) call stdlib_zlascl('G',0,0,bnrm,bnrmto,n,1,beta,n,ierr)
-                        
+
               ! select eigenvalues
               do i = 1,n
                  bwork(i) = selctg(alpha(i),beta(i))
               end do
               call stdlib_ztgsen(0,ilvsl,ilvsr,bwork,n,a,lda,b,ldb,alpha,beta,vsl, &
               ldvsl,vsr,ldvsr,sdim,pvsl,pvsr,dif,work(iwrk),lwork - iwrk + 1,idum,1,ierr)
-                        
+
               if (ierr == 1) info = n + 3
            end if
            ! apply back-permutation to vsl and vsr
@@ -77143,7 +77143,7 @@ module stdlib_linalg_lapack_z
                  lastsl = cursl
               end do
            end if
-30         continue
+           30 continue
            work(1) = cmplx(lwkopt,KIND=dp)
            return
      end subroutine stdlib_zgges3
@@ -77178,7 +77178,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*),b(ldb,*)
            complex(dp),intent(out) :: alpha(*),beta(*),vl(ldvl,*),vr(ldvr,*),work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: ilascl,ilbscl,ilv,ilvl,ilvr,lquery
            character :: chtemp
@@ -77412,7 +77412,7 @@ module stdlib_linalg_lapack_z
               end if
            end if
            ! undo scaling if necessary
-70   continue
+           70 continue
            if (ilascl) call stdlib_zlascl('G',0,0,anrmto,anrm,n,1,alpha,n,ierr)
            if (ilbscl) call stdlib_zlascl('G',0,0,bnrmto,bnrm,n,1,beta,n,ierr)
            work(1) = cmplx(lwkopt,KIND=dp)
@@ -77439,7 +77439,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(out) :: work(lwork)
            real(dp),intent(inout) :: sva(n)
         ! =====================================================================
-           
+
            ! Local Scalars
            complex(dp) :: aapq,ompq
            real(dp) :: aapp,aapp0,aapq1,aaqq,apoaq,aqoap,big,bigtheta,cs,mxaapq,mxsinj, &
@@ -77632,19 +77632,19 @@ module stdlib_linalg_lapack_z
                                                        conjg(ompq)*t)
                                          end if
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq1))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq1))
                                          mxsinj = max(mxsinj,abs(t))
                                       else
                        ! Choose Correct Signum For Theta And Rotate
                                          thsign = -sign(one,aapq1)
                                          t = one/(theta + thsign*sqrt(one + theta*theta))
-                                                   
+
                                          cs = sqrt(one/(one + t*t))
                                          sn = t*cs
                                          mxsinj = max(mxsinj,abs(sn))
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq1))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq1))
                                          call stdlib_zrot(m,a(1,p),1,a(1,q),1,cs,conjg(ompq) &
                                                    *sn)
@@ -77709,7 +77709,7 @@ module stdlib_linalg_lapack_z
                              end if
                           end do loop_2002
            ! end q-loop
-2103 continue
+           2103 continue
            ! bailed out of q-loop
                           sva(p) = aapp
                        else
@@ -77796,7 +77796,7 @@ module stdlib_linalg_lapack_z
                                                        conjg(ompq)*t)
                                          end if
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq1))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq1))
                                          mxsinj = max(mxsinj,abs(t))
                                       else
@@ -77804,12 +77804,12 @@ module stdlib_linalg_lapack_z
                                          thsign = -sign(one,aapq1)
                                          if (aaqq > aapp0) thsign = -thsign
                                          t = one/(theta + thsign*sqrt(one + theta*theta))
-                                                   
+
                                          cs = sqrt(one/(one + t*t))
                                          sn = t*cs
                                          mxsinj = max(mxsinj,abs(sn))
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq1))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq1))
                                          call stdlib_zrot(m,a(1,p),1,a(1,q),1,cs,conjg(ompq) &
                                                    *sn)
@@ -77828,11 +77828,11 @@ module stdlib_linalg_lapack_z
                                          call stdlib_zlascl('G',0,0,aaqq,one,m,1,a(1,q), &
                                                     lda,ierr)
                                          call stdlib_zaxpy(m,-aapq,work,1,a(1,q),1)
-                                                   
+
                                          call stdlib_zlascl('G',0,0,one,aaqq,m,1,a(1,q), &
                                                     lda,ierr)
                                          sva(q) = aaqq*sqrt(max(zero,one - aapq1*aapq1))
-                                                   
+
                                          mxsinj = max(mxsinj,sfmin)
                                     else
                                         call stdlib_zcopy(m,a(1,q),1,work,1)
@@ -77845,7 +77845,7 @@ module stdlib_linalg_lapack_z
                                          call stdlib_zlascl('G',0,0,one,aapp,m,1,a(1,p), &
                                                     lda,ierr)
                                          sva(p) = aapp*sqrt(max(zero,one - aapq1*aapq1))
-                                                   
+
                                          mxsinj = max(mxsinj,sfmin)
                                     end if
                                    end if
@@ -77897,7 +77897,7 @@ module stdlib_linalg_lapack_z
                              end if
                           end do loop_2200
               ! end of the q-loop
-2203 continue
+              2203 continue
                           sva(p) = aapp
                        else
                           if (aapp == zero) notrot = notrot + min(jgl + kbl - 1,n) - jgl + 1
@@ -77907,7 +77907,7 @@ module stdlib_linalg_lapack_z
            ! end of the p-loop
                  end do loop_2010
            ! end of the jbc-loop
-2011 continue
+           2011 continue
       ! 2011 bailed out of the jbc-loop
                  do p = igl,min(igl + kbl - 1,n)
                     sva(p) = abs(sva(p))
@@ -77936,12 +77936,12 @@ module stdlib_linalg_lapack_z
        ! #:( reaching this point means that the procedure has not converged.
            info = nsweep - 1
            go to 1995
-1994       continue
+           1994 continue
        ! #:) reaching this point means numerical convergence after the i-th
            ! sweep.
            info = 0
        ! #:) info = 0 confirms successful iterations.
-1995 continue
+       1995 continue
            ! sort the vector sva() of column norms.
            do p = 1,n - 1
               q = stdlib_idamax(n - p + 1,sva(p),1) + p - 1
@@ -77999,7 +77999,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(out) :: work(lwork)
            real(dp),intent(inout) :: sva(n)
         ! =====================================================================
-           
+
            ! Local Scalars
            complex(dp) :: aapq,ompq
            real(dp) :: aapp,aapp0,aapq1,aaqq,apoaq,aqoap,big,bigtheta,cs,mxaapq,mxsinj, &
@@ -78169,7 +78169,7 @@ module stdlib_linalg_lapack_z
                                                        conjg(ompq)*t)
                                          end if
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq1))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq1))
                                          mxsinj = max(mxsinj,abs(t))
                                       else
@@ -78177,12 +78177,12 @@ module stdlib_linalg_lapack_z
                                          thsign = -sign(one,aapq1)
                                          if (aaqq > aapp0) thsign = -thsign
                                          t = one/(theta + thsign*sqrt(one + theta*theta))
-                                                   
+
                                          cs = sqrt(one/(one + t*t))
                                          sn = t*cs
                                          mxsinj = max(mxsinj,abs(sn))
                                          sva(q) = aaqq*sqrt(max(zero,one + t*apoaq*aapq1))
-                                                   
+
                                          aapp = aapp*sqrt(max(zero,one - t*aqoap*aapq1))
                                          call stdlib_zrot(m,a(1,p),1,a(1,q),1,cs,conjg(ompq) &
                                                    *sn)
@@ -78201,11 +78201,11 @@ module stdlib_linalg_lapack_z
                                          call stdlib_zlascl('G',0,0,aaqq,one,m,1,a(1,q), &
                                                     lda,ierr)
                                          call stdlib_zaxpy(m,-aapq,work,1,a(1,q),1)
-                                                   
+
                                          call stdlib_zlascl('G',0,0,one,aaqq,m,1,a(1,q), &
                                                     lda,ierr)
                                          sva(q) = aaqq*sqrt(max(zero,one - aapq1*aapq1))
-                                                   
+
                                          mxsinj = max(mxsinj,sfmin)
                                     else
                                         call stdlib_zcopy(m,a(1,q),1,work,1)
@@ -78218,7 +78218,7 @@ module stdlib_linalg_lapack_z
                                          call stdlib_zlascl('G',0,0,one,aapp,m,1,a(1,p), &
                                                     lda,ierr)
                                          sva(p) = aapp*sqrt(max(zero,one - aapq1*aapq1))
-                                                   
+
                                          mxsinj = max(mxsinj,sfmin)
                                     end if
                                    end if
@@ -78270,7 +78270,7 @@ module stdlib_linalg_lapack_z
                              end if
                           end do loop_2200
               ! end of the q-loop
-2203 continue
+              2203 continue
                           sva(p) = aapp
                        else
                           if (aapp == zero) notrot = notrot + min(jgl + kbl - 1,n) - jgl + 1
@@ -78280,7 +78280,7 @@ module stdlib_linalg_lapack_z
            ! end of the p-loop
                  end do loop_2010
            ! end of the jbc-loop
-2011 continue
+           2011 continue
       ! 2011 bailed out of the jbc-loop
                  do p = igl,min(igl + kbl - 1,n)
                     sva(p) = abs(sva(p))
@@ -78309,12 +78309,12 @@ module stdlib_linalg_lapack_z
        ! #:( reaching this point means that the procedure has not converged.
            info = nsweep - 1
            go to 1995
-1994       continue
+           1994 continue
        ! #:) reaching this point means numerical convergence after the i-th
            ! sweep.
            info = 0
        ! #:) info = 0 confirms successful iterations.
-1995 continue
+       1995 continue
            ! sort the vector sva() of column norms.
            do p = 1,n - 1
               q = stdlib_idamax(n - p + 1,sva(p),1) + p - 1
@@ -78344,7 +78344,7 @@ module stdlib_linalg_lapack_z
      !> of A is then used to solve the system of equations A * X = B.
 
      pure subroutine stdlib_zhesv_aa(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -78398,7 +78398,7 @@ module stdlib_linalg_lapack_z
            if (info == 0) then
               ! solve the system a*x = b, overwriting b with x.
               call stdlib_zhetrs_aa(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-                        
+
            end if
            work(1) = lwkopt
            return
@@ -78424,7 +78424,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper
            integer(ilp) :: j,lwkopt
@@ -78481,7 +78481,7 @@ module stdlib_linalg_lapack_z
               ! jb, where jb is the number of columns factorized by stdlib_zlahef;
               ! jb is either nb, or n-j+1 for the last block
               j = 0
-10            continue
+              10 continue
               if (j >= n) go to 20
               ! each step of the main loop
                ! j is the last column of the previous panel
@@ -78513,7 +78513,7 @@ module stdlib_linalg_lapack_z
                     alpha = conjg(a(j,j + 1))
                     a(j,j + 1) = cone
                     call stdlib_zcopy(n - j,a(j - 1,j + 1),lda,work((j + 1 - j1 + 1) + jb*n),1)
-                              
+
                     call stdlib_zscal(n - j,alpha,work((j + 1 - j1 + 1) + jb*n),1)
                     ! k1 identifies if the previous column of the panel has been
                      ! explicitly stored, e.g., k1=0 and k2=1 for the first panel,
@@ -78534,7 +78534,7 @@ module stdlib_linalg_lapack_z
                        do mj = nj - 1,1,-1
                           call stdlib_zgemm('CONJUGATE TRANSPOSE','TRANSPOSE',1,mj,jb + 1,-cone, &
                            a(j1 - k2,j3),lda,work((j3 - j1 + 1) + k1*n),n,cone,a(j3,j3),lda)
-                                     
+
                           j3 = j3 + 1
                        end do
                        ! update off-diagonal block of j2-th block row with stdlib_zgemm
@@ -78560,7 +78560,7 @@ module stdlib_linalg_lapack_z
               ! jb, where jb is the number of columns factorized by stdlib_zlahef;
               ! jb is either nb, or n-j+1 for the last block
               j = 0
-11            continue
+              11 continue
               if (j >= n) go to 20
               ! each step of the main loop
                ! j is the last column of the previous panel
@@ -78628,7 +78628,7 @@ module stdlib_linalg_lapack_z
               end if
               go to 11
            end if
-20         continue
+           20 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_zhetrf_aa
@@ -78643,7 +78643,7 @@ module stdlib_linalg_lapack_z
      !> by the unitary matrix Q:  A = Q*H*Q**H = (QZ)*T*(QZ)**H.
 
      pure subroutine stdlib_zhseqr(job,compz,n,ilo,ihi,h,ldh,w,z,ldz,work,lwork,info)
-               
+
         ! -- lapack computational routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -78662,14 +78662,14 @@ module stdlib_linalg_lapack_z
            ! ==== matrices of order ntiny or smaller must be processed by
            ! .    stdlib_zlahqr because of insufficient subdiagonal scratch space.
            ! .    (this is a hard limit.) ====
-           
+
            ! ==== nl allocates some local workspace to help small matrices
            ! .    through a rare stdlib_zlahqr failure.  nl > ntiny = 15 is
            ! .    required and nl <= nmin = stdlib_ilaenv(ispec=12,...) is recom-
            ! .    mended.  (the default value of nmin is 75.)  using nl = 49
            ! .    allows up to six simultaneous shifts and a 16-by-16
            ! .    deflation window.  ====
-           
+
            ! Local Arrays
            complex(dp) :: hl(nl,nl),workl(nl)
            ! Local Scalars
@@ -78722,7 +78722,7 @@ module stdlib_linalg_lapack_z
               ! ==== copy eigenvalues isolated by stdlib_zgebal ====
               if (ilo > 1) call stdlib_zcopy(ilo - 1,h,ldh + 1,w,1)
               if (ihi < n) call stdlib_zcopy(n - ihi,h(ihi + 1,ihi + 1),ldh + 1,w(ihi + 1),1)
-                        
+
               ! ==== initialize z, if requested ====
               if (initz) call stdlib_zlaset('A',n,n,czero,cone,z,ldz)
               ! ==== quick return if possible ====
@@ -78732,7 +78732,7 @@ module stdlib_linalg_lapack_z
               end if
               ! ==== stdlib_zlahqr/stdlib_zlaqr0 crossover point ====
               nmin = stdlib_ilaenv(12,'ZHSEQR',job(:1)//compz(:1),n,ilo,ihi,lwork)
-                        
+
               nmin = max(ntiny,nmin)
               ! ==== stdlib_zlaqr0 for big matrices; stdlib_zlahqr for small ones ====
               if (n > nmin) then
@@ -78741,7 +78741,7 @@ module stdlib_linalg_lapack_z
               else
                  ! ==== small matrix ====
                  call stdlib_zlahqr(wantt,wantz,n,ilo,ihi,h,ldh,w,ilo,ihi,z,ldz,info)
-                           
+
                  if (info > 0) then
                     ! ==== a rare stdlib_zlahqr failure!  stdlib_zlaqr0 sometimes succeeds
                     ! .    when stdlib_zlahqr fails. ====
@@ -78762,7 +78762,7 @@ module stdlib_linalg_lapack_z
                        call stdlib_zlaqr0(wantt,wantz,nl,ilo,kbot,hl,nl,w,ilo,ihi,z, &
                                  ldz,workl,nl,info)
                        if (wantt .or. info /= 0) call stdlib_zlacpy('A',n,n,hl,nl,h,ldh)
-                                 
+
                     end if
                  end if
               end if
@@ -78799,7 +78799,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*),h(ldh,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j,k,k1,i1,i2,mj
            complex(dp) :: piv,alpha
@@ -78814,7 +78814,7 @@ module stdlib_linalg_lapack_z
               ! .....................................................
               ! factorize a as u**t*d*u using the upper triangle of a
               ! .....................................................
-10   continue
+              10 continue
               if (j > min(m,nb)) go to 20
               ! k is the column to be factorized
                ! when being called from stdlib_zhetrf_aa,
@@ -78870,7 +78870,7 @@ module stdlib_linalg_lapack_z
                     i1 = i1 + j - 1
                     i2 = i2 + j - 1
                     call stdlib_zswap(i2 - i1 - 1,a(j1 + i1 - 1,i1 + 1),lda,a(j1 + i1,i2),1)
-                              
+
                     call stdlib_zlacgv(i2 - i1,a(j1 + i1 - 1,i1 + 1),lda)
                     call stdlib_zlacgv(i2 - i1 - 1,a(j1 + i1,i2),1)
                     ! swap a(i1, i2+1:n) with a(i2, i2+1:n)
@@ -78906,18 +78906,18 @@ module stdlib_linalg_lapack_z
                        call stdlib_zscal(m - j - 1,alpha,a(k,j + 2),lda)
                     else
                        call stdlib_zlaset('FULL',1,m - j - 1,czero,czero,a(k,j + 2),lda)
-                                 
+
                     end if
                  end if
               end if
               j = j + 1
               go to 10
-20            continue
+              20 continue
            else
               ! .....................................................
               ! factorize a as l*d*l**t using the lower triangle of a
               ! .....................................................
-30   continue
+              30 continue
               if (j > min(m,nb)) go to 40
               ! k is the column to be factorized
                ! when being called from stdlib_zhetrf_aa,
@@ -78973,7 +78973,7 @@ module stdlib_linalg_lapack_z
                     i1 = i1 + j - 1
                     i2 = i2 + j - 1
                     call stdlib_zswap(i2 - i1 - 1,a(i1 + 1,j1 + i1 - 1),1,a(i2,j1 + i1),lda)
-                              
+
                     call stdlib_zlacgv(i2 - i1,a(i1 + 1,j1 + i1 - 1),1)
                     call stdlib_zlacgv(i2 - i1 - 1,a(i2,j1 + i1),lda)
                     ! swap a(i2+1:n, i1) with a(i2+1:n, i2)
@@ -79009,13 +79009,13 @@ module stdlib_linalg_lapack_z
                        call stdlib_zscal(m - j - 1,alpha,a(j + 2,k),1)
                     else
                        call stdlib_zlaset('FULL',m - j - 1,1,czero,czero,a(j + 2,k),lda)
-                                 
+
                     end if
                  end if
               end if
               j = j + 1
               go to 30
-40            continue
+              40 continue
            end if
            return
      end subroutine stdlib_zlahef_aa
@@ -79050,18 +79050,18 @@ module stdlib_linalg_lapack_z
            ! ==== matrices of order ntiny or smaller must be processed by
            ! .    stdlib_zlahqr because of insufficient subdiagonal scratch space.
            ! .    (this is a hard limit.) ====
-           
+
            ! ==== exceptional deflation windows:  try to cure rare
            ! .    slow convergence by varying the size of the
            ! .    deflation window after kexnw iterations. ====
-           
+
            ! ==== exceptional shifts: try to cure rare slow convergence
            ! .    with ad-hoc exceptional shifts every kexsh iterations.
            ! .    ====
-           
+
            ! ==== the constant wilk1 is used to form the exceptional
            ! .    shifts. ====
-           
+
            ! Local Scalars
            complex(dp) :: aa,bb,cc,cdum,dd,det,rtdisc,swap,tr2
            real(dp) :: s
@@ -79166,7 +79166,7 @@ module stdlib_linalg_lapack_z
                     if (h(k,k - 1) == czero) go to 20
                  end do
                  k = ilo
-20               continue
+                 20 continue
                  ktop = k
                  ! ==== select deflation window size:
                  ! .    typical case:
@@ -79262,7 +79262,7 @@ module stdlib_linalg_lapack_z
                           ks = kbot - ns + 1
                           kt = n - ns + 1
                           call stdlib_zlacpy('A',ns,ns,h(ks,ks),ldh,h(kt,1),ldh)
-                                    
+
                           if (ns > nmin) then
                              call stdlib_zlaqr4(.false.,.false.,ns,1,ns,h(kt,1),ldh,w( &
                                        ks),1,1,zdum,1,work,lwork,inf)
@@ -79307,7 +79307,7 @@ module stdlib_linalg_lapack_z
                                 end if
                              end do
                           end do
-60                        continue
+                          60 continue
                        end if
                     end if
                     ! ==== if there are only two shifts, then use
@@ -79359,7 +79359,7 @@ module stdlib_linalg_lapack_z
               ! ==== iteration limit exceeded.  set info to show where
               ! .    the problem occurred and exit. ====
               info = kbot
-80            continue
+              80 continue
            end if
            ! ==== return the optimal value of lwork. ====
            work(1) = cmplx(lwkopt,0,KIND=dp)
@@ -79392,7 +79392,7 @@ module stdlib_linalg_lapack_z
            ! Parameters
            real(dp),parameter :: rzero = 0.0_dp
            real(dp),parameter :: rone = 1.0_dp
-           
+
            ! Local Scalars
            complex(dp) :: beta,cdum,s,tau
            real(dp) :: foo,safmax,safmin,smlnum,ulp
@@ -79415,7 +79415,7 @@ module stdlib_linalg_lapack_z
               lwk1 = int(work(1),KIND=ilp)
               ! ==== workspace query call to stdlib_zunmhr ====
               call stdlib_zunmhr('R','N',jw,jw,1,jw - 1,t,ldt,work,v,ldv,work,-1,info)
-                        
+
               lwk2 = int(work(1),KIND=ilp)
               ! ==== workspace query call to stdlib_zlaqr4 ====
               call stdlib_zlaqr4(.true.,.true.,jw,1,jw,t,ldt,sh,1,jw,v,ldv,work,-1, &
@@ -79510,7 +79510,7 @@ module stdlib_linalg_lapack_z
                  end do
                  ilst = i
                  if (ifst /= ilst) call stdlib_ztrexc('V',jw,t,ldt,v,ldv,ifst,ilst,info)
-                           
+
               end do
            end if
            ! ==== restore shift/eigenvalue array from t ====
@@ -79529,11 +79529,11 @@ module stdlib_linalg_lapack_z
                  work(1) = cone
                  call stdlib_zlaset('L',jw - 2,jw - 2,czero,czero,t(3,1),ldt)
                  call stdlib_zlarf('L',ns,jw,work,1,conjg(tau),t,ldt,work(jw + 1))
-                           
+
                  call stdlib_zlarf('R',ns,ns,work,1,tau,t,ldt,work(jw + 1))
                  call stdlib_zlarf('R',jw,ns,work,1,tau,v,ldv,work(jw + 1))
                  call stdlib_zgehrd(jw,1,ns,t,ldt,work,work(jw + 1),lwork - jw,info)
-                           
+
               end if
               ! ==== copy updated reduced window into place ====
               if (kwtop > 1) h(kwtop,kwtop - 1) = s*conjg(v(1,1))
@@ -79622,18 +79622,18 @@ module stdlib_linalg_lapack_z
            ! ==== matrices of order ntiny or smaller must be processed by
            ! .    stdlib_zlahqr because of insufficient subdiagonal scratch space.
            ! .    (this is a hard limit.) ====
-           
+
            ! ==== exceptional deflation windows:  try to cure rare
            ! .    slow convergence by varying the size of the
            ! .    deflation window after kexnw iterations. ====
-           
+
            ! ==== exceptional shifts: try to cure rare slow convergence
            ! .    with ad-hoc exceptional shifts every kexsh iterations.
            ! .    ====
-           
+
            ! ==== the constant wilk1 is used to form the exceptional
            ! .    shifts. ====
-           
+
            ! Local Scalars
            complex(dp) :: aa,bb,cc,cdum,dd,det,rtdisc,swap,tr2
            real(dp) :: s
@@ -79738,7 +79738,7 @@ module stdlib_linalg_lapack_z
                     if (h(k,k - 1) == czero) go to 20
                  end do
                  k = ilo
-20               continue
+                 20 continue
                  ktop = k
                  ! ==== select deflation window size:
                  ! .    typical case:
@@ -79834,7 +79834,7 @@ module stdlib_linalg_lapack_z
                           ks = kbot - ns + 1
                           kt = n - ns + 1
                           call stdlib_zlacpy('A',ns,ns,h(ks,ks),ldh,h(kt,1),ldh)
-                                    
+
                           call stdlib_zlahqr(.false.,.false.,ns,1,ns,h(kt,1),ldh,w(ks) &
                                     ,1,1,zdum,1,inf)
                           ks = ks + inf
@@ -79874,7 +79874,7 @@ module stdlib_linalg_lapack_z
                                 end if
                              end do
                           end do
-60                        continue
+                          60 continue
                        end if
                     end if
                     ! ==== if there are only two shifts, then use
@@ -79926,7 +79926,7 @@ module stdlib_linalg_lapack_z
               ! ==== iteration limit exceeded.  set info to show where
               ! .    the problem occurred and exit. ====
               info = kbot
-80            continue
+              80 continue
            end if
            ! ==== return the optimal value of lwork. ====
            work(1) = cmplx(lwkopt,0,KIND=dp)
@@ -79982,7 +79982,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*),b(ldb,*),q(ldq,*),z(ldz,*), &
                      alpha(*),beta(*),work(*)
            real(dp),intent(out) :: rwork(*)
-           
+
            ! local scalars
            real(dp) :: smlnum,ulp,safmin,safmax,c1,tempr
            complex(dp) :: eshift,s1,temp
@@ -80186,7 +80186,7 @@ module stdlib_linalg_lapack_z
                        end if
                        if (k2 < istop) then
                           call stdlib_zlartg(a(k2,k2 - 1),a(k2 + 1,k2 - 1),c1,s1,temp)
-                                    
+
                           a(k2,k2 - 1) = temp
                           a(k2 + 1,k2 - 1) = czero
                           call stdlib_zrot(istopm - k2 + 1,a(k2,k2),lda,a(k2 + 1,k2),lda,c1, &
@@ -80195,7 +80195,7 @@ module stdlib_linalg_lapack_z
                                     s1)
                           if (ilq) then
                              call stdlib_zrot(n,q(1,k2),1,q(1,k2 + 1),1,c1,conjg(s1))
-                                       
+
                           end if
                        end if
                     end do
@@ -80298,7 +80298,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: qc(ldqc,*),zc(ldzc,*)
            complex(dp),intent(out) :: work(*)
            real(dp),intent(out) :: rwork(*)
-           
+
            ! local scalars
            integer(ilp) :: jw,kwtop,kwbot,istopm,istartm,k,k2,ztgexc_info,ifst,ilst, &
                      lworkreq,qz_small_info
@@ -80354,7 +80354,7 @@ module stdlib_linalg_lapack_z
            ! store window in case of convergence failure
            call stdlib_zlacpy('ALL',jw,jw,a(kwtop,kwtop),lda,work,jw)
            call stdlib_zlacpy('ALL',jw,jw,b(kwtop,kwtop),ldb,work(jw**2 + 1),jw)
-                     
+
            ! transform window to real schur form
            call stdlib_zlaset('FULL',jw,jw,czero,cone,qc,ldqc)
            call stdlib_zlaset('FULL',jw,jw,czero,cone,zc,ldzc)
@@ -80367,7 +80367,7 @@ module stdlib_linalg_lapack_z
               ns = jw - qz_small_info
               call stdlib_zlacpy('ALL',jw,jw,work,jw,a(kwtop,kwtop),lda)
               call stdlib_zlacpy('ALL',jw,jw,work(jw**2 + 1),jw,b(kwtop,kwtop),ldb)
-                        
+
               return
            end if
            ! deflation detection loop
@@ -80417,7 +80417,7 @@ module stdlib_linalg_lapack_z
                  k2 = max(kwtop,k - 1)
                  call stdlib_zrot(ihi - k2 + 1,a(k,k2),lda,a(k + 1,k2),lda,c1,s1)
                  call stdlib_zrot(ihi - (k - 1) + 1,b(k,k - 1),ldb,b(k + 1,k - 1),ldb,c1,s1)
-                           
+
                  call stdlib_zrot(jw,qc(1,k - kwtop + 1),1,qc(1,k + 1 - kwtop + 1),1,c1,conjg( &
                            s1))
               end do
@@ -80495,7 +80495,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*),h(ldh,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            integer(ilp) :: j,k,k1,i1,i2,mj
            complex(dp) :: piv,alpha
@@ -80510,7 +80510,7 @@ module stdlib_linalg_lapack_z
               ! .....................................................
               ! factorize a as u**t*d*u using the upper triangle of a
               ! .....................................................
-10   continue
+              10 continue
               if (j > min(m,nb)) go to 20
               ! k is the column to be factorized
                ! when being called from stdlib_zsytrf_aa,
@@ -80564,7 +80564,7 @@ module stdlib_linalg_lapack_z
                     i1 = i1 + j - 1
                     i2 = i2 + j - 1
                     call stdlib_zswap(i2 - i1 - 1,a(j1 + i1 - 1,i1 + 1),lda,a(j1 + i1,i2),1)
-                              
+
                     ! swap a(i1, i2+1:m) with a(i2, i2+1:m)
                     if (i2 < m) call stdlib_zswap(m - i2,a(j1 + i1 - 1,i2 + 1),lda,a(j1 + i2 - 1,i2 + 1), &
                                lda)
@@ -80598,18 +80598,18 @@ module stdlib_linalg_lapack_z
                        call stdlib_zscal(m - j - 1,alpha,a(k,j + 2),lda)
                     else
                        call stdlib_zlaset('FULL',1,m - j - 1,czero,czero,a(k,j + 2),lda)
-                                 
+
                     end if
                  end if
               end if
               j = j + 1
               go to 10
-20            continue
+              20 continue
            else
               ! .....................................................
               ! factorize a as l*d*l**t using the lower triangle of a
               ! .....................................................
-30   continue
+              30 continue
               if (j > min(m,nb)) go to 40
               ! k is the column to be factorized
                ! when being called from stdlib_zsytrf_aa,
@@ -80663,7 +80663,7 @@ module stdlib_linalg_lapack_z
                     i1 = i1 + j - 1
                     i2 = i2 + j - 1
                     call stdlib_zswap(i2 - i1 - 1,a(i1 + 1,j1 + i1 - 1),1,a(i2,j1 + i1),lda)
-                              
+
                     ! swap a(i2+1:m, i1) with a(i2+1:m, i2)
                     if (i2 < m) call stdlib_zswap(m - i2,a(i2 + 1,j1 + i1 - 1),1,a(i2 + 1,j1 + i2 - 1), &
                               1)
@@ -80697,13 +80697,13 @@ module stdlib_linalg_lapack_z
                        call stdlib_zscal(m - j - 1,alpha,a(j + 2,k),1)
                     else
                        call stdlib_zlaset('FULL',m - j - 1,1,czero,czero,a(j + 2,k),lda)
-                                 
+
                     end if
                  end if
               end if
               j = j + 1
               go to 30
-40            continue
+              40 continue
            end if
            return
      end subroutine stdlib_zlasyf_aa
@@ -80720,7 +80720,7 @@ module stdlib_linalg_lapack_z
      !> form of A is then used to solve the system of equations A * X = B.
 
      pure subroutine stdlib_zsysv_aa(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-               
+
         ! -- lapack driver routine --
         ! -- lapack is a software package provided by univ. of tennessee,    --
         ! -- univ. of california berkeley, univ. of colorado denver and nag ltd..--
@@ -80774,7 +80774,7 @@ module stdlib_linalg_lapack_z
            if (info == 0) then
               ! solve the system a*x = b, overwriting b with x.
               call stdlib_zsytrs_aa(uplo,n,nrhs,a,lda,ipiv,b,ldb,work,lwork,info)
-                        
+
            end if
            work(1) = lwkopt
            return
@@ -80800,7 +80800,7 @@ module stdlib_linalg_lapack_z
            complex(dp),intent(inout) :: a(lda,*)
            complex(dp),intent(out) :: work(*)
         ! =====================================================================
-           
+
            ! Local Scalars
            logical(lk) :: lquery,upper
            integer(ilp) :: j,lwkopt
@@ -80856,7 +80856,7 @@ module stdlib_linalg_lapack_z
               ! jb, where jb is the number of columns factorized by stdlib_zlasyf;
               ! jb is either nb, or n-j+1 for the last block
               j = 0
-10            continue
+              10 continue
               if (j >= n) go to 20
               ! each step of the main loop
                ! j is the last column of the previous panel
@@ -80888,7 +80888,7 @@ module stdlib_linalg_lapack_z
                     alpha = a(j,j + 1)
                     a(j,j + 1) = cone
                     call stdlib_zcopy(n - j,a(j - 1,j + 1),lda,work((j + 1 - j1 + 1) + jb*n),1)
-                              
+
                     call stdlib_zscal(n - j,alpha,work((j + 1 - j1 + 1) + jb*n),1)
                     ! k1 identifies if the previous column of the panel has been
                      ! explicitly stored, e.g., k1=1 and k2= 0 for the first panel,
@@ -80933,7 +80933,7 @@ module stdlib_linalg_lapack_z
               ! jb, where jb is the number of columns factorized by stdlib_zlasyf;
               ! jb is either nb, or n-j+1 for the last block
               j = 0
-11            continue
+              11 continue
               if (j >= n) go to 20
               ! each step of the main loop
                ! j is the last column of the previous panel
@@ -80990,7 +80990,7 @@ module stdlib_linalg_lapack_z
                        ! update off-diagonal block in j2-th block column with stdlib_zgemm
                        call stdlib_zgemm('NO TRANSPOSE','TRANSPOSE',n - j3 + 1,nj,jb + 1,-cone, &
                        work(j3 - j1 + 1 + k1*n),n,a(j2,j1 - k2),lda,cone,a(j3,j2),lda)
-                                 
+
                     end do
                     ! recover t( j+1, j )
                     a(j + 1,j) = alpha
@@ -81000,7 +81000,7 @@ module stdlib_linalg_lapack_z
               end if
               go to 11
            end if
-20         continue
+           20 continue
            work(1) = lwkopt
            return
      end subroutine stdlib_zsytrf_aa


### PR DESCRIPTION
- [x] Revert the ugly `fprettify` formatting of labelled `CONTINUE` statements: align with previous line
- [x] Fix automatic generation of KIND-changing routines
- [x] Begin adding `fypp` wrappers for stdlib  