### PR TITLE
Eigenvalues

### DIFF
--- a/scripts/preprocess.sh
+++ b/scripts/preprocess.sh
@@ -3,7 +3,7 @@
 #
 # preprocess linear algebra sources with fypp
 #
-declare -a linalg_sources=("solve" "inverse" "least_squares" "determinant" "eye" "svd")
+declare -a linalg_sources=("solve" "inverse" "least_squares" "determinant" "eye" "svd" "eigs")
 
 declare -a operations=("src" "test")
 declare -a oper_prefix=("stdlib" "test")

--- a/src/stdlib_linalg_eigs.f90
+++ b/src/stdlib_linalg_eigs.f90
@@ -19,7 +19,7 @@ module stdlib_linalg_eig
      ! Scipy: eig(a, b=None, left=False, right=True, overwrite_a=False, overwrite_b=False, check_finite=True, homogeneous_eigvals=False)
 
      ! Numpy: eigenvalues, eigenvectors = eigh(a, uplo='L')
-     !        eigenvalues = eighvals(a)
+     !        eigenvalues = eigvalsh(a)
 
      interface eig
         module procedure stdlib_linalg_eig_s
@@ -43,7 +43,25 @@ module stdlib_linalg_eig
         module procedure stdlib_linalg_eigh_s
         module procedure stdlib_linalg_eigh_d
         module procedure stdlib_linalg_eigh_q
+        module procedure stdlib_linalg_eigh_c
+        module procedure stdlib_linalg_eigh_z
+        module procedure stdlib_linalg_eigh_w
      end interface eigh
+     
+     interface eigvalsh
+        module procedure stdlib_linalg_eigvalsh_s
+        module procedure stdlib_linalg_eigvalsh_noerr_s
+        module procedure stdlib_linalg_eigvalsh_d
+        module procedure stdlib_linalg_eigvalsh_noerr_d
+        module procedure stdlib_linalg_eigvalsh_q
+        module procedure stdlib_linalg_eigvalsh_noerr_q
+        module procedure stdlib_linalg_eigvalsh_c
+        module procedure stdlib_linalg_eigvalsh_noerr_c
+        module procedure stdlib_linalg_eigvalsh_z
+        module procedure stdlib_linalg_eigvalsh_noerr_z
+        module procedure stdlib_linalg_eigvalsh_w
+        module procedure stdlib_linalg_eigvalsh_noerr_w
+     end interface eigvalsh
 
      character(*),parameter :: this = 'eigenvalues'
 
@@ -295,7 +313,174 @@ module stdlib_linalg_eig
 1        call linalg_error_handling(err0,err)
 
      end subroutine stdlib_linalg_eig_s
+     
+     !> Return an array of eigenvalues of real symmetric / complex hermitian A
+     function stdlib_linalg_eigvalsh_s(a,upper_a,err) result(lambda)
+         !> Input matrix A[m,n]
+         real(sp),intent(in),target :: a(:,:)
+         !> [optional] Should the upper/lower half of A be used? Default: lower
+         logical(lk),optional,intent(in) :: upper_a
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),intent(out) :: err
+         !> Array of singular values
+         real(sp),allocatable :: lambda(:)
+         
+         real(sp),pointer :: amat(:,:)
+         integer(ilp) :: m,n,k
 
+         !> Create an internal pointer so the intent of A won't affect the next call
+         amat => a
+
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+
+         !> Allocate return storage
+         allocate (lambda(k))
+
+         !> Compute eigenvalues only
+         call stdlib_linalg_eigh_s(amat,lambda,upper_a=upper_a,overwrite_a=.false.,err=err)
+         
+     end function stdlib_linalg_eigvalsh_s
+     
+     !> Return an array of eigenvalues of real symmetric / complex hermitian A
+     function stdlib_linalg_eigvalsh_noerr_s(a,upper_a) result(lambda)
+         !> Input matrix A[m,n]
+         real(sp),intent(in),target :: a(:,:)
+         !> [optional] Should the upper/lower half of A be used? Default: lower
+         logical(lk),optional,intent(in) :: upper_a
+         !> Array of singular values
+         real(sp),allocatable :: lambda(:)
+
+         real(sp),pointer :: amat(:,:)
+         integer(ilp) :: m,n,k
+
+         !> Create an internal pointer so the intent of A won't affect the next call
+         amat => a
+
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+
+         !> Allocate return storage
+         allocate (lambda(k))
+
+         !> Compute eigenvalues only
+         call stdlib_linalg_eigh_s(amat,lambda,upper_a=upper_a,overwrite_a=.false.)
+
+     end function stdlib_linalg_eigvalsh_noerr_s
+
+     !> Eigendecomposition of a real symmetric or complex Hermitian matrix A returning an array `lambda`
+     !> of eigenvalues, and optionally right or left eigenvectors.
+     subroutine stdlib_linalg_eigh_s(a,lambda,vectors,upper_a,overwrite_a,err)
+         !> Input matrix A[m,n]
+         real(sp),intent(inout),target :: a(:,:)
+         !> Array of eigenvalues
+         real(sp),intent(out) :: lambda(:)
+         !> The columns of vectors contain the orthonormal eigenvectors of A
+         real(sp),optional,intent(out),target :: vectors(:,:)
+         !> [optional] Can A data be overwritten and destroyed?
+         logical(lk),optional,intent(in) :: overwrite_a
+         !> [optional] Should the upper/lower half of A be used? Default: lower
+         logical(lk),optional,intent(in) :: upper_a
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+
+         !> Local variables
+         type(linalg_state) :: err0
+         integer(ilp) :: m,n,lda,info,k,lwork,neig
+         logical(lk) :: copy_a
+         character :: triangle,task
+         real(sp),target :: work_dummy(1)
+         real(sp),allocatable :: work(:)
+         real(sp),allocatable :: rwork(:)
+         real(sp),pointer :: amat(:,:)
+
+         !> Matrix size
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+         neig = size(lambda,kind=ilp)
+
+         if (.not. (k > 0 .and. m == n)) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid or matrix size a=', [m,n], &
+                                                        ', must be square.')
+            goto 1
+         end if
+
+         if (.not. neig >= k) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'eigenvalue array has insufficient size:', &
+                                                        ' lambda=',neig,' must be >= n=',n)
+            goto 1
+         end if
+        
+         ! Check if input A can be overwritten
+         if (present(vectors)) then
+            ! No need to copy A anyways
+            copy_a = .false.
+         elseif (present(overwrite_a)) then
+            copy_a = .not. overwrite_a
+         else
+            copy_a = .true._lk
+         end if
+         
+         ! Should we use the upper or lower half of the matrix?
+         triangle = symmetric_triangle(upper_a)
+         
+         ! Request for eigenvectors
+         task = eigenvectors_flag(present(vectors))
+         
+         if (present(vectors)) then
+            
+            ! Check size
+            if (any(shape(vectors,kind=ilp) < n)) then
+               err0 = linalg_state(this,LINALG_VALUE_ERROR, &
+                                        'eigenvector matrix has insufficient size: ', &
+                                        shape(vectors),', with n=',n)
+               goto 1
+            end if
+            
+            ! The input matrix will be overwritten by the vectors.
+            ! So, use this one as storage for syev/heev
+            amat => vectors
+            
+            ! Copy data in
+            amat(:n,:n) = a(:n,:n)
+                        
+         elseif (copy_a) then
+            ! Initialize a matrix temporary
+            allocate (amat(m,n),source=a)
+         else
+            ! Overwrite A
+            amat => a
+         end if
+
+         lda = size(amat,1,kind=ilp)
+
+         ! Request workspace size
+         lwork = -1_ilp
+         call syev(task,triangle,n,amat,lda,lambda,work_dummy,lwork,info)
+         call heev_info(err0,info,m,n)
+
+         ! Compute eigenvalues
+         if (info == 0) then
+
+            !> Prepare working storage
+            lwork = nint(real(work_dummy(1),kind=sp),kind=ilp)
+            allocate (work(lwork))
+
+            !> Compute eigensystem
+            call syev(task,triangle,n,amat,lda,lambda,work,lwork,info)
+            call heev_info(err0,info,m,n)
+
+         end if
+         
+         ! Finalize storage and process output flag
+         if (copy_a) deallocate (amat)
+1        call linalg_error_handling(err0,err)
+
+     end subroutine stdlib_linalg_eigh_s
+     
      !> Return an array of eigenvalues of matrix A.
      function stdlib_linalg_eigvals_d(a,err) result(lambda)
          !> Input matrix A[m,n]
@@ -464,7 +649,174 @@ module stdlib_linalg_eig
 1        call linalg_error_handling(err0,err)
 
      end subroutine stdlib_linalg_eig_d
+     
+     !> Return an array of eigenvalues of real symmetric / complex hermitian A
+     function stdlib_linalg_eigvalsh_d(a,upper_a,err) result(lambda)
+         !> Input matrix A[m,n]
+         real(dp),intent(in),target :: a(:,:)
+         !> [optional] Should the upper/lower half of A be used? Default: lower
+         logical(lk),optional,intent(in) :: upper_a
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),intent(out) :: err
+         !> Array of singular values
+         real(dp),allocatable :: lambda(:)
+         
+         real(dp),pointer :: amat(:,:)
+         integer(ilp) :: m,n,k
 
+         !> Create an internal pointer so the intent of A won't affect the next call
+         amat => a
+
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+
+         !> Allocate return storage
+         allocate (lambda(k))
+
+         !> Compute eigenvalues only
+         call stdlib_linalg_eigh_d(amat,lambda,upper_a=upper_a,overwrite_a=.false.,err=err)
+         
+     end function stdlib_linalg_eigvalsh_d
+     
+     !> Return an array of eigenvalues of real symmetric / complex hermitian A
+     function stdlib_linalg_eigvalsh_noerr_d(a,upper_a) result(lambda)
+         !> Input matrix A[m,n]
+         real(dp),intent(in),target :: a(:,:)
+         !> [optional] Should the upper/lower half of A be used? Default: lower
+         logical(lk),optional,intent(in) :: upper_a
+         !> Array of singular values
+         real(dp),allocatable :: lambda(:)
+
+         real(dp),pointer :: amat(:,:)
+         integer(ilp) :: m,n,k
+
+         !> Create an internal pointer so the intent of A won't affect the next call
+         amat => a
+
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+
+         !> Allocate return storage
+         allocate (lambda(k))
+
+         !> Compute eigenvalues only
+         call stdlib_linalg_eigh_d(amat,lambda,upper_a=upper_a,overwrite_a=.false.)
+
+     end function stdlib_linalg_eigvalsh_noerr_d
+
+     !> Eigendecomposition of a real symmetric or complex Hermitian matrix A returning an array `lambda`
+     !> of eigenvalues, and optionally right or left eigenvectors.
+     subroutine stdlib_linalg_eigh_d(a,lambda,vectors,upper_a,overwrite_a,err)
+         !> Input matrix A[m,n]
+         real(dp),intent(inout),target :: a(:,:)
+         !> Array of eigenvalues
+         real(dp),intent(out) :: lambda(:)
+         !> The columns of vectors contain the orthonormal eigenvectors of A
+         real(dp),optional,intent(out),target :: vectors(:,:)
+         !> [optional] Can A data be overwritten and destroyed?
+         logical(lk),optional,intent(in) :: overwrite_a
+         !> [optional] Should the upper/lower half of A be used? Default: lower
+         logical(lk),optional,intent(in) :: upper_a
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+
+         !> Local variables
+         type(linalg_state) :: err0
+         integer(ilp) :: m,n,lda,info,k,lwork,neig
+         logical(lk) :: copy_a
+         character :: triangle,task
+         real(dp),target :: work_dummy(1)
+         real(dp),allocatable :: work(:)
+         real(dp),allocatable :: rwork(:)
+         real(dp),pointer :: amat(:,:)
+
+         !> Matrix size
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+         neig = size(lambda,kind=ilp)
+
+         if (.not. (k > 0 .and. m == n)) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid or matrix size a=', [m,n], &
+                                                        ', must be square.')
+            goto 1
+         end if
+
+         if (.not. neig >= k) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'eigenvalue array has insufficient size:', &
+                                                        ' lambda=',neig,' must be >= n=',n)
+            goto 1
+         end if
+        
+         ! Check if input A can be overwritten
+         if (present(vectors)) then
+            ! No need to copy A anyways
+            copy_a = .false.
+         elseif (present(overwrite_a)) then
+            copy_a = .not. overwrite_a
+         else
+            copy_a = .true._lk
+         end if
+         
+         ! Should we use the upper or lower half of the matrix?
+         triangle = symmetric_triangle(upper_a)
+         
+         ! Request for eigenvectors
+         task = eigenvectors_flag(present(vectors))
+         
+         if (present(vectors)) then
+            
+            ! Check size
+            if (any(shape(vectors,kind=ilp) < n)) then
+               err0 = linalg_state(this,LINALG_VALUE_ERROR, &
+                                        'eigenvector matrix has insufficient size: ', &
+                                        shape(vectors),', with n=',n)
+               goto 1
+            end if
+            
+            ! The input matrix will be overwritten by the vectors.
+            ! So, use this one as storage for syev/heev
+            amat => vectors
+            
+            ! Copy data in
+            amat(:n,:n) = a(:n,:n)
+                        
+         elseif (copy_a) then
+            ! Initialize a matrix temporary
+            allocate (amat(m,n),source=a)
+         else
+            ! Overwrite A
+            amat => a
+         end if
+
+         lda = size(amat,1,kind=ilp)
+
+         ! Request workspace size
+         lwork = -1_ilp
+         call syev(task,triangle,n,amat,lda,lambda,work_dummy,lwork,info)
+         call heev_info(err0,info,m,n)
+
+         ! Compute eigenvalues
+         if (info == 0) then
+
+            !> Prepare working storage
+            lwork = nint(real(work_dummy(1),kind=dp),kind=ilp)
+            allocate (work(lwork))
+
+            !> Compute eigensystem
+            call syev(task,triangle,n,amat,lda,lambda,work,lwork,info)
+            call heev_info(err0,info,m,n)
+
+         end if
+         
+         ! Finalize storage and process output flag
+         if (copy_a) deallocate (amat)
+1        call linalg_error_handling(err0,err)
+
+     end subroutine stdlib_linalg_eigh_d
+     
      !> Return an array of eigenvalues of matrix A.
      function stdlib_linalg_eigvals_q(a,err) result(lambda)
          !> Input matrix A[m,n]
@@ -633,7 +985,174 @@ module stdlib_linalg_eig
 1        call linalg_error_handling(err0,err)
 
      end subroutine stdlib_linalg_eig_q
+     
+     !> Return an array of eigenvalues of real symmetric / complex hermitian A
+     function stdlib_linalg_eigvalsh_q(a,upper_a,err) result(lambda)
+         !> Input matrix A[m,n]
+         real(qp),intent(in),target :: a(:,:)
+         !> [optional] Should the upper/lower half of A be used? Default: lower
+         logical(lk),optional,intent(in) :: upper_a
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),intent(out) :: err
+         !> Array of singular values
+         real(qp),allocatable :: lambda(:)
+         
+         real(qp),pointer :: amat(:,:)
+         integer(ilp) :: m,n,k
 
+         !> Create an internal pointer so the intent of A won't affect the next call
+         amat => a
+
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+
+         !> Allocate return storage
+         allocate (lambda(k))
+
+         !> Compute eigenvalues only
+         call stdlib_linalg_eigh_q(amat,lambda,upper_a=upper_a,overwrite_a=.false.,err=err)
+         
+     end function stdlib_linalg_eigvalsh_q
+     
+     !> Return an array of eigenvalues of real symmetric / complex hermitian A
+     function stdlib_linalg_eigvalsh_noerr_q(a,upper_a) result(lambda)
+         !> Input matrix A[m,n]
+         real(qp),intent(in),target :: a(:,:)
+         !> [optional] Should the upper/lower half of A be used? Default: lower
+         logical(lk),optional,intent(in) :: upper_a
+         !> Array of singular values
+         real(qp),allocatable :: lambda(:)
+
+         real(qp),pointer :: amat(:,:)
+         integer(ilp) :: m,n,k
+
+         !> Create an internal pointer so the intent of A won't affect the next call
+         amat => a
+
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+
+         !> Allocate return storage
+         allocate (lambda(k))
+
+         !> Compute eigenvalues only
+         call stdlib_linalg_eigh_q(amat,lambda,upper_a=upper_a,overwrite_a=.false.)
+
+     end function stdlib_linalg_eigvalsh_noerr_q
+
+     !> Eigendecomposition of a real symmetric or complex Hermitian matrix A returning an array `lambda`
+     !> of eigenvalues, and optionally right or left eigenvectors.
+     subroutine stdlib_linalg_eigh_q(a,lambda,vectors,upper_a,overwrite_a,err)
+         !> Input matrix A[m,n]
+         real(qp),intent(inout),target :: a(:,:)
+         !> Array of eigenvalues
+         real(qp),intent(out) :: lambda(:)
+         !> The columns of vectors contain the orthonormal eigenvectors of A
+         real(qp),optional,intent(out),target :: vectors(:,:)
+         !> [optional] Can A data be overwritten and destroyed?
+         logical(lk),optional,intent(in) :: overwrite_a
+         !> [optional] Should the upper/lower half of A be used? Default: lower
+         logical(lk),optional,intent(in) :: upper_a
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+
+         !> Local variables
+         type(linalg_state) :: err0
+         integer(ilp) :: m,n,lda,info,k,lwork,neig
+         logical(lk) :: copy_a
+         character :: triangle,task
+         real(qp),target :: work_dummy(1)
+         real(qp),allocatable :: work(:)
+         real(qp),allocatable :: rwork(:)
+         real(qp),pointer :: amat(:,:)
+
+         !> Matrix size
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+         neig = size(lambda,kind=ilp)
+
+         if (.not. (k > 0 .and. m == n)) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid or matrix size a=', [m,n], &
+                                                        ', must be square.')
+            goto 1
+         end if
+
+         if (.not. neig >= k) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'eigenvalue array has insufficient size:', &
+                                                        ' lambda=',neig,' must be >= n=',n)
+            goto 1
+         end if
+        
+         ! Check if input A can be overwritten
+         if (present(vectors)) then
+            ! No need to copy A anyways
+            copy_a = .false.
+         elseif (present(overwrite_a)) then
+            copy_a = .not. overwrite_a
+         else
+            copy_a = .true._lk
+         end if
+         
+         ! Should we use the upper or lower half of the matrix?
+         triangle = symmetric_triangle(upper_a)
+         
+         ! Request for eigenvectors
+         task = eigenvectors_flag(present(vectors))
+         
+         if (present(vectors)) then
+            
+            ! Check size
+            if (any(shape(vectors,kind=ilp) < n)) then
+               err0 = linalg_state(this,LINALG_VALUE_ERROR, &
+                                        'eigenvector matrix has insufficient size: ', &
+                                        shape(vectors),', with n=',n)
+               goto 1
+            end if
+            
+            ! The input matrix will be overwritten by the vectors.
+            ! So, use this one as storage for syev/heev
+            amat => vectors
+            
+            ! Copy data in
+            amat(:n,:n) = a(:n,:n)
+                        
+         elseif (copy_a) then
+            ! Initialize a matrix temporary
+            allocate (amat(m,n),source=a)
+         else
+            ! Overwrite A
+            amat => a
+         end if
+
+         lda = size(amat,1,kind=ilp)
+
+         ! Request workspace size
+         lwork = -1_ilp
+         call syev(task,triangle,n,amat,lda,lambda,work_dummy,lwork,info)
+         call heev_info(err0,info,m,n)
+
+         ! Compute eigenvalues
+         if (info == 0) then
+
+            !> Prepare working storage
+            lwork = nint(real(work_dummy(1),kind=qp),kind=ilp)
+            allocate (work(lwork))
+
+            !> Compute eigensystem
+            call syev(task,triangle,n,amat,lda,lambda,work,lwork,info)
+            call heev_info(err0,info,m,n)
+
+         end if
+         
+         ! Finalize storage and process output flag
+         if (copy_a) deallocate (amat)
+1        call linalg_error_handling(err0,err)
+
+     end subroutine stdlib_linalg_eigh_q
+     
      !> Return an array of eigenvalues of matrix A.
      function stdlib_linalg_eigvals_c(a,err) result(lambda)
          !> Input matrix A[m,n]
@@ -791,7 +1310,175 @@ module stdlib_linalg_eig
 1        call linalg_error_handling(err0,err)
 
      end subroutine stdlib_linalg_eig_c
+     
+     !> Return an array of eigenvalues of real symmetric / complex hermitian A
+     function stdlib_linalg_eigvalsh_c(a,upper_a,err) result(lambda)
+         !> Input matrix A[m,n]
+         complex(sp),intent(in),target :: a(:,:)
+         !> [optional] Should the upper/lower half of A be used? Default: lower
+         logical(lk),optional,intent(in) :: upper_a
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),intent(out) :: err
+         !> Array of singular values
+         real(sp),allocatable :: lambda(:)
+         
+         complex(sp),pointer :: amat(:,:)
+         integer(ilp) :: m,n,k
 
+         !> Create an internal pointer so the intent of A won't affect the next call
+         amat => a
+
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+
+         !> Allocate return storage
+         allocate (lambda(k))
+
+         !> Compute eigenvalues only
+         call stdlib_linalg_eigh_c(amat,lambda,upper_a=upper_a,overwrite_a=.false.,err=err)
+         
+     end function stdlib_linalg_eigvalsh_c
+     
+     !> Return an array of eigenvalues of real symmetric / complex hermitian A
+     function stdlib_linalg_eigvalsh_noerr_c(a,upper_a) result(lambda)
+         !> Input matrix A[m,n]
+         complex(sp),intent(in),target :: a(:,:)
+         !> [optional] Should the upper/lower half of A be used? Default: lower
+         logical(lk),optional,intent(in) :: upper_a
+         !> Array of singular values
+         real(sp),allocatable :: lambda(:)
+
+         complex(sp),pointer :: amat(:,:)
+         integer(ilp) :: m,n,k
+
+         !> Create an internal pointer so the intent of A won't affect the next call
+         amat => a
+
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+
+         !> Allocate return storage
+         allocate (lambda(k))
+
+         !> Compute eigenvalues only
+         call stdlib_linalg_eigh_c(amat,lambda,upper_a=upper_a,overwrite_a=.false.)
+
+     end function stdlib_linalg_eigvalsh_noerr_c
+
+     !> Eigendecomposition of a real symmetric or complex Hermitian matrix A returning an array `lambda`
+     !> of eigenvalues, and optionally right or left eigenvectors.
+     subroutine stdlib_linalg_eigh_c(a,lambda,vectors,upper_a,overwrite_a,err)
+         !> Input matrix A[m,n]
+         complex(sp),intent(inout),target :: a(:,:)
+         !> Array of eigenvalues
+         real(sp),intent(out) :: lambda(:)
+         !> The columns of vectors contain the orthonormal eigenvectors of A
+         complex(sp),optional,intent(out),target :: vectors(:,:)
+         !> [optional] Can A data be overwritten and destroyed?
+         logical(lk),optional,intent(in) :: overwrite_a
+         !> [optional] Should the upper/lower half of A be used? Default: lower
+         logical(lk),optional,intent(in) :: upper_a
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+
+         !> Local variables
+         type(linalg_state) :: err0
+         integer(ilp) :: m,n,lda,info,k,lwork,neig
+         logical(lk) :: copy_a
+         character :: triangle,task
+         complex(sp),target :: work_dummy(1)
+         complex(sp),allocatable :: work(:)
+         real(sp),allocatable :: rwork(:)
+         complex(sp),pointer :: amat(:,:)
+
+         !> Matrix size
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+         neig = size(lambda,kind=ilp)
+
+         if (.not. (k > 0 .and. m == n)) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid or matrix size a=', [m,n], &
+                                                        ', must be square.')
+            goto 1
+         end if
+
+         if (.not. neig >= k) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'eigenvalue array has insufficient size:', &
+                                                        ' lambda=',neig,' must be >= n=',n)
+            goto 1
+         end if
+        
+         ! Check if input A can be overwritten
+         if (present(vectors)) then
+            ! No need to copy A anyways
+            copy_a = .false.
+         elseif (present(overwrite_a)) then
+            copy_a = .not. overwrite_a
+         else
+            copy_a = .true._lk
+         end if
+         
+         ! Should we use the upper or lower half of the matrix?
+         triangle = symmetric_triangle(upper_a)
+         
+         ! Request for eigenvectors
+         task = eigenvectors_flag(present(vectors))
+         
+         if (present(vectors)) then
+            
+            ! Check size
+            if (any(shape(vectors,kind=ilp) < n)) then
+               err0 = linalg_state(this,LINALG_VALUE_ERROR, &
+                                        'eigenvector matrix has insufficient size: ', &
+                                        shape(vectors),', with n=',n)
+               goto 1
+            end if
+            
+            ! The input matrix will be overwritten by the vectors.
+            ! So, use this one as storage for syev/heev
+            amat => vectors
+            
+            ! Copy data in
+            amat(:n,:n) = a(:n,:n)
+                        
+         elseif (copy_a) then
+            ! Initialize a matrix temporary
+            allocate (amat(m,n),source=a)
+         else
+            ! Overwrite A
+            amat => a
+         end if
+
+         lda = size(amat,1,kind=ilp)
+
+         ! Request workspace size
+         lwork = -1_ilp
+         allocate (rwork(max(1,3*n - 2)))
+         call heev(task,triangle,n,amat,lda,lambda,work_dummy,lwork,rwork,info)
+         call heev_info(err0,info,m,n)
+
+         ! Compute eigenvalues
+         if (info == 0) then
+
+            !> Prepare working storage
+            lwork = nint(real(work_dummy(1),kind=sp),kind=ilp)
+            allocate (work(lwork))
+
+            !> Compute eigensystem
+            call heev(task,triangle,n,amat,lda,lambda,work,lwork,rwork,info)
+            call heev_info(err0,info,m,n)
+
+         end if
+         
+         ! Finalize storage and process output flag
+         if (copy_a) deallocate (amat)
+1        call linalg_error_handling(err0,err)
+
+     end subroutine stdlib_linalg_eigh_c
+     
      !> Return an array of eigenvalues of matrix A.
      function stdlib_linalg_eigvals_z(a,err) result(lambda)
          !> Input matrix A[m,n]
@@ -949,7 +1636,175 @@ module stdlib_linalg_eig
 1        call linalg_error_handling(err0,err)
 
      end subroutine stdlib_linalg_eig_z
+     
+     !> Return an array of eigenvalues of real symmetric / complex hermitian A
+     function stdlib_linalg_eigvalsh_z(a,upper_a,err) result(lambda)
+         !> Input matrix A[m,n]
+         complex(dp),intent(in),target :: a(:,:)
+         !> [optional] Should the upper/lower half of A be used? Default: lower
+         logical(lk),optional,intent(in) :: upper_a
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),intent(out) :: err
+         !> Array of singular values
+         real(dp),allocatable :: lambda(:)
+         
+         complex(dp),pointer :: amat(:,:)
+         integer(ilp) :: m,n,k
 
+         !> Create an internal pointer so the intent of A won't affect the next call
+         amat => a
+
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+
+         !> Allocate return storage
+         allocate (lambda(k))
+
+         !> Compute eigenvalues only
+         call stdlib_linalg_eigh_z(amat,lambda,upper_a=upper_a,overwrite_a=.false.,err=err)
+         
+     end function stdlib_linalg_eigvalsh_z
+     
+     !> Return an array of eigenvalues of real symmetric / complex hermitian A
+     function stdlib_linalg_eigvalsh_noerr_z(a,upper_a) result(lambda)
+         !> Input matrix A[m,n]
+         complex(dp),intent(in),target :: a(:,:)
+         !> [optional] Should the upper/lower half of A be used? Default: lower
+         logical(lk),optional,intent(in) :: upper_a
+         !> Array of singular values
+         real(dp),allocatable :: lambda(:)
+
+         complex(dp),pointer :: amat(:,:)
+         integer(ilp) :: m,n,k
+
+         !> Create an internal pointer so the intent of A won't affect the next call
+         amat => a
+
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+
+         !> Allocate return storage
+         allocate (lambda(k))
+
+         !> Compute eigenvalues only
+         call stdlib_linalg_eigh_z(amat,lambda,upper_a=upper_a,overwrite_a=.false.)
+
+     end function stdlib_linalg_eigvalsh_noerr_z
+
+     !> Eigendecomposition of a real symmetric or complex Hermitian matrix A returning an array `lambda`
+     !> of eigenvalues, and optionally right or left eigenvectors.
+     subroutine stdlib_linalg_eigh_z(a,lambda,vectors,upper_a,overwrite_a,err)
+         !> Input matrix A[m,n]
+         complex(dp),intent(inout),target :: a(:,:)
+         !> Array of eigenvalues
+         real(dp),intent(out) :: lambda(:)
+         !> The columns of vectors contain the orthonormal eigenvectors of A
+         complex(dp),optional,intent(out),target :: vectors(:,:)
+         !> [optional] Can A data be overwritten and destroyed?
+         logical(lk),optional,intent(in) :: overwrite_a
+         !> [optional] Should the upper/lower half of A be used? Default: lower
+         logical(lk),optional,intent(in) :: upper_a
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+
+         !> Local variables
+         type(linalg_state) :: err0
+         integer(ilp) :: m,n,lda,info,k,lwork,neig
+         logical(lk) :: copy_a
+         character :: triangle,task
+         complex(dp),target :: work_dummy(1)
+         complex(dp),allocatable :: work(:)
+         real(dp),allocatable :: rwork(:)
+         complex(dp),pointer :: amat(:,:)
+
+         !> Matrix size
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+         neig = size(lambda,kind=ilp)
+
+         if (.not. (k > 0 .and. m == n)) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid or matrix size a=', [m,n], &
+                                                        ', must be square.')
+            goto 1
+         end if
+
+         if (.not. neig >= k) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'eigenvalue array has insufficient size:', &
+                                                        ' lambda=',neig,' must be >= n=',n)
+            goto 1
+         end if
+        
+         ! Check if input A can be overwritten
+         if (present(vectors)) then
+            ! No need to copy A anyways
+            copy_a = .false.
+         elseif (present(overwrite_a)) then
+            copy_a = .not. overwrite_a
+         else
+            copy_a = .true._lk
+         end if
+         
+         ! Should we use the upper or lower half of the matrix?
+         triangle = symmetric_triangle(upper_a)
+         
+         ! Request for eigenvectors
+         task = eigenvectors_flag(present(vectors))
+         
+         if (present(vectors)) then
+            
+            ! Check size
+            if (any(shape(vectors,kind=ilp) < n)) then
+               err0 = linalg_state(this,LINALG_VALUE_ERROR, &
+                                        'eigenvector matrix has insufficient size: ', &
+                                        shape(vectors),', with n=',n)
+               goto 1
+            end if
+            
+            ! The input matrix will be overwritten by the vectors.
+            ! So, use this one as storage for syev/heev
+            amat => vectors
+            
+            ! Copy data in
+            amat(:n,:n) = a(:n,:n)
+                        
+         elseif (copy_a) then
+            ! Initialize a matrix temporary
+            allocate (amat(m,n),source=a)
+         else
+            ! Overwrite A
+            amat => a
+         end if
+
+         lda = size(amat,1,kind=ilp)
+
+         ! Request workspace size
+         lwork = -1_ilp
+         allocate (rwork(max(1,3*n - 2)))
+         call heev(task,triangle,n,amat,lda,lambda,work_dummy,lwork,rwork,info)
+         call heev_info(err0,info,m,n)
+
+         ! Compute eigenvalues
+         if (info == 0) then
+
+            !> Prepare working storage
+            lwork = nint(real(work_dummy(1),kind=dp),kind=ilp)
+            allocate (work(lwork))
+
+            !> Compute eigensystem
+            call heev(task,triangle,n,amat,lda,lambda,work,lwork,rwork,info)
+            call heev_info(err0,info,m,n)
+
+         end if
+         
+         ! Finalize storage and process output flag
+         if (copy_a) deallocate (amat)
+1        call linalg_error_handling(err0,err)
+
+     end subroutine stdlib_linalg_eigh_z
+     
      !> Return an array of eigenvalues of matrix A.
      function stdlib_linalg_eigvals_w(a,err) result(lambda)
          !> Input matrix A[m,n]
@@ -1107,7 +1962,175 @@ module stdlib_linalg_eig
 1        call linalg_error_handling(err0,err)
 
      end subroutine stdlib_linalg_eig_w
+     
+     !> Return an array of eigenvalues of real symmetric / complex hermitian A
+     function stdlib_linalg_eigvalsh_w(a,upper_a,err) result(lambda)
+         !> Input matrix A[m,n]
+         complex(qp),intent(in),target :: a(:,:)
+         !> [optional] Should the upper/lower half of A be used? Default: lower
+         logical(lk),optional,intent(in) :: upper_a
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),intent(out) :: err
+         !> Array of singular values
+         real(qp),allocatable :: lambda(:)
+         
+         complex(qp),pointer :: amat(:,:)
+         integer(ilp) :: m,n,k
 
+         !> Create an internal pointer so the intent of A won't affect the next call
+         amat => a
+
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+
+         !> Allocate return storage
+         allocate (lambda(k))
+
+         !> Compute eigenvalues only
+         call stdlib_linalg_eigh_w(amat,lambda,upper_a=upper_a,overwrite_a=.false.,err=err)
+         
+     end function stdlib_linalg_eigvalsh_w
+     
+     !> Return an array of eigenvalues of real symmetric / complex hermitian A
+     function stdlib_linalg_eigvalsh_noerr_w(a,upper_a) result(lambda)
+         !> Input matrix A[m,n]
+         complex(qp),intent(in),target :: a(:,:)
+         !> [optional] Should the upper/lower half of A be used? Default: lower
+         logical(lk),optional,intent(in) :: upper_a
+         !> Array of singular values
+         real(qp),allocatable :: lambda(:)
+
+         complex(qp),pointer :: amat(:,:)
+         integer(ilp) :: m,n,k
+
+         !> Create an internal pointer so the intent of A won't affect the next call
+         amat => a
+
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+
+         !> Allocate return storage
+         allocate (lambda(k))
+
+         !> Compute eigenvalues only
+         call stdlib_linalg_eigh_w(amat,lambda,upper_a=upper_a,overwrite_a=.false.)
+
+     end function stdlib_linalg_eigvalsh_noerr_w
+
+     !> Eigendecomposition of a real symmetric or complex Hermitian matrix A returning an array `lambda`
+     !> of eigenvalues, and optionally right or left eigenvectors.
+     subroutine stdlib_linalg_eigh_w(a,lambda,vectors,upper_a,overwrite_a,err)
+         !> Input matrix A[m,n]
+         complex(qp),intent(inout),target :: a(:,:)
+         !> Array of eigenvalues
+         real(qp),intent(out) :: lambda(:)
+         !> The columns of vectors contain the orthonormal eigenvectors of A
+         complex(qp),optional,intent(out),target :: vectors(:,:)
+         !> [optional] Can A data be overwritten and destroyed?
+         logical(lk),optional,intent(in) :: overwrite_a
+         !> [optional] Should the upper/lower half of A be used? Default: lower
+         logical(lk),optional,intent(in) :: upper_a
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+
+         !> Local variables
+         type(linalg_state) :: err0
+         integer(ilp) :: m,n,lda,info,k,lwork,neig
+         logical(lk) :: copy_a
+         character :: triangle,task
+         complex(qp),target :: work_dummy(1)
+         complex(qp),allocatable :: work(:)
+         real(qp),allocatable :: rwork(:)
+         complex(qp),pointer :: amat(:,:)
+
+         !> Matrix size
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+         neig = size(lambda,kind=ilp)
+
+         if (.not. (k > 0 .and. m == n)) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid or matrix size a=', [m,n], &
+                                                        ', must be square.')
+            goto 1
+         end if
+
+         if (.not. neig >= k) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'eigenvalue array has insufficient size:', &
+                                                        ' lambda=',neig,' must be >= n=',n)
+            goto 1
+         end if
+        
+         ! Check if input A can be overwritten
+         if (present(vectors)) then
+            ! No need to copy A anyways
+            copy_a = .false.
+         elseif (present(overwrite_a)) then
+            copy_a = .not. overwrite_a
+         else
+            copy_a = .true._lk
+         end if
+         
+         ! Should we use the upper or lower half of the matrix?
+         triangle = symmetric_triangle(upper_a)
+         
+         ! Request for eigenvectors
+         task = eigenvectors_flag(present(vectors))
+         
+         if (present(vectors)) then
+            
+            ! Check size
+            if (any(shape(vectors,kind=ilp) < n)) then
+               err0 = linalg_state(this,LINALG_VALUE_ERROR, &
+                                        'eigenvector matrix has insufficient size: ', &
+                                        shape(vectors),', with n=',n)
+               goto 1
+            end if
+            
+            ! The input matrix will be overwritten by the vectors.
+            ! So, use this one as storage for syev/heev
+            amat => vectors
+            
+            ! Copy data in
+            amat(:n,:n) = a(:n,:n)
+                        
+         elseif (copy_a) then
+            ! Initialize a matrix temporary
+            allocate (amat(m,n),source=a)
+         else
+            ! Overwrite A
+            amat => a
+         end if
+
+         lda = size(amat,1,kind=ilp)
+
+         ! Request workspace size
+         lwork = -1_ilp
+         allocate (rwork(max(1,3*n - 2)))
+         call heev(task,triangle,n,amat,lda,lambda,work_dummy,lwork,rwork,info)
+         call heev_info(err0,info,m,n)
+
+         ! Compute eigenvalues
+         if (info == 0) then
+
+            !> Prepare working storage
+            lwork = nint(real(work_dummy(1),kind=qp),kind=ilp)
+            allocate (work(lwork))
+
+            !> Compute eigensystem
+            call heev(task,triangle,n,amat,lda,lambda,work,lwork,rwork,info)
+            call heev_info(err0,info,m,n)
+
+         end if
+         
+         ! Finalize storage and process output flag
+         if (copy_a) deallocate (amat)
+1        call linalg_error_handling(err0,err)
+
+     end subroutine stdlib_linalg_eigh_w
+     
      !> GEEV for real matrices returns complex eigenvalues in real arrays.
      !> Convert them to complex here, following the GEEV logic.
      pure subroutine assign_real_eigenvectors_sp(n,lambda,lmat,out_mat)
@@ -1140,117 +2163,6 @@ module stdlib_linalg_eig
         end do
         
      end subroutine assign_real_eigenvectors_sp
-
-     !> Eigendecomposition of a real symmetric or complex Hermitian matrix A returning an array `lambda`
-     !> of eigenvalues, and optionally right or left eigenvectors.
-     subroutine stdlib_linalg_eigh_s(a,lambda,vectors,upper_a,overwrite_a,err)
-         !> Input matrix A[m,n]
-         real(sp),intent(inout),target :: a(:,:)
-         !> Array of eigenvalues
-         real(sp),intent(out) :: lambda(:)
-         !> The columns of vectors contain the orthonormal eigenvectors of A
-         real(sp),optional,intent(out),target :: vectors(:,:)
-         !> [optional] Can A data be overwritten and destroyed?
-         logical(lk),optional,intent(in) :: overwrite_a
-         !> [optional] Should the upper/lower half of A be used? Default: lower
-         logical(lk),optional,intent(in) :: upper_a
-         !> [optional] state return flag. On error if not requested, the code will stop
-         type(linalg_state),optional,intent(out) :: err
-
-         !> Local variables
-         type(linalg_state) :: err0
-         integer(ilp) :: m,n,lda,info,k,lwork,neig
-         logical(lk) :: copy_a
-         character :: triangle,task
-         real(sp),target :: work_dummy(1)
-         real(sp),allocatable :: work(:)
-         real(sp),allocatable :: rwork(:)
-         real(sp),pointer :: amat(:,:)
-
-         !> Matrix size
-         m = size(a,1,kind=ilp)
-         n = size(a,2,kind=ilp)
-         k = min(m,n)
-         neig = size(lambda,kind=ilp)
-
-         if (.not. (k > 0 .and. m == n)) then
-            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid or matrix size a=', [m,n], &
-                                                        ', must be square.')
-            goto 1
-         end if
-
-         if (.not. neig >= k) then
-            err0 = linalg_state(this,LINALG_VALUE_ERROR,'eigenvalue array has insufficient size:', &
-                                                        ' lambda=',neig,' must be >= n=',n)
-            goto 1
-         end if
-        
-         ! Check if input A can be overwritten
-         if (present(vectors)) then
-            ! No need to copy A anyways
-            copy_a = .false.
-         elseif (present(overwrite_a)) then
-            copy_a = .not. overwrite_a
-         else
-            copy_a = .true._lk
-         end if
-         
-         ! Should we use the upper or lower half of the matrix?
-         triangle = symmetric_triangle(upper_a)
-         
-         ! Request for eigenvectors
-         task = eigenvectors_flag(present(vectors))
-         
-         if (present(vectors)) then
-            
-            ! Check size
-            if (any(shape(vectors,kind=ilp) < n)) then
-               err0 = linalg_state(this,LINALG_VALUE_ERROR, &
-                                        'eigenvector matrix has insufficient size: ', &
-                                        shape(vectors),', with n=',n)
-               goto 1
-            end if
-            
-            ! The input matrix will be overwritten by the vectors.
-            ! So, use this one as storage for syev/heev
-            amat => vectors
-            
-            ! Copy data in
-            amat(:n,:n) = a(:n,:n)
-                        
-         elseif (copy_a) then
-            ! Initialize a matrix temporary
-            allocate (amat(m,n),source=a)
-         else
-            ! Overwrite A
-            amat => a
-         end if
-
-         lda = size(amat,1,kind=ilp)
-
-         ! Request workspace size
-         lwork = -1_ilp
-         call syev(task,triangle,n,amat,lda,lambda,work_dummy,lwork,info)
-         call heev_info(err0,info,m,n)
-
-         ! Compute eigenvalues
-         if (info == 0) then
-
-            !> Prepare working storage
-            lwork = nint(real(work_dummy(1),kind=sp),kind=ilp)
-            allocate (work(lwork))
-
-            !> Compute eigensystem
-            call syev(task,triangle,n,amat,lda,lambda,work,lwork,info)
-            call heev_info(err0,info,m,n)
-
-         end if
-         
-         ! Finalize storage and process output flag
-2        if (copy_a) deallocate (amat)
-1        call linalg_error_handling(err0,err)
-
-     end subroutine stdlib_linalg_eigh_s
      !> GEEV for real matrices returns complex eigenvalues in real arrays.
      !> Convert them to complex here, following the GEEV logic.
      pure subroutine assign_real_eigenvectors_dp(n,lambda,lmat,out_mat)
@@ -1283,117 +2195,6 @@ module stdlib_linalg_eig
         end do
         
      end subroutine assign_real_eigenvectors_dp
-
-     !> Eigendecomposition of a real symmetric or complex Hermitian matrix A returning an array `lambda`
-     !> of eigenvalues, and optionally right or left eigenvectors.
-     subroutine stdlib_linalg_eigh_d(a,lambda,vectors,upper_a,overwrite_a,err)
-         !> Input matrix A[m,n]
-         real(dp),intent(inout),target :: a(:,:)
-         !> Array of eigenvalues
-         real(dp),intent(out) :: lambda(:)
-         !> The columns of vectors contain the orthonormal eigenvectors of A
-         real(dp),optional,intent(out),target :: vectors(:,:)
-         !> [optional] Can A data be overwritten and destroyed?
-         logical(lk),optional,intent(in) :: overwrite_a
-         !> [optional] Should the upper/lower half of A be used? Default: lower
-         logical(lk),optional,intent(in) :: upper_a
-         !> [optional] state return flag. On error if not requested, the code will stop
-         type(linalg_state),optional,intent(out) :: err
-
-         !> Local variables
-         type(linalg_state) :: err0
-         integer(ilp) :: m,n,lda,info,k,lwork,neig
-         logical(lk) :: copy_a
-         character :: triangle,task
-         real(dp),target :: work_dummy(1)
-         real(dp),allocatable :: work(:)
-         real(dp),allocatable :: rwork(:)
-         real(dp),pointer :: amat(:,:)
-
-         !> Matrix size
-         m = size(a,1,kind=ilp)
-         n = size(a,2,kind=ilp)
-         k = min(m,n)
-         neig = size(lambda,kind=ilp)
-
-         if (.not. (k > 0 .and. m == n)) then
-            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid or matrix size a=', [m,n], &
-                                                        ', must be square.')
-            goto 1
-         end if
-
-         if (.not. neig >= k) then
-            err0 = linalg_state(this,LINALG_VALUE_ERROR,'eigenvalue array has insufficient size:', &
-                                                        ' lambda=',neig,' must be >= n=',n)
-            goto 1
-         end if
-        
-         ! Check if input A can be overwritten
-         if (present(vectors)) then
-            ! No need to copy A anyways
-            copy_a = .false.
-         elseif (present(overwrite_a)) then
-            copy_a = .not. overwrite_a
-         else
-            copy_a = .true._lk
-         end if
-         
-         ! Should we use the upper or lower half of the matrix?
-         triangle = symmetric_triangle(upper_a)
-         
-         ! Request for eigenvectors
-         task = eigenvectors_flag(present(vectors))
-         
-         if (present(vectors)) then
-            
-            ! Check size
-            if (any(shape(vectors,kind=ilp) < n)) then
-               err0 = linalg_state(this,LINALG_VALUE_ERROR, &
-                                        'eigenvector matrix has insufficient size: ', &
-                                        shape(vectors),', with n=',n)
-               goto 1
-            end if
-            
-            ! The input matrix will be overwritten by the vectors.
-            ! So, use this one as storage for syev/heev
-            amat => vectors
-            
-            ! Copy data in
-            amat(:n,:n) = a(:n,:n)
-                        
-         elseif (copy_a) then
-            ! Initialize a matrix temporary
-            allocate (amat(m,n),source=a)
-         else
-            ! Overwrite A
-            amat => a
-         end if
-
-         lda = size(amat,1,kind=ilp)
-
-         ! Request workspace size
-         lwork = -1_ilp
-         call syev(task,triangle,n,amat,lda,lambda,work_dummy,lwork,info)
-         call heev_info(err0,info,m,n)
-
-         ! Compute eigenvalues
-         if (info == 0) then
-
-            !> Prepare working storage
-            lwork = nint(real(work_dummy(1),kind=dp),kind=ilp)
-            allocate (work(lwork))
-
-            !> Compute eigensystem
-            call syev(task,triangle,n,amat,lda,lambda,work,lwork,info)
-            call heev_info(err0,info,m,n)
-
-         end if
-         
-         ! Finalize storage and process output flag
-2        if (copy_a) deallocate (amat)
-1        call linalg_error_handling(err0,err)
-
-     end subroutine stdlib_linalg_eigh_d
      !> GEEV for real matrices returns complex eigenvalues in real arrays.
      !> Convert them to complex here, following the GEEV logic.
      pure subroutine assign_real_eigenvectors_qp(n,lambda,lmat,out_mat)
@@ -1426,116 +2227,5 @@ module stdlib_linalg_eig
         end do
         
      end subroutine assign_real_eigenvectors_qp
-
-     !> Eigendecomposition of a real symmetric or complex Hermitian matrix A returning an array `lambda`
-     !> of eigenvalues, and optionally right or left eigenvectors.
-     subroutine stdlib_linalg_eigh_q(a,lambda,vectors,upper_a,overwrite_a,err)
-         !> Input matrix A[m,n]
-         real(qp),intent(inout),target :: a(:,:)
-         !> Array of eigenvalues
-         real(qp),intent(out) :: lambda(:)
-         !> The columns of vectors contain the orthonormal eigenvectors of A
-         real(qp),optional,intent(out),target :: vectors(:,:)
-         !> [optional] Can A data be overwritten and destroyed?
-         logical(lk),optional,intent(in) :: overwrite_a
-         !> [optional] Should the upper/lower half of A be used? Default: lower
-         logical(lk),optional,intent(in) :: upper_a
-         !> [optional] state return flag. On error if not requested, the code will stop
-         type(linalg_state),optional,intent(out) :: err
-
-         !> Local variables
-         type(linalg_state) :: err0
-         integer(ilp) :: m,n,lda,info,k,lwork,neig
-         logical(lk) :: copy_a
-         character :: triangle,task
-         real(qp),target :: work_dummy(1)
-         real(qp),allocatable :: work(:)
-         real(qp),allocatable :: rwork(:)
-         real(qp),pointer :: amat(:,:)
-
-         !> Matrix size
-         m = size(a,1,kind=ilp)
-         n = size(a,2,kind=ilp)
-         k = min(m,n)
-         neig = size(lambda,kind=ilp)
-
-         if (.not. (k > 0 .and. m == n)) then
-            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid or matrix size a=', [m,n], &
-                                                        ', must be square.')
-            goto 1
-         end if
-
-         if (.not. neig >= k) then
-            err0 = linalg_state(this,LINALG_VALUE_ERROR,'eigenvalue array has insufficient size:', &
-                                                        ' lambda=',neig,' must be >= n=',n)
-            goto 1
-         end if
-        
-         ! Check if input A can be overwritten
-         if (present(vectors)) then
-            ! No need to copy A anyways
-            copy_a = .false.
-         elseif (present(overwrite_a)) then
-            copy_a = .not. overwrite_a
-         else
-            copy_a = .true._lk
-         end if
-         
-         ! Should we use the upper or lower half of the matrix?
-         triangle = symmetric_triangle(upper_a)
-         
-         ! Request for eigenvectors
-         task = eigenvectors_flag(present(vectors))
-         
-         if (present(vectors)) then
-            
-            ! Check size
-            if (any(shape(vectors,kind=ilp) < n)) then
-               err0 = linalg_state(this,LINALG_VALUE_ERROR, &
-                                        'eigenvector matrix has insufficient size: ', &
-                                        shape(vectors),', with n=',n)
-               goto 1
-            end if
-            
-            ! The input matrix will be overwritten by the vectors.
-            ! So, use this one as storage for syev/heev
-            amat => vectors
-            
-            ! Copy data in
-            amat(:n,:n) = a(:n,:n)
-                        
-         elseif (copy_a) then
-            ! Initialize a matrix temporary
-            allocate (amat(m,n),source=a)
-         else
-            ! Overwrite A
-            amat => a
-         end if
-
-         lda = size(amat,1,kind=ilp)
-
-         ! Request workspace size
-         lwork = -1_ilp
-         call syev(task,triangle,n,amat,lda,lambda,work_dummy,lwork,info)
-         call heev_info(err0,info,m,n)
-
-         ! Compute eigenvalues
-         if (info == 0) then
-
-            !> Prepare working storage
-            lwork = nint(real(work_dummy(1),kind=qp),kind=ilp)
-            allocate (work(lwork))
-
-            !> Compute eigensystem
-            call syev(task,triangle,n,amat,lda,lambda,work,lwork,info)
-            call heev_info(err0,info,m,n)
-
-         end if
-         
-         ! Finalize storage and process output flag
-2        if (copy_a) deallocate (amat)
-1        call linalg_error_handling(err0,err)
-
-     end subroutine stdlib_linalg_eigh_q
 
 end module stdlib_linalg_eig

--- a/src/stdlib_linalg_eigs.f90
+++ b/src/stdlib_linalg_eigs.f90
@@ -125,8 +125,7 @@ module stdlib_linalg_eig
          integer(ilp) :: m,n,lda,ldu,ldv,info,k,lwork,lrwork,neig
          logical(lk) :: copy_a
          character :: task_u,task_v
-         real(sp),target :: work_dummy(1)
-         complex(sp),target :: u_dummy(1,1),v_dummy(1,1)
+         real(sp),target :: work_dummy(1),u_dummy(1,1),v_dummy(1,1)
          real(sp),allocatable :: work(:)
          real(sp),allocatable :: rwork(:)
          real(sp),pointer :: amat(:,:),lreal(:),limag(:),umat(:,:),vmat(:,:)
@@ -298,8 +297,7 @@ module stdlib_linalg_eig
          integer(ilp) :: m,n,lda,ldu,ldv,info,k,lwork,lrwork,neig
          logical(lk) :: copy_a
          character :: task_u,task_v
-         real(dp),target :: work_dummy(1)
-         complex(dp),target :: u_dummy(1,1),v_dummy(1,1)
+         real(dp),target :: work_dummy(1),u_dummy(1,1),v_dummy(1,1)
          real(dp),allocatable :: work(:)
          real(dp),allocatable :: rwork(:)
          real(dp),pointer :: amat(:,:),lreal(:),limag(:),umat(:,:),vmat(:,:)
@@ -471,8 +469,7 @@ module stdlib_linalg_eig
          integer(ilp) :: m,n,lda,ldu,ldv,info,k,lwork,lrwork,neig
          logical(lk) :: copy_a
          character :: task_u,task_v
-         real(qp),target :: work_dummy(1)
-         complex(qp),target :: u_dummy(1,1),v_dummy(1,1)
+         real(qp),target :: work_dummy(1),u_dummy(1,1),v_dummy(1,1)
          real(qp),allocatable :: work(:)
          real(qp),allocatable :: rwork(:)
          real(qp),pointer :: amat(:,:),lreal(:),limag(:),umat(:,:),vmat(:,:)
@@ -644,8 +641,7 @@ module stdlib_linalg_eig
          integer(ilp) :: m,n,lda,ldu,ldv,info,k,lwork,lrwork,neig
          logical(lk) :: copy_a
          character :: task_u,task_v
-         complex(sp),target :: work_dummy(1)
-         complex(sp),target :: u_dummy(1,1),v_dummy(1,1)
+         complex(sp),target :: work_dummy(1),u_dummy(1,1),v_dummy(1,1)
          complex(sp),allocatable :: work(:)
          real(sp),allocatable :: rwork(:)
          complex(sp),pointer :: amat(:,:),lreal(:),limag(:),umat(:,:),vmat(:,:)
@@ -802,8 +798,7 @@ module stdlib_linalg_eig
          integer(ilp) :: m,n,lda,ldu,ldv,info,k,lwork,lrwork,neig
          logical(lk) :: copy_a
          character :: task_u,task_v
-         complex(dp),target :: work_dummy(1)
-         complex(dp),target :: u_dummy(1,1),v_dummy(1,1)
+         complex(dp),target :: work_dummy(1),u_dummy(1,1),v_dummy(1,1)
          complex(dp),allocatable :: work(:)
          real(dp),allocatable :: rwork(:)
          complex(dp),pointer :: amat(:,:),lreal(:),limag(:),umat(:,:),vmat(:,:)
@@ -960,8 +955,7 @@ module stdlib_linalg_eig
          integer(ilp) :: m,n,lda,ldu,ldv,info,k,lwork,lrwork,neig
          logical(lk) :: copy_a
          character :: task_u,task_v
-         complex(qp),target :: work_dummy(1)
-         complex(qp),target :: u_dummy(1,1),v_dummy(1,1)
+         complex(qp),target :: work_dummy(1),u_dummy(1,1),v_dummy(1,1)
          complex(qp),allocatable :: work(:)
          real(qp),allocatable :: rwork(:)
          complex(qp),pointer :: amat(:,:),lreal(:),limag(:),umat(:,:),vmat(:,:)

--- a/src/stdlib_linalg_eigs.f90
+++ b/src/stdlib_linalg_eigs.f90
@@ -32,11 +32,17 @@ module stdlib_linalg_eig
 
      interface eigvals
         module procedure stdlib_linalg_eigvals_s
+        module procedure stdlib_linalg_eigvals_noerr_s
         module procedure stdlib_linalg_eigvals_d
+        module procedure stdlib_linalg_eigvals_noerr_d
         module procedure stdlib_linalg_eigvals_q
+        module procedure stdlib_linalg_eigvals_noerr_q
         module procedure stdlib_linalg_eigvals_c
+        module procedure stdlib_linalg_eigvals_noerr_c
         module procedure stdlib_linalg_eigvals_z
+        module procedure stdlib_linalg_eigvals_noerr_z
         module procedure stdlib_linalg_eigvals_w
+        module procedure stdlib_linalg_eigvals_noerr_w
      end interface eigvals
      
      interface eigh
@@ -150,7 +156,7 @@ module stdlib_linalg_eig
          !> Input matrix A[m,n]
          real(sp),intent(in),target :: a(:,:)
          !> [optional] state return flag. On error if not requested, the code will stop
-         type(linalg_state),optional,intent(out) :: err
+         type(linalg_state),intent(out) :: err
          !> Array of singular values
          complex(sp),allocatable :: lambda(:)
 
@@ -172,6 +178,32 @@ module stdlib_linalg_eig
          call stdlib_linalg_eig_s(amat,lambda,overwrite_a=.false.,err=err)
 
      end function stdlib_linalg_eigvals_s
+
+     !> Return an array of eigenvalues of matrix A.
+     function stdlib_linalg_eigvals_noerr_s(a) result(lambda)
+         !> Input matrix A[m,n]
+         real(sp),intent(in),target :: a(:,:)
+         !> Array of singular values
+         complex(sp),allocatable :: lambda(:)
+
+         !> Create
+         real(sp),pointer :: amat(:,:)
+         integer(ilp) :: m,n,k
+
+         !> Create an internal pointer so the intent of A won't affect the next call
+         amat => a
+
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+
+         !> Allocate return storage
+         allocate (lambda(k))
+
+         !> Compute eigenvalues only
+         call stdlib_linalg_eig_s(amat,lambda,overwrite_a=.false.)
+
+     end function stdlib_linalg_eigvals_noerr_s
 
      !> Eigendecomposition of matrix A returning an array `lambda` of eigenvalues,
      !> and optionally right or left eigenvectors.
@@ -486,7 +518,7 @@ module stdlib_linalg_eig
          !> Input matrix A[m,n]
          real(dp),intent(in),target :: a(:,:)
          !> [optional] state return flag. On error if not requested, the code will stop
-         type(linalg_state),optional,intent(out) :: err
+         type(linalg_state),intent(out) :: err
          !> Array of singular values
          complex(dp),allocatable :: lambda(:)
 
@@ -508,6 +540,32 @@ module stdlib_linalg_eig
          call stdlib_linalg_eig_d(amat,lambda,overwrite_a=.false.,err=err)
 
      end function stdlib_linalg_eigvals_d
+
+     !> Return an array of eigenvalues of matrix A.
+     function stdlib_linalg_eigvals_noerr_d(a) result(lambda)
+         !> Input matrix A[m,n]
+         real(dp),intent(in),target :: a(:,:)
+         !> Array of singular values
+         complex(dp),allocatable :: lambda(:)
+
+         !> Create
+         real(dp),pointer :: amat(:,:)
+         integer(ilp) :: m,n,k
+
+         !> Create an internal pointer so the intent of A won't affect the next call
+         amat => a
+
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+
+         !> Allocate return storage
+         allocate (lambda(k))
+
+         !> Compute eigenvalues only
+         call stdlib_linalg_eig_d(amat,lambda,overwrite_a=.false.)
+
+     end function stdlib_linalg_eigvals_noerr_d
 
      !> Eigendecomposition of matrix A returning an array `lambda` of eigenvalues,
      !> and optionally right or left eigenvectors.
@@ -822,7 +880,7 @@ module stdlib_linalg_eig
          !> Input matrix A[m,n]
          real(qp),intent(in),target :: a(:,:)
          !> [optional] state return flag. On error if not requested, the code will stop
-         type(linalg_state),optional,intent(out) :: err
+         type(linalg_state),intent(out) :: err
          !> Array of singular values
          complex(qp),allocatable :: lambda(:)
 
@@ -844,6 +902,32 @@ module stdlib_linalg_eig
          call stdlib_linalg_eig_q(amat,lambda,overwrite_a=.false.,err=err)
 
      end function stdlib_linalg_eigvals_q
+
+     !> Return an array of eigenvalues of matrix A.
+     function stdlib_linalg_eigvals_noerr_q(a) result(lambda)
+         !> Input matrix A[m,n]
+         real(qp),intent(in),target :: a(:,:)
+         !> Array of singular values
+         complex(qp),allocatable :: lambda(:)
+
+         !> Create
+         real(qp),pointer :: amat(:,:)
+         integer(ilp) :: m,n,k
+
+         !> Create an internal pointer so the intent of A won't affect the next call
+         amat => a
+
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+
+         !> Allocate return storage
+         allocate (lambda(k))
+
+         !> Compute eigenvalues only
+         call stdlib_linalg_eig_q(amat,lambda,overwrite_a=.false.)
+
+     end function stdlib_linalg_eigvals_noerr_q
 
      !> Eigendecomposition of matrix A returning an array `lambda` of eigenvalues,
      !> and optionally right or left eigenvectors.
@@ -1158,7 +1242,7 @@ module stdlib_linalg_eig
          !> Input matrix A[m,n]
          complex(sp),intent(in),target :: a(:,:)
          !> [optional] state return flag. On error if not requested, the code will stop
-         type(linalg_state),optional,intent(out) :: err
+         type(linalg_state),intent(out) :: err
          !> Array of singular values
          complex(sp),allocatable :: lambda(:)
 
@@ -1180,6 +1264,32 @@ module stdlib_linalg_eig
          call stdlib_linalg_eig_c(amat,lambda,overwrite_a=.false.,err=err)
 
      end function stdlib_linalg_eigvals_c
+
+     !> Return an array of eigenvalues of matrix A.
+     function stdlib_linalg_eigvals_noerr_c(a) result(lambda)
+         !> Input matrix A[m,n]
+         complex(sp),intent(in),target :: a(:,:)
+         !> Array of singular values
+         complex(sp),allocatable :: lambda(:)
+
+         !> Create
+         complex(sp),pointer :: amat(:,:)
+         integer(ilp) :: m,n,k
+
+         !> Create an internal pointer so the intent of A won't affect the next call
+         amat => a
+
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+
+         !> Allocate return storage
+         allocate (lambda(k))
+
+         !> Compute eigenvalues only
+         call stdlib_linalg_eig_c(amat,lambda,overwrite_a=.false.)
+
+     end function stdlib_linalg_eigvals_noerr_c
 
      !> Eigendecomposition of matrix A returning an array `lambda` of eigenvalues,
      !> and optionally right or left eigenvectors.
@@ -1484,7 +1594,7 @@ module stdlib_linalg_eig
          !> Input matrix A[m,n]
          complex(dp),intent(in),target :: a(:,:)
          !> [optional] state return flag. On error if not requested, the code will stop
-         type(linalg_state),optional,intent(out) :: err
+         type(linalg_state),intent(out) :: err
          !> Array of singular values
          complex(dp),allocatable :: lambda(:)
 
@@ -1506,6 +1616,32 @@ module stdlib_linalg_eig
          call stdlib_linalg_eig_z(amat,lambda,overwrite_a=.false.,err=err)
 
      end function stdlib_linalg_eigvals_z
+
+     !> Return an array of eigenvalues of matrix A.
+     function stdlib_linalg_eigvals_noerr_z(a) result(lambda)
+         !> Input matrix A[m,n]
+         complex(dp),intent(in),target :: a(:,:)
+         !> Array of singular values
+         complex(dp),allocatable :: lambda(:)
+
+         !> Create
+         complex(dp),pointer :: amat(:,:)
+         integer(ilp) :: m,n,k
+
+         !> Create an internal pointer so the intent of A won't affect the next call
+         amat => a
+
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+
+         !> Allocate return storage
+         allocate (lambda(k))
+
+         !> Compute eigenvalues only
+         call stdlib_linalg_eig_z(amat,lambda,overwrite_a=.false.)
+
+     end function stdlib_linalg_eigvals_noerr_z
 
      !> Eigendecomposition of matrix A returning an array `lambda` of eigenvalues,
      !> and optionally right or left eigenvectors.
@@ -1810,7 +1946,7 @@ module stdlib_linalg_eig
          !> Input matrix A[m,n]
          complex(qp),intent(in),target :: a(:,:)
          !> [optional] state return flag. On error if not requested, the code will stop
-         type(linalg_state),optional,intent(out) :: err
+         type(linalg_state),intent(out) :: err
          !> Array of singular values
          complex(qp),allocatable :: lambda(:)
 
@@ -1832,6 +1968,32 @@ module stdlib_linalg_eig
          call stdlib_linalg_eig_w(amat,lambda,overwrite_a=.false.,err=err)
 
      end function stdlib_linalg_eigvals_w
+
+     !> Return an array of eigenvalues of matrix A.
+     function stdlib_linalg_eigvals_noerr_w(a) result(lambda)
+         !> Input matrix A[m,n]
+         complex(qp),intent(in),target :: a(:,:)
+         !> Array of singular values
+         complex(qp),allocatable :: lambda(:)
+
+         !> Create
+         complex(qp),pointer :: amat(:,:)
+         integer(ilp) :: m,n,k
+
+         !> Create an internal pointer so the intent of A won't affect the next call
+         amat => a
+
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+
+         !> Allocate return storage
+         allocate (lambda(k))
+
+         !> Compute eigenvalues only
+         call stdlib_linalg_eig_w(amat,lambda,overwrite_a=.false.)
+
+     end function stdlib_linalg_eigvals_noerr_w
 
      !> Eigendecomposition of matrix A returning an array `lambda` of eigenvalues,
      !> and optionally right or left eigenvectors.

--- a/src/stdlib_linalg_eigs.f90
+++ b/src/stdlib_linalg_eigs.f90
@@ -13,6 +13,8 @@ module stdlib_linalg_eig
      public :: eigvals
      !> Eigendecomposition of a real symmetric or complex hermitian matrix
      public :: eigh
+     !> Eigenvalues of a real symmetric or complex hermitian matrix
+     public :: eigvalsh
 
      ! Numpy: eigenvalues, eigenvectors = eig(a)
      !        eigenvalues = eigvals(a)
@@ -20,6 +22,7 @@ module stdlib_linalg_eig
 
      ! Numpy: eigenvalues, eigenvectors = eigh(a, uplo='L')
      !        eigenvalues = eigvalsh(a)
+     ! Scipy: eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False, overwrite_b=False, turbo=<object object>, eigvals=<object object>, type=1, check_finite=True, subset_by_index=None, subset_by_value=None, driver=None)
 
      interface eig
         module procedure stdlib_linalg_eig_s

--- a/src/stdlib_linalg_eigs.f90
+++ b/src/stdlib_linalg_eigs.f90
@@ -1074,13 +1074,11 @@ module stdlib_linalg_eig
         ! u(j)   = VL(:,j) + i*VL(:,j+1) and
         ! u(j+1) = VL(:,j) - i*VL(:,j+1).
         ! Convert these to complex numbers here.
-        do j = 1,n
-            do i = 1,n - 1
-               if (lambda(i) == conjg(lambda(i + 1))) then
-                  out_mat(i,j) = cmplx(lmat(i,j),lmat(i + 1,j),kind=sp)
-                  out_mat(i + 1,j) = cmplx(lmat(i,j),-lmat(i + 1,j),kind=sp)
-               end if
-            end do
+        do j = 1,n - 1
+           if (lambda(j) == conjg(lambda(j + 1))) then
+              out_mat(:,j) = cmplx(lmat(:,j),lmat(:,j + 1),kind=sp)
+              out_mat(:,j + 1) = cmplx(lmat(:,j),-lmat(:,j + 1),kind=sp)
+           end if
         end do
         
      end subroutine assign_real_eigenvectors_sp
@@ -1106,13 +1104,11 @@ module stdlib_linalg_eig
         ! u(j)   = VL(:,j) + i*VL(:,j+1) and
         ! u(j+1) = VL(:,j) - i*VL(:,j+1).
         ! Convert these to complex numbers here.
-        do j = 1,n
-            do i = 1,n - 1
-               if (lambda(i) == conjg(lambda(i + 1))) then
-                  out_mat(i,j) = cmplx(lmat(i,j),lmat(i + 1,j),kind=dp)
-                  out_mat(i + 1,j) = cmplx(lmat(i,j),-lmat(i + 1,j),kind=dp)
-               end if
-            end do
+        do j = 1,n - 1
+           if (lambda(j) == conjg(lambda(j + 1))) then
+              out_mat(:,j) = cmplx(lmat(:,j),lmat(:,j + 1),kind=dp)
+              out_mat(:,j + 1) = cmplx(lmat(:,j),-lmat(:,j + 1),kind=dp)
+           end if
         end do
         
      end subroutine assign_real_eigenvectors_dp
@@ -1138,13 +1134,11 @@ module stdlib_linalg_eig
         ! u(j)   = VL(:,j) + i*VL(:,j+1) and
         ! u(j+1) = VL(:,j) - i*VL(:,j+1).
         ! Convert these to complex numbers here.
-        do j = 1,n
-            do i = 1,n - 1
-               if (lambda(i) == conjg(lambda(i + 1))) then
-                  out_mat(i,j) = cmplx(lmat(i,j),lmat(i + 1,j),kind=qp)
-                  out_mat(i + 1,j) = cmplx(lmat(i,j),-lmat(i + 1,j),kind=qp)
-               end if
-            end do
+        do j = 1,n - 1
+           if (lambda(j) == conjg(lambda(j + 1))) then
+              out_mat(:,j) = cmplx(lmat(:,j),lmat(:,j + 1),kind=qp)
+              out_mat(:,j + 1) = cmplx(lmat(:,j),-lmat(:,j + 1),kind=qp)
+           end if
         end do
         
      end subroutine assign_real_eigenvectors_qp

--- a/src/stdlib_linalg_eigs.f90
+++ b/src/stdlib_linalg_eigs.f90
@@ -1,0 +1,1022 @@
+module stdlib_linalg_eig
+     use stdlib_linalg_constants
+     use stdlib_linalg_blas
+     use stdlib_linalg_lapack
+     use stdlib_linalg_state
+     use iso_fortran_env,only:real32,real64,real128,int8,int16,int32,int64,stderr => error_unit
+     implicit none(type,external)
+     private
+
+     !> Eigendecomposition of a square matrix: return eigenvalues, and optionally eigenvectors
+     public :: eig
+     !> Eigenvalues of a square matrix
+     public :: eigvals
+
+     ! Numpy: eigenvalues, eigenvectors = eig(a)
+     !        eigenvalues = eigvals(a)
+     ! Scipy: eig(a, b=None, left=False, right=True, overwrite_a=False, overwrite_b=False, check_finite=True, homogeneous_eigvals=False)
+
+     interface eig
+        module procedure stdlib_linalg_eig_s
+        module procedure stdlib_linalg_eig_d
+        module procedure stdlib_linalg_eig_q
+        module procedure stdlib_linalg_eig_c
+        module procedure stdlib_linalg_eig_z
+        module procedure stdlib_linalg_eig_w
+     end interface eig
+
+     interface eigvals
+        module procedure stdlib_linalg_eigvals_s
+        module procedure stdlib_linalg_eigvals_d
+        module procedure stdlib_linalg_eigvals_q
+        module procedure stdlib_linalg_eigvals_c
+        module procedure stdlib_linalg_eigvals_z
+        module procedure stdlib_linalg_eigvals_w
+     end interface eigvals
+
+     character(*),parameter :: this = 'eigenvalues'
+
+     contains
+     
+     !> Request for eigenvector calculation
+     elemental character function eigenvectors_flag(required)
+        logical,intent(in) :: required
+        eigenvectors_flag = merge('V','N',required)
+     end function eigenvectors_flag
+
+     !> Process GEEV output flags
+     elemental subroutine geev_info(err,info,m,n)
+        !> Error handler
+        type(linalg_state),intent(inout) :: err
+        !> geev return flag
+        integer(ilp),intent(in) :: info
+        !> Input matrix size
+        integer(ilp),intent(in) :: m,n
+
+        select case (info)
+           case (0)
+               ! Success!
+               err%state = LINALG_SUCCESS
+           case (-1)
+               err = linalg_state(this,LINALG_INTERNAL_ERROR,'Invalid task ID: left eigenvectors.')
+           case (-2)
+               err = linalg_state(this,LINALG_INTERNAL_ERROR,'Invalid task ID: right eigenvectors.')
+           case (-5,-3)
+               err = linalg_state(this,LINALG_VALUE_ERROR,'invalid matrix size: a=[',m,',',n,']')
+           case (-9)
+               err = linalg_state(this,LINALG_VALUE_ERROR,'insufficient left vector matrix size.')
+           case (-11)
+               err = linalg_state(this,LINALG_VALUE_ERROR,'insufficient right vector matrix size.')
+           case (-13)
+               err = linalg_state(this,LINALG_INTERNAL_ERROR,'Insufficient work array size.')
+           case (1:)
+               err = linalg_state(this,LINALG_ERROR,'Eigenvalue computation did not converge.')
+           case default
+               err = linalg_state(this,LINALG_INTERNAL_ERROR,'Unknown error returned by geev.')
+        end select
+
+     end subroutine geev_info
+
+     !> Singular values of matrix A
+     function stdlib_linalg_eigvals_s(a,err) result(s)
+         !> Input matrix A[m,n]
+         real(sp),intent(in),target :: a(:,:)
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+         !> Array of singular values
+         complex(sp),allocatable :: s(:)
+
+         !> Create
+         real(sp),pointer :: amat(:,:)
+         integer(ilp) :: m,n,k
+
+         !> Create an internal pointer so the intent of A won't affect the next call
+         amat => a
+
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+
+         !> Allocate return storage
+         allocate (s(k))
+
+         !> Compute singular values
+         call stdlib_linalg_eig_s(amat,s,overwrite_a=.false.,err=err)
+
+     end function stdlib_linalg_eigvals_s
+
+     !> SVD of matrix A = U S V^T, returning S and optionally U and V
+     subroutine stdlib_linalg_eig_s(a,lambda,left,right,overwrite_a,err)
+         !> Input matrix A[m,n]
+         real(sp),intent(inout),target :: a(:,:)
+         !> Array of eigenvalues
+         complex(sp),intent(out) :: lambda(:)
+         !> The columns of LEFT contain the left eigenvectors of A
+         real(sp),optional,intent(out),target :: left(:,:)
+         !> The columns of RIGHT contain the right eigenvectors of A
+         real(sp),optional,intent(out),target :: right(:,:)
+         !> [optional] Can A data be overwritten and destroyed?
+         logical(lk),optional,intent(in) :: overwrite_a
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+
+         !> Local variables
+         type(linalg_state) :: err0
+         integer(ilp) :: m,n,lda,ldu,ldv,info,k,lwork,lrwork,neig
+         logical(lk) :: copy_a
+         character :: task_u,task_v
+         real(sp),target :: work_dummy(1),u_dummy(1,1),v_dummy(1,1)
+         real(sp),allocatable :: work(:)
+         real(sp),allocatable :: rwork(:)
+         real(sp),pointer :: amat(:,:),umat(:,:),vmat(:,:),lreal(:),limag(:)
+
+         !> Matrix determinant size
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+         neig = size(lambda,kind=ilp)
+         lda = m
+
+         if (.not. (k > 0 .and. m == n)) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid or matrix size a=', [m,n],', must be square.')
+            goto 1
+         end if
+
+         if (.not. neig >= k) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'eigenvalue array has insufficient size:', &
+                                                        ' lambda=',neig,', n=',n)
+            goto 1
+         end if
+
+         ! Can A be overwritten? By default, do not overwrite
+         if (present(overwrite_a)) then
+            copy_a = .not. overwrite_a
+         else
+            copy_a = .true._lk
+         end if
+
+         ! Initialize a matrix temporary
+         if (copy_a) then
+            allocate (amat(m,n),source=a)
+         else
+            amat => a
+         end if
+
+         ! Decide if U, V eigenvectors
+         task_u = eigenvectors_flag(present(left))
+         task_v = eigenvectors_flag(present(right))
+         
+         if (present(right)) then
+            vmat => right
+            
+            if (size(vmat,2,kind=ilp) < n) then
+               err0 = linalg_state(this,LINALG_VALUE_ERROR, &
+                                        'right eigenvector matrix has insufficient size: ', &
+                                        shape(vmat),', with n=',n)
+               goto 2
+            end if
+            
+         else
+            vmat => v_dummy
+         end if
+            
+         if (present(left)) then
+            umat => left
+            
+            if (size(umat,2,kind=ilp) < n) then
+               err0 = linalg_state(this,LINALG_VALUE_ERROR, &
+                                        'left eigenvector matrix has insufficient size: ', &
+                                        shape(vmat),', with n=',n)
+               goto 2
+            end if
+            
+         else
+            umat => u_dummy
+         end if
+
+         ldu = size(umat,1,kind=ilp)
+         ldv = size(vmat,1,kind=ilp)
+
+         ! Compute workspace
+         allocate (lreal(n),limag(n))
+
+         lwork = -1_ilp
+        
+         call geev(task_u,task_v,n,amat,lda, &
+                   lreal,limag, &
+                   umat,ldu,vmat,ldv, &
+                   work_dummy,lwork,info)
+         call geev_info(err0,info,m,n)
+
+         ! Compute SVD
+         if (info == 0) then
+
+            !> Prepare working storage
+            lwork = nint(real(work_dummy(1),kind=sp),kind=ilp)
+            allocate (work(lwork))
+
+            !> Compute eigensystem
+            call geev(task_u,task_v,n,amat,lda, &
+                      lreal,limag, &
+                      umat,ldu,vmat,ldv, &
+                      work,lwork,info)
+            call geev_info(err0,info,m,n)
+
+         end if
+
+         ! Finalize storage and process output flag
+         lambda(:n) = cmplx(lreal(:n),limag(:n),kind=sp)
+         
+2        if (copy_a) deallocate (amat)
+1        call linalg_error_handling(err0,err)
+
+     end subroutine stdlib_linalg_eig_s
+
+     !> Singular values of matrix A
+     function stdlib_linalg_eigvals_d(a,err) result(s)
+         !> Input matrix A[m,n]
+         real(dp),intent(in),target :: a(:,:)
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+         !> Array of singular values
+         complex(dp),allocatable :: s(:)
+
+         !> Create
+         real(dp),pointer :: amat(:,:)
+         integer(ilp) :: m,n,k
+
+         !> Create an internal pointer so the intent of A won't affect the next call
+         amat => a
+
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+
+         !> Allocate return storage
+         allocate (s(k))
+
+         !> Compute singular values
+         call stdlib_linalg_eig_d(amat,s,overwrite_a=.false.,err=err)
+
+     end function stdlib_linalg_eigvals_d
+
+     !> SVD of matrix A = U S V^T, returning S and optionally U and V
+     subroutine stdlib_linalg_eig_d(a,lambda,left,right,overwrite_a,err)
+         !> Input matrix A[m,n]
+         real(dp),intent(inout),target :: a(:,:)
+         !> Array of eigenvalues
+         complex(dp),intent(out) :: lambda(:)
+         !> The columns of LEFT contain the left eigenvectors of A
+         real(dp),optional,intent(out),target :: left(:,:)
+         !> The columns of RIGHT contain the right eigenvectors of A
+         real(dp),optional,intent(out),target :: right(:,:)
+         !> [optional] Can A data be overwritten and destroyed?
+         logical(lk),optional,intent(in) :: overwrite_a
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+
+         !> Local variables
+         type(linalg_state) :: err0
+         integer(ilp) :: m,n,lda,ldu,ldv,info,k,lwork,lrwork,neig
+         logical(lk) :: copy_a
+         character :: task_u,task_v
+         real(dp),target :: work_dummy(1),u_dummy(1,1),v_dummy(1,1)
+         real(dp),allocatable :: work(:)
+         real(dp),allocatable :: rwork(:)
+         real(dp),pointer :: amat(:,:),umat(:,:),vmat(:,:),lreal(:),limag(:)
+
+         !> Matrix determinant size
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+         neig = size(lambda,kind=ilp)
+         lda = m
+
+         if (.not. (k > 0 .and. m == n)) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid or matrix size a=', [m,n],', must be square.')
+            goto 1
+         end if
+
+         if (.not. neig >= k) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'eigenvalue array has insufficient size:', &
+                                                        ' lambda=',neig,', n=',n)
+            goto 1
+         end if
+
+         ! Can A be overwritten? By default, do not overwrite
+         if (present(overwrite_a)) then
+            copy_a = .not. overwrite_a
+         else
+            copy_a = .true._lk
+         end if
+
+         ! Initialize a matrix temporary
+         if (copy_a) then
+            allocate (amat(m,n),source=a)
+         else
+            amat => a
+         end if
+
+         ! Decide if U, V eigenvectors
+         task_u = eigenvectors_flag(present(left))
+         task_v = eigenvectors_flag(present(right))
+         
+         if (present(right)) then
+            vmat => right
+            
+            if (size(vmat,2,kind=ilp) < n) then
+               err0 = linalg_state(this,LINALG_VALUE_ERROR, &
+                                        'right eigenvector matrix has insufficient size: ', &
+                                        shape(vmat),', with n=',n)
+               goto 2
+            end if
+            
+         else
+            vmat => v_dummy
+         end if
+            
+         if (present(left)) then
+            umat => left
+            
+            if (size(umat,2,kind=ilp) < n) then
+               err0 = linalg_state(this,LINALG_VALUE_ERROR, &
+                                        'left eigenvector matrix has insufficient size: ', &
+                                        shape(vmat),', with n=',n)
+               goto 2
+            end if
+            
+         else
+            umat => u_dummy
+         end if
+
+         ldu = size(umat,1,kind=ilp)
+         ldv = size(vmat,1,kind=ilp)
+
+         ! Compute workspace
+         allocate (lreal(n),limag(n))
+
+         lwork = -1_ilp
+        
+         call geev(task_u,task_v,n,amat,lda, &
+                   lreal,limag, &
+                   umat,ldu,vmat,ldv, &
+                   work_dummy,lwork,info)
+         call geev_info(err0,info,m,n)
+
+         ! Compute SVD
+         if (info == 0) then
+
+            !> Prepare working storage
+            lwork = nint(real(work_dummy(1),kind=dp),kind=ilp)
+            allocate (work(lwork))
+
+            !> Compute eigensystem
+            call geev(task_u,task_v,n,amat,lda, &
+                      lreal,limag, &
+                      umat,ldu,vmat,ldv, &
+                      work,lwork,info)
+            call geev_info(err0,info,m,n)
+
+         end if
+
+         ! Finalize storage and process output flag
+         lambda(:n) = cmplx(lreal(:n),limag(:n),kind=dp)
+         
+2        if (copy_a) deallocate (amat)
+1        call linalg_error_handling(err0,err)
+
+     end subroutine stdlib_linalg_eig_d
+
+     !> Singular values of matrix A
+     function stdlib_linalg_eigvals_q(a,err) result(s)
+         !> Input matrix A[m,n]
+         real(qp),intent(in),target :: a(:,:)
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+         !> Array of singular values
+         complex(qp),allocatable :: s(:)
+
+         !> Create
+         real(qp),pointer :: amat(:,:)
+         integer(ilp) :: m,n,k
+
+         !> Create an internal pointer so the intent of A won't affect the next call
+         amat => a
+
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+
+         !> Allocate return storage
+         allocate (s(k))
+
+         !> Compute singular values
+         call stdlib_linalg_eig_q(amat,s,overwrite_a=.false.,err=err)
+
+     end function stdlib_linalg_eigvals_q
+
+     !> SVD of matrix A = U S V^T, returning S and optionally U and V
+     subroutine stdlib_linalg_eig_q(a,lambda,left,right,overwrite_a,err)
+         !> Input matrix A[m,n]
+         real(qp),intent(inout),target :: a(:,:)
+         !> Array of eigenvalues
+         complex(qp),intent(out) :: lambda(:)
+         !> The columns of LEFT contain the left eigenvectors of A
+         real(qp),optional,intent(out),target :: left(:,:)
+         !> The columns of RIGHT contain the right eigenvectors of A
+         real(qp),optional,intent(out),target :: right(:,:)
+         !> [optional] Can A data be overwritten and destroyed?
+         logical(lk),optional,intent(in) :: overwrite_a
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+
+         !> Local variables
+         type(linalg_state) :: err0
+         integer(ilp) :: m,n,lda,ldu,ldv,info,k,lwork,lrwork,neig
+         logical(lk) :: copy_a
+         character :: task_u,task_v
+         real(qp),target :: work_dummy(1),u_dummy(1,1),v_dummy(1,1)
+         real(qp),allocatable :: work(:)
+         real(qp),allocatable :: rwork(:)
+         real(qp),pointer :: amat(:,:),umat(:,:),vmat(:,:),lreal(:),limag(:)
+
+         !> Matrix determinant size
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+         neig = size(lambda,kind=ilp)
+         lda = m
+
+         if (.not. (k > 0 .and. m == n)) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid or matrix size a=', [m,n],', must be square.')
+            goto 1
+         end if
+
+         if (.not. neig >= k) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'eigenvalue array has insufficient size:', &
+                                                        ' lambda=',neig,', n=',n)
+            goto 1
+         end if
+
+         ! Can A be overwritten? By default, do not overwrite
+         if (present(overwrite_a)) then
+            copy_a = .not. overwrite_a
+         else
+            copy_a = .true._lk
+         end if
+
+         ! Initialize a matrix temporary
+         if (copy_a) then
+            allocate (amat(m,n),source=a)
+         else
+            amat => a
+         end if
+
+         ! Decide if U, V eigenvectors
+         task_u = eigenvectors_flag(present(left))
+         task_v = eigenvectors_flag(present(right))
+         
+         if (present(right)) then
+            vmat => right
+            
+            if (size(vmat,2,kind=ilp) < n) then
+               err0 = linalg_state(this,LINALG_VALUE_ERROR, &
+                                        'right eigenvector matrix has insufficient size: ', &
+                                        shape(vmat),', with n=',n)
+               goto 2
+            end if
+            
+         else
+            vmat => v_dummy
+         end if
+            
+         if (present(left)) then
+            umat => left
+            
+            if (size(umat,2,kind=ilp) < n) then
+               err0 = linalg_state(this,LINALG_VALUE_ERROR, &
+                                        'left eigenvector matrix has insufficient size: ', &
+                                        shape(vmat),', with n=',n)
+               goto 2
+            end if
+            
+         else
+            umat => u_dummy
+         end if
+
+         ldu = size(umat,1,kind=ilp)
+         ldv = size(vmat,1,kind=ilp)
+
+         ! Compute workspace
+         allocate (lreal(n),limag(n))
+
+         lwork = -1_ilp
+        
+         call geev(task_u,task_v,n,amat,lda, &
+                   lreal,limag, &
+                   umat,ldu,vmat,ldv, &
+                   work_dummy,lwork,info)
+         call geev_info(err0,info,m,n)
+
+         ! Compute SVD
+         if (info == 0) then
+
+            !> Prepare working storage
+            lwork = nint(real(work_dummy(1),kind=qp),kind=ilp)
+            allocate (work(lwork))
+
+            !> Compute eigensystem
+            call geev(task_u,task_v,n,amat,lda, &
+                      lreal,limag, &
+                      umat,ldu,vmat,ldv, &
+                      work,lwork,info)
+            call geev_info(err0,info,m,n)
+
+         end if
+
+         ! Finalize storage and process output flag
+         lambda(:n) = cmplx(lreal(:n),limag(:n),kind=qp)
+         
+2        if (copy_a) deallocate (amat)
+1        call linalg_error_handling(err0,err)
+
+     end subroutine stdlib_linalg_eig_q
+
+     !> Singular values of matrix A
+     function stdlib_linalg_eigvals_c(a,err) result(s)
+         !> Input matrix A[m,n]
+         complex(sp),intent(in),target :: a(:,:)
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+         !> Array of singular values
+         complex(sp),allocatable :: s(:)
+
+         !> Create
+         complex(sp),pointer :: amat(:,:)
+         integer(ilp) :: m,n,k
+
+         !> Create an internal pointer so the intent of A won't affect the next call
+         amat => a
+
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+
+         !> Allocate return storage
+         allocate (s(k))
+
+         !> Compute singular values
+         call stdlib_linalg_eig_c(amat,s,overwrite_a=.false.,err=err)
+
+     end function stdlib_linalg_eigvals_c
+
+     !> SVD of matrix A = U S V^T, returning S and optionally U and V
+     subroutine stdlib_linalg_eig_c(a,lambda,left,right,overwrite_a,err)
+         !> Input matrix A[m,n]
+         complex(sp),intent(inout),target :: a(:,:)
+         !> Array of eigenvalues
+         complex(sp),intent(out) :: lambda(:)
+         !> The columns of LEFT contain the left eigenvectors of A
+         complex(sp),optional,intent(out),target :: left(:,:)
+         !> The columns of RIGHT contain the right eigenvectors of A
+         complex(sp),optional,intent(out),target :: right(:,:)
+         !> [optional] Can A data be overwritten and destroyed?
+         logical(lk),optional,intent(in) :: overwrite_a
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+
+         !> Local variables
+         type(linalg_state) :: err0
+         integer(ilp) :: m,n,lda,ldu,ldv,info,k,lwork,lrwork,neig
+         logical(lk) :: copy_a
+         character :: task_u,task_v
+         complex(sp),target :: work_dummy(1),u_dummy(1,1),v_dummy(1,1)
+         complex(sp),allocatable :: work(:)
+         real(sp),allocatable :: rwork(:)
+         complex(sp),pointer :: amat(:,:),umat(:,:),vmat(:,:),lreal(:),limag(:)
+
+         !> Matrix determinant size
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+         neig = size(lambda,kind=ilp)
+         lda = m
+
+         if (.not. (k > 0 .and. m == n)) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid or matrix size a=', [m,n],', must be square.')
+            goto 1
+         end if
+
+         if (.not. neig >= k) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'eigenvalue array has insufficient size:', &
+                                                        ' lambda=',neig,', n=',n)
+            goto 1
+         end if
+
+         ! Can A be overwritten? By default, do not overwrite
+         if (present(overwrite_a)) then
+            copy_a = .not. overwrite_a
+         else
+            copy_a = .true._lk
+         end if
+
+         ! Initialize a matrix temporary
+         if (copy_a) then
+            allocate (amat(m,n),source=a)
+         else
+            amat => a
+         end if
+
+         ! Decide if U, V eigenvectors
+         task_u = eigenvectors_flag(present(left))
+         task_v = eigenvectors_flag(present(right))
+         
+         if (present(right)) then
+            vmat => right
+            
+            if (size(vmat,2,kind=ilp) < n) then
+               err0 = linalg_state(this,LINALG_VALUE_ERROR, &
+                                        'right eigenvector matrix has insufficient size: ', &
+                                        shape(vmat),', with n=',n)
+               goto 2
+            end if
+            
+         else
+            vmat => v_dummy
+         end if
+            
+         if (present(left)) then
+            umat => left
+            
+            if (size(umat,2,kind=ilp) < n) then
+               err0 = linalg_state(this,LINALG_VALUE_ERROR, &
+                                        'left eigenvector matrix has insufficient size: ', &
+                                        shape(vmat),', with n=',n)
+               goto 2
+            end if
+            
+         else
+            umat => u_dummy
+         end if
+
+         ldu = size(umat,1,kind=ilp)
+         ldv = size(vmat,1,kind=ilp)
+
+         ! Compute workspace
+!         if (task==geev_SINGVAL_ONLY) then
+!            lrwork = max(1,7*k)
+!         else
+!            lrwork = max(1,5*k*(k+1),2*k*(k+max(m,n))+k)
+!         endif
+!         allocate(rwork(lrwork))
+
+         lwork = -1_ilp
+        
+         call geev(task_u,task_v,n,amat,lda, &
+                   lambda, &
+                   umat,ldu,vmat,ldv, &
+                   work_dummy,lwork,rwork,info)
+         call geev_info(err0,info,m,n)
+
+         ! Compute SVD
+         if (info == 0) then
+
+            !> Prepare working storage
+            lwork = nint(real(work_dummy(1),kind=sp),kind=ilp)
+            allocate (work(lwork))
+
+            !> Compute eigensystem
+            call geev(task_u,task_v,n,amat,lda, &
+                      lambda, &
+                      umat,ldu,vmat,ldv, &
+                      work,lwork,rwork,info)
+            call geev_info(err0,info,m,n)
+
+         end if
+
+         ! Finalize storage and process output flag
+         
+2        if (copy_a) deallocate (amat)
+1        call linalg_error_handling(err0,err)
+
+     end subroutine stdlib_linalg_eig_c
+
+     !> Singular values of matrix A
+     function stdlib_linalg_eigvals_z(a,err) result(s)
+         !> Input matrix A[m,n]
+         complex(dp),intent(in),target :: a(:,:)
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+         !> Array of singular values
+         complex(dp),allocatable :: s(:)
+
+         !> Create
+         complex(dp),pointer :: amat(:,:)
+         integer(ilp) :: m,n,k
+
+         !> Create an internal pointer so the intent of A won't affect the next call
+         amat => a
+
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+
+         !> Allocate return storage
+         allocate (s(k))
+
+         !> Compute singular values
+         call stdlib_linalg_eig_z(amat,s,overwrite_a=.false.,err=err)
+
+     end function stdlib_linalg_eigvals_z
+
+     !> SVD of matrix A = U S V^T, returning S and optionally U and V
+     subroutine stdlib_linalg_eig_z(a,lambda,left,right,overwrite_a,err)
+         !> Input matrix A[m,n]
+         complex(dp),intent(inout),target :: a(:,:)
+         !> Array of eigenvalues
+         complex(dp),intent(out) :: lambda(:)
+         !> The columns of LEFT contain the left eigenvectors of A
+         complex(dp),optional,intent(out),target :: left(:,:)
+         !> The columns of RIGHT contain the right eigenvectors of A
+         complex(dp),optional,intent(out),target :: right(:,:)
+         !> [optional] Can A data be overwritten and destroyed?
+         logical(lk),optional,intent(in) :: overwrite_a
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+
+         !> Local variables
+         type(linalg_state) :: err0
+         integer(ilp) :: m,n,lda,ldu,ldv,info,k,lwork,lrwork,neig
+         logical(lk) :: copy_a
+         character :: task_u,task_v
+         complex(dp),target :: work_dummy(1),u_dummy(1,1),v_dummy(1,1)
+         complex(dp),allocatable :: work(:)
+         real(dp),allocatable :: rwork(:)
+         complex(dp),pointer :: amat(:,:),umat(:,:),vmat(:,:),lreal(:),limag(:)
+
+         !> Matrix determinant size
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+         neig = size(lambda,kind=ilp)
+         lda = m
+
+         if (.not. (k > 0 .and. m == n)) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid or matrix size a=', [m,n],', must be square.')
+            goto 1
+         end if
+
+         if (.not. neig >= k) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'eigenvalue array has insufficient size:', &
+                                                        ' lambda=',neig,', n=',n)
+            goto 1
+         end if
+
+         ! Can A be overwritten? By default, do not overwrite
+         if (present(overwrite_a)) then
+            copy_a = .not. overwrite_a
+         else
+            copy_a = .true._lk
+         end if
+
+         ! Initialize a matrix temporary
+         if (copy_a) then
+            allocate (amat(m,n),source=a)
+         else
+            amat => a
+         end if
+
+         ! Decide if U, V eigenvectors
+         task_u = eigenvectors_flag(present(left))
+         task_v = eigenvectors_flag(present(right))
+         
+         if (present(right)) then
+            vmat => right
+            
+            if (size(vmat,2,kind=ilp) < n) then
+               err0 = linalg_state(this,LINALG_VALUE_ERROR, &
+                                        'right eigenvector matrix has insufficient size: ', &
+                                        shape(vmat),', with n=',n)
+               goto 2
+            end if
+            
+         else
+            vmat => v_dummy
+         end if
+            
+         if (present(left)) then
+            umat => left
+            
+            if (size(umat,2,kind=ilp) < n) then
+               err0 = linalg_state(this,LINALG_VALUE_ERROR, &
+                                        'left eigenvector matrix has insufficient size: ', &
+                                        shape(vmat),', with n=',n)
+               goto 2
+            end if
+            
+         else
+            umat => u_dummy
+         end if
+
+         ldu = size(umat,1,kind=ilp)
+         ldv = size(vmat,1,kind=ilp)
+
+         ! Compute workspace
+!         if (task==geev_SINGVAL_ONLY) then
+!            lrwork = max(1,7*k)
+!         else
+!            lrwork = max(1,5*k*(k+1),2*k*(k+max(m,n))+k)
+!         endif
+!         allocate(rwork(lrwork))
+
+         lwork = -1_ilp
+        
+         call geev(task_u,task_v,n,amat,lda, &
+                   lambda, &
+                   umat,ldu,vmat,ldv, &
+                   work_dummy,lwork,rwork,info)
+         call geev_info(err0,info,m,n)
+
+         ! Compute SVD
+         if (info == 0) then
+
+            !> Prepare working storage
+            lwork = nint(real(work_dummy(1),kind=dp),kind=ilp)
+            allocate (work(lwork))
+
+            !> Compute eigensystem
+            call geev(task_u,task_v,n,amat,lda, &
+                      lambda, &
+                      umat,ldu,vmat,ldv, &
+                      work,lwork,rwork,info)
+            call geev_info(err0,info,m,n)
+
+         end if
+
+         ! Finalize storage and process output flag
+         
+2        if (copy_a) deallocate (amat)
+1        call linalg_error_handling(err0,err)
+
+     end subroutine stdlib_linalg_eig_z
+
+     !> Singular values of matrix A
+     function stdlib_linalg_eigvals_w(a,err) result(s)
+         !> Input matrix A[m,n]
+         complex(qp),intent(in),target :: a(:,:)
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+         !> Array of singular values
+         complex(qp),allocatable :: s(:)
+
+         !> Create
+         complex(qp),pointer :: amat(:,:)
+         integer(ilp) :: m,n,k
+
+         !> Create an internal pointer so the intent of A won't affect the next call
+         amat => a
+
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+
+         !> Allocate return storage
+         allocate (s(k))
+
+         !> Compute singular values
+         call stdlib_linalg_eig_w(amat,s,overwrite_a=.false.,err=err)
+
+     end function stdlib_linalg_eigvals_w
+
+     !> SVD of matrix A = U S V^T, returning S and optionally U and V
+     subroutine stdlib_linalg_eig_w(a,lambda,left,right,overwrite_a,err)
+         !> Input matrix A[m,n]
+         complex(qp),intent(inout),target :: a(:,:)
+         !> Array of eigenvalues
+         complex(qp),intent(out) :: lambda(:)
+         !> The columns of LEFT contain the left eigenvectors of A
+         complex(qp),optional,intent(out),target :: left(:,:)
+         !> The columns of RIGHT contain the right eigenvectors of A
+         complex(qp),optional,intent(out),target :: right(:,:)
+         !> [optional] Can A data be overwritten and destroyed?
+         logical(lk),optional,intent(in) :: overwrite_a
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state),optional,intent(out) :: err
+
+         !> Local variables
+         type(linalg_state) :: err0
+         integer(ilp) :: m,n,lda,ldu,ldv,info,k,lwork,lrwork,neig
+         logical(lk) :: copy_a
+         character :: task_u,task_v
+         complex(qp),target :: work_dummy(1),u_dummy(1,1),v_dummy(1,1)
+         complex(qp),allocatable :: work(:)
+         real(qp),allocatable :: rwork(:)
+         complex(qp),pointer :: amat(:,:),umat(:,:),vmat(:,:),lreal(:),limag(:)
+
+         !> Matrix determinant size
+         m = size(a,1,kind=ilp)
+         n = size(a,2,kind=ilp)
+         k = min(m,n)
+         neig = size(lambda,kind=ilp)
+         lda = m
+
+         if (.not. (k > 0 .and. m == n)) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid or matrix size a=', [m,n],', must be square.')
+            goto 1
+         end if
+
+         if (.not. neig >= k) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'eigenvalue array has insufficient size:', &
+                                                        ' lambda=',neig,', n=',n)
+            goto 1
+         end if
+
+         ! Can A be overwritten? By default, do not overwrite
+         if (present(overwrite_a)) then
+            copy_a = .not. overwrite_a
+         else
+            copy_a = .true._lk
+         end if
+
+         ! Initialize a matrix temporary
+         if (copy_a) then
+            allocate (amat(m,n),source=a)
+         else
+            amat => a
+         end if
+
+         ! Decide if U, V eigenvectors
+         task_u = eigenvectors_flag(present(left))
+         task_v = eigenvectors_flag(present(right))
+         
+         if (present(right)) then
+            vmat => right
+            
+            if (size(vmat,2,kind=ilp) < n) then
+               err0 = linalg_state(this,LINALG_VALUE_ERROR, &
+                                        'right eigenvector matrix has insufficient size: ', &
+                                        shape(vmat),', with n=',n)
+               goto 2
+            end if
+            
+         else
+            vmat => v_dummy
+         end if
+            
+         if (present(left)) then
+            umat => left
+            
+            if (size(umat,2,kind=ilp) < n) then
+               err0 = linalg_state(this,LINALG_VALUE_ERROR, &
+                                        'left eigenvector matrix has insufficient size: ', &
+                                        shape(vmat),', with n=',n)
+               goto 2
+            end if
+            
+         else
+            umat => u_dummy
+         end if
+
+         ldu = size(umat,1,kind=ilp)
+         ldv = size(vmat,1,kind=ilp)
+
+         ! Compute workspace
+!         if (task==geev_SINGVAL_ONLY) then
+!            lrwork = max(1,7*k)
+!         else
+!            lrwork = max(1,5*k*(k+1),2*k*(k+max(m,n))+k)
+!         endif
+!         allocate(rwork(lrwork))
+
+         lwork = -1_ilp
+        
+         call geev(task_u,task_v,n,amat,lda, &
+                   lambda, &
+                   umat,ldu,vmat,ldv, &
+                   work_dummy,lwork,rwork,info)
+         call geev_info(err0,info,m,n)
+
+         ! Compute SVD
+         if (info == 0) then
+
+            !> Prepare working storage
+            lwork = nint(real(work_dummy(1),kind=qp),kind=ilp)
+            allocate (work(lwork))
+
+            !> Compute eigensystem
+            call geev(task_u,task_v,n,amat,lda, &
+                      lambda, &
+                      umat,ldu,vmat,ldv, &
+                      work,lwork,rwork,info)
+            call geev_info(err0,info,m,n)
+
+         end if
+
+         ! Finalize storage and process output flag
+         
+2        if (copy_a) deallocate (amat)
+1        call linalg_error_handling(err0,err)
+
+     end subroutine stdlib_linalg_eig_w
+
+end module stdlib_linalg_eig

--- a/src/stdlib_linalg_eigs.f90
+++ b/src/stdlib_linalg_eigs.f90
@@ -230,17 +230,13 @@ module stdlib_linalg_eig
          ! Finalize storage and process output flag
          lambda(:n) = cmplx(lreal(:n),limag(:n),kind=sp)
          
-         ! If the j-th and (j+1)-st eigenvalues form a complex conjugate pair, then
+         ! If the j-th and (j+1)-st eigenvalues form a complex conjugate pair,
+         ! geev returns reals as:
          ! u(j)   = VL(:,j) + i*VL(:,j+1) and
          ! u(j+1) = VL(:,j) - i*VL(:,j+1).
          ! Convert these to complex numbers here.
-         if (present(right)) right = real(vmat)
-         if (present(left)) left = real(umat)
-!         do i=2,n
-!            if (lreal(i)==lreal(i-1) .and. limag(i)==-limag(i-1)) then
-!
-!            endif
-!         end do
+         if (present(right)) call assign_real_eigenvectors_sp(n,lambda,vmat,right)
+         if (present(left)) call assign_real_eigenvectors_sp(n,lambda,umat,left)
          
 2        if (copy_a) deallocate (amat)
          if (present(right)) deallocate (vmat)
@@ -402,17 +398,13 @@ module stdlib_linalg_eig
          ! Finalize storage and process output flag
          lambda(:n) = cmplx(lreal(:n),limag(:n),kind=dp)
          
-         ! If the j-th and (j+1)-st eigenvalues form a complex conjugate pair, then
+         ! If the j-th and (j+1)-st eigenvalues form a complex conjugate pair,
+         ! geev returns reals as:
          ! u(j)   = VL(:,j) + i*VL(:,j+1) and
          ! u(j+1) = VL(:,j) - i*VL(:,j+1).
          ! Convert these to complex numbers here.
-         if (present(right)) right = real(vmat)
-         if (present(left)) left = real(umat)
-!         do i=2,n
-!            if (lreal(i)==lreal(i-1) .and. limag(i)==-limag(i-1)) then
-!
-!            endif
-!         end do
+         if (present(right)) call assign_real_eigenvectors_dp(n,lambda,vmat,right)
+         if (present(left)) call assign_real_eigenvectors_dp(n,lambda,umat,left)
          
 2        if (copy_a) deallocate (amat)
          if (present(right)) deallocate (vmat)
@@ -574,17 +566,13 @@ module stdlib_linalg_eig
          ! Finalize storage and process output flag
          lambda(:n) = cmplx(lreal(:n),limag(:n),kind=qp)
          
-         ! If the j-th and (j+1)-st eigenvalues form a complex conjugate pair, then
+         ! If the j-th and (j+1)-st eigenvalues form a complex conjugate pair,
+         ! geev returns reals as:
          ! u(j)   = VL(:,j) + i*VL(:,j+1) and
          ! u(j+1) = VL(:,j) - i*VL(:,j+1).
          ! Convert these to complex numbers here.
-         if (present(right)) right = real(vmat)
-         if (present(left)) left = real(umat)
-!         do i=2,n
-!            if (lreal(i)==lreal(i-1) .and. limag(i)==-limag(i-1)) then
-!
-!            endif
-!         end do
+         if (present(right)) call assign_real_eigenvectors_qp(n,lambda,vmat,right)
+         if (present(left)) call assign_real_eigenvectors_qp(n,lambda,umat,left)
          
 2        if (copy_a) deallocate (amat)
          if (present(right)) deallocate (vmat)
@@ -1063,5 +1051,102 @@ module stdlib_linalg_eig
 1        call linalg_error_handling(err0,err)
 
      end subroutine stdlib_linalg_eig_w
+
+     pure subroutine assign_real_eigenvectors_sp(n,lambda,lmat,out_mat)
+        !> Problem size
+        integer(ilp),intent(in) :: n
+        !> Array of eigenvalues
+        complex(sp),intent(in) :: lambda(:)
+        !> Real matrix as returned by geev
+        real(sp),intent(in) :: lmat(:,:)
+        !> Complex matrix as returned by eig
+        complex(sp),intent(out) :: out_mat(:,:)
+        
+        integer(ilp) :: i,j
+        
+        ! Copy matrix
+        do concurrent(i=1:n,j=1:n)
+           out_mat(i,j) = lmat(i,j)
+        end do
+        
+        ! If the j-th and (j+1)-st eigenvalues form a complex conjugate pair,
+        ! geev returns them as reals as:
+        ! u(j)   = VL(:,j) + i*VL(:,j+1) and
+        ! u(j+1) = VL(:,j) - i*VL(:,j+1).
+        ! Convert these to complex numbers here.
+        do j = 1,n
+            do i = 1,n - 1
+               if (lambda(i) == conjg(lambda(i + 1))) then
+                  out_mat(i,j) = cmplx(lmat(i,j),lmat(i + 1,j),kind=sp)
+                  out_mat(i + 1,j) = cmplx(lmat(i,j),-lmat(i + 1,j),kind=sp)
+               end if
+            end do
+        end do
+        
+     end subroutine assign_real_eigenvectors_sp
+     pure subroutine assign_real_eigenvectors_dp(n,lambda,lmat,out_mat)
+        !> Problem size
+        integer(ilp),intent(in) :: n
+        !> Array of eigenvalues
+        complex(dp),intent(in) :: lambda(:)
+        !> Real matrix as returned by geev
+        real(dp),intent(in) :: lmat(:,:)
+        !> Complex matrix as returned by eig
+        complex(dp),intent(out) :: out_mat(:,:)
+        
+        integer(ilp) :: i,j
+        
+        ! Copy matrix
+        do concurrent(i=1:n,j=1:n)
+           out_mat(i,j) = lmat(i,j)
+        end do
+        
+        ! If the j-th and (j+1)-st eigenvalues form a complex conjugate pair,
+        ! geev returns them as reals as:
+        ! u(j)   = VL(:,j) + i*VL(:,j+1) and
+        ! u(j+1) = VL(:,j) - i*VL(:,j+1).
+        ! Convert these to complex numbers here.
+        do j = 1,n
+            do i = 1,n - 1
+               if (lambda(i) == conjg(lambda(i + 1))) then
+                  out_mat(i,j) = cmplx(lmat(i,j),lmat(i + 1,j),kind=dp)
+                  out_mat(i + 1,j) = cmplx(lmat(i,j),-lmat(i + 1,j),kind=dp)
+               end if
+            end do
+        end do
+        
+     end subroutine assign_real_eigenvectors_dp
+     pure subroutine assign_real_eigenvectors_qp(n,lambda,lmat,out_mat)
+        !> Problem size
+        integer(ilp),intent(in) :: n
+        !> Array of eigenvalues
+        complex(qp),intent(in) :: lambda(:)
+        !> Real matrix as returned by geev
+        real(qp),intent(in) :: lmat(:,:)
+        !> Complex matrix as returned by eig
+        complex(qp),intent(out) :: out_mat(:,:)
+        
+        integer(ilp) :: i,j
+        
+        ! Copy matrix
+        do concurrent(i=1:n,j=1:n)
+           out_mat(i,j) = lmat(i,j)
+        end do
+        
+        ! If the j-th and (j+1)-st eigenvalues form a complex conjugate pair,
+        ! geev returns them as reals as:
+        ! u(j)   = VL(:,j) + i*VL(:,j+1) and
+        ! u(j+1) = VL(:,j) - i*VL(:,j+1).
+        ! Convert these to complex numbers here.
+        do j = 1,n
+            do i = 1,n - 1
+               if (lambda(i) == conjg(lambda(i + 1))) then
+                  out_mat(i,j) = cmplx(lmat(i,j),lmat(i + 1,j),kind=qp)
+                  out_mat(i + 1,j) = cmplx(lmat(i,j),-lmat(i + 1,j),kind=qp)
+               end if
+            end do
+        end do
+        
+     end subroutine assign_real_eigenvectors_qp
 
 end module stdlib_linalg_eig

--- a/src/stdlib_linalg_eigs.f90
+++ b/src/stdlib_linalg_eigs.f90
@@ -78,13 +78,13 @@ module stdlib_linalg_eig
      end subroutine geev_info
 
      !> Singular values of matrix A
-     function stdlib_linalg_eigvals_s(a,err) result(s)
+     function stdlib_linalg_eigvals_s(a,err) result(lambda)
          !> Input matrix A[m,n]
          real(sp),intent(in),target :: a(:,:)
          !> [optional] state return flag. On error if not requested, the code will stop
          type(linalg_state),optional,intent(out) :: err
          !> Array of singular values
-         complex(sp),allocatable :: s(:)
+         complex(sp),allocatable :: lambda(:)
 
          !> Create
          real(sp),pointer :: amat(:,:)
@@ -98,10 +98,10 @@ module stdlib_linalg_eig
          k = min(m,n)
 
          !> Allocate return storage
-         allocate (s(k))
+         allocate (lambda(k))
 
-         !> Compute singular values
-         call stdlib_linalg_eig_s(amat,s,overwrite_a=.false.,err=err)
+         !> Compute eigenvalues only
+         call stdlib_linalg_eig_s(amat,lambda,overwrite_a=.false.,err=err)
 
      end function stdlib_linalg_eigvals_s
 
@@ -233,13 +233,13 @@ module stdlib_linalg_eig
      end subroutine stdlib_linalg_eig_s
 
      !> Singular values of matrix A
-     function stdlib_linalg_eigvals_d(a,err) result(s)
+     function stdlib_linalg_eigvals_d(a,err) result(lambda)
          !> Input matrix A[m,n]
          real(dp),intent(in),target :: a(:,:)
          !> [optional] state return flag. On error if not requested, the code will stop
          type(linalg_state),optional,intent(out) :: err
          !> Array of singular values
-         complex(dp),allocatable :: s(:)
+         complex(dp),allocatable :: lambda(:)
 
          !> Create
          real(dp),pointer :: amat(:,:)
@@ -253,10 +253,10 @@ module stdlib_linalg_eig
          k = min(m,n)
 
          !> Allocate return storage
-         allocate (s(k))
+         allocate (lambda(k))
 
-         !> Compute singular values
-         call stdlib_linalg_eig_d(amat,s,overwrite_a=.false.,err=err)
+         !> Compute eigenvalues only
+         call stdlib_linalg_eig_d(amat,lambda,overwrite_a=.false.,err=err)
 
      end function stdlib_linalg_eigvals_d
 
@@ -388,13 +388,13 @@ module stdlib_linalg_eig
      end subroutine stdlib_linalg_eig_d
 
      !> Singular values of matrix A
-     function stdlib_linalg_eigvals_q(a,err) result(s)
+     function stdlib_linalg_eigvals_q(a,err) result(lambda)
          !> Input matrix A[m,n]
          real(qp),intent(in),target :: a(:,:)
          !> [optional] state return flag. On error if not requested, the code will stop
          type(linalg_state),optional,intent(out) :: err
          !> Array of singular values
-         complex(qp),allocatable :: s(:)
+         complex(qp),allocatable :: lambda(:)
 
          !> Create
          real(qp),pointer :: amat(:,:)
@@ -408,10 +408,10 @@ module stdlib_linalg_eig
          k = min(m,n)
 
          !> Allocate return storage
-         allocate (s(k))
+         allocate (lambda(k))
 
-         !> Compute singular values
-         call stdlib_linalg_eig_q(amat,s,overwrite_a=.false.,err=err)
+         !> Compute eigenvalues only
+         call stdlib_linalg_eig_q(amat,lambda,overwrite_a=.false.,err=err)
 
      end function stdlib_linalg_eigvals_q
 
@@ -543,13 +543,13 @@ module stdlib_linalg_eig
      end subroutine stdlib_linalg_eig_q
 
      !> Singular values of matrix A
-     function stdlib_linalg_eigvals_c(a,err) result(s)
+     function stdlib_linalg_eigvals_c(a,err) result(lambda)
          !> Input matrix A[m,n]
          complex(sp),intent(in),target :: a(:,:)
          !> [optional] state return flag. On error if not requested, the code will stop
          type(linalg_state),optional,intent(out) :: err
          !> Array of singular values
-         complex(sp),allocatable :: s(:)
+         complex(sp),allocatable :: lambda(:)
 
          !> Create
          complex(sp),pointer :: amat(:,:)
@@ -563,10 +563,10 @@ module stdlib_linalg_eig
          k = min(m,n)
 
          !> Allocate return storage
-         allocate (s(k))
+         allocate (lambda(k))
 
-         !> Compute singular values
-         call stdlib_linalg_eig_c(amat,s,overwrite_a=.false.,err=err)
+         !> Compute eigenvalues only
+         call stdlib_linalg_eig_c(amat,lambda,overwrite_a=.false.,err=err)
 
      end function stdlib_linalg_eigvals_c
 
@@ -702,13 +702,13 @@ module stdlib_linalg_eig
      end subroutine stdlib_linalg_eig_c
 
      !> Singular values of matrix A
-     function stdlib_linalg_eigvals_z(a,err) result(s)
+     function stdlib_linalg_eigvals_z(a,err) result(lambda)
          !> Input matrix A[m,n]
          complex(dp),intent(in),target :: a(:,:)
          !> [optional] state return flag. On error if not requested, the code will stop
          type(linalg_state),optional,intent(out) :: err
          !> Array of singular values
-         complex(dp),allocatable :: s(:)
+         complex(dp),allocatable :: lambda(:)
 
          !> Create
          complex(dp),pointer :: amat(:,:)
@@ -722,10 +722,10 @@ module stdlib_linalg_eig
          k = min(m,n)
 
          !> Allocate return storage
-         allocate (s(k))
+         allocate (lambda(k))
 
-         !> Compute singular values
-         call stdlib_linalg_eig_z(amat,s,overwrite_a=.false.,err=err)
+         !> Compute eigenvalues only
+         call stdlib_linalg_eig_z(amat,lambda,overwrite_a=.false.,err=err)
 
      end function stdlib_linalg_eigvals_z
 
@@ -861,13 +861,13 @@ module stdlib_linalg_eig
      end subroutine stdlib_linalg_eig_z
 
      !> Singular values of matrix A
-     function stdlib_linalg_eigvals_w(a,err) result(s)
+     function stdlib_linalg_eigvals_w(a,err) result(lambda)
          !> Input matrix A[m,n]
          complex(qp),intent(in),target :: a(:,:)
          !> [optional] state return flag. On error if not requested, the code will stop
          type(linalg_state),optional,intent(out) :: err
          !> Array of singular values
-         complex(qp),allocatable :: s(:)
+         complex(qp),allocatable :: lambda(:)
 
          !> Create
          complex(qp),pointer :: amat(:,:)
@@ -881,10 +881,10 @@ module stdlib_linalg_eig
          k = min(m,n)
 
          !> Allocate return storage
-         allocate (s(k))
+         allocate (lambda(k))
 
-         !> Compute singular values
-         call stdlib_linalg_eig_w(amat,s,overwrite_a=.false.,err=err)
+         !> Compute eigenvalues only
+         call stdlib_linalg_eig_w(amat,lambda,overwrite_a=.false.,err=err)
 
      end function stdlib_linalg_eigvals_w
 

--- a/src/stdlib_linalg_eigs.fypp
+++ b/src/stdlib_linalg_eigs.fypp
@@ -78,13 +78,13 @@ module stdlib_linalg_eig
      #:for rk,rt,ri in ALL_KINDS_TYPES
 
      !> Singular values of matrix A
-     function stdlib_linalg_eigvals_${ri}$(a,err) result(s)
+     function stdlib_linalg_eigvals_${ri}$(a,err) result(lambda)
          !> Input matrix A[m,n]
          ${rt}$, intent(in), target :: a(:,:)
          !> [optional] state return flag. On error if not requested, the code will stop
          type(linalg_state), optional, intent(out) :: err
          !> Array of singular values
-         complex(${rk}$), allocatable :: s(:)
+         complex(${rk}$), allocatable :: lambda(:)
 
          !> Create
          ${rt}$, pointer :: amat(:,:)
@@ -98,10 +98,10 @@ module stdlib_linalg_eig
          k   = min(m,n)
 
          !> Allocate return storage
-         allocate(s(k))
+         allocate(lambda(k))
 
-         !> Compute singular values
-         call stdlib_linalg_eig_${ri}$(amat,s,overwrite_a=.false.,err=err)
+         !> Compute eigenvalues only
+         call stdlib_linalg_eig_${ri}$(amat,lambda,overwrite_a=.false.,err=err)
 
      end function stdlib_linalg_eigvals_${ri}$
 

--- a/src/stdlib_linalg_eigs.fypp
+++ b/src/stdlib_linalg_eigs.fypp
@@ -125,8 +125,7 @@ module stdlib_linalg_eig
          integer(ilp) :: m,n,lda,ldu,ldv,info,k,lwork,lrwork,neig
          logical(lk) :: copy_a
          character :: task_u,task_v
-         ${rt}$, target :: work_dummy(1)
-         complex(${rk}$), target :: u_dummy(1,1),v_dummy(1,1)
+         ${rt}$, target :: work_dummy(1),u_dummy(1,1),v_dummy(1,1)
          ${rt}$, allocatable :: work(:)
          real(${rk}$), allocatable :: rwork(:)
          ${rt}$, pointer :: amat(:,:),lreal(:),limag(:),umat(:,:),vmat(:,:)

--- a/src/stdlib_linalg_eigs.fypp
+++ b/src/stdlib_linalg_eigs.fypp
@@ -284,13 +284,11 @@ module stdlib_linalg_eig
         ! u(j)   = VL(:,j) + i*VL(:,j+1) and
         ! u(j+1) = VL(:,j) - i*VL(:,j+1). 
         ! Convert these to complex numbers here.   
-        do j=1,n
-            do i=1,n-1
-               if (lambda(i)==conjg(lambda(i+1))) then  
-                  out_mat(  i,j) = cmplx(lmat(i,j), lmat(i+1,j),kind=${rk}$)
-                  out_mat(i+1,j) = cmplx(lmat(i,j),-lmat(i+1,j),kind=${rk}$)
-               endif
-            end do  
+        do j=1,n-1
+           if (lambda(j)==conjg(lambda(j+1))) then  
+              out_mat(:,  j) = cmplx(lmat(:,j), lmat(:,j+1),kind=${rk}$)
+              out_mat(:,j+1) = cmplx(lmat(:,j),-lmat(:,j+1),kind=${rk}$)
+           endif
         end do           
         
      end subroutine assign_real_eigenvectors_${rk}$

--- a/src/stdlib_linalg_eigs.fypp
+++ b/src/stdlib_linalg_eigs.fypp
@@ -106,15 +106,15 @@ module stdlib_linalg_eig
      end function stdlib_linalg_eigvals_${ri}$
 
      !> SVD of matrix A = U S V^T, returning S and optionally U and V
-     subroutine stdlib_linalg_eig_${ri}$(a,lambda,left,right,overwrite_a,err)
+     subroutine stdlib_linalg_eig_${ri}$(a,lambda,right,left,overwrite_a,err)
          !> Input matrix A[m,n]
          ${rt}$, intent(inout), target :: a(:,:)
          !> Array of eigenvalues
          complex(${rk}$), intent(out) :: lambda(:)
-         !> The columns of LEFT contain the left eigenvectors of A
-         ${rt}$, optional, intent(out), target :: left(:,:)
          !> The columns of RIGHT contain the right eigenvectors of A
-         ${rt}$, optional, intent(out), target :: right(:,:)
+         complex(${rk}$), optional, intent(out), target :: right(:,:)
+         !> The columns of LEFT contain the left eigenvectors of A
+         complex(${rk}$), optional, intent(out), target :: left(:,:)
          !> [optional] Can A data be overwritten and destroyed?
          logical(lk), optional, intent(in) :: overwrite_a
          !> [optional] state return flag. On error if not requested, the code will stop
@@ -125,10 +125,11 @@ module stdlib_linalg_eig
          integer(ilp) :: m,n,lda,ldu,ldv,info,k,lwork,lrwork,neig
          logical(lk) :: copy_a
          character :: task_u,task_v
-         ${rt}$, target :: work_dummy(1),u_dummy(1,1),v_dummy(1,1)
+         ${rt}$, target :: work_dummy(1)
+         complex(${rk}$), target :: u_dummy(1,1),v_dummy(1,1)
          ${rt}$, allocatable :: work(:)
          real(${rk}$), allocatable :: rwork(:)
-         ${rt}$, pointer :: amat(:,:),umat(:,:),vmat(:,:),lreal(:),limag(:)
+         ${rt}$, pointer :: amat(:,:),lreal(:),limag(:),umat(:,:),vmat(:,:)
 
          !> Matrix determinant size
          m    = size(a,1,kind=ilp)
@@ -138,7 +139,8 @@ module stdlib_linalg_eig
          lda  = m
 
          if (.not.(k>0 .and. m==n)) then
-            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid or matrix size a=',[m,n],', must be square.')
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid or matrix size a=',[m,n], &
+                                                        ', must be square.')
             goto 1
          end if
 
@@ -167,7 +169,12 @@ module stdlib_linalg_eig
          task_v = eigenvectors_flag(present(right))
          
          if (present(right)) then 
+            
+            #:if rt.startswith('complex')
             vmat => right
+            #:else
+            allocate(vmat(n,n))
+            #:endif            
             
             if (size(vmat,2,kind=ilp)<n) then 
                err0 = linalg_state(this,LINALG_VALUE_ERROR,&
@@ -181,7 +188,12 @@ module stdlib_linalg_eig
          endif
             
          if (present(left)) then
+            
+            #:if rt.startswith('complex')
             umat => left
+            #:else
+            allocate(umat(n,n))
+            #:endif
             
             if (size(umat,2,kind=ilp)<n) then 
                err0 = linalg_state(this,LINALG_VALUE_ERROR,&
@@ -199,12 +211,7 @@ module stdlib_linalg_eig
 
          ! Compute workspace
          #:if rt.startswith('complex')
-!         if (task==geev_SINGVAL_ONLY) then
-!            lrwork = max(1,7*k)
-!         else
-!            lrwork = max(1,5*k*(k+1),2*k*(k+max(m,n))+k)
-!         endif
-!         allocate(rwork(lrwork))
+         allocate(rwork(2*n))
          #:else
          allocate(lreal(n),limag(n))
          #:endif
@@ -232,14 +239,30 @@ module stdlib_linalg_eig
             call geev_info(err0,info,m,n)
 
          endif
-
          
          ! Finalize storage and process output flag
          #:if not rt.startswith('complex')
          lambda(:n) = cmplx(lreal(:n),limag(:n),kind=${rk}$) 
+         
+         ! If the j-th and (j+1)-st eigenvalues form a complex conjugate pair, then 
+         ! u(j)   = VL(:,j) + i*VL(:,j+1) and
+         ! u(j+1) = VL(:,j) - i*VL(:,j+1). 
+         ! Convert these to complex numbers here.   
+         if (present(right)) right = real(vmat)
+         if (present(left)) left = real(umat)      
+!         do i=2,n
+!            if (lreal(i)==lreal(i-1) .and. limag(i)==-limag(i-1)) then 
+!                
+!            endif
+!         end do
+         
          #:endif
          
          2 if (copy_a) deallocate(amat)
+         #:if not rt.startswith('complex')
+         if (present(right)) deallocate(vmat)
+         if (present(left)) deallocate(umat)
+         #:endif           
          1 call linalg_error_handling(err0,err)
 
      end subroutine stdlib_linalg_eig_${ri}$

--- a/src/stdlib_linalg_eigs.fypp
+++ b/src/stdlib_linalg_eigs.fypp
@@ -17,6 +17,9 @@ module stdlib_linalg_eig
      !        eigenvalues = eigvals(a)
      ! Scipy: eig(a, b=None, left=False, right=True, overwrite_a=False, overwrite_b=False, check_finite=True, homogeneous_eigvals=False)
 
+     ! Numpy: eigenvalues, eigenvectors = eigh(a, uplo='L')
+     !        eigenvalues = eighvals(a)
+
      interface eig
         #:for rk,rt,ri in ALL_KINDS_TYPES
         module procedure stdlib_linalg_eig_${ri}$
@@ -28,6 +31,12 @@ module stdlib_linalg_eig
         module procedure stdlib_linalg_eigvals_${ri}$
         #:endfor
      end interface eigvals
+     
+     interface eigh
+        #:for rk,rt,ri in ALL_KINDS_TYPES
+        module procedure stdlib_linalg_eig_${ri}$
+        #:endfor        
+     end interface eigh
 
 
      character(*), parameter :: this = 'eigenvalues'
@@ -37,9 +46,19 @@ module stdlib_linalg_eig
      
      !> Request for eigenvector calculation
      elemental character function eigenvectors_flag(required)
-        logical, intent(in) :: required
+        logical(lk), intent(in) :: required
         eigenvectors_flag = merge('V','N',required)
      end function eigenvectors_flag
+     
+     !> Request for symmetry side (default: lower)
+     elemental character function symmetric_triangle(upper)
+        logical(lk), optional, intent(in) :: upper
+        if (present(upper)) then 
+           symmetric_triangle = merge('U','L',upper)
+        else 
+           symmetric_triangle = 'L'
+        endif
+     end function symmetric_triangle
 
      !> Process GEEV output flags
      elemental subroutine geev_info(err,info,m,n)
@@ -59,7 +78,7 @@ module stdlib_linalg_eig
            case (-2)
                err = linalg_state(this,LINALG_INTERNAL_ERROR,'Invalid task ID: right eigenvectors.')
            case (-5,-3)
-               err = linalg_state(this,LINALG_VALUE_ERROR,'invalid matrix size: a=[',m,',',n,']')
+               err = linalg_state(this,LINALG_VALUE_ERROR,'invalid matrix size: a=',[m,n])
            case (-9)
                err = linalg_state(this,LINALG_VALUE_ERROR,'insufficient left vector matrix size.')
            case (-11)
@@ -74,9 +93,39 @@ module stdlib_linalg_eig
 
      end subroutine geev_info
 
+
+     !> Process SYEV/HEEV output flags
+     elemental subroutine heev_info(err,info,m,n)
+        !> Error handler
+        type(linalg_state), intent(inout) :: err
+        !> geev return flag
+        integer(ilp), intent(in) :: info
+        !> Input matrix size
+        integer(ilp), intent(in) :: m,n
+
+        select case (info)
+           case (0)
+               ! Success!
+               err%state = LINALG_SUCCESS
+           case (-1)
+               err = linalg_state(this,LINALG_INTERNAL_ERROR,'Invalid eigenvector request.')
+           case (-2)
+               err = linalg_state(this,LINALG_INTERNAL_ERROR,'Invalid triangular section request.')
+           case (-5,-3)
+               err = linalg_state(this,LINALG_VALUE_ERROR,'invalid matrix size: a=',[m,n])
+           case (-8)
+               err = linalg_state(this,LINALG_INTERNAL_ERROR,'insufficient workspace size.')
+           case (1:)
+               err = linalg_state(this,LINALG_ERROR,'Eigenvalue computation did not converge.')
+           case default
+               err = linalg_state(this,LINALG_INTERNAL_ERROR,'Unknown error returned by syev/heev.')
+        end select
+
+     end subroutine heev_info
+
      #:for rk,rt,ri in ALL_KINDS_TYPES
 
-     !> Singular values of matrix A
+     !> Return an array of eigenvalues of matrix A.
      function stdlib_linalg_eigvals_${ri}$(a,err) result(lambda)
          !> Input matrix A[m,n]
          ${rt}$, intent(in), target :: a(:,:)
@@ -104,7 +153,8 @@ module stdlib_linalg_eig
 
      end function stdlib_linalg_eigvals_${ri}$
 
-     !> SVD of matrix A = U S V^T, returning S and optionally U and V
+     !> Eigendecomposition of matrix A returning an array `lambda` of eigenvalues, 
+     !> and optionally right or left eigenvectors.
      subroutine stdlib_linalg_eig_${ri}$(a,lambda,right,left,overwrite_a,err)
          !> Input matrix A[m,n]
          ${rt}$, intent(inout), target :: a(:,:)
@@ -129,7 +179,7 @@ module stdlib_linalg_eig
          real(${rk}$), allocatable :: rwork(:)
          ${rt}$, pointer :: amat(:,:),lreal(:),limag(:),umat(:,:),vmat(:,:)
 
-         !> Matrix determinant size
+         !> Matrix size
          m    = size(a,1,kind=ilp)
          n    = size(a,2,kind=ilp)
          k    = min(m,n)
@@ -148,6 +198,8 @@ module stdlib_linalg_eig
             goto 1
          endif
 
+
+
          ! Can A be overwritten? By default, do not overwrite
          if (present(overwrite_a)) then
             copy_a = .not.overwrite_a
@@ -161,10 +213,26 @@ module stdlib_linalg_eig
          else
             amat => a
          endif
+         
+         ! Request for eigenvectors
+         task = eigenvectors_flag(present(vectors))
+         if (present(vectors)) then 
+            
+            ! Check size
+            if (any(shape(vectors,kind=ilp)<n)) then 
+               err0 = linalg_state(this,LINALG_VALUE_ERROR,&
+                                        'eigenvector matrix has insufficient size: ',&
+                                        shape(vectors),', with n=',n)
+               goto 2
+            endif            
+            
+            ! The input matrix will be overwritten by the vectors. 
+            ! So, use this one as storage for syev/heev
+            amat => 
+            
 
-         ! Decide if U, V eigenvectors 
-         task_u = eigenvectors_flag(present(left))
-         task_v = eigenvectors_flag(present(right))
+
+         
          
          if (present(right)) then 
             
@@ -174,12 +242,7 @@ module stdlib_linalg_eig
             allocate(vmat(n,n))
             #:endif            
             
-            if (size(vmat,2,kind=ilp)<n) then 
-               err0 = linalg_state(this,LINALG_VALUE_ERROR,&
-                                        'right eigenvector matrix has insufficient size: ',&
-                                        shape(vmat),', with n=',n)
-               goto 2
-            endif
+
             
          else
             vmat => v_dummy
@@ -207,7 +270,7 @@ module stdlib_linalg_eig
          ldu = size(umat,1,kind=ilp)
          ldv = size(vmat,1,kind=ilp)
 
-         ! Compute workspace
+         ! Compute workspace size
          #:if rt.startswith('complex')
          allocate(rwork(2*n))
          #:else
@@ -222,7 +285,7 @@ module stdlib_linalg_eig
                    work_dummy,lwork,#{if rt.startswith('complex')}#rwork,#{endif}#info)
          call geev_info(err0,info,m,n)
 
-         ! Compute SVD
+         ! Compute eigenvalues
          if (info==0) then
 
             !> Prepare working storage
@@ -262,6 +325,8 @@ module stdlib_linalg_eig
      #:endfor
 
      #:for rk,rt,ri in REAL_KINDS_TYPES
+     !> GEEV for real matrices returns complex eigenvalues in real arrays. 
+     !> Convert them to complex here, following the GEEV logic.
      pure subroutine assign_real_eigenvectors_${rk}$(n,lambda,lmat,out_mat)
         !> Problem size
         integer(ilp), intent(in) :: n
@@ -293,5 +358,128 @@ module stdlib_linalg_eig
         
      end subroutine assign_real_eigenvectors_${rk}$
      #:endfor
+
+     !> Eigendecomposition of a real symmetric or complex Hermitian matrix A returning an array `lambda` 
+     !> of eigenvalues, and optionally right or left eigenvectors.
+     subroutine stdlib_linalg_eigh_${ri}$(a,lambda,vectors,upper_a,overwrite_a,err)
+         !> Input matrix A[m,n]
+         ${rt}$, intent(inout), target :: a(:,:)
+         !> Array of eigenvalues
+         complex(${rk}$), intent(out) :: lambda(:)
+         !> The columns of vectors contain the orthonormal eigenvectors of A
+         complex(${rk}$), optional, intent(out), target :: vectors(:,:)
+         !> [optional] Can A data be overwritten and destroyed?
+         logical(lk), optional, intent(in) :: overwrite_a
+         !> [optional] Should the upper/lower half of A be used? Default: lower
+         logical(lk), optional, intent(in) :: upper_a
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state), optional, intent(out) :: err
+
+         !> Local variables
+         type(linalg_state) :: err0
+         integer(ilp) :: m,n,lda,ldu,ldv,info,k,lwork,liwork,neig
+         logical(lk) :: copy_a
+         character :: triangle,task
+         ${rt}$, target :: work_dummy(1),u_dummy(1,1),v_dummy(1,1)
+         ${rt}$, allocatable :: work(:)
+         real(${rk}$), allocatable :: rwork(:)
+         ${rt}$, pointer :: amat(:,:)
+
+         !> Matrix size
+         m    = size(a,1,kind=ilp)
+         n    = size(a,2,kind=ilp)
+         k    = min(m,n)
+         neig = size(lambda,kind=ilp) 
+
+         if (.not.(k>0 .and. m==n)) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid or matrix size a=',[m,n], &
+                                                        ', must be square.')
+            goto 1
+         end if
+
+         if (.not.neig>=k) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'eigenvalue array has insufficient size:',&
+                                                        ' lambda=',neig,' must be >= n=',n)
+            goto 1
+         endif
+        
+         ! Check if input A can be overwritten
+         if (present(vectors)) then 
+            ! No need to copy A anyways
+            copy_a = .false.
+         elseif (present(overwrite_a)) then
+            copy_a = .not.overwrite_a
+         else
+            copy_a = .true._lk
+         endif        
+         
+         ! Should we use the upper or lower half of the matrix?
+         triangle = symmetric_triangle(upper_a)
+         
+         ! Request for eigenvectors
+         task = eigenvectors_flag(present(vectors))
+         
+         if (present(vectors)) then 
+            
+            ! Check size
+            if (any(shape(vectors,kind=ilp)<n)) then 
+               err0 = linalg_state(this,LINALG_VALUE_ERROR,&
+                                        'eigenvector matrix has insufficient size: ',&
+                                        shape(vectors),', with n=',n)
+               goto 2
+            endif            
+            
+            ! The input matrix will be overwritten by the vectors. 
+            ! So, use this one as storage for syev/heev
+            amat => vectors
+            
+            ! Copy data in
+            amat(:n,:n) = a(:n,:n)
+                        
+         elseif (copy_a) then
+            ! Initialize a matrix temporary
+            allocate(amat(m,n),source=a)
+         else
+            ! Overwrite A
+            amat => a
+         endif
+
+
+         lda = size(amat,1,kind=ilp)
+
+         ! Request workspace size
+         lwork = -1_ilp
+         #:if rf.startswith('complex')
+             allocate(rwork(max(1,3*n-2))
+             call heev(task,triangle,n,amat,lda,lambda,work_dummy,lwork,rwork,info)
+         #:else
+             call syev(task,triangle,n,amat,lda,lambda,work_dummy,lwork,info)
+         #:endif
+         call heev_info(err0,info,m,n)
+
+         ! Compute eigenvalues
+         if (info==0) then
+
+            !> Prepare working storage
+            lwork = nint(real(work_dummy(1),kind=${rk}$), kind=ilp)
+            allocate(work(lwork))
+
+            !> Compute eigensystem
+            #:if rf.startswith('complex')
+                call heev(task,triangle,n,amat,lda,lambda,work,lwork,rwork,info)
+            #:else
+                call syev(task,triangle,n,amat,lda,lambda,work,lwork,info)
+            #:endif
+            call heev_info(err0,info,m,n)
+
+         endif
+         
+         ! Finalize storage and process output flag         
+         2 if (copy_a) deallocate(amat)
+         1 call linalg_error_handling(err0,err)
+
+     end subroutine stdlib_linalg_eigh_${ri}$
+     #:endfor
+
 
 end module stdlib_linalg_eig

--- a/src/stdlib_linalg_eigs.fypp
+++ b/src/stdlib_linalg_eigs.fypp
@@ -31,6 +31,7 @@ module stdlib_linalg_eig
      interface eigvals
         #:for rk,rt,ri in ALL_KINDS_TYPES
         module procedure stdlib_linalg_eigvals_${ri}$
+        module procedure stdlib_linalg_eigvals_noerr_${ri}$
         #:endfor
      end interface eigvals
      
@@ -139,7 +140,7 @@ module stdlib_linalg_eig
          !> Input matrix A[m,n]
          ${rt}$, intent(in), target :: a(:,:)
          !> [optional] state return flag. On error if not requested, the code will stop
-         type(linalg_state), optional, intent(out) :: err
+         type(linalg_state), intent(out) :: err
          !> Array of singular values
          complex(${rk}$), allocatable :: lambda(:)
 
@@ -161,6 +162,32 @@ module stdlib_linalg_eig
          call stdlib_linalg_eig_${ri}$(amat,lambda,overwrite_a=.false.,err=err)
 
      end function stdlib_linalg_eigvals_${ri}$
+
+     !> Return an array of eigenvalues of matrix A.
+     function stdlib_linalg_eigvals_noerr_${ri}$(a) result(lambda)
+         !> Input matrix A[m,n]
+         ${rt}$, intent(in), target :: a(:,:)
+         !> Array of singular values
+         complex(${rk}$), allocatable :: lambda(:)
+
+         !> Create
+         ${rt}$, pointer :: amat(:,:)
+         integer(ilp) :: m,n,k
+
+         !> Create an internal pointer so the intent of A won't affect the next call
+         amat => a
+
+         m   = size(a,1,kind=ilp)
+         n   = size(a,2,kind=ilp)
+         k   = min(m,n)
+
+         !> Allocate return storage
+         allocate(lambda(k))
+
+         !> Compute eigenvalues only
+         call stdlib_linalg_eig_${ri}$(amat,lambda,overwrite_a=.false.)
+
+     end function stdlib_linalg_eigvals_noerr_${ri}$
 
      !> Eigendecomposition of matrix A returning an array `lambda` of eigenvalues, 
      !> and optionally right or left eigenvectors.

--- a/src/stdlib_linalg_eigs.fypp
+++ b/src/stdlib_linalg_eigs.fypp
@@ -12,6 +12,8 @@ module stdlib_linalg_eig
      public :: eig
      !> Eigenvalues of a square matrix
      public :: eigvals
+     !> Eigendecomposition of a real symmetric or complex hermitian matrix
+     public :: eigh
 
      ! Numpy: eigenvalues, eigenvectors = eig(a)
      !        eigenvalues = eigvals(a)
@@ -33,8 +35,8 @@ module stdlib_linalg_eig
      end interface eigvals
      
      interface eigh
-        #:for rk,rt,ri in ALL_KINDS_TYPES
-        module procedure stdlib_linalg_eig_${ri}$
+        #:for rk,rt,ri in REAL_KINDS_TYPES
+        module procedure stdlib_linalg_eigh_${ri}$
         #:endfor        
      end interface eigh
 
@@ -213,26 +215,10 @@ module stdlib_linalg_eig
          else
             amat => a
          endif
-         
-         ! Request for eigenvectors
-         task = eigenvectors_flag(present(vectors))
-         if (present(vectors)) then 
-            
-            ! Check size
-            if (any(shape(vectors,kind=ilp)<n)) then 
-               err0 = linalg_state(this,LINALG_VALUE_ERROR,&
-                                        'eigenvector matrix has insufficient size: ',&
-                                        shape(vectors),', with n=',n)
-               goto 2
-            endif            
-            
-            ! The input matrix will be overwritten by the vectors. 
-            ! So, use this one as storage for syev/heev
-            amat => 
-            
 
-
-         
+         ! Decide if U, V eigenvectors
+         task_u = eigenvectors_flag(present(left))
+         task_v = eigenvectors_flag(present(right))         
          
          if (present(right)) then 
             
@@ -242,7 +228,12 @@ module stdlib_linalg_eig
             allocate(vmat(n,n))
             #:endif            
             
-
+            if (size(vmat,2,kind=ilp)<n) then 
+               err0 = linalg_state(this,LINALG_VALUE_ERROR,&
+                                        'right eigenvector matrix has insufficient size: ',&
+                                        shape(vmat),', with n=',n)
+               goto 2
+            endif  
             
          else
             vmat => v_dummy
@@ -259,7 +250,7 @@ module stdlib_linalg_eig
             if (size(umat,2,kind=ilp)<n) then 
                err0 = linalg_state(this,LINALG_VALUE_ERROR,&
                                         'left eigenvector matrix has insufficient size: ',&
-                                        shape(vmat),', with n=',n)
+                                        shape(umat),', with n=',n)
                goto 2
             endif            
             
@@ -357,7 +348,7 @@ module stdlib_linalg_eig
         end do           
         
      end subroutine assign_real_eigenvectors_${rk}$
-     #:endfor
+
 
      !> Eigendecomposition of a real symmetric or complex Hermitian matrix A returning an array `lambda` 
      !> of eigenvalues, and optionally right or left eigenvectors.
@@ -365,9 +356,9 @@ module stdlib_linalg_eig
          !> Input matrix A[m,n]
          ${rt}$, intent(inout), target :: a(:,:)
          !> Array of eigenvalues
-         complex(${rk}$), intent(out) :: lambda(:)
+         ${rt}$, intent(out) :: lambda(:)
          !> The columns of vectors contain the orthonormal eigenvectors of A
-         complex(${rk}$), optional, intent(out), target :: vectors(:,:)
+         ${rt}$, optional, intent(out), target :: vectors(:,:)
          !> [optional] Can A data be overwritten and destroyed?
          logical(lk), optional, intent(in) :: overwrite_a
          !> [optional] Should the upper/lower half of A be used? Default: lower
@@ -377,10 +368,10 @@ module stdlib_linalg_eig
 
          !> Local variables
          type(linalg_state) :: err0
-         integer(ilp) :: m,n,lda,ldu,ldv,info,k,lwork,liwork,neig
+         integer(ilp) :: m,n,lda,info,k,lwork,neig
          logical(lk) :: copy_a
          character :: triangle,task
-         ${rt}$, target :: work_dummy(1),u_dummy(1,1),v_dummy(1,1)
+         ${rt}$, target :: work_dummy(1)
          ${rt}$, allocatable :: work(:)
          real(${rk}$), allocatable :: rwork(:)
          ${rt}$, pointer :: amat(:,:)
@@ -426,7 +417,7 @@ module stdlib_linalg_eig
                err0 = linalg_state(this,LINALG_VALUE_ERROR,&
                                         'eigenvector matrix has insufficient size: ',&
                                         shape(vectors),', with n=',n)
-               goto 2
+               goto 1
             endif            
             
             ! The input matrix will be overwritten by the vectors. 
@@ -449,11 +440,11 @@ module stdlib_linalg_eig
 
          ! Request workspace size
          lwork = -1_ilp
-         #:if rf.startswith('complex')
-             allocate(rwork(max(1,3*n-2))
-             call heev(task,triangle,n,amat,lda,lambda,work_dummy,lwork,rwork,info)
+         #:if rt.startswith('complex')
+         allocate(rwork(max(1,3*n-2))
+         call heev(task,triangle,n,amat,lda,lambda,work_dummy,lwork,rwork,info)
          #:else
-             call syev(task,triangle,n,amat,lda,lambda,work_dummy,lwork,info)
+         call syev(task,triangle,n,amat,lda,lambda,work_dummy,lwork,info)
          #:endif
          call heev_info(err0,info,m,n)
 
@@ -465,17 +456,17 @@ module stdlib_linalg_eig
             allocate(work(lwork))
 
             !> Compute eigensystem
-            #:if rf.startswith('complex')
-                call heev(task,triangle,n,amat,lda,lambda,work,lwork,rwork,info)
+            #:if rt.startswith('complex')
+            call heev(task,triangle,n,amat,lda,lambda,work,lwork,rwork,info)
             #:else
-                call syev(task,triangle,n,amat,lda,lambda,work,lwork,info)
+            call syev(task,triangle,n,amat,lda,lambda,work,lwork,info)
             #:endif
             call heev_info(err0,info,m,n)
 
          endif
          
          ! Finalize storage and process output flag         
-         2 if (copy_a) deallocate(amat)
+         if (copy_a) deallocate(amat)
          1 call linalg_error_handling(err0,err)
 
      end subroutine stdlib_linalg_eigh_${ri}$

--- a/src/stdlib_linalg_eigs.fypp
+++ b/src/stdlib_linalg_eigs.fypp
@@ -20,7 +20,7 @@ module stdlib_linalg_eig
      ! Scipy: eig(a, b=None, left=False, right=True, overwrite_a=False, overwrite_b=False, check_finite=True, homogeneous_eigvals=False)
 
      ! Numpy: eigenvalues, eigenvectors = eigh(a, uplo='L')
-     !        eigenvalues = eighvals(a)
+     !        eigenvalues = eigvalsh(a)
 
      interface eig
         #:for rk,rt,ri in ALL_KINDS_TYPES
@@ -35,10 +35,17 @@ module stdlib_linalg_eig
      end interface eigvals
      
      interface eigh
-        #:for rk,rt,ri in REAL_KINDS_TYPES
+        #:for rk,rt,ri in ALL_KINDS_TYPES
         module procedure stdlib_linalg_eigh_${ri}$
         #:endfor        
      end interface eigh
+     
+     interface eigvalsh
+        #:for rk,rt,ri in ALL_KINDS_TYPES
+        module procedure stdlib_linalg_eigvalsh_${ri}$
+        module procedure stdlib_linalg_eigvalsh_noerr_${ri}$
+        #:endfor                
+     end interface eigvalsh
 
 
      character(*), parameter :: this = 'eigenvalues'
@@ -313,42 +320,62 @@ module stdlib_linalg_eig
          1 call linalg_error_handling(err0,err)
 
      end subroutine stdlib_linalg_eig_${ri}$
-     #:endfor
+     
+     !> Return an array of eigenvalues of real symmetric / complex hermitian A
+     function stdlib_linalg_eigvalsh_${ri}$(a,upper_a,err) result(lambda)
+         !> Input matrix A[m,n]
+         ${rt}$, intent(in), target :: a(:,:)
+         !> [optional] Should the upper/lower half of A be used? Default: lower
+         logical(lk), optional, intent(in) :: upper_a         
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state), intent(out) :: err
+         !> Array of singular values
+         real(${rk}$), allocatable :: lambda(:)
+         
+         ${rt}$, pointer :: amat(:,:)
+         integer(ilp) :: m,n,k
 
-     #:for rk,rt,ri in REAL_KINDS_TYPES
-     !> GEEV for real matrices returns complex eigenvalues in real arrays. 
-     !> Convert them to complex here, following the GEEV logic.
-     pure subroutine assign_real_eigenvectors_${rk}$(n,lambda,lmat,out_mat)
-        !> Problem size
-        integer(ilp), intent(in) :: n
-        !> Array of eigenvalues
-        complex(${rk}$), intent(in) :: lambda(:)
-        !> Real matrix as returned by geev 
-        ${rt}$, intent(in) :: lmat(:,:)
-        !> Complex matrix as returned by eig
-        complex(${rk}$), intent(out) :: out_mat(:,:)
-        
-        integer(ilp) :: i,j
-        
-        ! Copy matrix
-        do concurrent(i=1:n,j=1:n)
-           out_mat(i,j) = lmat(i,j)
-        end do
-        
-        ! If the j-th and (j+1)-st eigenvalues form a complex conjugate pair, 
-        ! geev returns them as reals as: 
-        ! u(j)   = VL(:,j) + i*VL(:,j+1) and
-        ! u(j+1) = VL(:,j) - i*VL(:,j+1). 
-        ! Convert these to complex numbers here.   
-        do j=1,n-1
-           if (lambda(j)==conjg(lambda(j+1))) then  
-              out_mat(:,  j) = cmplx(lmat(:,j), lmat(:,j+1),kind=${rk}$)
-              out_mat(:,j+1) = cmplx(lmat(:,j),-lmat(:,j+1),kind=${rk}$)
-           endif
-        end do           
-        
-     end subroutine assign_real_eigenvectors_${rk}$
+         !> Create an internal pointer so the intent of A won't affect the next call
+         amat => a
 
+         m   = size(a,1,kind=ilp)
+         n   = size(a,2,kind=ilp)
+         k   = min(m,n)
+
+         !> Allocate return storage
+         allocate(lambda(k))
+
+         !> Compute eigenvalues only
+         call stdlib_linalg_eigh_${ri}$(amat,lambda,upper_a=upper_a,overwrite_a=.false.,err=err)
+         
+     end function stdlib_linalg_eigvalsh_${ri}$
+     
+     !> Return an array of eigenvalues of real symmetric / complex hermitian A
+     function stdlib_linalg_eigvalsh_noerr_${ri}$(a,upper_a) result(lambda)
+         !> Input matrix A[m,n]
+         ${rt}$, intent(in), target :: a(:,:)
+         !> [optional] Should the upper/lower half of A be used? Default: lower
+         logical(lk), optional, intent(in) :: upper_a         
+         !> Array of singular values
+         real(${rk}$), allocatable :: lambda(:)
+
+         ${rt}$, pointer :: amat(:,:)
+         integer(ilp) :: m,n,k
+
+         !> Create an internal pointer so the intent of A won't affect the next call
+         amat => a
+
+         m   = size(a,1,kind=ilp)
+         n   = size(a,2,kind=ilp)
+         k   = min(m,n)
+
+         !> Allocate return storage
+         allocate(lambda(k))
+
+         !> Compute eigenvalues only
+         call stdlib_linalg_eigh_${ri}$(amat,lambda,upper_a=upper_a,overwrite_a=.false.)
+
+     end function stdlib_linalg_eigvalsh_noerr_${ri}$     
 
      !> Eigendecomposition of a real symmetric or complex Hermitian matrix A returning an array `lambda` 
      !> of eigenvalues, and optionally right or left eigenvectors.
@@ -356,7 +383,7 @@ module stdlib_linalg_eig
          !> Input matrix A[m,n]
          ${rt}$, intent(inout), target :: a(:,:)
          !> Array of eigenvalues
-         ${rt}$, intent(out) :: lambda(:)
+         real(${rk}$), intent(out) :: lambda(:)
          !> The columns of vectors contain the orthonormal eigenvectors of A
          ${rt}$, optional, intent(out), target :: vectors(:,:)
          !> [optional] Can A data be overwritten and destroyed?
@@ -441,7 +468,7 @@ module stdlib_linalg_eig
          ! Request workspace size
          lwork = -1_ilp
          #:if rt.startswith('complex')
-         allocate(rwork(max(1,3*n-2))
+         allocate(rwork(max(1,3*n-2)))
          call heev(task,triangle,n,amat,lda,lambda,work_dummy,lwork,rwork,info)
          #:else
          call syev(task,triangle,n,amat,lda,lambda,work_dummy,lwork,info)
@@ -470,6 +497,42 @@ module stdlib_linalg_eig
          1 call linalg_error_handling(err0,err)
 
      end subroutine stdlib_linalg_eigh_${ri}$
+     
+     #:endfor
+     
+     #:for rk,rt,ri in REAL_KINDS_TYPES
+     !> GEEV for real matrices returns complex eigenvalues in real arrays. 
+     !> Convert them to complex here, following the GEEV logic.
+     pure subroutine assign_real_eigenvectors_${rk}$(n,lambda,lmat,out_mat)
+        !> Problem size
+        integer(ilp), intent(in) :: n
+        !> Array of eigenvalues
+        complex(${rk}$), intent(in) :: lambda(:)
+        !> Real matrix as returned by geev 
+        ${rt}$, intent(in) :: lmat(:,:)
+        !> Complex matrix as returned by eig
+        complex(${rk}$), intent(out) :: out_mat(:,:)
+        
+        integer(ilp) :: i,j
+        
+        ! Copy matrix
+        do concurrent(i=1:n,j=1:n)
+           out_mat(i,j) = lmat(i,j)
+        end do
+        
+        ! If the j-th and (j+1)-st eigenvalues form a complex conjugate pair, 
+        ! geev returns them as reals as: 
+        ! u(j)   = VL(:,j) + i*VL(:,j+1) and
+        ! u(j+1) = VL(:,j) - i*VL(:,j+1). 
+        ! Convert these to complex numbers here.   
+        do j=1,n-1
+           if (lambda(j)==conjg(lambda(j+1))) then  
+              out_mat(:,  j) = cmplx(lmat(:,j), lmat(:,j+1),kind=${rk}$)
+              out_mat(:,j+1) = cmplx(lmat(:,j),-lmat(:,j+1),kind=${rk}$)
+           endif
+        end do           
+        
+     end subroutine assign_real_eigenvectors_${rk}$
      #:endfor
 
 

--- a/src/stdlib_linalg_eigs.fypp
+++ b/src/stdlib_linalg_eigs.fypp
@@ -1,0 +1,248 @@
+#:include "common.fypp"
+module stdlib_linalg_eig
+     use stdlib_linalg_constants
+     use stdlib_linalg_blas
+     use stdlib_linalg_lapack
+     use stdlib_linalg_state
+     use iso_fortran_env,only:real32,real64,real128,int8,int16,int32,int64,stderr => error_unit
+     implicit none(type,external)
+     private
+
+     !> Eigendecomposition of a square matrix: return eigenvalues, and optionally eigenvectors
+     public :: eig
+     !> Eigenvalues of a square matrix
+     public :: eigvals
+
+     ! Numpy: eigenvalues, eigenvectors = eig(a)
+     !        eigenvalues = eigvals(a)
+     ! Scipy: eig(a, b=None, left=False, right=True, overwrite_a=False, overwrite_b=False, check_finite=True, homogeneous_eigvals=False)
+
+     interface eig
+        #:for rk,rt,ri in ALL_KINDS_TYPES
+        module procedure stdlib_linalg_eig_${ri}$
+        #:endfor
+     end interface eig
+
+     interface eigvals
+        #:for rk,rt,ri in ALL_KINDS_TYPES
+        module procedure stdlib_linalg_eigvals_${ri}$
+        #:endfor
+     end interface eigvals
+
+
+     character(*), parameter :: this = 'eigenvalues'
+
+
+     contains
+     
+     !> Request for eigenvector calculation
+     elemental character function eigenvectors_flag(required)
+        logical, intent(in) :: required
+        eigenvectors_flag = merge('V','N',required)
+     end function eigenvectors_flag
+
+     !> Process GEEV output flags
+     elemental subroutine geev_info(err,info,m,n)
+        !> Error handler
+        type(linalg_state), intent(inout) :: err
+        !> geev return flag
+        integer(ilp), intent(in) :: info
+        !> Input matrix size
+        integer(ilp), intent(in) :: m,n
+
+        select case (info)
+           case (0)
+               ! Success!
+               err%state = LINALG_SUCCESS
+           case (-1)
+               err = linalg_state(this,LINALG_INTERNAL_ERROR,'Invalid task ID: left eigenvectors.')
+           case (-2)
+               err = linalg_state(this,LINALG_INTERNAL_ERROR,'Invalid task ID: right eigenvectors.')
+           case (-5,-3)
+               err = linalg_state(this,LINALG_VALUE_ERROR,'invalid matrix size: a=[',m,',',n,']')
+           case (-9)
+               err = linalg_state(this,LINALG_VALUE_ERROR,'insufficient left vector matrix size.')
+           case (-11)
+               err = linalg_state(this,LINALG_VALUE_ERROR,'insufficient right vector matrix size.')
+           case (-13)
+               err = linalg_state(this,LINALG_INTERNAL_ERROR,'Insufficient work array size.')
+           case (1:)
+               err = linalg_state(this,LINALG_ERROR,'Eigenvalue computation did not converge.')
+           case default
+               err = linalg_state(this,LINALG_INTERNAL_ERROR,'Unknown error returned by geev.')
+        end select
+
+     end subroutine geev_info
+
+
+     #:for rk,rt,ri in ALL_KINDS_TYPES
+
+     !> Singular values of matrix A
+     function stdlib_linalg_eigvals_${ri}$(a,err) result(s)
+         !> Input matrix A[m,n]
+         ${rt}$, intent(in), target :: a(:,:)
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state), optional, intent(out) :: err
+         !> Array of singular values
+         complex(${rk}$), allocatable :: s(:)
+
+         !> Create
+         ${rt}$, pointer :: amat(:,:)
+         integer(ilp) :: m,n,k
+
+         !> Create an internal pointer so the intent of A won't affect the next call
+         amat => a
+
+         m   = size(a,1,kind=ilp)
+         n   = size(a,2,kind=ilp)
+         k   = min(m,n)
+
+         !> Allocate return storage
+         allocate(s(k))
+
+         !> Compute singular values
+         call stdlib_linalg_eig_${ri}$(amat,s,overwrite_a=.false.,err=err)
+
+     end function stdlib_linalg_eigvals_${ri}$
+
+     !> SVD of matrix A = U S V^T, returning S and optionally U and V
+     subroutine stdlib_linalg_eig_${ri}$(a,lambda,left,right,overwrite_a,err)
+         !> Input matrix A[m,n]
+         ${rt}$, intent(inout), target :: a(:,:)
+         !> Array of eigenvalues
+         complex(${rk}$), intent(out) :: lambda(:)
+         !> The columns of LEFT contain the left eigenvectors of A
+         ${rt}$, optional, intent(out), target :: left(:,:)
+         !> The columns of RIGHT contain the right eigenvectors of A
+         ${rt}$, optional, intent(out), target :: right(:,:)
+         !> [optional] Can A data be overwritten and destroyed?
+         logical(lk), optional, intent(in) :: overwrite_a
+         !> [optional] state return flag. On error if not requested, the code will stop
+         type(linalg_state), optional, intent(out) :: err
+
+         !> Local variables
+         type(linalg_state) :: err0
+         integer(ilp) :: m,n,lda,ldu,ldv,info,k,lwork,lrwork,neig
+         logical(lk) :: copy_a
+         character :: task_u,task_v
+         ${rt}$, target :: work_dummy(1),u_dummy(1,1),v_dummy(1,1)
+         ${rt}$, allocatable :: work(:)
+         real(${rk}$), allocatable :: rwork(:)
+         ${rt}$, pointer :: amat(:,:),umat(:,:),vmat(:,:),lreal(:),limag(:)
+
+         !> Matrix determinant size
+         m    = size(a,1,kind=ilp)
+         n    = size(a,2,kind=ilp)
+         k    = min(m,n)
+         neig = size(lambda,kind=ilp) 
+         lda  = m
+
+         if (.not.(k>0 .and. m==n)) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'invalid or matrix size a=',[m,n],', must be square.')
+            goto 1
+         end if
+
+         if (.not.neig>=k) then
+            err0 = linalg_state(this,LINALG_VALUE_ERROR,'eigenvalue array has insufficient size:',&
+                                                        ' lambda=',neig,', n=',n)
+            goto 1
+         endif
+
+         ! Can A be overwritten? By default, do not overwrite
+         if (present(overwrite_a)) then
+            copy_a = .not.overwrite_a
+         else
+            copy_a = .true._lk
+         endif
+
+         ! Initialize a matrix temporary
+         if (copy_a) then
+            allocate(amat(m,n),source=a)
+         else
+            amat => a
+         endif
+
+         ! Decide if U, V eigenvectors 
+         task_u = eigenvectors_flag(present(left))
+         task_v = eigenvectors_flag(present(right))
+         
+         if (present(right)) then 
+            vmat => right
+            
+            if (size(vmat,2,kind=ilp)<n) then 
+               err0 = linalg_state(this,LINALG_VALUE_ERROR,&
+                                        'right eigenvector matrix has insufficient size: ',&
+                                        shape(vmat),', with n=',n)
+               goto 2
+            endif
+            
+         else
+            vmat => v_dummy
+         endif
+            
+         if (present(left)) then
+            umat => left
+            
+            if (size(umat,2,kind=ilp)<n) then 
+               err0 = linalg_state(this,LINALG_VALUE_ERROR,&
+                                        'left eigenvector matrix has insufficient size: ',&
+                                        shape(vmat),', with n=',n)
+               goto 2
+            endif            
+            
+         else
+            umat => u_dummy
+         endif
+
+         ldu = size(umat,1,kind=ilp)
+         ldv = size(vmat,1,kind=ilp)
+
+         ! Compute workspace
+         #:if rt.startswith('complex')
+!         if (task==geev_SINGVAL_ONLY) then
+!            lrwork = max(1,7*k)
+!         else
+!            lrwork = max(1,5*k*(k+1),2*k*(k+max(m,n))+k)
+!         endif
+!         allocate(rwork(lrwork))
+         #:else
+         allocate(lreal(n),limag(n))
+         #:endif
+
+         lwork = -1_ilp
+        
+         call geev(task_u,task_v,n,amat,lda,&
+                   #{if rt.startswith('complex')}#lambda,#{else}#lreal,limag,#{endif}#  &
+                   umat,ldu,vmat,ldv,&
+                   work_dummy,lwork,#{if rt.startswith('complex')}#rwork,#{endif}#info)
+         call geev_info(err0,info,m,n)
+
+         ! Compute SVD
+         if (info==0) then
+
+            !> Prepare working storage
+            lwork = nint(real(work_dummy(1),kind=${rk}$), kind=ilp)
+            allocate(work(lwork))
+
+            !> Compute eigensystem
+            call geev(task_u,task_v,n,amat,lda,&
+                      #{if rt.startswith('complex')}#lambda,#{else}#lreal,limag,#{endif}#  &
+                      umat,ldu,vmat,ldv,&            
+                      work,lwork,#{if rt.startswith('complex')}#rwork,#{endif}#info)
+            call geev_info(err0,info,m,n)
+
+         endif
+
+         
+         ! Finalize storage and process output flag
+         #:if not rt.startswith('complex')
+         lambda(:n) = cmplx(lreal(:n),limag(:n),kind=${rk}$) 
+         #:endif
+         
+         2 if (copy_a) deallocate(amat)
+         1 call linalg_error_handling(err0,err)
+
+     end subroutine stdlib_linalg_eig_${ri}$
+     #:endfor
+
+end module stdlib_linalg_eig

--- a/src/stdlib_linalg_eigs.fypp
+++ b/src/stdlib_linalg_eigs.fypp
@@ -74,7 +74,6 @@ module stdlib_linalg_eig
 
      end subroutine geev_info
 
-
      #:for rk,rt,ri in ALL_KINDS_TYPES
 
      !> Singular values of matrix A
@@ -243,18 +242,13 @@ module stdlib_linalg_eig
          #:if not rt.startswith('complex')
          lambda(:n) = cmplx(lreal(:n),limag(:n),kind=${rk}$) 
          
-         ! If the j-th and (j+1)-st eigenvalues form a complex conjugate pair, then 
+         ! If the j-th and (j+1)-st eigenvalues form a complex conjugate pair, 
+         ! geev returns reals as: 
          ! u(j)   = VL(:,j) + i*VL(:,j+1) and
          ! u(j+1) = VL(:,j) - i*VL(:,j+1). 
-         ! Convert these to complex numbers here.   
-         if (present(right)) right = real(vmat)
-         if (present(left)) left = real(umat)      
-!         do i=2,n
-!            if (lreal(i)==lreal(i-1) .and. limag(i)==-limag(i-1)) then 
-!                
-!            endif
-!         end do
-         
+         ! Convert these to complex numbers here.            
+         if (present(right)) call assign_real_eigenvectors_${rk}$(n,lambda,vmat,right)
+         if (present(left))  call assign_real_eigenvectors_${rk}$(n,lambda,umat,left)
          #:endif
          
          2 if (copy_a) deallocate(amat)
@@ -265,6 +259,41 @@ module stdlib_linalg_eig
          1 call linalg_error_handling(err0,err)
 
      end subroutine stdlib_linalg_eig_${ri}$
+     #:endfor
+
+     #:for rk,rt,ri in REAL_KINDS_TYPES
+     pure subroutine assign_real_eigenvectors_${rk}$(n,lambda,lmat,out_mat)
+        !> Problem size
+        integer(ilp), intent(in) :: n
+        !> Array of eigenvalues
+        complex(${rk}$), intent(in) :: lambda(:)
+        !> Real matrix as returned by geev 
+        ${rt}$, intent(in) :: lmat(:,:)
+        !> Complex matrix as returned by eig
+        complex(${rk}$), intent(out) :: out_mat(:,:)
+        
+        integer(ilp) :: i,j
+        
+        ! Copy matrix
+        do concurrent(i=1:n,j=1:n)
+           out_mat(i,j) = lmat(i,j)
+        end do
+        
+        ! If the j-th and (j+1)-st eigenvalues form a complex conjugate pair, 
+        ! geev returns them as reals as: 
+        ! u(j)   = VL(:,j) + i*VL(:,j+1) and
+        ! u(j+1) = VL(:,j) - i*VL(:,j+1). 
+        ! Convert these to complex numbers here.   
+        do j=1,n
+            do i=1,n-1
+               if (lambda(i)==conjg(lambda(i+1))) then  
+                  out_mat(  i,j) = cmplx(lmat(i,j), lmat(i+1,j),kind=${rk}$)
+                  out_mat(i+1,j) = cmplx(lmat(i,j),-lmat(i+1,j),kind=${rk}$)
+               endif
+            end do  
+        end do           
+        
+     end subroutine assign_real_eigenvectors_${rk}$
      #:endfor
 
 end module stdlib_linalg_eig

--- a/src/stdlib_linalg_eigs.fypp
+++ b/src/stdlib_linalg_eigs.fypp
@@ -14,6 +14,8 @@ module stdlib_linalg_eig
      public :: eigvals
      !> Eigendecomposition of a real symmetric or complex hermitian matrix
      public :: eigh
+     !> Eigenvalues of a real symmetric or complex hermitian matrix
+     public :: eigvalsh     
 
      ! Numpy: eigenvalues, eigenvectors = eig(a)
      !        eigenvalues = eigvals(a)
@@ -21,6 +23,7 @@ module stdlib_linalg_eig
 
      ! Numpy: eigenvalues, eigenvectors = eigh(a, uplo='L')
      !        eigenvalues = eigvalsh(a)
+     ! Scipy: eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False, overwrite_b=False, turbo=<object object>, eigvals=<object object>, type=1, check_finite=True, subset_by_index=None, subset_by_value=None, driver=None)
 
      interface eig
         #:for rk,rt,ri in ALL_KINDS_TYPES

--- a/src/stdlib_linalg_interface.f90
+++ b/src/stdlib_linalg_interface.f90
@@ -9,6 +9,7 @@ module stdlib_linalg_interface
      use stdlib_linalg_solve
      use stdlib_linalg_state
      use stdlib_linalg_svd
+     use stdlib_linalg_eig
      implicit none(type,external)
      public
 

--- a/src/stdlib_linalg_state.f90
+++ b/src/stdlib_linalg_state.f90
@@ -229,7 +229,7 @@ module stdlib_linalg_state
 
     !> Error creation message, with location location
     pure type(linalg_state) function new_state(where_at,flag,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10, &
-                                               v1,v2,v3,v4,v5)
+                                               a11,a12,a13,a14,a15,a16,a17,a18,a19,a20) 
 
        !> Location
        character(len=*),intent(in) :: where_at
@@ -237,32 +237,30 @@ module stdlib_linalg_state
        !> Input error flag
        integer,intent(in) :: flag
 
-       !> Optional scalar arguments
-       class(*),optional,intent(in) :: a1,a2,a3,a4,a5,a6,a7,a8,a9,a10
-
-       !> Optional vector arguments
-       class(*),optional,intent(in),dimension(:) :: v1,v2,v3,v4,v5
+       !> Optional rank-agnostic arguments
+       class(*),optional,intent(in),dimension(..) :: a1,a2,a3,a4,a5,a6,a7,a8,a9,a10, &
+                                                     a11,a12,a13,a14,a15,a16,a17,a18,a19,a20  
 
        !> Create state with no message
-       new_state = new_state_nowhere(flag,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,v1,v2,v3,v4,v5)
+       new_state = new_state_nowhere(flag,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10, &
+                                     a11,a12,a13,a14,a15,a16,a17,a18,a19,a20)
 
        !> Add location
        if (len_trim(where_at) > 0) new_state%where_at = adjustl(where_at)
 
     end function new_state
-
+    
     !> Error creation message, from N input variables (numeric or strings)
     pure type(linalg_state) function new_state_nowhere(flag,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10, &
-                                               v1,v2,v3,v4,v5) result(new_state)
+                                                       a11,a12,a13,a14,a15,a16,a17,a18,a19,a20) &
+                                                       result(new_state)
 
        !> Input error flag
        integer,intent(in) :: flag
 
-       !> Optional scalar arguments
-       class(*),optional,intent(in) :: a1,a2,a3,a4,a5,a6,a7,a8,a9,a10
-
-       !> Optional vector arguments
-       class(*),optional,intent(in),dimension(:) :: v1,v2,v3,v4,v5
+       !> Optional rank-agnostic arguments
+       class(*),optional,intent(in),dimension(..) :: a1,a2,a3,a4,a5,a6,a7,a8,a9,a10, &
+                                                     a11,a12,a13,a14,a15,a16,a17,a18,a19,a20  
 
        ! Init object
        call new_state%destroy()
@@ -272,35 +270,61 @@ module stdlib_linalg_state
 
        !> Set chain
        new_state%message = ""
-       call append(new_state%message,a1)
-       call append(new_state%message,a2)
-       call append(new_state%message,a3)
-       call append(new_state%message,a4)
-       call append(new_state%message,a5)
-       call append(new_state%message,a6)
-       call append(new_state%message,a7)
-       call append(new_state%message,a8)
-       call append(new_state%message,a9)
-       call append(new_state%message,a10)
-       call appendv(new_state%message,v1)
-       call appendv(new_state%message,v2)
-       call appendv(new_state%message,v3)
-       call appendv(new_state%message,v4)
-       call appendv(new_state%message,v5)
+       call appendr(new_state%message,a1)
+       call appendr(new_state%message,a2)
+       call appendr(new_state%message,a3)
+       call appendr(new_state%message,a4)
+       call appendr(new_state%message,a5)
+       call appendr(new_state%message,a6)
+       call appendr(new_state%message,a7)
+       call appendr(new_state%message,a8)
+       call appendr(new_state%message,a9)
+       call appendr(new_state%message,a10)
+       call appendr(new_state%message,a11)
+       call appendr(new_state%message,a12)
+       call appendr(new_state%message,a13)
+       call appendr(new_state%message,a14)
+       call appendr(new_state%message,a15)
+       call appendr(new_state%message,a16)
+       call appendr(new_state%message,a17)
+       call appendr(new_state%message,a18)
+       call appendr(new_state%message,a19)
+       call appendr(new_state%message,a20)
 
     end function new_state_nowhere
+    
+    ! Append a generic value to the error flag (rank-agnostic)
+    pure subroutine appendr(msg,a,prefix)
+       class(*),optional,intent(in) :: a(..)
+       character(len=*),intent(inout) :: msg
+       character,optional,intent(in) :: prefix
+       
+       character(len=MSG_LENGTH) :: buffer
+       
+       if (present(a)) then 
+          select rank (v=>a)
+             rank (0)
+                call append (msg,v,prefix)
+             rank (1)
+                call appendv(msg,v)
+             rank default
+                write (buffer,'(i0)') rank(v)
+                msg = trim(msg)//' <ERROR: INVALID RANK>'
+          
+          end select   
+       endif
+       
+    end subroutine appendr
 
     ! Append a generic value to the error flag
     pure subroutine append(msg,a,prefix)
-       class(*),optional,intent(in) :: a
+       class(*),intent(in) :: a
        character(len=*),intent(inout) :: msg
        character,optional,intent(in) :: prefix
 
        character(len=MSG_LENGTH) :: buffer,buffer2
        character(len=2) :: sep
        integer :: ls
-
-       if (.not. present(a)) return
 
        ! Do not add separator if this is the first instance
        sep = '  '
@@ -380,14 +404,13 @@ module stdlib_linalg_state
 
     ! Append a generic vector to the error flag
     pure subroutine appendv(msg,a)
-       class(*),optional,intent(in) :: a(:)
+       class(*),intent(in) :: a(:)
        character(len=*),intent(inout) :: msg
 
        integer :: j,ls
        character(len=MSG_LENGTH) :: buffer,buffer2
        character(len=2) :: sep
 
-       if (.not. present(a)) return
        if (size(a) <= 0) return
 
        ! Default: separate elements with one space

--- a/test/stdlib_linalg_tests.f90
+++ b/test/stdlib_linalg_tests.f90
@@ -6,6 +6,7 @@ program stdlib_linalg_tests
     use test_linalg_least_squares
     use test_linalg_determinant
     use test_linalg_svd
+    use test_linalg_eig
     implicit none(type, external)
 
     logical :: error
@@ -30,6 +31,9 @@ program stdlib_linalg_tests
 
     call test_svd(error)
     if (error) error stop 'test_svd'
+    
+    call test_eig(error)
+    if (error) error stop 'test_eig'
 
     !> All tests passed
     stop 0

--- a/test/test_linalg_aux.f90
+++ b/test/test_linalg_aux.f90
@@ -33,7 +33,7 @@ module test_linalg_aux
         '128-bit complex: (1.00000000000000000000000000000000000E+0000,1.00000000000000000000000000000000000E+0000)') &
         error = .true.
 
-        state = linalg_state(LINALG_SUCCESS,' 32-bit array: ',v1=[(1.0_sp,0.0_sp),(0.0_sp,1.0_sp)])
+        state = linalg_state(LINALG_SUCCESS,' 32-bit array: ',[(1.0_sp,0.0_sp),(0.0_sp,1.0_sp)])
         if (state%message/=' 32-bit array: [(1.00000000E+00,0.00000000E+00) (0.00000000E+00,1.00000000E+00)]') &
         error = .true.
 

--- a/test/test_linalg_eigs.f90
+++ b/test/test_linalg_eigs.f90
@@ -14,23 +14,23 @@ module test_linalg_eig
 
         call cpu_time(t0)
 
-        call test_eig_s(error)
+        call test_eig_diagonal_s(error)
         if (error) return
-        call test_eig_d(error)
+        call test_eig_diagonal_d(error)
         if (error) return
-        call test_eig_q(error)
+        call test_eig_diagonal_q(error)
         if (error) return
-
+        
         call cpu_time(t1)
 
         print 1,1000*(t1 - t0),merge('SUCCESS','ERROR  ',.not. error)
 
-1       format('SVD tests completed in ',f9.4,' milliseconds, result=',a)
+1       format('Eigenproblem tests completed in ',f9.4,' milliseconds, result=',a)
 
     end subroutine test_eig
 
-    !> Real matrix svd
-    subroutine test_eig_s(error)
+    !> Simple diagonal matrix eigenvalues
+    subroutine test_eig_diagonal_s(error)
         logical,intent(out) :: error
 
         !> Reference solution
@@ -39,10 +39,10 @@ module test_linalg_eig
 
         !> Local variables
         type(linalg_state) :: state
-        real(sp) :: A(3,3)
-        complex(sp) :: lambda(3)
+        real(sp) :: A(3,3),B(2,2)
+        complex(sp) :: lambda(3),lambdab(2),Bvec(2,2)
 
-        !> Initialize matrix
+        !> Matrix with real eigenvalues
         A = reshape([1,0,0, &
                      0,2,0, &
                      0,0,3], [3,3])
@@ -50,12 +50,27 @@ module test_linalg_eig
         call eig(A,lambda,err=state)
         error = state%error() .or. &
                 .not. all(aimag(lambda) == zero .and. real(lambda,kind=sp) == [1,2,3])
-
         if (error) return
+        
+        !> Matrix with complex eigenvalues
+        B = transpose(reshape([1,-1, &
+                               1,1], [2,2]))
+        
+        call eig(B,lambda,left=Bvec,err=state)
+        error = state%error()
+        if (error) return
+        
+!eigenvalues, eigenvectors = LA.eig(np.array([[1, -1], [1, 1]]))
+!eigenvalues
+!array([1.+1.j, 1.-1.j])
+!eigenvectors
+!array([[0.70710678+0.j        , 0.70710678-0.j        ],
+!       [0.        -0.70710678j, 0.        +0.70710678j]])
+!
 
-    end subroutine test_eig_s
+    end subroutine test_eig_diagonal_s
 
-    subroutine test_eig_d(error)
+    subroutine test_eig_diagonal_d(error)
         logical,intent(out) :: error
 
         !> Reference solution
@@ -64,10 +79,10 @@ module test_linalg_eig
 
         !> Local variables
         type(linalg_state) :: state
-        real(dp) :: A(3,3)
-        complex(dp) :: lambda(3)
+        real(dp) :: A(3,3),B(2,2)
+        complex(dp) :: lambda(3),lambdab(2),Bvec(2,2)
 
-        !> Initialize matrix
+        !> Matrix with real eigenvalues
         A = reshape([1,0,0, &
                      0,2,0, &
                      0,0,3], [3,3])
@@ -75,12 +90,27 @@ module test_linalg_eig
         call eig(A,lambda,err=state)
         error = state%error() .or. &
                 .not. all(aimag(lambda) == zero .and. real(lambda,kind=dp) == [1,2,3])
-
         if (error) return
+        
+        !> Matrix with complex eigenvalues
+        B = transpose(reshape([1,-1, &
+                               1,1], [2,2]))
+        
+        call eig(B,lambda,left=Bvec,err=state)
+        error = state%error()
+        if (error) return
+        
+!eigenvalues, eigenvectors = LA.eig(np.array([[1, -1], [1, 1]]))
+!eigenvalues
+!array([1.+1.j, 1.-1.j])
+!eigenvectors
+!array([[0.70710678+0.j        , 0.70710678-0.j        ],
+!       [0.        -0.70710678j, 0.        +0.70710678j]])
+!
 
-    end subroutine test_eig_d
+    end subroutine test_eig_diagonal_d
 
-    subroutine test_eig_q(error)
+    subroutine test_eig_diagonal_q(error)
         logical,intent(out) :: error
 
         !> Reference solution
@@ -89,10 +119,10 @@ module test_linalg_eig
 
         !> Local variables
         type(linalg_state) :: state
-        real(qp) :: A(3,3)
-        complex(qp) :: lambda(3)
+        real(qp) :: A(3,3),B(2,2)
+        complex(qp) :: lambda(3),lambdab(2),Bvec(2,2)
 
-        !> Initialize matrix
+        !> Matrix with real eigenvalues
         A = reshape([1,0,0, &
                      0,2,0, &
                      0,0,3], [3,3])
@@ -100,10 +130,25 @@ module test_linalg_eig
         call eig(A,lambda,err=state)
         error = state%error() .or. &
                 .not. all(aimag(lambda) == zero .and. real(lambda,kind=qp) == [1,2,3])
-
         if (error) return
+        
+        !> Matrix with complex eigenvalues
+        B = transpose(reshape([1,-1, &
+                               1,1], [2,2]))
+        
+        call eig(B,lambda,left=Bvec,err=state)
+        error = state%error()
+        if (error) return
+        
+!eigenvalues, eigenvectors = LA.eig(np.array([[1, -1], [1, 1]]))
+!eigenvalues
+!array([1.+1.j, 1.-1.j])
+!eigenvectors
+!array([[0.70710678+0.j        , 0.70710678-0.j        ],
+!       [0.        -0.70710678j, 0.        +0.70710678j]])
+!
 
-    end subroutine test_eig_q
+    end subroutine test_eig_diagonal_q
 
 end module test_linalg_eig
 

--- a/test/test_linalg_eigs.f90
+++ b/test/test_linalg_eigs.f90
@@ -14,13 +14,20 @@ module test_linalg_eig
 
         call cpu_time(t0)
 
-        call test_eig_diagonal_s(error)
+        call test_eig_real_s(error)
         if (error) return
-        call test_eig_diagonal_d(error)
+        call test_eig_real_d(error)
         if (error) return
-        call test_eig_diagonal_q(error)
+        call test_eig_real_q(error)
         if (error) return
         
+        call test_eig_complex_c(error)
+        if (error) return
+        call test_eig_complex_z(error)
+        if (error) return
+        call test_eig_complex_w(error)
+        if (error) return
+
         call cpu_time(t1)
 
         print 1,1000*(t1 - t0),merge('SUCCESS','ERROR  ',.not. error)
@@ -29,18 +36,20 @@ module test_linalg_eig
 
     end subroutine test_eig
 
-    !> Simple diagonal matrix eigenvalues
-    subroutine test_eig_diagonal_s(error)
+    !> Simple real matrix eigenvalues
+    subroutine test_eig_real_s(error)
         logical,intent(out) :: error
 
         !> Reference solution
         real(sp),parameter :: zero = 0.0_sp
+        real(sp),parameter :: two = 2.0_sp
+        real(sp),parameter :: sqrt2o2 = sqrt(two)*0.5_sp
         real(sp),parameter :: tol = sqrt(epsilon(zero))
 
         !> Local variables
         type(linalg_state) :: state
         real(sp) :: A(3,3),B(2,2)
-        complex(sp) :: lambda(3),lambdab(2),Bvec(2,2)
+        complex(sp) :: lambda(3),Bvec(2,2),Bres(2,2)
 
         !> Matrix with real eigenvalues
         A = reshape([1,0,0, &
@@ -55,32 +64,36 @@ module test_linalg_eig
         !> Matrix with complex eigenvalues
         B = transpose(reshape([1,-1, &
                                1,1], [2,2]))
+                               
+        !> Expected right eigenvectors
+        Bres(1,1:2) = sqrt2o2
+        Bres(2,1) = cmplx(zero,-sqrt2o2,kind=sp)
+        Bres(2,2) = cmplx(zero,+sqrt2o2,kind=sp)
         
-        call eig(B,lambda,left=Bvec,err=state)
-        error = state%error()
+        call eig(B,lambda,right=Bvec,err=state)
+        error = state%error() .or. any(abs(Bres - Bvec) > tol)
+        
+        print *, bvec(1,:)
+        print *, bvec(2,:)
+        print *, bres
+        
         if (error) return
         
-!eigenvalues, eigenvectors = LA.eig(np.array([[1, -1], [1, 1]]))
-!eigenvalues
-!array([1.+1.j, 1.-1.j])
-!eigenvectors
-!array([[0.70710678+0.j        , 0.70710678-0.j        ],
-!       [0.        -0.70710678j, 0.        +0.70710678j]])
-!
+    end subroutine test_eig_real_s
 
-    end subroutine test_eig_diagonal_s
-
-    subroutine test_eig_diagonal_d(error)
+    subroutine test_eig_real_d(error)
         logical,intent(out) :: error
 
         !> Reference solution
         real(dp),parameter :: zero = 0.0_dp
+        real(dp),parameter :: two = 2.0_dp
+        real(dp),parameter :: sqrt2o2 = sqrt(two)*0.5_dp
         real(dp),parameter :: tol = sqrt(epsilon(zero))
 
         !> Local variables
         type(linalg_state) :: state
         real(dp) :: A(3,3),B(2,2)
-        complex(dp) :: lambda(3),lambdab(2),Bvec(2,2)
+        complex(dp) :: lambda(3),Bvec(2,2),Bres(2,2)
 
         !> Matrix with real eigenvalues
         A = reshape([1,0,0, &
@@ -95,32 +108,36 @@ module test_linalg_eig
         !> Matrix with complex eigenvalues
         B = transpose(reshape([1,-1, &
                                1,1], [2,2]))
+                               
+        !> Expected right eigenvectors
+        Bres(1,1:2) = sqrt2o2
+        Bres(2,1) = cmplx(zero,-sqrt2o2,kind=dp)
+        Bres(2,2) = cmplx(zero,+sqrt2o2,kind=dp)
         
-        call eig(B,lambda,left=Bvec,err=state)
-        error = state%error()
+        call eig(B,lambda,right=Bvec,err=state)
+        error = state%error() .or. any(abs(Bres - Bvec) > tol)
+        
+        print *, bvec(1,:)
+        print *, bvec(2,:)
+        print *, bres
+        
         if (error) return
         
-!eigenvalues, eigenvectors = LA.eig(np.array([[1, -1], [1, 1]]))
-!eigenvalues
-!array([1.+1.j, 1.-1.j])
-!eigenvectors
-!array([[0.70710678+0.j        , 0.70710678-0.j        ],
-!       [0.        -0.70710678j, 0.        +0.70710678j]])
-!
+    end subroutine test_eig_real_d
 
-    end subroutine test_eig_diagonal_d
-
-    subroutine test_eig_diagonal_q(error)
+    subroutine test_eig_real_q(error)
         logical,intent(out) :: error
 
         !> Reference solution
         real(qp),parameter :: zero = 0.0_qp
+        real(qp),parameter :: two = 2.0_qp
+        real(qp),parameter :: sqrt2o2 = sqrt(two)*0.5_qp
         real(qp),parameter :: tol = sqrt(epsilon(zero))
 
         !> Local variables
         type(linalg_state) :: state
         real(qp) :: A(3,3),B(2,2)
-        complex(qp) :: lambda(3),lambdab(2),Bvec(2,2)
+        complex(qp) :: lambda(3),Bvec(2,2),Bres(2,2)
 
         !> Matrix with real eigenvalues
         A = reshape([1,0,0, &
@@ -135,20 +152,134 @@ module test_linalg_eig
         !> Matrix with complex eigenvalues
         B = transpose(reshape([1,-1, &
                                1,1], [2,2]))
+                               
+        !> Expected right eigenvectors
+        Bres(1,1:2) = sqrt2o2
+        Bres(2,1) = cmplx(zero,-sqrt2o2,kind=qp)
+        Bres(2,2) = cmplx(zero,+sqrt2o2,kind=qp)
         
-        call eig(B,lambda,left=Bvec,err=state)
-        error = state%error()
+        call eig(B,lambda,right=Bvec,err=state)
+        error = state%error() .or. any(abs(Bres - Bvec) > tol)
+        
+        print *, bvec(1,:)
+        print *, bvec(2,:)
+        print *, bres
+        
         if (error) return
         
-!eigenvalues, eigenvectors = LA.eig(np.array([[1, -1], [1, 1]]))
-!eigenvalues
-!array([1.+1.j, 1.-1.j])
-!eigenvectors
-!array([[0.70710678+0.j        , 0.70710678-0.j        ],
-!       [0.        -0.70710678j, 0.        +0.70710678j]])
-!
+    end subroutine test_eig_real_q
 
-    end subroutine test_eig_diagonal_q
+    !> Simple complex matrix eigenvalues
+    subroutine test_eig_complex_c(error)
+        logical,intent(out) :: error
+
+        !> Reference solution
+        real(sp),parameter :: zero = 0.0_sp
+        real(sp),parameter :: two = 2.0_sp
+        real(sp),parameter :: sqrt2o2 = sqrt(two)*0.5_sp
+        real(sp),parameter :: tol = sqrt(epsilon(zero))
+        complex(sp),parameter :: cone = (1.0_sp,0.0_sp)
+        complex(sp),parameter :: cimg = (0.0_sp,1.0_sp)
+        complex(sp),parameter :: czero = (0.0_sp,0.0_sp)
+
+        !> Local vaciables
+        type(linalg_state) :: state
+        complex(sp) :: A(2,2),lambda(2),Avec(2,2),Ares(2,2),lres(2)
+
+        !> Matcix with real eigenvalues
+        A = transpose(reshape([cone,cimg, &
+                               -cimg,cone], [2,2]))
+                
+        call eig(A,lambda,right=Avec,err=state)
+        
+        !> Expected eigenvalues and eigenvectors
+        lres(1) = two
+        lres(2) = zero
+        
+        !> Eigenvectors may vary: do not use for error
+        Ares(1,1) = cmplx(zero,sqrt2o2,kind=sp)
+        Ares(1,2) = cmplx(sqrt2o2,zero,kind=sp)
+        Ares(2,1) = cmplx(sqrt2o2,zero,kind=sp)
+        Ares(2,2) = cmplx(zero,sqrt2o2,kind=sp)
+        
+        error = state%error() .or. any(abs(lambda - lres) > tol)
+        if (error) return
+        
+    end subroutine test_eig_complex_c
+
+    subroutine test_eig_complex_z(error)
+        logical,intent(out) :: error
+
+        !> Reference solution
+        real(dp),parameter :: zero = 0.0_dp
+        real(dp),parameter :: two = 2.0_dp
+        real(dp),parameter :: sqrt2o2 = sqrt(two)*0.5_dp
+        real(dp),parameter :: tol = sqrt(epsilon(zero))
+        complex(dp),parameter :: cone = (1.0_dp,0.0_dp)
+        complex(dp),parameter :: cimg = (0.0_dp,1.0_dp)
+        complex(dp),parameter :: czero = (0.0_dp,0.0_dp)
+
+        !> Local vaciables
+        type(linalg_state) :: state
+        complex(dp) :: A(2,2),lambda(2),Avec(2,2),Ares(2,2),lres(2)
+
+        !> Matcix with real eigenvalues
+        A = transpose(reshape([cone,cimg, &
+                               -cimg,cone], [2,2]))
+                
+        call eig(A,lambda,right=Avec,err=state)
+        
+        !> Expected eigenvalues and eigenvectors
+        lres(1) = two
+        lres(2) = zero
+        
+        !> Eigenvectors may vary: do not use for error
+        Ares(1,1) = cmplx(zero,sqrt2o2,kind=dp)
+        Ares(1,2) = cmplx(sqrt2o2,zero,kind=dp)
+        Ares(2,1) = cmplx(sqrt2o2,zero,kind=dp)
+        Ares(2,2) = cmplx(zero,sqrt2o2,kind=dp)
+        
+        error = state%error() .or. any(abs(lambda - lres) > tol)
+        if (error) return
+        
+    end subroutine test_eig_complex_z
+
+    subroutine test_eig_complex_w(error)
+        logical,intent(out) :: error
+
+        !> Reference solution
+        real(qp),parameter :: zero = 0.0_qp
+        real(qp),parameter :: two = 2.0_qp
+        real(qp),parameter :: sqrt2o2 = sqrt(two)*0.5_qp
+        real(qp),parameter :: tol = sqrt(epsilon(zero))
+        complex(qp),parameter :: cone = (1.0_qp,0.0_qp)
+        complex(qp),parameter :: cimg = (0.0_qp,1.0_qp)
+        complex(qp),parameter :: czero = (0.0_qp,0.0_qp)
+
+        !> Local vaciables
+        type(linalg_state) :: state
+        complex(qp) :: A(2,2),lambda(2),Avec(2,2),Ares(2,2),lres(2)
+
+        !> Matcix with real eigenvalues
+        A = transpose(reshape([cone,cimg, &
+                               -cimg,cone], [2,2]))
+                
+        call eig(A,lambda,right=Avec,err=state)
+        
+        !> Expected eigenvalues and eigenvectors
+        lres(1) = two
+        lres(2) = zero
+        
+        !> Eigenvectors may vary: do not use for error
+        Ares(1,1) = cmplx(zero,sqrt2o2,kind=qp)
+        Ares(1,2) = cmplx(sqrt2o2,zero,kind=qp)
+        Ares(2,1) = cmplx(sqrt2o2,zero,kind=qp)
+        Ares(2,2) = cmplx(zero,sqrt2o2,kind=qp)
+        
+        error = state%error() .or. any(abs(lambda - lres) > tol)
+        if (error) return
+        
+    end subroutine test_eig_complex_w
 
 end module test_linalg_eig
 

--- a/test/test_linalg_eigs.f90
+++ b/test/test_linalg_eigs.f90
@@ -1,0 +1,243 @@
+! Test eigendecomposition
+module test_linalg_eigs
+    use stdlib_linalg_interface
+
+    implicit none(type,external)
+
+    contains
+
+    !> SVD tests
+    subroutine test_eig(error)
+        logical,intent(out) :: error
+
+        real :: t0,t1
+
+        call cpu_time(t0)
+
+        call test_eig_s(error)
+        if (error) return
+        call test_eig_d(error)
+        if (error) return
+        call test_eig_q(error)
+        if (error) return
+
+        call test_complex_svd_c(error)
+        if (error) return
+        call test_complex_svd_z(error)
+        if (error) return
+        call test_complex_svd_w(error)
+        if (error) return
+
+        call cpu_time(t1)
+
+        print 1,1000*(t1 - t0),merge('SUCCESS','ERROR  ',.not. error)
+
+1       format('SVD tests completed in ',f9.4,' milliseconds, result=',a)
+
+    end subroutine test_eig
+
+    !> Real matrix svd
+    subroutine test_eig_s(error)
+        logical,intent(out) :: error
+
+        !> Reference solution
+        real(sp),parameter :: tol = sqrt(epsilon(0.0_sp))
+
+        !> Local variables
+        type(linalg_state) :: state
+        real(sp) :: A(3,3)
+        complex(sp) :: lambda
+
+        !> Initialize matrix
+        A = diag([1,2,3])
+        
+        call eig(A,lambda,err=state)
+        error = state%error()
+
+        if (error) return
+
+    end subroutine test_eig_s
+
+    subroutine test_eig_d(error)
+        logical,intent(out) :: error
+
+        !> Reference solution
+        real(dp),parameter :: tol = sqrt(epsilon(0.0_dp))
+
+        !> Local variables
+        type(linalg_state) :: state
+        real(dp) :: A(3,3)
+        complex(dp) :: lambda
+
+        !> Initialize matrix
+        A = diag([1,2,3])
+        
+        call eig(A,lambda,err=state)
+        error = state%error()
+
+        if (error) return
+
+    end subroutine test_eig_d
+
+    subroutine test_eig_q(error)
+        logical,intent(out) :: error
+
+        !> Reference solution
+        real(qp),parameter :: tol = sqrt(epsilon(0.0_qp))
+
+        !> Local variables
+        type(linalg_state) :: state
+        real(qp) :: A(3,3)
+        complex(qp) :: lambda
+
+        !> Initialize matrix
+        A = diag([1,2,3])
+        
+        call eig(A,lambda,err=state)
+        error = state%error()
+
+        if (error) return
+
+    end subroutine test_eig_q
+
+    !> Test complex svd
+    subroutine test_complex_svd_c(error)
+        logical,intent(out) :: error
+
+        !> Reference solution
+        real(sp),parameter :: tol = sqrt(epsilon(0.0_sp))
+        real(sp),parameter :: one = 1.0_sp
+        real(sp),parameter :: zero = 0.0_sp
+        real(sp),parameter :: sqrt2 = sqrt(2.0_sp)
+        real(sp),parameter :: rsqrt2 = one/sqrt2
+        complex(sp),parameter :: cone = (1.0_sp,0.0_sp)
+        complex(sp),parameter :: cimg = (0.0_sp,1.0_sp)
+        complex(sp),parameter :: czero = (0.0_sp,0.0_sp)
+
+        real(sp),parameter :: s_sol(2) = [sqrt2,sqrt2]
+        complex(sp),parameter :: A_mat(2,2) = reshape([cone,cimg,cimg,cone], [2,2])
+        complex(sp),parameter :: u_sol(2,2) = reshape(rsqrt2*[cone,cimg,cimg,cone], [2,2])
+        complex(sp),parameter :: vt_sol(2,2) = reshape([cone,czero,czero,cone], [2,2])
+
+        !> Local variables
+        type(linalg_state) :: state
+        complex(sp) :: A(2,2),u(2,2),vt(2,2)
+        real(sp) :: s(2)
+
+        !> Initialize matrix
+        A = A_mat
+
+        !> Simple subroutine version
+        call svd(A,s,err=state)
+        error = state%error() .or. .not. all(abs(s - s_sol) <= tol)
+        if (error) return
+
+        !> Function interface
+        s = svdvals(A,err=state)
+        error = state%error() .or. .not. all(abs(s - s_sol) <= tol)
+        if (error) return
+
+        !> [S, U, V^T]
+        A = A_mat
+        call svd(A,s,u,vt,overwrite_a=.true.,err=state)
+        error = state%error() .or. &
+                .not. all(abs(s - s_sol) <= tol) .or. &
+                .not. all(abs(matmul(u,matmul(diag(s),vt)) - A_mat) <= tol)
+        if (error) return
+
+    end subroutine test_complex_svd_c
+
+    subroutine test_complex_svd_z(error)
+        logical,intent(out) :: error
+
+        !> Reference solution
+        real(dp),parameter :: tol = sqrt(epsilon(0.0_dp))
+        real(dp),parameter :: one = 1.0_dp
+        real(dp),parameter :: zero = 0.0_dp
+        real(dp),parameter :: sqrt2 = sqrt(2.0_dp)
+        real(dp),parameter :: rsqrt2 = one/sqrt2
+        complex(dp),parameter :: cone = (1.0_dp,0.0_dp)
+        complex(dp),parameter :: cimg = (0.0_dp,1.0_dp)
+        complex(dp),parameter :: czero = (0.0_dp,0.0_dp)
+
+        real(dp),parameter :: s_sol(2) = [sqrt2,sqrt2]
+        complex(dp),parameter :: A_mat(2,2) = reshape([cone,cimg,cimg,cone], [2,2])
+        complex(dp),parameter :: u_sol(2,2) = reshape(rsqrt2*[cone,cimg,cimg,cone], [2,2])
+        complex(dp),parameter :: vt_sol(2,2) = reshape([cone,czero,czero,cone], [2,2])
+
+        !> Local variables
+        type(linalg_state) :: state
+        complex(dp) :: A(2,2),u(2,2),vt(2,2)
+        real(dp) :: s(2)
+
+        !> Initialize matrix
+        A = A_mat
+
+        !> Simple subroutine version
+        call svd(A,s,err=state)
+        error = state%error() .or. .not. all(abs(s - s_sol) <= tol)
+        if (error) return
+
+        !> Function interface
+        s = svdvals(A,err=state)
+        error = state%error() .or. .not. all(abs(s - s_sol) <= tol)
+        if (error) return
+
+        !> [S, U, V^T]
+        A = A_mat
+        call svd(A,s,u,vt,overwrite_a=.true.,err=state)
+        error = state%error() .or. &
+                .not. all(abs(s - s_sol) <= tol) .or. &
+                .not. all(abs(matmul(u,matmul(diag(s),vt)) - A_mat) <= tol)
+        if (error) return
+
+    end subroutine test_complex_svd_z
+
+    subroutine test_complex_svd_w(error)
+        logical,intent(out) :: error
+
+        !> Reference solution
+        real(qp),parameter :: tol = sqrt(epsilon(0.0_qp))
+        real(qp),parameter :: one = 1.0_qp
+        real(qp),parameter :: zero = 0.0_qp
+        real(qp),parameter :: sqrt2 = sqrt(2.0_qp)
+        real(qp),parameter :: rsqrt2 = one/sqrt2
+        complex(qp),parameter :: cone = (1.0_qp,0.0_qp)
+        complex(qp),parameter :: cimg = (0.0_qp,1.0_qp)
+        complex(qp),parameter :: czero = (0.0_qp,0.0_qp)
+
+        real(qp),parameter :: s_sol(2) = [sqrt2,sqrt2]
+        complex(qp),parameter :: A_mat(2,2) = reshape([cone,cimg,cimg,cone], [2,2])
+        complex(qp),parameter :: u_sol(2,2) = reshape(rsqrt2*[cone,cimg,cimg,cone], [2,2])
+        complex(qp),parameter :: vt_sol(2,2) = reshape([cone,czero,czero,cone], [2,2])
+
+        !> Local variables
+        type(linalg_state) :: state
+        complex(qp) :: A(2,2),u(2,2),vt(2,2)
+        real(qp) :: s(2)
+
+        !> Initialize matrix
+        A = A_mat
+
+        !> Simple subroutine version
+        call svd(A,s,err=state)
+        error = state%error() .or. .not. all(abs(s - s_sol) <= tol)
+        if (error) return
+
+        !> Function interface
+        s = svdvals(A,err=state)
+        error = state%error() .or. .not. all(abs(s - s_sol) <= tol)
+        if (error) return
+
+        !> [S, U, V^T]
+        A = A_mat
+        call svd(A,s,u,vt,overwrite_a=.true.,err=state)
+        error = state%error() .or. &
+                .not. all(abs(s - s_sol) <= tol) .or. &
+                .not. all(abs(matmul(u,matmul(diag(s),vt)) - A_mat) <= tol)
+        if (error) return
+
+    end subroutine test_complex_svd_w
+
+end module test_linalg_eigs
+

--- a/test/test_linalg_eigs.f90
+++ b/test/test_linalg_eigs.f90
@@ -21,6 +21,13 @@ module test_linalg_eig
         call test_eig_real_q(error)
         if (error) return
         
+        call test_eigh_real_s(error)
+        if (error) return
+        call test_eigh_real_d(error)
+        if (error) return
+        call test_eigh_real_q(error)
+        if (error) return
+                
         call test_eig_complex_c(error)
         if (error) return
         call test_eig_complex_z(error)
@@ -81,6 +88,47 @@ module test_linalg_eig
         
     end subroutine test_eig_real_s
 
+    ! Symmetric matrix eigenvalues
+    subroutine test_eigh_real_s(error)
+        logical,intent(out) :: error
+
+        !> Reference solution
+        real(sp),parameter :: zero = 0.0_sp
+        real(sp),parameter :: tol = sqrt(epsilon(zero))
+        real(sp),parameter :: A(4,4) = reshape([6,3,1,5, &
+                                               3,0,5,1, &
+                                               1,5,6,2, &
+                                               5,1,2,2], [4,4])
+        
+        !> Local variables
+        real(sp) :: Amat(4,4),lambda(4),vect(4,4),Av(4,4),lv(4,4)
+        type(linalg_state) :: state
+        
+        Amat = A
+        
+        call eigh(Amat,lambda,vect,err=state)
+        
+        Av = matmul(A,vect)
+        lv = matmul(vect,diag(lambda))
+        
+        error = state%error() .or. .not. all(abs(Av - lv) < tol*abs(Av))
+        if (error) return
+        
+        !> Test functional versions
+        lambda = eigvalsh(Amat)
+   
+        lambda = eigvalsh(Amat,err=state)
+        error = state%error()
+        if (error) return
+        
+        !> Test functional versions
+        Amat = A
+        lambda = eigvalsh(Amat,upper_a=.false.,err=state)
+        error = state%error()
+        if (error) return
+        
+    end subroutine test_eigh_real_s
+
     subroutine test_eig_real_d(error)
         logical,intent(out) :: error
 
@@ -125,6 +173,47 @@ module test_linalg_eig
         
     end subroutine test_eig_real_d
 
+    ! Symmetric matrix eigenvalues
+    subroutine test_eigh_real_d(error)
+        logical,intent(out) :: error
+
+        !> Reference solution
+        real(dp),parameter :: zero = 0.0_dp
+        real(dp),parameter :: tol = sqrt(epsilon(zero))
+        real(dp),parameter :: A(4,4) = reshape([6,3,1,5, &
+                                               3,0,5,1, &
+                                               1,5,6,2, &
+                                               5,1,2,2], [4,4])
+        
+        !> Local variables
+        real(dp) :: Amat(4,4),lambda(4),vect(4,4),Av(4,4),lv(4,4)
+        type(linalg_state) :: state
+        
+        Amat = A
+        
+        call eigh(Amat,lambda,vect,err=state)
+        
+        Av = matmul(A,vect)
+        lv = matmul(vect,diag(lambda))
+        
+        error = state%error() .or. .not. all(abs(Av - lv) < tol*abs(Av))
+        if (error) return
+        
+        !> Test functional versions
+        lambda = eigvalsh(Amat)
+   
+        lambda = eigvalsh(Amat,err=state)
+        error = state%error()
+        if (error) return
+        
+        !> Test functional versions
+        Amat = A
+        lambda = eigvalsh(Amat,upper_a=.false.,err=state)
+        error = state%error()
+        if (error) return
+        
+    end subroutine test_eigh_real_d
+
     subroutine test_eig_real_q(error)
         logical,intent(out) :: error
 
@@ -168,6 +257,47 @@ module test_linalg_eig
         if (error) return
         
     end subroutine test_eig_real_q
+
+    ! Symmetric matrix eigenvalues
+    subroutine test_eigh_real_q(error)
+        logical,intent(out) :: error
+
+        !> Reference solution
+        real(qp),parameter :: zero = 0.0_qp
+        real(qp),parameter :: tol = sqrt(epsilon(zero))
+        real(qp),parameter :: A(4,4) = reshape([6,3,1,5, &
+                                               3,0,5,1, &
+                                               1,5,6,2, &
+                                               5,1,2,2], [4,4])
+        
+        !> Local variables
+        real(qp) :: Amat(4,4),lambda(4),vect(4,4),Av(4,4),lv(4,4)
+        type(linalg_state) :: state
+        
+        Amat = A
+        
+        call eigh(Amat,lambda,vect,err=state)
+        
+        Av = matmul(A,vect)
+        lv = matmul(vect,diag(lambda))
+        
+        error = state%error() .or. .not. all(abs(Av - lv) < tol*abs(Av))
+        if (error) return
+        
+        !> Test functional versions
+        lambda = eigvalsh(Amat)
+   
+        lambda = eigvalsh(Amat,err=state)
+        error = state%error()
+        if (error) return
+        
+        !> Test functional versions
+        Amat = A
+        lambda = eigvalsh(Amat,upper_a=.false.,err=state)
+        error = state%error()
+        if (error) return
+        
+    end subroutine test_eigh_real_q
 
     !> Simple complex matrix eigenvalues
     subroutine test_eig_complex_c(error)

--- a/test/test_linalg_eigs.fypp
+++ b/test/test_linalg_eigs.fypp
@@ -16,10 +16,14 @@ module test_linalg_eig
         call cpu_time(t0)
 
         #:for rk,rt,ri in REAL_KINDS_TYPES
-        call test_eig_diagonal_${ri}$(error)
+        call test_eig_real_${ri}$(error)
         if (error) return
         #: endfor
         
+        #:for ck,ct,ci in CMPL_KINDS_TYPES
+        call test_eig_complex_${ci}$(error)
+        if (error) return    
+        #: endfor 
 
         call cpu_time(t1)
 
@@ -29,19 +33,21 @@ module test_linalg_eig
 
     end subroutine test_eig
 
-    !> Simple diagonal matrix eigenvalues
+    !> Simple real matrix eigenvalues
     #:for rk,rt,ri in REAL_KINDS_TYPES
-    subroutine test_eig_diagonal_${ri}$(error)
+    subroutine test_eig_real_${ri}$(error)
         logical,intent(out) :: error
 
         !> Reference solution
-        real(${rk}$), parameter :: zero = 0.0_${rk}$
-        real(${rk}$), parameter :: tol  = sqrt(epsilon(zero))
+        real(${rk}$), parameter :: zero    = 0.0_${rk}$
+        real(${rk}$), parameter :: two     = 2.0_${rk}$
+        real(${rk}$), parameter :: sqrt2o2 = sqrt(two)*0.5_${rk}$
+        real(${rk}$), parameter :: tol     = sqrt(epsilon(zero))
 
         !> Local variables
         type(linalg_state) :: state
         ${rt}$ :: A(3,3),B(2,2)
-        complex(${rk}$) :: lambda(3),lambdab(2),Bvec(2,2)
+        complex(${rk}$) :: lambda(3),Bvec(2,2),Bres(2,2)
 
         !> Matrix with real eigenvalues
         A = reshape([1,0,0, &
@@ -56,25 +62,65 @@ module test_linalg_eig
         !> Matrix with complex eigenvalues
         B = transpose(reshape([1, -1, &
                                1,  1],[2,2]))
+                               
+        !> Expected right eigenvectors
+        Bres(1,1:2) = sqrt2o2
+        Bres(2,1)   = cmplx(zero,-sqrt2o2,kind=${rk}$)
+        Bres(2,2)   = cmplx(zero,+sqrt2o2,kind=${rk}$)
         
-        call eig(B,lambda,left=Bvec,err=state)
-        error = state%error()
-        if (error) return        
+        call eig(B,lambda,right=Bvec,err=state)
+        error = state%error() .or. any(abs(Bres-Bvec)>tol)
         
-!eigenvalues, eigenvectors = LA.eig(np.array([[1, -1], [1, 1]]))
-!eigenvalues
-!array([1.+1.j, 1.-1.j])
-!eigenvectors
-!array([[0.70710678+0.j        , 0.70710678-0.j        ],
-!       [0.        -0.70710678j, 0.        +0.70710678j]])        
-!        
-
-    end subroutine test_eig_diagonal_${ri}$
+        print *, bvec(1,:)
+        print *, bvec(2,:) 
+        print *, bres 
+        
+        if (error) return       
+        
+    end subroutine test_eig_real_${ri}$
 
     #:endfor
 
+    !> Simple complex matrix eigenvalues
+    #:for ck,ct,ci in CMPL_KINDS_TYPES
+    subroutine test_eig_complex_${ci}$(error)
+        logical,intent(out) :: error
 
+        !> Reference solution
+        real(${ck}$), parameter :: zero    = 0.0_${ck}$
+        real(${ck}$), parameter :: two     = 2.0_${ck}$
+        real(${ck}$), parameter :: sqrt2o2 = sqrt(two)*0.5_${ck}$
+        real(${ck}$), parameter :: tol     = sqrt(epsilon(zero))
+        ${ct}$, parameter :: cone  = (1.0_${ck}$,0.0_${ck}$)
+        ${ct}$, parameter :: cimg  = (0.0_${ck}$,1.0_${ck}$)
+        ${ct}$, parameter :: czero = (0.0_${ck}$,0.0_${ck}$)
 
+        !> Local vaciables
+        type(linalg_state) :: state
+        ${ct}$ :: A(2,2),lambda(2),Avec(2,2),Ares(2,2),lres(2)
+
+        !> Matcix with real eigenvalues
+        A = transpose(reshape([ cone, cimg, &
+                               -cimg, cone], [2,2]))
+                
+        call eig(A,lambda,right=Avec,err=state)
+        
+        !> Expected eigenvalues and eigenvectors
+        lres(1)   = two
+        lres(2)   = zero
+        
+        !> Eigenvectors may vary: do not use for error
+        Ares(1,1) = cmplx(zero,sqrt2o2,kind=${ck}$)
+        Ares(1,2) = cmplx(sqrt2o2,zero,kind=${ck}$)
+        Ares(2,1) = cmplx(sqrt2o2,zero,kind=${ck}$)
+        Ares(2,2) = cmplx(zero,sqrt2o2,kind=${ck}$)        
+        
+        error = state%error() .or. any(abs(lambda-lres)>tol)
+        if (error) return       
+        
+    end subroutine test_eig_complex_${ci}$
+
+    #:endfor
 
 
 end module test_linalg_eig

--- a/test/test_linalg_eigs.fypp
+++ b/test/test_linalg_eigs.fypp
@@ -20,6 +20,13 @@ module test_linalg_eig
         if (error) return
         #: endfor
         
+
+        #:for rk,rt,ri in REAL_KINDS_TYPES
+        call test_eigh_real_${ri}$(error)
+        if (error) return
+        #: endfor
+                
+        
         #:for ck,ct,ci in CMPL_KINDS_TYPES
         call test_eig_complex_${ci}$(error)
         if (error) return    
@@ -78,6 +85,47 @@ module test_linalg_eig
         if (error) return       
         
     end subroutine test_eig_real_${ri}$
+
+    ! Symmetric matrix eigenvalues
+    subroutine test_eigh_real_${ri}$(error)
+        logical,intent(out) :: error
+
+        !> Reference solution
+        real(${rk}$), parameter :: zero   = 0.0_${rk}$
+        real(${rk}$), parameter :: tol    = sqrt(epsilon(zero))
+        real(${rk}$), parameter :: A(4,4) = reshape([6,3,1,5, &
+                                               3,0,5,1, &
+                                               1,5,6,2, &
+                                               5,1,2,2],[4,4])
+        
+        !> Local variables
+        real(${rk}$) :: Amat(4,4),lambda(4),vect(4,4),Av(4,4),lv(4,4)
+        type(linalg_state) :: state
+        
+        Amat = A
+        
+        call eigh(Amat,lambda,vect,err=state)
+        
+        Av = matmul(A,vect)
+        lv = matmul(vect,diag(lambda))
+        
+        error = state%error() .or. .not. all(abs(Av-lv)<tol*abs(Av))
+        if (error) return
+        
+        !> Test functional versions
+        lambda = eigvalsh(Amat)
+   
+        lambda = eigvalsh(Amat,err=state)
+        error = state%error()
+        if (error) return
+        
+        !> Test functional versions
+        Amat = A
+        lambda = eigvalsh(Amat,upper_a=.false.,err=state)
+        error = state%error()
+        if (error) return        
+        
+    end subroutine test_eigh_real_${ri}$
 
     #:endfor
 

--- a/test/test_linalg_eigs.fypp
+++ b/test/test_linalg_eigs.fypp
@@ -1,6 +1,6 @@
 #:include "common.fypp"
 ! Test eigendecomposition
-module test_linalg_eigs
+module test_linalg_eig
     use stdlib_linalg_interface
 
     implicit none (type,external)
@@ -20,11 +20,6 @@ module test_linalg_eigs
         if (error) return
         #: endfor
 
-        #:for ck,ct,ci in CMPL_KINDS_TYPES
-        call test_complex_svd_${ci}$(error)
-        if (error) return
-        #: endfor
-
         call cpu_time(t1)
 
         print 1, 1000*(t1-t0), merge('SUCCESS','ERROR  ',.not.error)
@@ -39,18 +34,22 @@ module test_linalg_eigs
         logical,intent(out) :: error
 
         !> Reference solution
-        ${rt}$, parameter :: tol     = sqrt(epsilon(0.0_${rk}$))
+        real(${rk}$), parameter :: zero = 0.0_${rk}$
+        real(${rk}$), parameter :: tol  = sqrt(epsilon(zero))
 
         !> Local variables
         type(linalg_state) :: state
         ${rt}$ :: A(3,3)
-        complex(${rk}$) :: lambda
+        complex(${rk}$) :: lambda(3)
 
         !> Initialize matrix
-        A = diag([1,2,3])
+        A = reshape([1,0,0, &
+                     0,2,0, &
+                     0,0,3],[3,3])
         
         call eig(A,lambda,err=state)
-        error = state%error() 
+        error = state%error() .or. &
+                .not. all(aimag(lambda)==zero .and. real(lambda,kind=${rk}$)==[1,2,3])
 
         if (error) return
 
@@ -58,57 +57,7 @@ module test_linalg_eigs
 
     #:endfor
 
-    !> Test complex svd
-    #:for ck,ct,ci in CMPL_KINDS_TYPES
-    subroutine test_complex_svd_${ci}$(error)
-        logical,intent(out) :: error
 
-        !> Reference solution
-        real(${ck}$), parameter :: tol     = sqrt(epsilon(0.0_${ck}$))
-        real(${ck}$), parameter :: one     = 1.0_${ck}$
-        real(${ck}$), parameter :: zero    = 0.0_${ck}$
-        real(${ck}$), parameter ::  sqrt2  = sqrt(2.0_${ck}$)
-        real(${ck}$), parameter :: rsqrt2  = one/sqrt2
-        ${ct}$, parameter :: cone  = (1.0_${ck}$,0.0_${ck}$)
-        ${ct}$, parameter :: cimg  = (0.0_${ck}$,1.0_${ck}$)
-        ${ct}$, parameter :: czero = (0.0_${ck}$,0.0_${ck}$)
-
-        real(${ck}$), parameter ::  s_sol(2)   = [sqrt2,sqrt2]
-        ${ct}$, parameter ::  A_mat(2,2) = reshape([cone,cimg,cimg,cone],[2,2])
-        ${ct}$, parameter ::  u_sol(2,2) = reshape(rsqrt2*[cone,cimg,cimg,cone],[2,2])
-        ${ct}$, parameter :: vt_sol(2,2) = reshape([cone,czero,czero,cone],[2,2])
-
-        !> Local variables
-        type(linalg_state) :: state
-        ${ct}$ :: A(2,2),u(2,2),vt(2,2)
-        real(${ck}$) :: s(2)
-
-        !> Initialize matrix
-        A = A_mat
-
-        !> Simple subroutine version
-        call svd(A,s,err=state)
-        error = state%error() .or. .not. all(abs(s-s_sol)<=tol)
-        if (error) return
-
-        !> Function interface
-        s = svdvals(A,err=state)
-        error = state%error() .or. .not. all(abs(s-s_sol)<=tol)
-        if (error) return
-
-        !> [S, U, V^T]
-        A = A_mat
-        call svd(A,s,u,vt,overwrite_a=.true.,err=state)
-        error = state%error() .or. &
-                .not. all(abs(s-s_sol)<=tol) .or. &
-                .not. all(abs(matmul(u,matmul(diag(s),vt)) - A_mat)<=tol)
-        if (error) return
-
-    end subroutine test_complex_svd_${ci}$
-
-    #:endfor
-
-
-end module test_linalg_eigs
+end module test_linalg_eig
 
 

--- a/test/test_linalg_eigs.fypp
+++ b/test/test_linalg_eigs.fypp
@@ -1,0 +1,114 @@
+#:include "common.fypp"
+! Test eigendecomposition
+module test_linalg_eigs
+    use stdlib_linalg_interface
+
+    implicit none (type,external)
+
+    contains
+
+    !> SVD tests
+    subroutine test_eig(error)
+        logical, intent(out) :: error
+
+        real :: t0,t1
+
+        call cpu_time(t0)
+
+        #:for rk,rt,ri in REAL_KINDS_TYPES
+        call test_eig_${ri}$(error)
+        if (error) return
+        #: endfor
+
+        #:for ck,ct,ci in CMPL_KINDS_TYPES
+        call test_complex_svd_${ci}$(error)
+        if (error) return
+        #: endfor
+
+        call cpu_time(t1)
+
+        print 1, 1000*(t1-t0), merge('SUCCESS','ERROR  ',.not.error)
+
+        1 format('SVD tests completed in ',f9.4,' milliseconds, result=',a)
+
+    end subroutine test_eig
+
+    !> Real matrix svd
+    #:for rk,rt,ri in REAL_KINDS_TYPES
+    subroutine test_eig_${ri}$(error)
+        logical,intent(out) :: error
+
+        !> Reference solution
+        ${rt}$, parameter :: tol     = sqrt(epsilon(0.0_${rk}$))
+
+        !> Local variables
+        type(linalg_state) :: state
+        ${rt}$ :: A(3,3)
+        complex(${rk}$) :: lambda
+
+        !> Initialize matrix
+        A = diag([1,2,3])
+        
+        call eig(A,lambda,err=state)
+        error = state%error() 
+
+        if (error) return
+
+    end subroutine test_eig_${ri}$
+
+    #:endfor
+
+    !> Test complex svd
+    #:for ck,ct,ci in CMPL_KINDS_TYPES
+    subroutine test_complex_svd_${ci}$(error)
+        logical,intent(out) :: error
+
+        !> Reference solution
+        real(${ck}$), parameter :: tol     = sqrt(epsilon(0.0_${ck}$))
+        real(${ck}$), parameter :: one     = 1.0_${ck}$
+        real(${ck}$), parameter :: zero    = 0.0_${ck}$
+        real(${ck}$), parameter ::  sqrt2  = sqrt(2.0_${ck}$)
+        real(${ck}$), parameter :: rsqrt2  = one/sqrt2
+        ${ct}$, parameter :: cone  = (1.0_${ck}$,0.0_${ck}$)
+        ${ct}$, parameter :: cimg  = (0.0_${ck}$,1.0_${ck}$)
+        ${ct}$, parameter :: czero = (0.0_${ck}$,0.0_${ck}$)
+
+        real(${ck}$), parameter ::  s_sol(2)   = [sqrt2,sqrt2]
+        ${ct}$, parameter ::  A_mat(2,2) = reshape([cone,cimg,cimg,cone],[2,2])
+        ${ct}$, parameter ::  u_sol(2,2) = reshape(rsqrt2*[cone,cimg,cimg,cone],[2,2])
+        ${ct}$, parameter :: vt_sol(2,2) = reshape([cone,czero,czero,cone],[2,2])
+
+        !> Local variables
+        type(linalg_state) :: state
+        ${ct}$ :: A(2,2),u(2,2),vt(2,2)
+        real(${ck}$) :: s(2)
+
+        !> Initialize matrix
+        A = A_mat
+
+        !> Simple subroutine version
+        call svd(A,s,err=state)
+        error = state%error() .or. .not. all(abs(s-s_sol)<=tol)
+        if (error) return
+
+        !> Function interface
+        s = svdvals(A,err=state)
+        error = state%error() .or. .not. all(abs(s-s_sol)<=tol)
+        if (error) return
+
+        !> [S, U, V^T]
+        A = A_mat
+        call svd(A,s,u,vt,overwrite_a=.true.,err=state)
+        error = state%error() .or. &
+                .not. all(abs(s-s_sol)<=tol) .or. &
+                .not. all(abs(matmul(u,matmul(diag(s),vt)) - A_mat)<=tol)
+        if (error) return
+
+    end subroutine test_complex_svd_${ci}$
+
+    #:endfor
+
+
+end module test_linalg_eigs
+
+

--- a/test/test_linalg_eigs.fypp
+++ b/test/test_linalg_eigs.fypp
@@ -16,21 +16,22 @@ module test_linalg_eig
         call cpu_time(t0)
 
         #:for rk,rt,ri in REAL_KINDS_TYPES
-        call test_eig_${ri}$(error)
+        call test_eig_diagonal_${ri}$(error)
         if (error) return
         #: endfor
+        
 
         call cpu_time(t1)
 
         print 1, 1000*(t1-t0), merge('SUCCESS','ERROR  ',.not.error)
 
-        1 format('SVD tests completed in ',f9.4,' milliseconds, result=',a)
+        1 format('Eigenproblem tests completed in ',f9.4,' milliseconds, result=',a)
 
     end subroutine test_eig
 
-    !> Real matrix svd
+    !> Simple diagonal matrix eigenvalues
     #:for rk,rt,ri in REAL_KINDS_TYPES
-    subroutine test_eig_${ri}$(error)
+    subroutine test_eig_diagonal_${ri}$(error)
         logical,intent(out) :: error
 
         !> Reference solution
@@ -39,10 +40,10 @@ module test_linalg_eig
 
         !> Local variables
         type(linalg_state) :: state
-        ${rt}$ :: A(3,3)
-        complex(${rk}$) :: lambda(3)
+        ${rt}$ :: A(3,3),B(2,2)
+        complex(${rk}$) :: lambda(3),lambdab(2),Bvec(2,2)
 
-        !> Initialize matrix
+        !> Matrix with real eigenvalues
         A = reshape([1,0,0, &
                      0,2,0, &
                      0,0,3],[3,3])
@@ -50,12 +51,30 @@ module test_linalg_eig
         call eig(A,lambda,err=state)
         error = state%error() .or. &
                 .not. all(aimag(lambda)==zero .and. real(lambda,kind=${rk}$)==[1,2,3])
-
         if (error) return
+        
+        !> Matrix with complex eigenvalues
+        B = transpose(reshape([1, -1, &
+                               1,  1],[2,2]))
+        
+        call eig(B,lambda,left=Bvec,err=state)
+        error = state%error()
+        if (error) return        
+        
+!eigenvalues, eigenvectors = LA.eig(np.array([[1, -1], [1, 1]]))
+!eigenvalues
+!array([1.+1.j, 1.-1.j])
+!eigenvectors
+!array([[0.70710678+0.j        , 0.70710678-0.j        ],
+!       [0.        -0.70710678j, 0.        +0.70710678j]])        
+!        
 
-    end subroutine test_eig_${ri}$
+    end subroutine test_eig_diagonal_${ri}$
 
     #:endfor
+
+
+
 
 
 end module test_linalg_eig


### PR DESCRIPTION
- [x] `eig` subroutine interface: return eigenvalues, and optionally, eigenvectors
- [x] `eigvals` function interface: return eigenvalues only
- [x] assemble `complex` eigenvectors also from real version (can be complex conjugates)
- [x] test real and complex versions
- [x] `eigh` for hermitian matrices
- [x] `eigvalsh` for hermitian matrices
- [x] test high
- [x] 2 separate function interfaces: with, without error output  

Numpy: 
`eigenvalues, eigenvectors = eig(a)`
`eigenvalues = eigvals(a)`
Scipy: 
`eig(a, b=None, left=False, right=True, overwrite_a=False, overwrite_b=False, check_finite=True, homogeneous_eigvals=False)`

